### PR TITLE
Update MAUI documentation with project reference warning

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/maui.mdx
@@ -84,7 +84,7 @@ builder.Build().Run();
 ```
 
 <Aside type="caution" title="Don't add a project reference">
-The .NET MAUI app is referenced here by source path. Don't add a project dependency on the .NET MAUI app to `AppHost`; it doesn't support the same target frameworks and won't build.
+The .NET MAUI app is added here via its `.csproj` path passed to `AddMauiProject`. Don't add a `ProjectReference` from the AppHost project to the .NET MAUI project; this will cause the AppHost project to fail to build because their target frameworks are incompatible.
 </Aside>
 
 ### Platform-specific device configurations


### PR DESCRIPTION
The docs already provide guidance on how to add a reference to your .NET MAUI app in AppHost. However developer muscle memory will likely lead many to add a direct project reference (by "many developers" I mean me...).

I think adding a caution against this would be helpful. AppHost doesn't have the same TFMs and will fail to build if it references the .NET MAUI project.