### PR TITLE
Add CI gate check for conditional jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,60 @@ jobs:
     uses: ./.github/workflows/integration.yml
     with:
       node_version:  '24.x'
+
+  ci-gate:
+    needs: [changes, frontend-build, apphost-build, integration-test]
+    if: ${{ always() && !cancelled() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify CI results
+        shell: bash
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          FRONTEND_CHANGED: ${{ needs.changes.outputs.frontend }}
+          APPHOST_CHANGED: ${{ needs.changes.outputs.apphost }}
+          FRONTEND_RESULT: ${{ needs['frontend-build'].result }}
+          APPHOST_RESULT: ${{ needs['apphost-build'].result }}
+          INTEGRATION_RESULT: ${{ needs['integration-test'].result }}
+        run: |
+          echo "changes result: $CHANGES_RESULT"
+          echo "frontend changed: $FRONTEND_CHANGED"
+          echo "frontend-build result: $FRONTEND_RESULT"
+          echo "apphost changed: $APPHOST_CHANGED"
+          echo "apphost-build result: $APPHOST_RESULT"
+          echo "integration-test result: $INTEGRATION_RESULT"
+
+          if [[ "$CHANGES_RESULT" != "success" ]]; then
+            echo "The changes job must succeed."
+            exit 1
+          fi
+
+          if [[ "$FRONTEND_CHANGED" == "true" ]]; then
+            if [[ "$FRONTEND_RESULT" != "success" ]]; then
+              echo "frontend-build should have run and succeeded."
+              exit 1
+            fi
+          elif [[ "$FRONTEND_RESULT" != "skipped" ]]; then
+            echo "frontend-build should have been skipped."
+            exit 1
+          fi
+
+          if [[ "$APPHOST_CHANGED" == "true" ]]; then
+            if [[ "$APPHOST_RESULT" != "success" ]]; then
+              echo "apphost-build should have run and succeeded."
+              exit 1
+            fi
+          elif [[ "$APPHOST_RESULT" != "skipped" ]]; then
+            echo "apphost-build should have been skipped."
+            exit 1
+          fi
+
+          if [[ "$FRONTEND_CHANGED" == "true" || "$APPHOST_CHANGED" == "true" ]]; then
+            if [[ "$INTEGRATION_RESULT" != "success" ]]; then
+              echo "integration-test should have run and succeeded."
+              exit 1
+            fi
+          elif [[ "$INTEGRATION_RESULT" != "skipped" ]]; then
+            echo "integration-test should have been skipped."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- add a single always-run `ci-gate` job to fan in conditional CI results
- keep `frontend-build`, `apphost-build`, and `integration-test` conditional
- make it possible to require one stable status check in GitHub rulesets

## Why
Skipped jobs already complete successfully, but a single gate check makes branch protection configuration simpler and avoids requiring multiple conditional jobs directly.

After merging, update the repo ruleset to require `ci-gate` instead of the individual conditional checks.