### PR TITLE
Remove watch mode option from aspire run documentation

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
@@ -49,10 +49,6 @@ The following options are available:
 
 - <Include relativePath="reference/cli/includes/option-project.md" />
 
-- **`-w, --watch`**
-
-  Start project resources in watch mode.
-
 - <Include relativePath="reference/cli/includes/option-help.md" />
 
 - <Include relativePath="reference/cli/includes/option-debug.md" />


### PR DESCRIPTION
Removed documentation for the '-w, --watch' option from aspire run command.

The watch flag was removed.
https://aspire.dev/whats-new/aspire-13/#removed-apis

It sounds like run will default to watching in the future so this option won't return.
<img width="284" height="242" alt="image" src="https://github.com/user-attachments/assets/86c470cc-7eec-4098-95d8-223e6f28a4d6" />

