### PR TITLE
Update MAUI app references from weatherApi to api

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13.mdx
@@ -902,23 +902,23 @@ var mauiapp = builder.AddMauiProject("myapp", @"../MyApp/MyApp.csproj");
 
 // Add MAUI app for Windows
 mauiapp.AddWindowsDevice()
-    .WithReference(weatherApi);
+    .WithReference(api);
 
 // Add MAUI app for Mac Catalyst
 mauiapp.AddMacCatalystDevice()
-    .WithReference(weatherApi);
+    .WithReference(api);
 
 // Add MAUI app for iOS running on the iOS Simulator (starts 
 // a random one, or uses the currently started one)
 mauiapp.AddiOSSimulator()
     .WithOtlpDevTunnel() // Needed to get the OpenTelemetry data to "localhost"
-    .WithReference(weatherApi, publicDevTunnel); // Needs a dev tunnel to reach "localhost"
+    .WithReference(api, publicDevTunnel); // Needs a dev tunnel to reach "localhost"
 
 // Add MAUI app for Android running on the emulator with 
 // default emulator (uses running or default emulator, needs to be started)
 mauiapp.AddAndroidEmulator()
     .WithOtlpDevTunnel() // Needed to get the OpenTelemetry data to "localhost"
-    .WithReference(weatherApi, publicDevTunnel); // Needs a dev tunnel to reach "localhost"
+    .WithReference(api, publicDevTunnel); // Needs a dev tunnel to reach "localhost"
 
 builder.Build().Run();
 ```


### PR DESCRIPTION
This pull request makes a small update to the Aspire 1.3 documentation example by changing the referenced variable from `weatherApi` to `api` in several places. This ensures consistency in the code sample and aligns the references with the correct variable.

- Updated all `.WithReference(weatherApi)` calls to `.WithReference(api)` for Windows, Mac Catalyst, iOS Simulator, and Android Emulator MAUI app device configurations in `aspire-13.mdx`.