### PR TITLE
Update command for Docker Compose cleanup

### DIFF
--- a/src/frontend/src/content/docs/get-started/deploy-first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/deploy-first-app.mdx
@@ -975,7 +975,7 @@ After deploying your application, it's important to clean up resources to avoid 
         To clean up resources after deploying with Docker Compose, you can stop and remove the running containers using the following command:
 
         ```bash title="Aspire CLI - Stop and remove containers"
-        aspire do docker-compose-env-down
+        aspire do docker-compose-down-env
         ```
     </TabItem>
     <TabItem id="azure" label="Azure">


### PR DESCRIPTION
The docs state the command to clean up resources when using Docker Compose wrongly: `docker-compose-env-down` instead of `docker-compose-down-env`