### PR TITLE
Update eventing docs to new APIs

### DIFF
--- a/src/frontend/src/content/docs/app-host/eventing.mdx
+++ b/src/frontend/src/content/docs/app-host/eventing.mdx
@@ -250,7 +250,7 @@ The default behavior is `EventDispatchBehavior.BlockingSequential`. To override 
 
 ## Eventing subscribers
 
-In some cases, such as extension libraries, you may need to access lifecycle events from a service rather than directly from the Aspire application model. You can implement `IDistributedApplicationEventingSubscriber` and register the service with `TryAddEventingSubscriber`.
+In some cases, such as extension libraries, you may need to access lifecycle events from a service rather than directly from the Aspire application model. You can implement `IDistributedApplicationEventingSubscriber` and register the service with `AddEventingSubscriber` (or `TryAddEventingSubscriber` if you want to avoid duplicate registrations).
 
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Eventing;


### PR DESCRIPTION
Fixes #190

Updates the AppModel eventing docs to cover the new `IDistributedApplicationEventingSubscriber` interface instead of the obsolete `IDistributedApplicationLifecycleHook`.