### PR TITLE
Explain how to start & stop resources manually

### DIFF
--- a/src/frontend/src/content/docs/testing/accessing-resources.mdx
+++ b/src/frontend/src/content/docs/testing/accessing-resources.mdx
@@ -44,3 +44,25 @@ await app.ResourceNotifications.WaitForResourceHealthyAsync(
 ```
 
 This resource-notification pattern ensures that the resources are available before running the tests, avoiding potential issues with the tests failing due to the resources not being ready.
+
+## Start & Stop
+
+In some cases, you may want to manually start a resource when it is not initially started, for when the resource was created `WithExplicitStart` for example.
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+await app.ResourceCommands.ExecuteCommandAsync(
+    "webfrontend",
+    KnownResourceCommands.StartCommand,
+    cts.Token);
+```
+
+You could also want to stop a resource manually to see if your application is resilient when a particular resource shuts down.
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+await app.ResourceCommands.ExecuteCommandAsync(
+    "webfrontend",
+    KnownResourceCommands.StopCommand,
+    cts.Token);
+```


### PR DESCRIPTION
For cases of testing a resource that run a task (like sort of a cronjob), it can be convenient to know how to start (or stop) a resource.