### PR TITLE
Restructure PostgresSQL integration articles

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-client.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-client.mdx
@@ -58,6 +58,35 @@ public class ExampleService(
 }
 ```
 
+## Properties of the PostgreSQL resources
+
+When you use the `WithReference` method to pass a PostgreSQL server or database resource from the AppHost project to a consuming client project, several properties are available to use in the consuming project.
+
+Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db1` becomes `DB1_URI`.
+
+### PostgreSQL server resource
+
+The PostgreSQL server resource exposes the following connection properties:
+
+| Property Name | Description |
+|---------------|-------------|
+| `Host` | The hostname or IP address of the PostgreSQL server |
+| `Port` | The port number the PostgreSQL server is listening on |
+| `Username` | The username for authentication |
+| `Password` | The password for authentication |
+| `Uri` | The connection URI in postgresql:// format, with the format `postgresql://{Username}:{Password}@{Host}:{Port}` |
+| `JdbcConnectionString` | JDBC-format connection string, with the format `jdbc:postgresql://{Host}:{Port}`. User and password credentials are provided as separate `Username` and `Password` properties. |
+
+### PostgreSQL database resource
+
+The PostgreSQL database resource inherits all properties from its parent `PostgresServerResource` and adds:
+
+| Property Name | Description |
+|---------------|-------------|
+| `Uri` | The connection URI with the database name, with the format `postgresql://{Username}:{Password}@{Host}:{Port}/{DatabaseName}` |
+| `JdbcConnectionString` | JDBC connection string with database name, with the format `jdbc:postgresql://{Host}:{Port}/{DatabaseName}`. User and password credentials are provided as separate `Username` and `Password` properties. |
+| `DatabaseName` | The name of the database |
+
 ## Configuration
 
 The Aspire PostgreSQL integration provides multiple configuration approaches and options to meet the requirements and conventions of your project.

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -56,6 +56,10 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
     If you'd rather connect to an existing PostgreSQL server, chain a call to `AsExisting` instead—passing the appropriate parameters.
 </Aside>
 
+<Aside type="note">
+    When you call `WithReference` in the AppHost to pass PostgreSQL resources to a consuming project, Aspire makes several properties available to that project, such as connection strings, URIs, and port numbers. For a complete list of these properties, see [Properties of the PostgreSQL resources](../postgres-client/#properties-of-the-postgresql-resources).
+</Aside>
+
 ## Add PostgreSQL resource with database scripts
 
 By default, when you add a `PostgresDatabaseResource`, it relies on the following script to create the database:


### PR DESCRIPTION
This is to improve the experience of PostgreSQL integration documentation. It's currently in a large, comprehensive document that covers both hosting and client integrations. Content is difficult to find. There is no quick introduction for those who want to get going quickly. 

This PR implements:

- Hosting and Client integrations now in separate reference docs.
- A new "Getting Started" article including minimal steps for implementing both client and hosting integration.

Partially addresses #30 