### PR TITLE
Clarify commitSHA suffix explanation in install-cli.mdx

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -125,7 +125,7 @@ If that command works, you're presented with the version of the Aspire CLI tool:
 13.2.0+{commitSHA}
 ```
 
-The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CLI was built. This suffix is included in pre-release builds and may not be present in stable releases.
+The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CLI was built.
 
 <LearnMore>
   Learn more by reading the [Aspire CLI reference](/reference/cli/overview/)


### PR DESCRIPTION
Removed mention of the suffix in stable releases for clarity.

@blowdart