### PR TITLE
Remove Aspire.Hosting.AppHost package reference

### DIFF
--- a/src/apphost/Aspire.Dev.AppHost/Aspire.Dev.AppHost.csproj
+++ b/src/apphost/Aspire.Dev.AppHost/Aspire.Dev.AppHost.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.0.0" />
     <PackageReference Include="Aspire.Hosting.Azure.AppService" Version="13.0.0-preview.1.25560.3" />
     <PackageReference Include="Aspire.Hosting.NodeJs" Version="9.5.2" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.NodeJS.Extensions" Version="9.9.0" />


### PR DESCRIPTION
Removed the PackageReference for Aspire.Hosting.AppHost. This is redundant based on: https://aspire.dev/whats-new/aspire-13/#-apphost-template-updates