### PR TITLE
Revamp VS Code extension doc and add cross-references

### DIFF
--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -940,6 +940,7 @@ Congratulations! You've successfully added Aspire to your existing application. 
   - See [Standalone dashboard for Node.js](/dashboard/standalone-for-nodejs/)
   </Pivot>
 - **Deploy your app** — Follow the [Deploy your first app](/get-started/deploy-first-app/) tutorial to deploy your Aspire application
+- **Use the VS Code extension** — Run, debug, and manage integrations from within VS Code with the [Aspire extension](/get-started/aspire-vscode-extension/)
 - **Explore the dashboard** — Learn more about the [Aspire dashboard](/dashboard/overview/) and its features
 - **Learn about polyglot features**:
   - [Python support in Aspire](/whats-new/aspire-13/#python-as-a-first-class-citizen)

--- a/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
@@ -3,143 +3,73 @@ title: Aspire Visual Studio Code extension
 description: Learn how to use the Aspire Visual Studio Code extension to create, configure, run, and deploy Aspire solutions.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
+import { Aside, Steps } from '@astrojs/starlight/components';
 import ThemeImage from '@components/ThemeImage.astro';
+import LearnMore from '@components/LearnMore.astro';
 import installExtension from '@assets/get-started/install-aspire-code-extension.png';
 import installExtensionLight from '@assets/get-started/install-aspire-code-extension-light.png';
 import createProject from '@assets/get-started/code-extension-create-aspire-project.png';
 import createProjectLight from '@assets/get-started/code-extension-create-aspire-project-light.png';
 import { Kbd } from 'starlight-kbd/components';
 
-The Aspire Visual Studio Code extension provides a set of commands and tools to streamline your work with Aspire within Visual Studio Code. The extension includes commands to create projects, add integrations, configure solutions, and manage deployments. The extension requires the Aspire CLI and provides similar functionality on the Visual Studio Code command palette.
+The official Aspire extension for VS Code. Run, debug, and deploy your Aspire apps without leaving the editor, with debugging support for C#, Python, Node.js, and more.
+
+## Features at a glance
+
+| Feature | Description |
+|---------|-------------|
+| **Run & debug** | Start your whole app and attach debuggers to every service with <Kbd windows='F5' /> |
+| **Dashboard** | View resources, endpoints, logs, traces, and metrics while your app runs |
+| **Sidebar** | Browse running apphosts and resources in the Activity Bar |
+| **Integrations** | Add databases, queues, and cloud services from the Command Palette |
+| **Scaffolding** | Create new Aspire projects from templates |
+| **Deploy** | Generate deployment artifacts or push to cloud targets |
+| **MCP** | Let AI tools like GitHub Copilot see your running app via the Model Context Protocol |
+| **Multi-language** | Debug C#, Python, Node.js, Azure Functions, and browser apps together |
 
 ## Prerequisites
 
-Before you can use the Aspire Visual Studio Code extension, you need:
+- **Aspire CLI** — Install via the **Aspire: Install Aspire CLI (stable)** command in VS Code, or follow the [installation guide](/get-started/install-cli/).
+- **.NET 10** or later — [Download .NET](https://dotnet.microsoft.com/download).
+- **VS Code 1.98** or later.
 
-- The [Aspire CLI](/reference/cli/overview/) installed and available on your PATH
-
-## Install the Aspire extension
-
-To install the Aspire VS Code extension:
+## Install the extension
 
 <Steps>
 
 1. Open VS Code.
-1. Open the **Extensions** view by selecting **View** > **Extensions** or pressing <Kbd windows='Ctrl+Shift+X' mac='Cmd+Shift+X' />.
-1. Search for "aspire" in the Extensions marketplace.
-1. Select the **Aspire** extension published by **Microsoft**.
-1. Select **Install**.
+1. Open the **Extensions** view (<Kbd windows='Ctrl+Shift+X' mac='Cmd+Shift+X' />).
+1. Search for **Aspire** and install the extension published by **Microsoft**.
 
 </Steps>
 
 <ThemeImage
   dark={installExtension}
   light={installExtensionLight}
-  alt="A screenshot of VS Code showing how to install the Aspire extension from the Extensions marketplace."
+  alt="VS Code Extensions marketplace showing the Aspire extension."
 />
 
-Alternatively, you can install the extension directly from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode).
+Or install directly from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode).
 
-## Access extension commands
+## Getting started
 
-All Aspire extension commands are available from the VS Code Command Palette:
-
-<Steps>
-
-1. Open the Command Palette by pressing <Kbd windows='Ctrl+Shift+P' mac='Cmd+Shift+P' />.
-1. Type "Aspire" to filter and display all available Aspire commands.
-1. Select the desired command from the list.
-
-</Steps>
-
-All commands are grouped under the **Aspire** category in the Command Palette for easy discovery.
-
-## Available commands
-
-The Aspire VS Code extension provides the following commands:
-
-| Command | Description | Availability |
-|--|--|--|
-| Aspire: New Aspire project | Create a new Aspire apphost or starter app from a template. | Available |
-| Aspire: Add an integration | Add a hosting integration (`Aspire.Hosting.*`) to the Aspire apphost. | Available |
-| Aspire: Configure launch.json | Adds the default Aspire debugger launch configuration to your workspace's `launch.json`, which will detect and run the apphost in the workspace. | Available |
-| Aspire: Manage configuration settings | Manage configuration settings including feature flags. | Available |
-| Aspire: Open Aspire terminal | Open an Aspire VS Code terminal for working with Aspire projects. | Available |
-| Aspire: Publish deployment artifacts | Generates deployment artifacts for an Aspire apphost. | Preview |
-| Aspire: Deploy app | Deploy the contents of an Aspire apphost to its defined deployment targets. | Preview |
-| Aspire: Update integrations | Update hosting integrations and Aspire SDK in the apphost. | Preview |
-
-## Create a new Aspire app
-
-To create a new Aspire app using the extension:
-
-<Steps>
-
-1. Open the Command Palette (<Kbd windows='Ctrl+Shift+P' mac='Cmd+Shift+P' />).
-1. Run the **Aspire: New Aspire project** command.
-1. Select the desired template.
-1. Specify the project name and location.
-
-</Steps>
+Open your Aspire project in VS Code, or create one with **Aspire: New Aspire project** from the Command Palette. Run **Aspire: Configure launch.json file** to set up the debug configuration, then press <Kbd windows='F5' />. The extension builds your apphost, starts your services, attaches debuggers, and opens the dashboard.
 
 <ThemeImage
   dark={createProject}
   light={createProjectLight}
-  alt="A screenshot of VS Code showing how to create a new Aspire solution by using the Aspire extension with template options displayed."
+  alt="VS Code showing the Aspire new project command with template options."
 />
 
-The extension creates the project and opens it in VS Code.
+There's also a built-in walkthrough at **Help > Get Started > Get started with Aspire** that covers the basics step by step.
 
-## Add an integration to the Aspire solution
+## Running and debugging
 
-Aspire integrations provide pre-configured connections to various cloud services and dependencies. To add an integration:
+### Launch configuration
 
-<Steps>
+Add an entry to `.vscode/launch.json` pointing at your apphost project:
 
-1. Open the Command Palette.
-1. Run the **Aspire: Add an integration** command.
-1. Browse or search for the desired integration package.
-1. Select the integration to add it to your AppHost project.
-
-</Steps>
-
-The extension adds the appropriate NuGet package reference to your AppHost project.
-
-:::note
-The **Add an integration** command adds a hosting integration to the AppHost project. It doesn't add the corresponding client integration to any consuming projects.
-:::
-
-## Configure an Aspire solution
-
-The Aspire extension includes several commands that configure the behavior of Aspire and the Aspire CLI during development:
-
-### Configure launch.json for debugging
-
-To run and debug your Aspire application in VS Code, you need to configure the `launch.json` file:
-
-<Steps>
-
-1. Open the Command Palette.
-1. Run the **Aspire: Configure launch.json** command.
-1. The extension adds a default Aspire debugger configuration to your workspace's `launch.json` file.
-
-</Steps>
-
-The default configuration looks like this:
-
-```json title='.vscode/launch.json'
-{
-  "type": "aspire",
-  "request": "launch",
-  "name": "Aspire: Launch Default AppHost",
-  "program": "${workspaceFolder}"
-}
-```
-
-You can customize the `program` field to point to a specific AppHost project file. For example:
-
-```json title='.vscode/launch.json'
+```json title=".vscode/launch.json"
 {
   "type": "aspire",
   "request": "launch",
@@ -148,86 +78,127 @@ You can customize the `program` field to point to a specific AppHost project fil
 }
 ```
 
-### Manage configuration settings
+Or run **Aspire: Configure launch.json file** from the Command Palette to generate one automatically.
 
-The **Aspire: Manage configuration settings** command executes `aspire config` request options and displays the results in the VS Code terminal. Use `get` and `set` commands to configure the Aspire CLI. Use the `list` command to show current configuration values.
+When you press <Kbd windows='F5' />, the extension builds the apphost, starts all resources (services, containers, databases) in the right order, attaches debuggers based on each service's language, and opens the dashboard.
 
-## Run an Aspire solution in development mode
+You can also right-click an AppHost file in the Explorer and select **Run Aspire apphost** or **Debug Aspire apphost**.
 
-To run your Aspire application in development mode:
+### Deploy, publish, and pipeline steps
 
-<Steps>
+The `command` property in the launch config supports more than just running:
 
-1. Ensure you have configured `launch.json` as described in the [Configure launch.json for debugging](#configure-launchjson-for-debugging) section.
-1. Open the Run and Debug view by selecting **View** > **Run** or pressing <Kbd windows='Ctrl+Shift+D' mac='Cmd+Shift+D' />.
-1. Select your Aspire launch configuration from the dropdown.
-1. Select the green **Start Debugging** button or press <Kbd windows='F5' />.
+- **`deploy`** — Push to your defined deployment targets.
+- **`publish`** — Generate deployment artifacts (manifests, Bicep files, etc.).
+- **`do`** — Run a specific pipeline step. Set `step` to the step name.
 
-</Steps>
+```json title=".vscode/launch.json"
+{
+  "type": "aspire",
+  "request": "launch",
+  "name": "Aspire: Deploy MyAppHost",
+  "program": "${workspaceFolder}/MyAppHost/MyAppHost.csproj",
+  "command": "deploy"
+}
+```
 
-The extension builds and starts the AppHost project, launches the Aspire dashboard in your browser, and enables debugging for all resources in your solution.
+<LearnMore>
+For more information, see [Aspire publishing and deployment overview](/deployment/overview/).
+</LearnMore>
 
-Alternatively, you can open an Aspire VS Code terminal using `Aspire: Open Aspire terminal` and run `aspire run --start-debug-session` to start a VS Code debug session.
+### Customizing debugger settings per language
 
-### Run or debug from the editor
+The `debuggers` property lets you pass debug configuration specific to a language. Use `project` for C#/.NET services, `python` for Python, and `apphost` for the apphost itself:
 
-When an AppHost project is detected in your workspace, you can also run or debug it directly from the editor. Use the run buttons in the editor title bar when viewing an AppHost file.
+```json title=".vscode/launch.json"
+{
+  "type": "aspire",
+  "request": "launch",
+  "name": "Aspire: Launch MyAppHost",
+  "program": "${workspaceFolder}/MyAppHost/MyAppHost.csproj",
+  "debuggers": {
+    "project": {
+      "console": "integratedTerminal",
+      "logging": { "moduleLoad": false }
+    },
+    "apphost": {
+      "stopAtEntry": true
+    }
+  }
+}
+```
 
-## Publish deployment artifacts
+## The Aspire sidebar
 
-:::caution
-This feature is in **Preview**.
-:::
+The extension adds an **Aspire** panel to the Activity Bar with a live tree of your resources. In **Workspace** mode you see resources from the apphost in your current workspace, updating in real time. Switch to **Global** mode with the toggle in the panel header to see every running apphost on your machine.
 
-The **Aspire: Publish deployment artifacts** command generates deployment artifacts for your Aspire AppHost. This command serializes resources to disk, allowing them to be consumed by deployment tools.
+Right-click a resource to start, stop, or restart it, view its logs, run resource-specific commands, or open the dashboard.
 
-To publish deployment artifacts:
+## Commands
 
-<Steps>
+All commands are available from the Command Palette (<Kbd windows='Ctrl+Shift+P' mac='Cmd+Shift+P' />) under **Aspire**.
 
-1. Open the Command Palette.
-1. Run the **Aspire: Publish deployment artifacts** command.
-1. Select the output location for the generated artifacts.
+| Command | Description |
+|---------|-------------|
+| **New Aspire project** | Create a new apphost or starter app from a template |
+| **Initialize Aspire in an existing codebase** | Add Aspire to an existing project |
+| **Add an integration** | Add a hosting integration (`Aspire.Hosting.*`) |
+| **Update integrations** | Update hosting integrations and the Aspire SDK |
+| **Publish deployment artifacts** | Generate deployment manifests |
+| **Deploy app** | Deploy to your defined targets |
+| **Execute pipeline step** | Run a pipeline step and its dependencies (`aspire do`) |
+| **Configure launch.json file** | Add the Aspire debug config to your workspace |
+| **Extension settings** | Open Aspire extension settings |
+| **Open local Aspire settings** | Open `.aspire/settings.json` for this workspace |
+| **Open global Aspire settings** | Open `~/.aspire/globalsettings.json` |
+| **Open Aspire terminal** | Open a terminal with the Aspire CLI ready |
+| **Install Aspire CLI (stable)** | Install the latest stable CLI |
+| **Install Aspire CLI (daily)** | Install the daily preview build |
+| **Update Aspire CLI** | Update the CLI |
+| **Verify Aspire CLI installation** | Check that the CLI works |
 
-</Steps>
+## Language and debugger support
 
-The command invokes registered publishing callback annotations to generate artifacts such as:
+The extension detects each resource's language and attaches the right debugger. Some languages need a companion extension:
 
-- Bicep files for Azure resources.
-- Docker Compose YAML files.
-- Kubernetes Helm charts.
+| Language | Debugger | Extension needed |
+|----------|----------|------------------|
+| C# / .NET | coreclr | [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) or [C#](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) |
+| Python | debugpy | [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python) |
+| Node.js | js-debug (built-in) | None |
+| Browser apps | js-debug (built-in) | None |
+| Azure Functions | Varies by language | [Azure Functions](https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-azurefunctions) + language extension |
 
-For more information about Aspire publishing, see [Aspire publishing and deployment overview](/deployment/overview/).
+Node.js and browser debugging work out of the box — VS Code includes a built-in JavaScript debugger. C# Dev Kit gives you richer build integration than the standalone C# extension, but either works for debugging. Azure Functions debugging supports C#, JavaScript/TypeScript, and Python.
 
-## Deploy an Aspire solution
+## Extension settings
 
-:::caution
-This feature is in **Preview**.
-:::
+Configure the extension under **Settings > Aspire**, or jump there with **Aspire: Extension settings**.
 
-The **Aspire: Deploy app host** command deploys the contents of an Aspire AppHost to its defined deployment targets.
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `aspire.aspireCliExecutablePath` | `""` | Path to the Aspire CLI. Leave empty to use `aspire` from PATH. |
+| `aspire.dashboardBrowser` | `openExternalBrowser` | Which browser opens the dashboard — system default, or Chrome/Edge/Firefox as a debug session. |
+| `aspire.enableAspireDashboardAutoLaunch` | `true` | Open the dashboard automatically when you start debugging. |
+| `aspire.registerMcpServerInWorkspace` | `false` | Register the Aspire MCP server (see [MCP Server Integration](#mcp-server-integration)). |
 
-To deploy an Aspire solution:
+There are more settings for verbose logging, startup prompts, and polling intervals — run **Aspire: Extension settings** to see them all.
 
-<Steps>
+The extension also provides IntelliSense and validation when editing `.aspire/settings.json` (workspace-level) and `~/.aspire/globalsettings.json` (user-level). Use the **Open local/global Aspire settings** commands to open them.
 
-1. Open the Command Palette.
-1. Run the **Aspire: Deploy app host** command.
-1. Follow the prompts to select deployment targets and provide any required configuration.
+## MCP server integration
 
-</Steps>
+The extension can register an Aspire [MCP](https://modelcontextprotocol.io/) server with VS Code. This lets AI tools — GitHub Copilot included — see your running app's resources, endpoints, and configuration for better context when helping you write code.
 
-The command publishes deployment artifacts and then invokes deployment callback annotations to deploy resources to the specified targets.
+Turn it on by setting `aspire.registerMcpServerInWorkspace` to `true`. When enabled, the extension registers the MCP server definition via the Aspire CLI whenever a workspace is open and the CLI is available.
 
-For more information about Aspire deployment, see [Aspire publishing and deployment overview](/deployment/overview/).
-
-## Open Aspire terminal
-
-The **Aspire: Open Aspire terminal** command opens a terminal window configured for working with Aspire projects. This terminal provides easy access to Aspire CLI commands and is preconfigured with the appropriate environment variables.
+<LearnMore>
+For more information, see [Configure MCP with Aspire](/get-started/configure-mcp/).
+</LearnMore>
 
 ## Feedback and issues
 
-To report issues or request features for the Aspire VS Code extension:
+Found a bug or have an idea? File it on the [dotnet/aspire](https://github.com/dotnet/aspire/issues) repo:
 
-1. Visit the [Aspire GitHub repository](https://github.com/dotnet/aspire/issues).
-1. Create a new issue and add the `area-extension` label.
+- [Report a bug](https://github.com/dotnet/aspire/issues/new?template=10_bug_report.yml&labels=area-extension)
+- [Request a feature](https://github.com/dotnet/aspire/issues/new?template=20_feature-request.yml&labels=area-extension)

--- a/src/frontend/src/content/docs/get-started/dev-containers.mdx
+++ b/src/frontend/src/content/docs/get-started/dev-containers.mdx
@@ -67,7 +67,7 @@ To configure Dev Containers in Visual Studio Code, use the `.devcontainer/devcon
 
    After a few moments, the project will be created and initial dependencies restored.
 
-1. Open the `HelloAspire.AppHost/AppHost.cs` file in the editor and select the run button on the top right corner of the editor window.
+1. Open the `HelloAspire.AppHost/AppHost.cs` file in the editor and select the run button on the top right corner of the editor window. This run button is provided by the [Aspire VS Code extension](/get-started/aspire-vscode-extension/) or [C# Dev Kit](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit).
 
    <Image
      src={vscodeRunButton}

--- a/src/frontend/src/content/docs/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/first-app.mdx
@@ -380,3 +380,4 @@ You might be eager to deploy this app next—and we'll show you how Aspire handl
 ## See also
 
 - Having trouble? Check out our [Troubleshooting guide](/get-started/troubleshooting/) for solutions to common problems.
+- Prefer a GUI? The [Aspire VS Code extension](/get-started/aspire-vscode-extension/) lets you create, run, and debug Aspire apps from VS Code.

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -138,3 +138,4 @@ The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CL
 
 - [aspire-install script reference](/reference/cli/install-script/)
 - [`aspire` command reference](/reference/cli/commands/aspire/)
+- [Aspire VS Code extension](/get-started/aspire-vscode-extension/) — install the CLI and use Aspire commands from within VS Code

--- a/src/frontend/src/content/docs/integrations/frameworks/python.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/python.mdx
@@ -295,7 +295,7 @@ The connection string will be available as an environment variable in the Python
 
 The Python hosting integration provides full debugging support in Visual Studio Code:
 
-1. Install the [Aspire VS Code extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.dotnet-aspire)
+1. Install the [Aspire VS Code extension](/get-started/aspire-vscode-extension/)
 2. Set breakpoints in your Python code
 3. Run the Aspire app host
 4. The debugger will automatically attach to your Python application


### PR DESCRIPTION
Revamps the VS Code extension doc page and adds cross-references from related pages. Rewrote with clear structure, consolidated commands table, added launch config examples, new sections for sidebar/language support/settings/MCP. Fixed wrong marketplace link in python.mdx. Added extension cross-references to install-cli, first-app, add-aspire-existing-app, and dev-containers.