### PR TITLE
Add TypeScript AppHost parity guidance to doc-writer skill

### DIFF
--- a/.github/skills/doc-writer/SKILL.md
+++ b/.github/skills/doc-writer/SKILL.md
@@ -416,7 +416,7 @@ Place integration docs in the appropriate category folder under `src/frontend/sr
 
 #### For Hosting-Only Integrations
 
-```mdx
+````mdx
 ---
 title: [Technology] integration
 description: Learn how to use the [Technology] integration with Aspire.
@@ -474,13 +474,13 @@ Describe available configuration methods and options.
 
 - [Official Technology documentation](https://...)
 - [Related Aspire documentation](/path/to/related/)
-```
+````
 
 #### For Hosting + Client Integrations
 
 Include both hosting and client sections:
 
-```mdx
+````mdx
 ## Hosting integration
 
 <InstallPackage package="Aspire.Hosting.Technology" />
@@ -573,7 +573,7 @@ The connection name must match the resource name defined in the AppHost.
 ## See also
 
 - [Official documentation](https://...)
-```
+````
 
 ### Community Toolkit Integrations
 
@@ -848,7 +848,7 @@ This feature is experimental and may change in future releases.
 
 The site supports Mermaid diagrams for architecture visualization:
 
-```mdx
+````mdx
 ```mermaid
 architecture-beta
   service api(logos:dotnet)[API service]
@@ -856,7 +856,7 @@ architecture-beta
 
   frontend:L --> R:api
 ```
-```
+````
 
 Use the `architecture-beta` diagram type for service architecture diagrams.
 


### PR DESCRIPTION
## Summary

Updates the `doc-writer` skill to ensure documentation is written with both C# and TypeScript AppHost support in mind, eliminating C#-only bias.

## What changed

- **New "AppHost Language Parity" section** with core principles:
  - Always show both C# and TypeScript variants for AppHost code
  - Use language-neutral prose ("Add a Redis resource" not "Call `builder.AddRedis()`")
  - Neither language is the default — both are equal peers
  - Verify TypeScript APIs exist before writing samples
- **Documented the standard tab pattern** (`syncKey="apphost-lang"`) matching existing site conventions
- **Added conventions table** covering method casing, async patterns, file titles, and builder creation differences
- **Prose do/don't guidelines** to help writers avoid C#-biased language
- **Fallback guidance** for when TypeScript support isn't yet available (skip tabs, add a note)
- **Updated integration doc templates** (hosting-only and hosting+client) to include both C# and TypeScript examples