### PR TITLE
Fix docker integration code to compile and run.

### DIFF
--- a/src/frontend/src/content/docs/integrations/compute/docker.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/docker.mdx
@@ -43,24 +43,24 @@ var compose = builder.AddDockerComposeEnvironment("compose");
 
 var cache = builder.AddRedis("cache")
                    .PublishAsDockerComposeService((resource, service) => 
-                     { 
+                   { 
                        service.Name = "redis";
-                     });
+                   });
 
 var api = builder.AddProject<Projects.Api>("api")
                  .WithReference(cache)
                  .PublishAsDockerComposeService((resource, service) =>
-                   { 
+                 { 
                      service.Name = "api";
-                   });
+                 });
 
 var web = builder.AddProject<Projects.Web>("web")
                  .WithReference(cache)
                  .WithReference(api)
                  .PublishAsDockerComposeService((resource, service) =>
-                   { 
+                 { 
                      service.Name = "web";
-                  });
+                 });
 
 builder.Build().Run();
 ```


### PR DESCRIPTION
Previous to this PR, the article suggested that the method is called like this:

```csharp
var cache = builder.AddRedis("cache")
                   .PublishAsDockerComposeService();
```

This won't compile or run because you need to pass an action:

```csharp
var apiService = builder.AddProject<Projects.AspireDockerExp_ApiService>("apiservice")
    .PublishAsDockerComposeService((resource, service) => 
      { 
        service.Name = "redis"; 
      });
```

Plus a couple of other fixes.