### PR TITLE
Fix capitalization of PublishAsDockerFile method

### DIFF
--- a/src/frontend/src/content/docs/app-host/executable-resources.mdx
+++ b/src/frontend/src/content/docs/app-host/executable-resources.mdx
@@ -146,19 +146,19 @@ var app = builder.AddExecutable(
     });
 ```
 
-## Publishing with PublishAsDockerfile
+## Publishing with PublishAsDockerFile
 
-For production deployment, executable resources need to be containerized. Use the `PublishAsDockerfile` method to specify how the executable should be packaged:
+For production deployment, executable resources need to be containerized. Use the `PublishAsDockerFile` method to specify how the executable should be packaged:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var app = builder.AddExecutable(
         "frontend", "npm", ".", "start", "--port", "3000")
-    .PublishAsDockerfile();
+    .PublishAsDockerFile();
 ```
 
-When you call `PublishAsDockerfile()`, Aspire generates a Dockerfile during the publish process. You can customize this by providing your own Dockerfile:
+When you call `PublishAsDockerFile()`, Aspire generates a Dockerfile during the publish process. You can customize this by providing your own Dockerfile:
 
 ### Custom Dockerfile for publishing
 
@@ -180,7 +180,7 @@ Then reference it in your AppHost:
 var builder = DistributedApplication.CreateBuilder(args);
 
 var app = builder.AddExecutable("frontend", "npm", ".", "start")
-    .PublishAsDockerfile([new DockerfileBuildArg("NODE_ENV", "production")]);
+    .PublishAsDockerFile([new DockerfileBuildArg("NODE_ENV", "production")]);
 ```
 
 ## Best practices
@@ -192,7 +192,7 @@ When working with executable resources:
 1. **Use explicit paths**: For better reliability, use full paths to executables when possible.
 1. **Handle dependencies**: Use `WithReference` to establish proper dependency relationships.
 1. **Configure explicit start**: Use `WithExplicitStart()` for executables that shouldn't start automatically.
-1. **Prepare for deployment**: Always use `PublishAsDockerfile()` for production scenarios.
+1. **Prepare for deployment**: Always use `PublishAsDockerFile()` for production scenarios.
 1. **Environment isolation**: Use environment variables rather than command-line arguments for sensitive configuration.
 1. **Resource naming**: Use descriptive names that clearly identify the executable's purpose.
 


### PR DESCRIPTION
The suggested `PublishAsDockerfile` was not working. `PublishAsDockerFile` is available.