### PR TITLE
Add missing namespace

### DIFF
--- a/src/frontend/src/content/docs/app-host/eventing.mdx
+++ b/src/frontend/src/content/docs/app-host/eventing.mdx
@@ -254,6 +254,7 @@ In some cases, such as extension libraries, you may need to access lifecycle eve
 
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Eventing;
+using Aspire.Hosting.Lifecycle;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 


### PR DESCRIPTION
`IDistributedApplicationEventingSubscriber` is in `Aspire.Hosting.Lifecycle`