### PR TITLE
refactor: reorganize and enhance the "Why HTTPS matters" section in c…

### DIFF
--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -5,20 +5,6 @@ description: Learn how to configure HTTPS endpoints and certificate trust for re
 
 import { Aside } from '@astrojs/starlight/components';
 
-## Why HTTPS matters
-
-HTTPS is essential for protecting the security and privacy of data transmitted between services. It encrypts traffic to prevent eavesdropping, tampering, and man-in-the-middle attacks. For production environments, HTTPS is a fundamental security requirement.
-
-However, enabling HTTPS during local development to match the production configuration presents unique challenges. Development environments typically use self-signed certificates that browsers and applications don't trust by default. Managing these certificates across multiple services, containers, and different language runtimes can be complex and time-consuming, often creating friction in the development workflow.
-
-Aspire simplifies HTTPS configuration for local development by providing APIs to:
-
-- Configure HTTPS endpoints with appropriate certificates for server authentication
-- Manage certificate trust so resources can communicate with services using self-signed certificates
-- Automatically handle the .NET provided ASP.NET Core development certificate (a per-user self-signed certificate valid only for local domains) across different resource types
-
-## Overview
-
 Aspire provides two complementary sets of certificate APIs:
 
 1. **HTTPS endpoint APIs**: Configure the certificates that resources use for their own HTTPS endpoints (server authentication)
@@ -30,6 +16,18 @@ Both sets of APIs work together to enable secure HTTPS communication during loca
   Certificate customization only applies at run time. Custom certificates aren't
   included in publish or deployment artifacts.
 </Aside>
+
+### Why HTTPS matters
+
+HTTPS is essential for protecting the security and privacy of data transmitted between services. It encrypts traffic to prevent eavesdropping, tampering, and man-in-the-middle attacks. For production environments, HTTPS is a fundamental security requirement.
+
+However, enabling HTTPS during local development to match the production configuration presents unique challenges. Development environments typically use self-signed certificates that browsers and applications don't trust by default. Managing these certificates across multiple services, containers, and different language runtimes can be complex and time-consuming, often creating friction in the development workflow.
+
+Aspire simplifies HTTPS configuration for local development by providing APIs to:
+
+- Configure HTTPS endpoints with appropriate certificates for server authentication
+- Manage certificate trust so resources can communicate with services using self-signed certificates
+- Automatically handle the .NET provided ASP.NET Core development certificate (a per-user self-signed certificate valid only for local domains) across different resource types
 
 ## HTTPS endpoint configuration
 


### PR DESCRIPTION
…ertificate configuration documentation

Today, this article has two "Overview" headings, we there's an implicit one for the top of the article. I slightly reorganized this to have the actual overview be first, then why HTTPS matters as a subsection.