### PR TITLE
Refactor Tooltips component for improved readability

### DIFF
--- a/src/frontend/src/components/starlight/Head.astro
+++ b/src/frontend/src/components/starlight/Head.astro
@@ -34,6 +34,13 @@ function computeSourceUrl() {
 
 <DefaultHead {...Astro.props} />
 
-<Tooltips interactive={false} allowHTML={true} delay={[0, 0]} animation="scale" />
+<Tooltips
+  interactive={false}
+  allowHTML={true}
+  delay={[0, 0]}
+  duration={[0, 0]}
+  hideOnClick={true}
+  animation="scale"
+/>
 
 <AccessibleCodeButtons />


### PR DESCRIPTION
Fixes #208, needed to set [the duration](https://atomiks.github.io/tippyjs/v5/all-props/). Also, set the `hideOnClick`.

https://github.com/user-attachments/assets/5a1aa934-1149-4667-9760-fcfef2e6afb1

