### PR TITLE
Fixed punctuation in Python example code.

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
@@ -155,7 +155,7 @@ For example, if you reference an Oracle database resource named `oracledb`:
 var oracle = builder.AddOracle("oracle");
 var oracledb = oracle.AddDatabase("oracledb");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(oracledb);
 ```
 

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-get-started.mdx
@@ -70,7 +70,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var elasticsearch = builder.AddElasticsearch("elasticsearch");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(elasticsearch)
                             .WithReference(elasticsearch);

--- a/src/frontend/src/content/docs/integrations/databases/milvus/milvus-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/milvus/milvus-get-started.mdx
@@ -76,7 +76,7 @@ var milvus = builder.AddMilvus("milvus")
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(milvusdb)
                             .WithReference(milvusdb);

--- a/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
@@ -172,7 +172,7 @@ For example, if you reference a Milvus database resource named `milvusdb`:
 var milvus = builder.AddMilvus("milvus");
 var milvusdb = milvus.AddDatabase("milvusdb");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(milvusdb);
 ```
 

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-get-started.mdx
@@ -76,7 +76,7 @@ var mongo = builder.AddMongoDB("mongo")
 
 var mongodb = mongo.AddDatabase("mongodb");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(mongodb)
                             .WithReference(mongodb);

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
@@ -231,7 +231,7 @@ For example, if you reference a MongoDB database resource named `mongodb`:
 var mongo = builder.AddMongoDB("mongo");
 var mongodb = mongo.AddDatabase("mongodb");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(mongodb);
 ```
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-get-started.mdx
@@ -72,7 +72,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var mysql = builder.AddMySql("mysql");
 var mysqldb = mysql.AddDatabase("mysqldb");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(mysqldb)
                             .WithReference(mysqldb);

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-get-started.mdx
@@ -72,7 +72,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var postgres = builder.AddPostgres("postgres");
 var postgresdb = postgres.AddDatabase("postgresdb");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(postgresdb)
                             .WithReference(postgresdb);

--- a/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-get-started.mdx
@@ -72,7 +72,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var qdrant = builder.AddQdrant("qdrant")
                     .WithLifetime(ContainerLifetime.Persistent);
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(qdrant)
                             .WithReference(qdrant);

--- a/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
@@ -140,7 +140,7 @@ For example, if you reference a Qdrant resource named `qdrant`:
 ```csharp title="C# — AppHost.cs"
 var qdrant = builder.AddQdrant("qdrant");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(qdrant);
 ```
 

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-get-started.mdx
@@ -72,7 +72,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var sql = builder.AddSqlServer("sql");
 var sqldb = sql.AddDatabase("sqldb");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WaitFor(sqldb)
                             .WithReference(sqldb);

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
@@ -300,7 +300,7 @@ For example, if you reference a SQL Server database resource named `sqldb`:
 ```csharp title="C# — AppHost.cs"
 var sqldb = sql.AddDatabase("sqldb");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(sqldb);
 ```
 

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
@@ -72,7 +72,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 var sqlite = builder.AddSqlite("sqlite");
 
-var exampleProject = builder.AddUvicornApp("api", "./api", "main.app")
+var exampleProject = builder.AddUvicornApp("api", "./api", "main:app")
                             .WithExternalHttpEndpoints()
                             .WithReference(sqlite);
 ```

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -114,7 +114,7 @@ For example, if you reference a SQLite database resource named `sqlite`:
 ```csharp title="C# — AppHost.cs"
 var sqlite = builder.AddSqlite("sqlite");
 
-var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
+var pythonApp = builder.AddUvicornApp("api", "./api", "main:app")
     .WithReference(sqlite);
 ```
 


### PR DESCRIPTION
In several get started articles, punctuation in Python examples is incorrect. For example:

```
var pythonApp = builder.AddUvicornApp("api", "./api", "main.app")
    .WithReference(oracledb);
```
`main.app` should be `main:app`. This PR fixes those errors.

Fixes: #318