### PR TITLE
Fix a redirect to the PostgreSQL content.

### DIFF
--- a/src/frontend/config/redirects.mjs
+++ b/src/frontend/config/redirects.mjs
@@ -3,7 +3,7 @@ export const redirects = {
   // For example:
   // '/original/path/': '/new/path'
   '/get-started/welcome/': '/docs/',
-  '/integrations/postgres/': '/integrations/databases/postgres/',
+  '/integrations/postgres/': '/integrations/databases/postgres/postgres-getting-started/',
   '/integrations/rabbitmq/': '/integrations/messaging/rabbitmq/',
   '/integrations/eventstore/': '/integrations/databases/kurrentdb/',
 };


### PR DESCRIPTION
The PostgreSQL documents have been restructured and files moved. This is causing a broken link from the integrations gallery. This PR fixes that issue by updating the link in the *redirects.mjs* file.

Fixes: #166 