### PR TITLE
Fix typo in Options array for AllowCustomInput

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13.mdx
@@ -1149,7 +1149,7 @@ var input = new InteractionInput
     Name = "AllowCustomInput",
     Label = "Favorite food?",
     InputType = InputType.Choice,
-    Options = [KeyValuePair.Create("pizza", "Pizza"), KeyValuePair.reate("burger", "Burger")],
+    Options = [KeyValuePair.Create("pizza", "Pizza"), KeyValuePair.Create("burger", "Burger")],
     AllowCustomChoice = true
 };
 


### PR DESCRIPTION
This pull request corrects a small typo in the initialization of the `Options` array for the `InteractionInput` object. The change ensures that both options are created using the correct method name.

- Fixed a typo in the `Options` array by changing `KeyValuePair.reate` to `KeyValuePair.Create` in the `src/frontend/src/content/docs/whats-new/aspire-13.mdx` file.