### PR TITLE
Fix link for referencing existing SQL Server resources

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/sql-server.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server.mdx
@@ -54,7 +54,7 @@ The SQL Server container is slow to start, so it's best to use a _persistent_ li
 
 When Aspire adds a container image to the AppHost, as shown in the preceding example with the `mcr.microsoft.com/mssql/server` image, it creates a new SQL Server instance on your local machine. A reference to your SQL Server resource builder (the `sql` variable) is used to add a database. The database is named `database` and then added to the `ExampleProject`.
 
-When adding a database resource to the app model, the database is created if it doesn't already exist. The creation of the database relies on the [AppHost eventing APIs](../../app-host/eventing.md), specifically `ResourceReadyEvent`. In other words, when the `sql` resource is _ready_, the event is raised and the database resource is created.
+When adding a database resource to the app model, the database is created if it doesn't already exist. The creation of the database relies on the [AppHost eventing APIs](/app-host/eventing/), specifically `ResourceReadyEvent`. In other words, when the `sql` resource is _ready_, the event is raised and the database resource is created.
 
 The SQL Server resource includes default credentials with a `username` of `sa` and a random `password` generated using the `CreateDefaultPasswordParameter` method.
 
@@ -71,7 +71,7 @@ The name of the parameter is `sql-password`, but really it's just formatting the
 The `WithReference` method configures a connection in the `ExampleProject` named `database`.
 
 <Aside type="tip">
-If you'd rather connect to an existing SQL Server, call `AddConnectionString` instead. For more information, see [Reference existing resources](../../fundamentals/external-parameters/#connection-string-values).
+If you'd rather connect to an existing SQL Server, call `AddConnectionString` instead. For more information, see [Reference existing resources](/fundamentals/external-parameters/#connection-string-values).
 </Aside>
 
 ### Add SQL Server resource with database scripts


### PR DESCRIPTION
Unsure if this is the correct link. Was exploring the docs and found that the previous link returned a 404.

Updated to point at [this external parameters doc page](https://aspire.dev/fundamentals/external-parameters/#connection-string-values) instead of the previous [app-host-overview](https://aspire.dev/integrations/fundamentals/app-host-overview.md#reference-existing-resources) page which may not exist any longer.

---

Updated the link for referencing existing resources in SQL Server documentation.