### PR TITLE
Add standalone section to dashboard landing page

### DIFF
--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -18,6 +18,8 @@ import ImageShowcase from '@components/ImageShowcase.astro';
 import CapabilityGrid from '@components/CapabilityGrid.astro';
 import CTABanner from '@components/CTABanner.astro';
 
+import OsAwareTabs from '@components/OsAwareTabs.astro';
+
 import projectsImage from '@assets/dashboard/explore/resources-filtered-containers.png';
 import tracesImage from '@assets/dashboard/explore/trace-span-details.png';
 import metricsImage from '@assets/dashboard/explore/metrics-view.png';
@@ -71,6 +73,31 @@ The Aspire Dashboard is your command center during development. Powered by [Open
     href: '/dashboard/explore/#structured-logs',
   }}
 />
+
+## Run the dashboard standalone
+
+The dashboard starts automatically with your Aspire app, but it can also run standalone as a Docker container to monitor any application that sends OpenTelemetry data. Start it with a single command:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard \
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+</div>
+<div slot="windows">
+
+```powershell
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+</div>
+</OsAwareTabs>
+
+Navigate to `http://localhost:18888` to open the dashboard, and point your apps' OTLP exporter to `http://localhost:4317`. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
 
 ## AI-powered debugging
 

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -29,11 +29,7 @@ The dashboard is started using the Docker command line.
 <div slot="unix">
 
 ```bash
-docker run --rm -it -d \
-    -p 18888:18888 \
-    -p 4317:18889 \
-    -p 4318:18890 \
-    --name aspire-dashboard \
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard \
     mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
 
@@ -41,11 +37,7 @@ docker run --rm -it -d \
 <div slot="windows">
 
 ```powershell
-docker run --rm -it -d `
-    -p 18888:18888 `
-    -p 4317:18889 `
-    -p 4318:18890 `
-    --name aspire-dashboard `
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard `
     mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
 


### PR DESCRIPTION
Adds a "Run the dashboard standalone" section to the dashboard landing page, positioned above the "AI-powered debugging" section.

## Changes

- **dashboard/index.mdx**: Added new standalone section with OS-aware tabbed `docker run` commands (bash/PowerShell) and a link to the full standalone guide.
- **dashboard/standalone.mdx**: Updated `docker run` commands to use a condensed two-line format matching the new style.