### PR TITLE
Corrected command name in code snippet

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
@@ -73,7 +73,7 @@ Each command represents a template. Pass the `--help` parameter to the template 
 - Create an AppHost project named `aspireapp` from the **13.1.0** templates and place the output in a folder named `dev`.
 
   ```bash title="Aspire CLI"
-  aspire new aspire-apphost --version 13.1.0 --name aspireapp --output ./dev
+  aspire new aspire-apphost-singlefile --version 13.1.0 --name aspireapp --output ./dev
   ```
 
 - Create an Aspire starter app using templates from the `daily` channel to get the latest pre-release templates.


### PR DESCRIPTION
Updated command to create an AppHost project with single-file option.

The current code example will give you:

Unrecognized command or argument 'aspire-apphost'.
