### PR TITLE
Add OTLP client certificate auth details to dashboard config

### DIFF
--- a/src/frontend/src/content/docs/dashboard/configuration.mdx
+++ b/src/frontend/src/content/docs/dashboard/configuration.mdx
@@ -145,9 +145,14 @@ For more information, see [Configure ASP.NET Core to work with proxy servers and
 
 ## OTLP
 
-The OTLP endpoint authentication is configured with `Dashboard:Otlp:AuthMode`. The OTLP endpoint can be secured with an API key or [client certificate](http://learn.microsoft.com/aspnet/core/security/authentication/certauth) authentication.
+The OTLP endpoint authentication is configured with `Dashboard:Otlp:AuthMode`. The OTLP endpoint can be secured with an API key or client certificate authentication.
 
 API key authentication works by requiring each OTLP request to have a valid `x-otlp-api-key` header value. It must match either the primary or secondary key.
+
+Client certificate authentication validates the TLS connection's client certificate. When a request with a client certificate is received, two sets of validation are performed:
+
+- **ASP.NET Core certificate authentication validation:** By default this verifies that the certificate chains to a trusted root on the machine, the certificate hasn't expired, and that its Extended Key Usage value is appropriate for Client Authentication. For more information on this validation and how to configure it, see [Configure ASP.NET Core certificate validation](https://learn.microsoft.com/aspnet/core/security/authentication/certauth#configure-certificate-validation).
+- **Optional explicit certificate allowlist:** You can optionally configure an explicit list of allowed certificates using `AllowedCertificates`. If `AllowedCertificates` is configured and a client certificate does not match any of the listed thumbprints, the request is rejected. If no allowed certificates are specified, all certificates that pass the minimum validation are accepted.
 
 | Option | Description |
 |--------|-------------|
@@ -155,7 +160,42 @@ API key authentication works by requiring each OTLP request to have a valid `x-o
 | `Dashboard:Otlp:PrimaryApiKey`<br/>Default: `null` | Specifies the primary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is required if auth mode is API key. |
 | `Dashboard:Otlp:SecondaryApiKey`<br/>Default: `null` | Specifies the secondary API key. The API key can be any text, but a value with at least 128 bits of entropy is recommended. This value is optional. If a second API key is specified, then the incoming `x-otlp-api-key` header value can match either the primary or secondary key. |
 | `Dashboard:Otlp:SuppressUnsecuredMessage`<br/>Default: `false` | Suppresses the unsecured message displayed in the dashboard when `Dashboard:Otlp:AuthMode` is `Unsecured`. This message should only be suppressed if an external frontdoor proxy is securing access to the endpoint. |
-| `Dashboard:Otlp:AllowedCertificates`<br/>Default: `null` | A list of allowed certificate rules for client certificate authentication. Each entry specifies a `Thumbprint` to match against. Only used when `Dashboard:Otlp:AuthMode` is `ClientCertificate`. |
+| `Dashboard:Otlp:AllowedCertificates`<br/>Default: `null` | Specifies a list of allowed client certificates. See [allowed certificates](#allowed-certificates) for more information. |
+| Properties of [`CertificateAuthenticationOptions`](https://learn.microsoft.com/dotnet/api/microsoft.aspnetcore.authentication.certificate.certificateauthenticationoptions)<br/>Default: `null` | Values inside configuration section `Dashboard:Otlp:CertificateAuthOptions:*` are bound to `CertificateAuthenticationOptions`, such as `AllowedCertificateTypes`. |
+
+### Allowed certificates
+
+When using client certificate authentication you can optionally configure an explicit list of allowed certificates using `AllowedCertificates`. Each allowed certificate in the `Dashboard:Otlp:AllowedCertificates` collection supports the following properties:
+
+| Property | Description |
+|----------|-------------|
+| `Thumbprint` (required) | The SHA256 thumbprint of the certificate to allow. |
+
+The following example shows how to configure allowed certificates using JSON configuration:
+
+```json title="JSON — appsettings.json"
+{
+  "Dashboard": {
+    "Otlp": {
+      "AllowedCertificates": [
+        {
+          "Thumbprint": "HEX_SHA256_THUMBPRINT"
+        }
+      ]
+    }
+  }
+}
+```
+
+Or using environment variables for configuration:
+
+```bash
+export Dashboard__Otlp__AllowedCertificates__0__Thumbprint="HEX_SHA256_THUMBPRINT"
+```
+
+<Aside type="note">
+If no allowed certificates are configured then all certificates that pass [ASP.NET Core certificate validation](https://learn.microsoft.com/aspnet/core/security/authentication/certauth#configure-certificate-validation) can authenticate.
+</Aside>
 
 ## OTLP CORS
 

--- a/src/frontend/src/content/docs/dashboard/configuration.mdx
+++ b/src/frontend/src/content/docs/dashboard/configuration.mdx
@@ -190,7 +190,7 @@ The following example shows how to configure allowed certificates using JSON con
 Or using environment variables for configuration:
 
 ```bash
-export Dashboard__Otlp__AllowedCertificates__0__Thumbprint="HEX_SHA256_THUMBPRINT"
+export DASHBOARD__OTLP__ALLOWEDCERTIFICATES__0__THUMBPRINT="HEX_SHA256_THUMBPRINT"
 ```
 
 <Aside type="note">


### PR DESCRIPTION
Ports changes from [dotnet/docs-aspire#5196](https://github.com/dotnet/docs-aspire/pull/5196) to the dashboard configuration page.

## Changes

- Updated client certificate authentication description with detailed validation info
- Added `AllowedCertificates` and `CertificateAuthenticationOptions` configuration options to the OTLP table
- Added new "Allowed certificates" subsection with:
  - Properties table (`Thumbprint`)
  - JSON configuration example
  - Environment variable configuration example
  - Note about default behavior when no allowed certificates are configured