### PR TITLE
Add TypeScript samples to container registry docs

### DIFF
--- a/src/frontend/src/content/docs/app-host/container-registry.mdx
+++ b/src/frontend/src/content/docs/app-host/container-registry.mdx
@@ -282,10 +282,10 @@ Aspire 13.1 introduces explicit container registry configuration for Azure Conta
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var acr = builder.AddAzureContainerAppEnvironment("myenv");
+var environment = builder.AddAzureContainerAppEnvironment("myenv");
 
 var api = builder.AddProject<Projects.Api>("api")
-    .WithContainerRegistry(acr);
+    .WithContainerRegistry(environment);
 
 builder.Build().Run();
 ```


### PR DESCRIPTION
## Summary
- add TypeScript AppHost samples to the container registry documentation
- convert the main generic registry and Azure Container Registry sections to C#/TypeScript tabs
- keep shared shell, JSON, and YAML examples as shared samples

## Validation
- verified the updated page renders locally at `/app-host/container-registry/`
- confirmed the page shows C# and TypeScript tabs and includes the new TypeScript examples