### PR TITLE
Update link for standalone mode in configuration docs

### DIFF
--- a/src/frontend/src/content/docs/dashboard/configuration.mdx
+++ b/src/frontend/src/content/docs/dashboard/configuration.mdx
@@ -21,7 +21,7 @@ For more information, see [dashboard security](/dashboard/security-consideration
 
 ## How to configure the dashboard
 
-How you configure the dashboard depends on whether it's started by the Aspire AppHost project or run in [standalone mode](overview#standalone-mode).
+How you configure the dashboard depends on whether it's started by the Aspire AppHost project or run in [standalone mode](/dashboard/standalone/).
 
 ### Aspire AppHost
 


### PR DESCRIPTION
Current link at https://aspire.dev/dashboard/configuration/#how-to-configure-the-dashboard is broken.