### PR TITLE
Small fixes to PostgreSQL revisions

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-get-started.mdx
@@ -45,7 +45,7 @@ Next, in the AppHost project, create instances of PostgreSQL server and database
     options={[
         { id: "csharp", title: "C#" },
         { id: "python", title: "Python" },
-        { id: "javascript", title: "JavaScript"},
+        { id: "javascript", title: "JavaScript" },
     ]}
 />
 
@@ -66,7 +66,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 <Pivot id="python">
 
-```csharp title="AppHost.cs"
+```csharp title="apphost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres");


### PR DESCRIPTION
These fixes are to feedback from @maddymontaquila and @davidfowl:

- Remove "C#" from the title of the apphost.cs examples for Python and JavaScript in the get started document.
- Move the pivot selector as low in the document as possible.

Fixes: #132 