### PR TITLE
Add OFREP provider integration details to flagd documentation

### DIFF
--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -220,3 +220,69 @@ For more information, see the [OpenFeature JavaScript SDK](https://openfeature.d
 
 </TabItem>
 </Tabs>
+
+## Use OFREP provider
+
+As an alternative to the native provider, you can connect to flagd using the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/). OFREP is a standardized HTTP/REST-based protocol for remote feature flag evaluation, making it language-agnostic and well-suited for polyglot environments.
+
+### Install the OFREP provider
+
+Install the [📦 OpenFeature.Providers.Ofrep](https://www.nuget.org/packages/OpenFeature.Providers.Ofrep) NuGet package in the client-consuming project:
+
+```powershell
+dotnet add package OpenFeature.Providers.Ofrep
+```
+
+### Configure the app host
+
+In your app host project, retrieve the OFREP endpoint from the flagd resource and pass it to your consuming project as an environment variable:
+
+```csharp title="C# — AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var flagd = builder.AddFlagd("flagd")
+                   .WithBindFileSync("./flags/");
+
+var ofrepEndpoint = flagd.GetEndpoint("ofrep");
+
+builder.AddProject<Projects.ExampleProject>()
+       .WaitFor(flagd)
+       .WithEnvironment("OFREP_ENDPOINT", ofrepEndpoint);
+
+// After adding all resources, run the app...
+```
+
+### Configure the client
+
+In the `Program.cs` file of your client-consuming project, register the OpenFeature SDK with the OFREP provider using dependency injection:
+
+```csharp
+using OpenFeature.Providers.Ofrep;
+using OpenFeature.Providers.Ofrep.DependencyInjection;
+
+builder.Services.AddOpenFeature(featureBuilder =>
+{
+    featureBuilder.AddOfrepProvider();
+});
+```
+
+The OFREP provider automatically reads the `OFREP_ENDPOINT` environment variable to discover the flagd OFREP endpoint. You can then evaluate feature flags by injecting `IFeatureClient`:
+
+```csharp
+using OpenFeature;
+
+app.MapGet("/", async (IFeatureClient flagClient) =>
+{
+    var welcomeBanner = await flagClient.GetBooleanValueAsync(
+        "welcome-banner",
+        defaultValue: false);
+
+    var backgroundColor = await flagClient.GetStringValueAsync(
+        "background-color",
+        defaultValue: "#000000");
+
+    return Results.Ok(new { welcomeBanner, backgroundColor });
+});
+```
+
+For more information on the OFREP specification, see the [OFREP specification](https://openfeature.dev/specification/appendix-c/).

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -233,9 +233,9 @@ Install the [📦 OpenFeature.Providers.Ofrep](https://www.nuget.org/packages/Op
 dotnet add package OpenFeature.Providers.Ofrep
 ```
 
-### Configure the app host
+### Configure the AppHost
 
-In your app host project, retrieve the OFREP endpoint from the flagd resource and pass it to your consuming project as an environment variable:
+In your AppHost, retrieve the OFREP endpoint from the flagd resource and pass it to your consuming project as an environment variable:
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -87,7 +87,7 @@ Getting there is a two-step process: model the flagd resource in your AppHost, t
 
 <Aside type="tip">
 
-flagd also supports the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/), an HTTP/REST-based alternative to the gRPC provider shown above. OFREP is well-suited for polyglot environments since it uses a standardized protocol that works across any language. To learn more, see [Use OFREP provider](/integrations/devtools/flagd/flagd-client/#use-ofrep-provider).
+Flagd also supports the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/), an HTTP/REST-based alternative to the gRPC provider shown above. OFREP is well-suited for polyglot environments since it uses a standardized protocol that works across any language. To learn more, see [Use OFREP provider](/integrations/devtools/flagd/flagd-client/#use-ofrep-provider).
 
 </Aside>
 

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -85,9 +85,16 @@ Getting there is a two-step process: model the flagd resource in your AppHost, t
 
 </Steps>
 
+<Aside type="tip">
+
+flagd also supports the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/), an HTTP/REST-based alternative to the gRPC provider shown above. OFREP is well-suited for polyglot environments since it uses a standardized protocol that works across any language. To learn more, see [Use OFREP provider](/integrations/devtools/flagd/flagd-client/#use-ofrep-provider).
+
+</Aside>
+
 ## See also
 
 - [flagd documentation](https://flagd.dev/)
 - [OpenFeature documentation](https://openfeature.dev/)
+- [OFREP specification](https://openfeature.dev/specification/appendix-c/)
 - [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire)
 - [Aspire integrations overview](/integrations/overview/)

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -5,7 +5,7 @@ prev: false
 ---
 
 import { Image } from 'astro:assets';
-import { Badge, LinkButton, Steps } from '@astrojs/starlight/components';
+import { Aside, Badge, LinkButton, Steps } from '@astrojs/starlight/components';
 import ThemeImage from '@components/ThemeImage.astro';
 import flagdIcon from '@assets/icons/flagd-icon.svg';
 import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';


### PR DESCRIPTION
This pull request adds documentation for using the OFREP (OpenFeature Remote Evaluation Protocol) provider as an alternative to the native flagd provider in Aspire integrations. It introduces a new section with setup instructions for the OFREP provider and highlights its benefits for polyglot environments. Additionally, it updates the getting started guide to mention OFREP as an alternative and provides relevant links for further reading.

**OFREP provider documentation and integration:**

* Adds a new section to `flagd-client.mdx` detailing how to install, configure, and use the OFREP provider with Aspire, including code samples for both the app host and client projects.
* Explains that the OFREP provider uses the `OFREP_ENDPOINT` environment variable and references the official OFREP specification for more information.

**Getting started guide updates:**

* Adds a tip in `flagd-get-started.mdx` introducing OFREP as an HTTP/REST-based alternative to the gRPC provider, with a link to the new documentation section.
* Adds a link to the OFREP specification in the "See also" section for easier access to protocol details.