### PR TITLE
Update integration package links in deployment overview

### DIFF
--- a/src/frontend/src/content/docs/deployment/overview.mdx
+++ b/src/frontend/src/content/docs/deployment/overview.mdx
@@ -134,8 +134,8 @@ This example shows how you could explicitly map services to different compute en
 
 | Integration | Target | Publish | Deploy | Notes |
 |---------------------|--------|---------|--------|-------|
-| [📦 Aspire.Hosting.Docker](/integrations/compute/docker/) | Docker / Docker Compose | ✅ Yes | ❌ No | Use generated Compose with your own scripts or tooling. |
-| [📦 Aspire.Hosting.Kubernetes](/integrations/compute/kubernetes/) | Kubernetes | ✅ Yes | ❌ No | Apply with `kubectl`, GitOps, or other controllers. |
+| [📦 Aspire.Hosting.Docker](/integrations/compute/docker/) | Docker / Docker Compose | ✅ Yes | 🧪 Preview | Use generated Compose with your own scripts or tooling. |
+| [📦 Aspire.Hosting.Kubernetes](/integrations/compute/kubernetes/) | Kubernetes | ✅ Yes | 🧪 Preview | Apply with `kubectl`, GitOps, or other controllers. |
 | [📦 Aspire.Hosting.Azure.AppContainers](/integrations/cloud/azure/configure-container-apps/) | Azure Container Apps | ✅ Yes | ✅ Yes (Preview) | Deploy capability is in Preview and may change. |
 | [📦 Aspire.Hosting.Azure.AppService](/integrations/cloud/azure/azure-app-service/) | Azure App Service | ✅ Yes | ✅ Yes (Preview) | Deploy capability is in Preview and may change. |
 


### PR DESCRIPTION
Update Hosting integration support matrix to link to the integration docs and not the package on NuGet.