### PR TITLE
Add write permission for security events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   frontend-build:


### PR DESCRIPTION
Noticed CI wasn't running for #58 and there was an error in the GH Action saying that this change was needed. 