### PR TITLE
Add .editorconfig with settings aligned to dotnet/aspire

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -29,4 +29,5 @@ trim_trailing_whitespace = false
 # Lock files - don't modify
 [pnpm-lock.yaml]
 indent_size = 2
+trim_trailing_whitespace = false
 insert_final_newline = false


### PR DESCRIPTION
Add an `.editorconfig` file to enforce consistent formatting across the repo.

### Settings

- **Default**: 4-space indent, UTF-8, trim trailing whitespace, final newline
- **Web files** (JS, TS, Astro, CSS, HTML): 2-space indent
- **Data/config** (JSON, JSONC): 2-space indent
- **XML/YAML/project files** (config, *proj, targets, yml, yaml, slnx): 2-space indent
- **Markdown** (md, mdx): 2-space indent, trailing whitespace preserved
- **Lock files** (pnpm-lock.yaml): no final newline insertion

Settings are aligned with the [dotnet/aspire](https://github.com/dotnet/aspire) repository where applicable, only including extensions for file types that actually exist in this repo.