### PR TITLE
Update obsoleted method name from AddAzureBlobClient to AddAzureBlobServiceClient

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs.mdx
@@ -241,10 +241,10 @@ To get started with the Aspire Azure Blob Storage client integration, install th
 
 ### Add Azure Blob Storage client
 
-In the `Program.cs` file of your client-consuming project, call the `AddAzureBlobClient` extension method to register a `BlobServiceClient` for dependency injection. The method takes a connection name parameter:
+In the `Program.cs` file of your client-consuming project, call the `AddAzureBlobServiceClient` extension method to register a `BlobServiceClient` for dependency injection. The method takes a connection name parameter:
 
 ```csharp
-builder.AddAzureBlobClient("blobs");
+builder.AddAzureBlobServiceClient("blobs");
 ```
 
 You can then retrieve the `BlobServiceClient` instance using dependency injection:
@@ -262,10 +262,10 @@ The Azure Blob Storage integration provides multiple options to configure the `B
 
 #### Use a connection string
 
-When using a connection string from the `ConnectionStrings` configuration section, provide the name when calling `AddAzureBlobClient`:
+When using a connection string from the `ConnectionStrings` configuration section, provide the name when calling `AddAzureBlobServiceClient`:
 
 ```csharp
-builder.AddAzureBlobClient("blobs");
+builder.AddAzureBlobServiceClient("blobs");
 ```
 
 Two connection formats are supported:
@@ -351,11 +351,11 @@ The Azure Blob Storage integration supports named configuration for multiple ins
 }
 ```
 
-Use the connection names when calling `AddAzureBlobClient`:
+Use the connection names when calling `AddAzureBlobServiceClient`:
 
 ```csharp
-builder.AddAzureBlobClient("blob1");
-builder.AddAzureBlobClient("blob2");
+builder.AddAzureBlobServiceClient("blob1");
+builder.AddAzureBlobServiceClient("blob2");
 ```
 
 #### Use inline delegates
@@ -363,7 +363,7 @@ builder.AddAzureBlobClient("blob2");
 You can also pass the `Action<AzureStorageBlobsSettings>` delegate to set up options inline:
 
 ```csharp
-builder.AddAzureBlobClient(
+builder.AddAzureBlobServiceClient(
     "blobs",
     settings => settings.DisableHealthChecks = true);
 ```
@@ -371,7 +371,7 @@ builder.AddAzureBlobClient(
 You can also configure the `BlobClientOptions`:
 
 ```csharp
-builder.AddAzureBlobClient(
+builder.AddAzureBlobServiceClient(
     "blobs",
     configureClientBuilder: clientBuilder =>
         clientBuilder.ConfigureOptions(


### PR DESCRIPTION
Updated document to use the latest method name.
```
AspireBlobStorageExtensions.AddAzureBlobClient(IHostApplicationBuilder, string, Action<AzureStorageBlobsSettings>?, Action<IAzureClientBuilder<BlobServiceClient, BlobClientOptions>>?)'
is obsolete: 
'Use AddAzureBlobServiceClient instead. This method will be removed in a future version.
```