### PR TITLE
Fix markdown links in Python quickstart

### DIFF
--- a/src/frontend/src/content/docs/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/first-app.mdx
@@ -51,9 +51,9 @@ architecture-beta
 
 This starter template combines a modern Python and JavaScript stack:
 
-- [FastAPI]("https://fastapi.tiangolo.com/") for building APIs with Python
-- [Uv]("https://docs.astral.sh/uv/") for Python package installation and environment management
-- [React]("https://react.dev/") for building user interfaces with JavaScript
+- [FastAPI](https://fastapi.tiangolo.com/) for building APIs with Python
+- [Uv](https://docs.astral.sh/uv/) for Python package installation and environment management
+- [React](https://react.dev/) for building user interfaces with JavaScript
 
 The following diagram shows the architecture of the sample app you're creating:
 


### PR DESCRIPTION
With the current formatting links are pointing to invalid URLs like `https://aspire.dev/get-started/first-app/%22https://fastapi.tiangolo.com/%22`, removing the quotations with this PR should fix that