### PR TITLE
Remove inner-loop networking diagram from documentation

### DIFF
--- a/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
+++ b/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
@@ -33,34 +33,6 @@ Upon creating a binding, whether implicit or explicit, Aspire launches a lightwe
 
 To help visualize how endpoints work, consider the Aspire starter templates inner-loop networking diagram:
 
-```mermaid
-architecture-beta
-    group app [Aspire AppHost]
-    group docker [Docker Daemon]
-
-    service browser(internet)[Browser]
-
-    service frontend_proxy(server)[Frontend Proxy]
-    service api_proxy(server)[API Proxy]
-    service redis_proxy(server)[Redis Proxy]
-
-    service frontend(disk)[frontend] in app
-    service apiservice(disk)[apiservice] in app
-    service redis(database)[redis] in docker
-
-    browser:R --> L:frontend_proxy
-    frontend_proxy:R --> L:frontend
-
-    browser:R --> L:api_proxy
-    api_proxy:R --> L:apiservice
-
-    browser:R --> L:redis_proxy
-    redis_proxy:R --> L:redis
-
-    frontend:B --> T:frontend
-    frontend:R --> L:api_proxy
-```
-
 <Image
   src={networkingProxies}
   alt="Aspire Starter Application template inner loop networking diagram."


### PR DESCRIPTION
Removed the mermaid diagram illustrating the Aspire starter templates inner-loop networking.