### PR TITLE
Fix URL of Standalone Dashboard

### DIFF
--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -146,7 +146,7 @@ To configure applications:
 
 ## Sample
 
-For a sample of using the standalone dashboard, see the [Standalone Aspire dashboard sample app](https://github.com/dotnet/aspire-samples/tree/main/samples/StandaloneDashboard).
+For a sample of using the standalone dashboard, see the [Standalone Aspire dashboard sample app](https://github.com/dotnet/aspire-samples/tree/main/samples/standalone-dashboard).
 
 ## Next steps
 


### PR DESCRIPTION
I just simply updated the URL of the Standalone Dashboard since the folder name was changed.