### PR TITLE
Update write-your-first-test.mdx

### DIFF
--- a/src/frontend/src/content/docs/testing/write-your-first-test.mdx
+++ b/src/frontend/src/content/docs/testing/write-your-first-test.mdx
@@ -493,7 +493,7 @@ public class EnvVarTests
         // Act
         var executionConfiguration = await ExecutionConfigurationBuilder.Create(frontend.Resource)
             .WithEnvironmentVariablesConfig()
-            .BuildAsync(new(DistributedApplicationOperation.Publish), Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance, CancellationToken.None)
+            .BuildAsync(new(DistributedApplicationOperation.Publish), NullLogger.Instance, CancellationToken.None)
             .ConfigureAwait(true);
 
         var envVars = executionConfiguration.EnvironmentVariables.ToDictionary();


### PR DESCRIPTION
- 'ResourceExtensions.GetEnvironmentVariableValuesAsync(IResourceWithEnvironment, DistributedApplicationOperation)' is obsolete: 'Use ExecutionConfigurationBuilder instead.'

- Got help from CoPilot: "Use ExecutionConfigurationBuilder directly."

- Passing test