### PR TITLE
Fix connection string syntax in MongoDB docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-get-started.mdx
@@ -178,7 +178,7 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 Use the `GetValue()` method to obtain these environment variables in consuming projects:
 
 ```csharp title="C# - Obtain configuration properties"
-string connectionUri = builder.Configuration.GetValue<string>("ConnectionStrings:mongodb");
+string connectionUri = builder.Configuration.GetConnectionString("mongodb");
 string host = builder.Configuration.GetValue<string>("MONGODB_HOST");
 string databaseName = builder.Configuration.GetValue<string>("MONGODB_DATABASENAME");
 ```


### PR DESCRIPTION
`"ConnectionStrings__mongoDb"`  should be `"ConnectionStrings:mongoDb"`.

The former returns `null`.