### PR TITLE
Update section header and links for AI integrations

### DIFF
--- a/src/frontend/src/content/docs/dashboard/explore.mdx
+++ b/src/frontend/src/content/docs/dashboard/explore.mdx
@@ -460,12 +460,13 @@ $env:OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT="true"
 
 You can set this environment variable in your application's configuration, in your development environment, or in your deployment settings.
 
-##### Azure AI integrations
+##### AI integrations
 
 For specific guidance on configuring message content recording with different AI integrations, see the documentation for each integration:
 
 - [Azure OpenAI integration](https://learn.microsoft.com/dotnet/aspire/azureai/azureai-openai-integration#configuring-sensitive-data-in-telemetry).
 - [Azure AI Inference integration](https://learn.microsoft.com/dotnet/aspire/azureai/azureai-inference-integration#configuring-sensitive-data-in-telemetry).
+- [OpenAI integration](https://learn.microsoft.com/dotnet/aspire/openai/openai-integration#configuring-sensitive-data-in-telemetry).
 
 <Aside type="tip">
 When message content recording is disabled, the GenAI telemetry visualizer still provides valuable information about AI operations, including timing, metadata, and performance metrics. However, enabling message content recording provides the most comprehensive view of your AI interactions.


### PR DESCRIPTION
Add non-Azure OpenAI integration link.

Note: New section in OpenAI integration docs is being added with https://github.com/dotnet/docs-aspire/pull/5745