### PR TITLE
Fix code for adding SQL project

### DIFF
--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
@@ -39,7 +39,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 var sql = builder.AddSqlServer("sql")
                  .AddDatabase("sqldb");
 
-sql.AddSqlProject<Projects.DatabaseProject>("database-project");
+builder.AddSqlProject<Projects.DatabaseProject>("database-project")
+       .WithReference(sql);
 
 builder.AddProject<Projects.ExampleProject>()
        .WithReference(sql);
@@ -71,7 +72,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 var sql = builder.AddSqlServer("sql")
                  .AddDatabase("sqldb");
 
-sql.AddSqlPackage("Contoso.DatabasePackage", "1.0.0");
+builder.AddSqlPackage("Contoso.DatabasePackage", "1.0.0")
+       .WithReference(sql);
 
 builder.AddProject<Projects.ExampleProject>()
        .WithReference(sql);


### PR DESCRIPTION
Code in the current docs runs ``AddSqlProject`` on ``sql`` instead of ``builder``. This results in an error when attempting to run code and is not in line with the [documentation of the package in NuGet](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects#readme-body-tab).