### PR TITLE
Revert "Updates for Agent-ready messaging for 13.2 release (#535)"

### DIFF
--- a/src/frontend/src/content/docs/index.mdx
+++ b/src/frontend/src/content/docs/index.mdx
@@ -153,30 +153,6 @@ Use Aspire's CLI to spin everything up locally or create deployment artifacts du
   </a>
 </CardGrid>
 
-## Your coding agents, supercharged
-
-**Aspire is the control plane for agentic development.** AI agents use your app model to understand, build, and operate your entire stack. [Configure your agents](/get-started/configure-mcp/).
-
-<LoopingVideo
-  aria-label="Video of Aspire CLI being used by Copilot coding agent demonstrating building, operating, and debugging your entire stack."
-  sources={[
-    {
-      src: '/dashboard-demo-dark.mp4',
-      type: 'video/mp4',
-      title:
-        'Agent operating Aspire CLI (dark-theme) video demonstrating build, run, debug.',
-      theme: 'dark',
-    },
-    {
-      src: '/dashboard-demo-light.mp4',
-      type: 'video/mp4',
-      title:
-        'Agent operating Aspire CLI (light-theme) video demonstrating build, run, debug.',
-      theme: 'light',
-    },
-  ]}
-/>
-
 ## OpenTelemetry developer dashboard
 
 **Monitor logs, metrics, and traces** in real time with the ready-to-use OpenTelemetry dashboard, integrated directly into your workflow. [Dive into the dashboard](/dashboard/).


### PR DESCRIPTION
This reverts commit 813b77e0137d68c1c5e09fd85fa9f06dcfced9c5.

The video in this section is not the right one for agentic development. It is the dashboard