### PR TITLE
Call RunAsEmulator in blob example to match prose

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
@@ -28,6 +28,7 @@ In your AppHost project, register the Azure Blob Storage integration by chaining
 var builder = DistributedApplication.CreateBuilder(args);
 
 var blobs = builder.AddAzureStorage("storage")
+    .RunAsEmulator(azurite => { /* optional azurite configuration */ })
     .AddBlobs("blobs");
 
 builder.AddProject<Projects.ExampleProject>()


### PR DESCRIPTION
Update the example in src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx to chain RunAsEmulator(...) before AddBlobs. This aligns the code sample with the surrounding text that says the example uses the Azurite emulator and prevents accidental provisioning of Azure resources when following the example.