### PR TITLE
Ollama - Use .WithGPUSupport() in examples

### DIFF
--- a/src/frontend/src/content/docs/integrations/ai/ollama.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama.mdx
@@ -74,7 +74,7 @@ var llama = ollama.AddModel("llama3");
 
 ### Use GPUs when available
 
-One or more LLMs are downloaded into the container which Ollama is running from, and by default this container runs on CPU. If you need to run the container in GPU you need to pass a parameter to the container runtime args.
+One or more LLMs are downloaded into the container which Ollama is running from, and by default this container runs on CPU. If you need to run the container with GPU support, you can enable it using the `WithGPUSupport()` extension method.
 
 **Nvidia:**
 


### PR DESCRIPTION
The Ollama integration from the community toolkit has built-in extensions for enabling GPU support.
```cs
var ollama = builder.AddOllama("ollama")
                    .AddModel("llama3")
                    .WithGPUSupport();
```

This is maintained by the community and configures the correct container runtime arguments:
| Nvidia + Docker | Nvidia + Podman                    | AMD + Docker / Podman                  |
|-------------------|----------------------------------|-----------------------------------------|
| `--gpus=all`        | `--device nvidia.com/gpu=all` | `--device /dev/kfd --device /dev/dri` |

Benefits of using the built in extension:
- `CommunityToolkit` maintains the extensions
- Support for new runtimes can be added for everyone
- Support for new GPU vendors can be added for everyone
- If the dev uses an unsupported container runtime or GPU, `.WithContainerRuntimeArgs(...)` is always available