### PR TITLE
Update documentation for Node.js hosting extensions

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/nodejs-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/nodejs-extensions.mdx
@@ -23,6 +23,10 @@ import nodejsLightIcon from '@assets/icons/nodejs-light-icon.png';
 
 The Aspire Community Toolkit Node.js hosting extensions package provides extra functionality to the [Aspire.Hosting.NodeJS](https://www.nuget.org/packages/Aspire.Hosting.NodeJS) hosting package.
 
+:::caution[Package rename]
+In Aspire 13.0, the `Aspire.Hosting.NodeJs` package was renamed to [`Aspire.Hosting.JavaScript`](/integrations/frameworks/javascript) to better reflect its broader support for JavaScript applications.
+:::
+
 This package provides the following features:
 
 - Running [Vite](https://vitejs.dev/) applications


### PR DESCRIPTION
Add note about package rename.
I think it adds to the DX to add a deprecation note, similar to how it's done on the newer page. This prevents devs to configure the NodeJs package to later find out it was renamed, and thus the developer needs to update the config.

<img width="1410" height="202" alt="image" src="https://github.com/user-attachments/assets/6dd40634-3443-45da-921d-0bf837e2168e" />

Creating a PR was easier than an issue, so feel free to close this one if this change is not desired.