### PR TITLE
Add instructions on trusting the development certificate

### DIFF
--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -49,24 +49,7 @@ To create and trust the ASP.NET Core development certificate, run the following 
 dotnet dev-certs https --trust
 ```
 
-This generates a self-signed development certificate and adds it to your system's trusted certificate store. You may be prompted to confirm the trust action depending on your operating system.
-
-#### Refresh the development certificate
-
-When updating the installed .NET SDK or troubleshooting development certificate errors, it's recommended to refresh the development certificate. Newer SDK versions may include improvements or bug fixes in the generated certificate. Refreshing the certificate also avoids possible issues caused by redundant certificates being installed.
-
-To refresh the certificate, first clean the existing certificates and then re-trust:
-
-```bash
-dotnet dev-certs https --clean
-dotnet dev-certs https --trust
-```
-
-<Aside type="tip">
-  If you encounter unexpected HTTPS or certificate trust errors during local
-  development, refreshing the development certificate with the commands above is
-  a good first troubleshooting step.
-</Aside>
+This generates a self-signed development certificate and on Windows and MacOS adds it to your user certificate store. On Linux the certificate is stored in a well known path under your user folder. You may be prompted to confirm the trust action depending on your operating system.
 
 <Aside type="note" title="Linux certificate trust">
   On Linux, `dotnet dev-certs https --trust` exports the development certificate to `~/.aspnet/dev-certs/trust`, but applications using OpenSSL won't discover it unless the `SSL_CERT_DIR` environment variable includes that path. You can set `SSL_CERT_DIR` in your shell profile (~/.bashrc, ~/.zshrc, ~/.profile, etc.):
@@ -84,6 +67,23 @@ dotnet dev-certs https --trust
   ```
 
   You may need to reload your profile or start a new terminal session for the change to take effect.
+</Aside>
+
+#### Refresh the development certificate
+
+When updating the installed .NET SDK or troubleshooting development certificate errors, it's recommended to refresh the development certificate. Newer SDK versions may include improvements or bug fixes in the generated certificate. Refreshing the certificate also avoids possible issues caused by redundant certificates being installed.
+
+To refresh the certificate, first clean the existing certificates and then re-trust:
+
+```bash
+dotnet dev-certs https --clean
+dotnet dev-certs https --trust
+```
+
+<Aside type="tip">
+  If you encounter unexpected HTTPS or certificate trust errors during local
+  development, refreshing the development certificate with the commands above is
+  a good first troubleshooting step.
 </Aside>
 
 ## HTTPS endpoint configuration


### PR DESCRIPTION
Adds a prerequisite section on trusting the ASP.NET Core development certificate.