### PR TITLE
Update resource creation in Node.js docs

### DIFF
--- a/src/frontend/src/content/docs/dashboard/enable-browser-telemetry.mdx
+++ b/src/frontend/src/content/docs/dashboard/enable-browser-telemetry.mdx
@@ -210,7 +210,7 @@ import { ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/sdk-tra
 import { DocumentLoadInstrumentation } from '@opentelemetry/instrumentation-document-load';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-proto';
 import { registerInstrumentations } from '@opentelemetry/instrumentation';
-import { Resource } from '@opentelemetry/resources';
+import { resourceFromAttributes } from '@opentelemetry/resources';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
 import { WebTracerProvider } from '@opentelemetry/sdk-trace-web';
 import { ZoneContextManager } from '@opentelemetry/context-zone';
@@ -225,7 +225,7 @@ export function initializeTelemetry(otlpUrl, headers, resourceAttributes) {
     attributes[SemanticResourceAttributes.SERVICE_NAME] = 'browser';
 
     const provider = new WebTracerProvider({
-        resource: new Resource(attributes),
+        resource: resourceFromAttributes(attributes),
     });
     provider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
     provider.addSpanProcessor(new SimpleSpanProcessor(new OTLPTraceExporter(otlpOptions)));

--- a/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
@@ -115,14 +115,14 @@ Now let's add OpenTelemetry instrumentation to send telemetry data to the Aspire
     const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
     const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-grpc');
     const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
-    const { Resource } = require('@opentelemetry/resources');
+    const { resourceFromAttributes } = require('@opentelemetry/resources');
     const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
     // Configure the OTLP endpoint for standalone dashboard
     const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4317';
 
     // Create resource with service name
-    const resource = new Resource({
+    const resource = resourceFromAttributes({
         [ATTR_SERVICE_NAME]: 'weather-api-nodejs',
     });
 

--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -635,12 +635,18 @@ JavaScript/Node.js applications can also send telemetry using OpenTelemetry:
    const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-grpc');
    const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-grpc');
    const { PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
-   const { Resource } = require('@opentelemetry/resources');
+   const { resourceFromAttributes } = require('@opentelemetry/resources');
+   const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
    const otlpEndpoint = process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4317';
 
+   // Create resource with service name
+   const resource = resourceFromAttributes({
+       [ATTR_SERVICE_NAME]: 'frontend',
+   });
+
    const sdk = new NodeSDK({
-     resource: new Resource({ 'service.name': 'frontend' }),
+     resource: resource,
      traceExporter: new OTLPTraceExporter({ url: otlpEndpoint }),
      metricReader: new PeriodicExportingMetricReader({
        exporter: new OTLPMetricExporter({ url: otlpEndpoint })

--- a/src/frontend/src/content/docs/ja/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/ja/get-started/add-aspire-existing-app.mdx
@@ -677,13 +677,19 @@ JavaScript / Node.js アプリケーションも、OpenTelemetry を使用して
    const {
      PeriodicExportingMetricReader,
    } = require('@opentelemetry/sdk-metrics');
-   const { Resource } = require('@opentelemetry/resources');
+   const { resourceFromAttributes } = require('@opentelemetry/resources');
+   const { ATTR_SERVICE_NAME } = require('@opentelemetry/semantic-conventions');
 
    const otlpEndpoint =
      process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4317';
 
+   // Create resource with service name
+   const resource = resourceFromAttributes({
+       [ATTR_SERVICE_NAME]: 'frontend',
+   });
+
    const sdk = new NodeSDK({
-     resource: new Resource({ 'service.name': 'frontend' }),
+     resource: resource,
      traceExporter: new OTLPTraceExporter({ url: otlpEndpoint }),
      metricReader: new PeriodicExportingMetricReader({
        exporter: new OTLPMetricExporter({ url: otlpEndpoint }),


### PR DESCRIPTION
Since v2.0.0 of `@opentelemetry/resources` the `resource` class is no longer exported.

The examples have been updated accordingly.