### PR TITLE
CLI overview: add new command sections and mark otel as Preview

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-logs.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-logs.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire otel logs command
 description: Learn about the aspire otel logs command and its usage. This command views structured logs from the Dashboard telemetry API.
+sidebar:
+  badge: Preview
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-spans.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-spans.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire otel spans command
 description: Learn about the aspire otel spans command and its usage. This command views spans from the Dashboard telemetry API.
+sidebar:
+  badge: Preview
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-traces.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-otel-traces.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire otel traces command
 description: Learn about the aspire otel traces command and its usage. This command views traces from the Dashboard telemetry API.
+sidebar:
+  badge: Preview
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-otel.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-otel.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire otel command
 description: Learn about the aspire otel command and its usage. This command is used to view OpenTelemetry data (logs, spans, traces) from a running apphost.
+sidebar:
+  badge: Preview
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire.mdx
@@ -64,7 +64,7 @@ The following commands are available:
 | [`aspire describe`](../aspire-describe/)   | Stable  | Describe resources in a running apphost.                              |
 | [`aspire export`](../aspire-export/)       | Stable  | Export telemetry and resource data to a zip file.                     |
 | [`aspire logs`](../aspire-logs/)           | Stable  | Display logs from resources in a running apphost.                     |
-| [`aspire otel`](../aspire-otel/)           | Stable  | View OpenTelemetry data from a running apphost.                       |
+| [`aspire otel`](../aspire-otel/)           | Preview | View OpenTelemetry data from a running apphost.                       |
 | [`aspire deploy`](../aspire-deploy/)       | Preview | Deploy an apphost to its deployment targets.                          |
 | [`aspire do`](../aspire-do/)               | Preview | Execute a specific pipeline step and its dependencies.                |
 | [`aspire publish`](../aspire-publish/)     | Preview | Generate deployment artifacts for an apphost.                         |

--- a/src/frontend/src/content/docs/reference/cli/overview.mdx
+++ b/src/frontend/src/content/docs/reference/cli/overview.mdx
@@ -162,6 +162,30 @@ The `aspire start` command starts an AppHost in the background and returns once 
   [Command reference: `aspire start`](../commands/aspire-start/)
 </LearnMore>
 
+## Stop a running AppHost
+
+The `aspire stop` command stops a running Aspire AppHost process. When multiple AppHosts are running, the command prompts you to select which one to stop, or you can use `--all` to stop them all at once.
+
+<LearnMore>
+  [Command reference: `aspire stop`](../commands/aspire-stop/)
+</LearnMore>
+
+## List running AppHosts
+
+The `aspire ps` command lists all running Aspire AppHost processes. The output includes the AppHost project path, process IDs, and dashboard URLs for each running instance. Use `--format Json` for machine-readable output suitable for scripting and automation.
+
+<LearnMore>
+  [Command reference: `aspire ps`](../commands/aspire-ps/)
+</LearnMore>
+
+## Wait for resource readiness
+
+The `aspire wait` command blocks until a named resource within a running AppHost reaches a target status such as `healthy`, `up`, or `down`. This is useful for CI/CD pipelines and automation workflows where you need to wait for resources to be ready after starting an AppHost in the background.
+
+<LearnMore>
+  [Command reference: `aspire wait`](../commands/aspire-wait/)
+</LearnMore>
+
 ## Run resource commands
 
 The `aspire resource` command executes a command exposed by a resource in a running AppHost, such as `start`, `stop`, or `restart`. Use it when you need to manage an individual resource directly from the terminal.
@@ -172,10 +196,10 @@ The `aspire resource` command executes a command exposed by a resource in a runn
 
 ## Inspect runtime data
 
-Use `aspire describe`, `aspire logs`, and `aspire export` to inspect resources, stream logs, and package telemetry and resource data from a running AppHost. Together, these commands give you a CLI-first workflow for monitoring and collecting diagnostics.
+Use `aspire describe`, `aspire logs`, and `aspire export` to inspect resources, stream logs, and package telemetry and resource data from a running AppHost. Use `aspire otel` to view OpenTelemetry data—structured logs, distributed trace spans, and trace summaries—collected by the Aspire Dashboard directly from the terminal. Together, these commands give you a CLI-first workflow for monitoring and collecting diagnostics.
 
 <LearnMore>
-  [Command reference: `aspire describe`](../commands/aspire-describe/), [Command reference: `aspire logs`](../commands/aspire-logs/), and [Command reference: `aspire export`](../commands/aspire-export/)
+  [Command reference: `aspire describe`](../commands/aspire-describe/), [Command reference: `aspire logs`](../commands/aspire-logs/), [Command reference: `aspire export`](../commands/aspire-export/), and [Command reference: `aspire otel`](../commands/aspire-otel/)
 </LearnMore>
 
 ## Diagnose and prepare the environment
@@ -200,6 +224,24 @@ The `aspire config` command lets you manage Aspire CLI configuration settings. U
 
 <LearnMore>
   [Command reference: `aspire config`](../commands/aspire-config/)
+</LearnMore>
+
+## Manage secrets
+
+The `aspire secret` command manages user secrets for an Aspire AppHost project. User secrets provide a safe way to store sensitive configuration values—such as passwords, API keys, and connection strings—outside of your project files during local development.
+
+Aspire uses user secrets to persist values that resources need across restarts, such as auto-generated passwords for database containers.
+
+<LearnMore>
+  [Command reference: `aspire secret`](../commands/aspire-secret/)
+</LearnMore>
+
+## Browse documentation
+
+The `aspire docs` command lets you browse and search the official Aspire documentation directly from the terminal. You can list all available pages, search for specific topics by keyword, or retrieve the full content of a page by its slug—all without leaving your development workflow.
+
+<LearnMore>
+  [Command reference: `aspire docs`](../commands/aspire-docs/)
 </LearnMore>
 
 ## Manage CLI cache


### PR DESCRIPTION
## Summary

Updates the Aspire CLI reference documentation for 13.2:

### Mark `aspire otel` commands as Preview
- Added `sidebar: badge: Preview` frontmatter to `aspire-otel.mdx`, `aspire-otel-logs.mdx`, `aspire-otel-spans.mdx`, and `aspire-otel-traces.mdx`
- Updated the status column in the `aspire.mdx` command table from "Stable" to "Preview"

### Add missing command sections to CLI overview
Added overview sections for 6 commands that were missing from `overview.mdx`:
- **Stop a running AppHost** (`aspire stop`)
- **List running AppHosts** (`aspire ps`)
- **Wait for resource readiness** (`aspire wait`)
- **Manage secrets** (`aspire secret`)
- **Browse documentation** (`aspire docs`)
- **View OpenTelemetry data** (`aspire otel`) — merged into the existing "Inspect runtime data" section