### PR TITLE
Fix aspire-samples links from microsoft to dotnet org

### DIFF
--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -146,7 +146,7 @@ To configure applications:
 
 ## Sample
 
-For a sample of using the standalone dashboard, see the [Standalone Aspire dashboard sample app](https://github.com/microsoft/aspire-samples/tree/main/samples/standalone-dashboard).
+For a sample of using the standalone dashboard, see the [Standalone Aspire dashboard sample app](https://github.com/dotnet/aspire-samples/tree/main/samples/standalone-dashboard).
 
 ## Next steps
 

--- a/src/frontend/src/content/docs/integrations/custom-integrations/client-integrations.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/client-integrations.mdx
@@ -443,7 +443,7 @@ if (settings.DisableHealthChecks is false)
 }
 ```
 
-The consumer could choose to omit health checks by setting the `DisableHealthChecks` property to `true` in the configuration. A common pattern for integrations is to have optional features and Aspire integrations strongly encourages these types of configurations. For more information on health checks and a working sample that includes a user interface, see [Aspire ASP.NET Core HealthChecksUI sample](https://github.com/microsoft/aspire-samples/tree/main/samples/health-checks-ui).
+The consumer could choose to omit health checks by setting the `DisableHealthChecks` property to `true` in the configuration. A common pattern for integrations is to have optional features and Aspire integrations strongly encourages these types of configurations. For more information on health checks and a working sample that includes a user interface, see [Aspire ASP.NET Core HealthChecksUI sample](https://github.com/dotnet/aspire-samples/tree/main/samples/health-checks-ui).
 
 ### Wire up telemetry
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -43,7 +43,7 @@ Aspire enables you to resolve these challenges using volumes, bind mounts, and a
 > Container hosts like Docker and Podman support volumes and bind mounts, both of which provide locations for data that persist when a container restarts. Volumes are the recommended solution, because they offer better performance, portability, and security. The container host creates and remains in control of volumes. Each volume can store data for multiple containers. Bind mounts have relatively limited functionality in comparison but enable you to access the data from the host machine.
 
 > [!NOTE]
-> Visit the [Database Container Sample App](https://github.com/microsoft/aspire-samples/blob/main/samples/DatabaseContainers/DatabaseContainers.AppHost/AppHost.cs) to view the full project and file structure for each database option.
+> Visit the [Database Container Sample App](https://github.com/dotnet/aspire-samples/blob/main/samples/DatabaseContainers/DatabaseContainers.AppHost/AppHost.cs) to view the full project and file structure for each database option.
 
 ## Seed data using SQL scripts
 

--- a/src/frontend/src/content/docs/whats-new/aspire-9-3.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-9-3.mdx
@@ -105,7 +105,7 @@ builder.Eventing.Subscribe<InitializeResourceEvent>(myCustom, async (e, ct) =>
 });
 ```
 
-This replaces awkward patterns like `Task.Run` inside constructors or `Configure()` methods. You can see a more complex version in the [TalkingClock sample](https://github.com/microsoft/aspire-samples/tree/3dee8cd7c7880fe421ea61ba167301eb1369000a/samples/CustomResources/CustomResources.AppHost) in the official Aspire samples repo.
+This replaces awkward patterns like `Task.Run` inside constructors or `Configure()` methods. You can see a more complex version in the [TalkingClock sample](https://github.com/dotnet/aspire-samples/tree/3dee8cd7c7880fe421ea61ba167301eb1369000a/samples/CustomResources/CustomResources.AppHost) in the official Aspire samples repo.
 
 #### `ResourceEndpointsAllocatedEvent`
 


### PR DESCRIPTION
Update aspire-samples repository links from `microsoft/aspire-samples` to `dotnet/aspire-samples` across 4 documentation pages:

- `standalone.mdx` - Standalone dashboard sample link
- `client-integrations.mdx` - HealthChecksUI sample link
- `seed-database.mdx` - Database Container sample link
- `aspire-9-3.mdx` - TalkingClock sample link