### PR TITLE
Change command from 'dotnet run' to 'aspire run'

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions.mdx
@@ -84,7 +84,7 @@ The Aspire Azure Functions integration has the following project constraints:
 - It currently only supports .NET workers with the [isolated worker model](https://learn.microsoft.com/azure/azure-functions/dotnet-isolated-process-guide).
 - Requires the following NuGet packages:
   - [📦 Microsoft.Azure.Functions.Worker](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker): Use the `FunctionsApplicationBuilder`.
-  - [📦 Microsoft.Azure.Functions.Worker.Sdk](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Sdk): Adds support for `dotnet run` and `azd publish`.
+  - [📦 Microsoft.Azure.Functions.Worker.Sdk](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Sdk): Adds support for `aspire run` and `aspire deploy`.
   - [📦 Microsoft.Azure.Functions.Http.AspNetCore](https://www.nuget.org/packages/Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore): Adds HTTP trigger-supporting APIs.
 
 <Pivot id="visual-studio">


### PR DESCRIPTION
Updated the command references for the Azure Functions SDK.