### PR TITLE
Add brotli compression back and ensure index.html files are served compressed

### DIFF
--- a/src/statichost/StaticHost/Program.cs
+++ b/src/statichost/StaticHost/Program.cs
@@ -20,6 +20,9 @@ if (!app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseDefaultFiles();
 
+// add routing after default files, so the default file middleware can modify the path first
+app.UseRouting();
+
 app.UseStatusCodePages(async context =>
 {
     var response = context.HttpContext.Response;
@@ -38,37 +41,6 @@ app.UseStatusCodePages(async context =>
             response.ContentType = "text/html; charset=utf-8";
 
             await response.SendFileAsync(notFoundPath);
-        }
-    }
-});
-
-var provider = new FileExtensionContentTypeProvider();
-provider.Mappings[".cast"] = "application/x-asciinema+json";
-
-app.UseStaticFiles(new StaticFileOptions
-{
-    ContentTypeProvider = provider,
-    OnPrepareResponse = ctx =>
-    {
-        var headers = ctx.Context.Response.Headers;
-        var name = ctx.File.Name.ToLowerInvariant();
-
-        // Astro hashes CSS/JS files, but HTML files should not be cached
-        // They'll always reference the hashed assets
-        if (name.EndsWith(".html") || name.EndsWith(".htm"))
-        {
-            headers.CacheControl = "no-cache, no-store, must-revalidate";
-            headers.Pragma = "no-cache";
-            headers.Expires = "0";
-        }
-        else if (name.EndsWith(".css") || name.EndsWith(".js")
-            || name.EndsWith(".jpg") || name.EndsWith(".jpeg")
-            || name.EndsWith(".png") || name.EndsWith(".gif")
-            || name.EndsWith(".svg") || name.EndsWith(".webp")
-            || name.EndsWith(".woff") || name.EndsWith(".woff2")
-            || name.EndsWith(".ttf") || name.EndsWith(".eot"))
-        {
-            headers.CacheControl = "public, max-age=31536000, immutable";
         }
     }
 });

--- a/src/statichost/StaticHost/StaticHost.csproj
+++ b/src/statichost/StaticHost/StaticHost.csproj
@@ -6,9 +6,11 @@
     <SelfContained>false</SelfContained>
     <PublishAot>false</PublishAot>
     <InvariantGlobalization>true</InvariantGlobalization>
-    <!-- Disable default compression formats since we don't use the compressed assets. -->
-    <EnableDefaultCompressionFormats>false</EnableDefaultCompressionFormats>
     <ContainerBaseImage>mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled</ContainerBaseImage>
+
+    <!-- Disable default compression formats to specify only brotli. -->
+    <EnableDefaultCompressionFormats>false</EnableDefaultCompressionFormats>
+    <PublishCompressionFormats>brotli</PublishCompressionFormats>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Only enable brotli and not gzip since all modern browsers support brotli. This decreases the docker image from `1.8 GB` to `1.46 GB`
- Fix an issue with index.html files not being served as compressed. Ensure the DefaultFiles is before the UseRouting middleware in the pipeline.
    - With this there is no need for UseStaticFiles since MapStaticAssets will serve the static content.

cc @javiercn