### PR TITLE
Fix Accessibility Violations - Remove Duplicate Link Text and Image A…

### DIFF
--- a/src/frontend/src/components/LanguagesSupported.astro
+++ b/src/frontend/src/components/LanguagesSupported.astro
@@ -35,7 +35,7 @@ const getSearchParam = (lang: { name: string; search?: string; icon?: any }) => 
           data-tooltip-placement="top"
         >
           {'icon' in lang && lang.icon ? (
-            <Image src={lang.icon} alt={lang.name} class:list={['icon']} width="64" height="64" />
+            <Image src={lang.icon} alt="" class:list={['icon']} width="64" height="64" />
           ) : (
             <div class="icon-placeholder" aria-hidden="true" />
           )}


### PR DESCRIPTION
## Summary
This PR fixes accessibility violations where image alt text duplicated the adjacent link text, causing screen readers to announce the same information twice.

## Related Issue
Close #298 

## Solution
Changed the image alt text from alt={lang.name} to alt="" (empty string) since:

- The images are decorative - they serve to visually enhance the link but don't convey unique information
- The link text already provides the necessary context
- Setting alt="" tells screen readers to skip the image, avoiding redundancy



