### PR TITLE
Fix service defaults method in MAUI integration

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
@@ -226,7 +226,7 @@ public static class MauiProgram
             });
 
         // Add service defaults
-        builder.Services.AddServiceDefaults();
+        builder.AddServiceDefaults();
 
         // Configure HTTP client with service discovery
         builder.Services.AddHttpClient<WeatherApiClient>(client =>


### PR DESCRIPTION
AddServiceDefaults was wrongly called on builder.Services in sample code.