### PR TITLE
Service Defaults Clarification

### DIFF
--- a/src/frontend/src/content/docs/fundamentals/service-defaults.mdx
+++ b/src/frontend/src/content/docs/fundamentals/service-defaults.mdx
@@ -12,9 +12,9 @@ In this article, you learn about the Aspire service defaults project, a set of e
 
 Cloud-native applications often require extensive configurations to ensure they work across different environments reliably and securely. Aspire provides many helper methods and tools to streamline the management of configurations for OpenTelemetry, health checks, environment variables, and more.
 
-File-based Apphost configurations do not come with the ServiceDefaults project automatically.  If you are using a file-based apphost, you can run the following command to generate one for your resources that need it:
+File-based AppHost configurations don't include the [Service defaults project](/fundamentals/service-defaults/). When using a file-based AppHost, run the following command to generate one for the resources that need it:
 
-```bash
+```bash title='.NET CLI — Create new service defaults template'
 dotnet new aspire-servicedefaults -n YourAppName.ServiceDefaults
 ```
 


### PR DESCRIPTION
Updating to include guide to install the ServiceDefaults project when you don't have one because you did an aspire init for a file based app.