### PR TITLE
Update link to external parameters documentation

### DIFF
--- a/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
@@ -111,7 +111,7 @@ Resource names in Kubernetes must follow DNS naming conventions. The integration
 
 ### Environment-specific configuration
 
-Use [external parameters](/get-started/resources/) to configure environment-specific values that should be different between development and production environments.
+Use [external parameters](/fundamentals/external-parameters/) to configure environment-specific values that should be different between development and production environments.
 
 ## See also
 


### PR DESCRIPTION
Direct the link to the correct documentation page relevant to the content