### PR TITLE
Change TabItem label to 'iOS Simulator'

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
@@ -104,7 +104,7 @@ mauiapp.AddMacCatalystDevice()
     .WithReference(weatherApi);
 ```
 </TabItem>
-<TabItem label="OS Simulator">
+<TabItem label="iOS Simulator">
 iOS Simulator requires Dev Tunnels to connect to local services:
 
 ```csharp title="C# — AppHost.cs"


### PR DESCRIPTION
Updated TabItem label from 'OS Simulator' to 'iOS Simulator' for clarity.