### PR TITLE
Add environments documentation guide

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -33,8 +33,6 @@ jobs:
         env:
           PULL_NUMBER: ${{ inputs.pull_number }}
         run: |
-          shallow_file="$(git rev-parse --git-dir)/shallow"
-
           if [ -n "$PULL_NUMBER" ]; then
             case "$PULL_NUMBER" in
               (*[!0-9]*)
@@ -44,20 +42,14 @@ jobs:
             esac
 
             pull_ref="+refs/pull/${PULL_NUMBER}/head:refs/remotes/origin/pull/${PULL_NUMBER}/head"
-            git fetch origin "$pull_ref"
-          fi
 
-          if [ "$(git rev-parse --is-shallow-repository)" = "true" ] || [ -f "$shallow_file" ]; then
-            git fetch --unshallow 2>/dev/null || true
-          fi
-
-          if [ -f "$shallow_file" ]; then
-            rm -f "$shallow_file"
-          fi
-
-          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-            echo "Git repository is still shallow after history remediation." >&2
-            exit 1
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              git fetch origin "$pull_ref" --unshallow
+            else
+              git fetch origin "$pull_ref"
+            fi
+          elif [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow
           fi
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -33,6 +33,8 @@ jobs:
         env:
           PULL_NUMBER: ${{ inputs.pull_number }}
         run: |
+          shallow_file="$(git rev-parse --git-dir)/shallow"
+
           if [ -n "$PULL_NUMBER" ]; then
             case "$PULL_NUMBER" in
               (*[!0-9]*)
@@ -42,14 +44,20 @@ jobs:
             esac
 
             pull_ref="+refs/pull/${PULL_NUMBER}/head:refs/remotes/origin/pull/${PULL_NUMBER}/head"
+            git fetch origin "$pull_ref"
+          fi
 
-            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-              git fetch origin "$pull_ref" --unshallow
-            else
-              git fetch origin "$pull_ref"
-            fi
-          elif [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
-            git fetch --unshallow
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ] || [ -f "$shallow_file" ]; then
+            git fetch --unshallow 2>/dev/null || true
+          fi
+
+          if [ -f "$shallow_file" ]; then
+            rm -f "$shallow_file"
+          fi
+
+          if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            echo "Git repository is still shallow after history remediation." >&2
+            exit 1
           fi
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/src/frontend/astro.config.mjs
+++ b/src/frontend/astro.config.mjs
@@ -8,7 +8,7 @@ import { locales } from './config/locales.ts';
 import { headAttrs } from './config/head.attrs.ts';
 import { socialConfig } from './config/socials.config.ts';
 import catppuccin from '@catppuccin/starlight';
-import lunaria from '@lunariajs/starlight';
+import lunaria from './config/lunaria-starlight.mjs';
 import mermaid from 'astro-mermaid';
 import starlight from '@astrojs/starlight';
 import starlightGitHubAlerts from 'starlight-github-alerts';

--- a/src/frontend/config/lunaria-starlight.mjs
+++ b/src/frontend/config/lunaria-starlight.mjs
@@ -1,0 +1,107 @@
+import { loadConfig, readConfig, writeConfig } from '@lunariajs/core/config';
+import { git } from '@lunariajs/core/git';
+import { z } from 'astro/zod';
+
+const LunariaStarlightConfigSchema = z
+  .object({
+    configPath: z.string().default('./lunaria.config.json'),
+    route: z.string().default('/lunaria'),
+    sync: z.boolean().default(false),
+  })
+  .default({});
+
+export default function lunariaStarlight(userConfig) {
+  const pluginConfig = LunariaStarlightConfigSchema.parse(userConfig);
+
+  return {
+    name: '@lunariajs/starlight',
+    hooks: {
+      setup: async ({ addIntegration, config, logger, command }) => {
+        if (pluginConfig.sync && command === 'build') {
+          if (config.locales) {
+            logger.info('Syncing Lunaria configuration with Starlight...');
+
+            const lunariaConfig = await readConfig(pluginConfig.configPath);
+            const starlightFilesEntry = {
+              location: 'src/content/docs/**/*.{md,mdx}',
+              pattern: 'src/content/docs/@lang/@path',
+              type: 'universal',
+            };
+
+            const otherFiles =
+              lunariaConfig?.files?.filter((file) => file.location !== starlightFilesEntry.location) ??
+              [];
+
+            const locEntries = Object.entries(config.locales);
+            const locales = locEntries
+              .filter(([key]) => key !== 'root' && key !== config.defaultLocale)
+              .map(([key, locale]) => ({
+                label: locale.label,
+                lang: key,
+              }));
+
+            const [defaultKey, defaultValue] = locEntries.find(
+              ([key]) => key === config.defaultLocale || key === 'root'
+            );
+
+            const defaultLocale = {
+              label: defaultValue.label,
+              lang: defaultValue.lang?.toLowerCase() ?? defaultKey,
+            };
+
+            lunariaConfig.files = [starlightFilesEntry, ...otherFiles];
+            lunariaConfig.locales = locales;
+            lunariaConfig.defaultLocale = defaultLocale;
+
+            writeConfig(pluginConfig.configPath, lunariaConfig);
+            logger.info('Sync complete.');
+          } else {
+            logger.warn(
+              'Sync is only supported when your Starlight config includes the locales field.'
+            );
+          }
+        }
+
+        await loadConfig(pluginConfig.configPath);
+        const isShallowRepo = (await git.revparse(['--is-shallow-repository'])) === 'true';
+
+        addIntegration({
+          name: '@lunariajs/starlight',
+          hooks: {
+            'astro:config:setup': ({ updateConfig, injectRoute }) => {
+              updateConfig({
+                vite: {
+                  plugins: [vitePluginLunariaStarlight(pluginConfig, isShallowRepo)],
+                },
+              });
+
+              injectRoute({
+                pattern: pluginConfig.route,
+                entrypoint: './src/components/lunaria/Dashboard.astro',
+              });
+            },
+          },
+        });
+      },
+    },
+  };
+}
+
+function vitePluginLunariaStarlight(pluginConfig, isShallowRepo) {
+  const moduleId = 'virtual:lunaria-starlight';
+  const resolvedModuleId = `\0${moduleId}`;
+  const moduleContent = `
+  export const pluginConfig = ${JSON.stringify(pluginConfig)}
+  export const isShallowRepo = ${JSON.stringify(isShallowRepo)}
+  `;
+
+  return {
+    name: 'vite-plugin-lunaria-starlight',
+    load(id) {
+      return id === resolvedModuleId ? moduleContent : undefined;
+    },
+    resolveId(id) {
+      return id === moduleId ? resolvedModuleId : undefined;
+    },
+  };
+}

--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -64,6 +64,10 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
       slug: 'deployment/overview',
     },
     {
+      label: 'Environments',
+      slug: 'deployment/environments',
+    },
+    {
       label: 'Pipelines (aspire do)',
       slug: 'deployment/pipelines',
     },

--- a/src/frontend/src/components/lunaria/Dashboard.astro
+++ b/src/frontend/src/components/lunaria/Dashboard.astro
@@ -1,0 +1,11 @@
+---
+import { loadConfig } from '@lunariajs/core/config';
+import { generateDashboard } from '@lunariajs/core/dashboard';
+import { pluginConfig, isShallowRepo } from 'virtual:lunaria-starlight';
+import { getStatusFromCache } from './cache.mjs';
+
+const { userConfig, rendererConfig } = await loadConfig(pluginConfig.configPath);
+const status = await getStatusFromCache(userConfig, isShallowRepo);
+---
+
+<Fragment set:html={generateDashboard(userConfig, rendererConfig, status)} />

--- a/src/frontend/src/components/lunaria/cache.mjs
+++ b/src/frontend/src/components/lunaria/cache.mjs
@@ -1,0 +1,111 @@
+import { info } from '@lunariajs/core/console';
+import { getGitHostingLinks, git } from '@lunariajs/core/git';
+import { getLocalizationStatus } from '@lunariajs/core/status';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+let lastExecutionDate;
+let shallowRepoPrepared = false;
+
+const cacheDir = resolve('./node_modules/.cache/lunaria/');
+const cachedStatusPath = join(cacheDir, 'status.json');
+
+export async function getStatusFromCache(userConfig, isShallowRepo) {
+  await prepareShallowRepo(userConfig, isShallowRepo);
+
+  const latestCommitDate = (await git.log({ maxCount: 1 })).latest?.date;
+
+  if (latestCommitDate === lastExecutionDate) {
+    return JSON.parse(readFileSync(cachedStatusPath, 'utf-8'));
+  }
+
+  const status = await getLocalizationStatus(userConfig, isShallowRepo);
+
+  if (!existsSync(cacheDir)) {
+    mkdirSync(cacheDir, { recursive: true });
+  }
+
+  writeFileSync(cachedStatusPath, JSON.stringify(status));
+  lastExecutionDate = latestCommitDate;
+
+  return status;
+}
+
+async function prepareShallowRepo({ cloneDir, repository }, isShallowRepo) {
+  if (!isShallowRepo || shallowRepoPrepared) {
+    return;
+  }
+
+  console.log(
+    info("Shallow repository detected. A clone of your repository's history will be downloaded and used. ")
+  );
+
+  const target = resolve(cloneDir);
+
+  if (existsSync(target)) {
+    rmSync(target, { recursive: true, force: true });
+  }
+
+  const checkoutGitDir = await git.revparse(['--absolute-git-dir']);
+  const checkoutHistoryRef = await getCheckoutHistoryRef();
+  const historyBranchRef = `refs/heads/${repository.branch}`;
+
+  await git.clone(getGitHostingLinks(repository).clone(), target, ['--bare']);
+  await git.cwd({ path: target, root: true });
+
+  if (checkoutHistoryRef) {
+    await git.raw(['fetch', 'origin', `+${checkoutHistoryRef}:${historyBranchRef}`]);
+  } else {
+    await git.raw(['fetch', checkoutGitDir, `+HEAD:${historyBranchRef}`]);
+  }
+
+  await git.raw(['symbolic-ref', 'HEAD', historyBranchRef]);
+  shallowRepoPrepared = true;
+}
+
+async function getCheckoutHistoryRef() {
+  const pointsAtHead = await listOriginRefs(['--points-at', 'HEAD']);
+  const directRef = pointsAtHead.find(isPullHeadRef) ?? pointsAtHead.find(isNonMainRef);
+
+  if (directRef) {
+    return toRemoteRef(directRef);
+  }
+
+  const mergedRefs = await listOriginRefs(['--merged', 'HEAD']);
+  const mergedRef = mergedRefs.find(isPullHeadRef) ?? mergedRefs.find(isNonMainRef);
+
+  return mergedRef ? toRemoteRef(mergedRef) : null;
+}
+
+async function listOriginRefs(extraArgs) {
+  const output = await git.raw([
+    'for-each-ref',
+    '--format=%(refname)',
+    ...extraArgs,
+    'refs/remotes/origin',
+  ]);
+
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function isPullHeadRef(ref) {
+  return ref.startsWith('refs/remotes/origin/pull/') && ref.endsWith('/head');
+}
+
+function isNonMainRef(ref) {
+  return ref !== 'refs/remotes/origin/HEAD' && ref !== 'refs/remotes/origin/main';
+}
+
+function toRemoteRef(ref) {
+  const prefix = 'refs/remotes/origin/';
+
+  if (!ref.startsWith(prefix)) {
+    return null;
+  }
+
+  const suffix = ref.slice(prefix.length);
+  return suffix.startsWith('pull/') ? `refs/${suffix}` : `refs/heads/${suffix}`;
+}

--- a/src/frontend/src/content/docs/deployment/azure/azure-developer-cli.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/azure-developer-cli.mdx
@@ -98,6 +98,108 @@ await env.withAzdResourceNaming();
 ```
 </Pivot>
 
+## Environments and configuration
+
+The `azd` CLI has its own environment management system that maps to Aspire environments. Understanding how these two systems connect helps you deploy the same application to multiple targets like staging and production.
+
+### azd environments
+
+Each `azd` environment is a named configuration scope stored under `.azure/{name}/` in your project. Create and switch between environments with:
+
+```bash title="Create and select environments"
+azd env new staging
+azd env new production
+azd env select staging
+```
+
+Each environment stores its own:
+
+- **Configuration** — `.azure/{name}/config.json` for infrastructure parameters (subscription, location, resource group)
+- **Environment variables** — `.azure/{name}/.env` for deployment-specific values
+- **Secrets** — referenced through a local vault in `~/.azd/vaults/`
+
+### How azd passes the environment to Aspire
+
+When `azd` invokes your AppHost to generate the deployment manifest, it passes the `DOTNET_ENVIRONMENT` value from the active azd environment's `.env` file to the AppHost process. This means your AppHost's `builder.Environment.EnvironmentName` reflects that value.
+
+To configure this, set `DOTNET_ENVIRONMENT` in your azd environment:
+
+```bash title="Set the Aspire environment for an azd environment"
+azd env set DOTNET_ENVIRONMENT staging
+azd up
+# → AppHost runs with DOTNET_ENVIRONMENT=staging
+# → builder.Environment.IsEnvironment("staging") returns true
+```
+
+<Aside type="caution">
+  The azd environment name (from `azd env select staging`) does **not**
+  automatically set `DOTNET_ENVIRONMENT`. You must explicitly set
+  `DOTNET_ENVIRONMENT` in each azd environment using `azd env set`. Without
+  this, the AppHost defaults to `Production` when no environment is specified.
+</Aside>
+
+Your AppHost code can branch on this value to vary topology or configuration per environment, as described in the [Environments](/deployment/environments/) guide.
+
+### How parameters work with azd
+
+Parameters in Aspire and `azd` follow different paths:
+
+| Parameter type                                     | How it reaches Azure resources                                                                                                                     |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Aspire parameters** (`AddParameter`)             | Resolved by the AppHost through .NET configuration when generating the manifest. Use `appsettings.{env}.json` or environment variables.            |
+| **`azd` infrastructure inputs (Bicep parameters)** | Prompted by `azd provision` and stored in `.azure/{name}/config.json`. Used by `azd` directly during Bicep deployment — not passed to the AppHost. |
+| **Secrets**                                        | Prompted by `azd provision` and stored in a local vault. Injected into Bicep parameters during provisioning.                                       |
+
+<Aside type="note">
+  `azd` infrastructure inputs stored in `.azure/{name}/config.json` are consumed
+  as Bicep parameters during provisioning. They are **not** passed as
+  environment variables to the AppHost process. If you need a value available in
+  both your AppHost code and your infrastructure, define it as an Aspire
+  parameter and provide it through .NET configuration or an environment
+  variable.
+</Aside>
+
+### Deploy to multiple environments
+
+To deploy the same application to staging and production with different Azure resources:
+
+<Steps>
+
+1. **Create environments:**
+
+   ```bash
+   azd env new staging
+   azd env new production
+   ```
+
+2. **Configure the Aspire environment for each:**
+
+   ```bash
+   azd env select staging
+   azd env set DOTNET_ENVIRONMENT staging
+
+   azd env select production
+   azd env set DOTNET_ENVIRONMENT production
+   ```
+
+3. **Deploy to staging** — `azd` prompts for subscription, location, and any required parameters on the first deployment:
+
+   ```bash
+   azd env select staging
+   azd up
+   ```
+
+4. **Deploy to production** — switch environments and deploy. Each environment provisions its own independent set of Azure resources:
+
+   ```bash
+   azd env select production
+   azd up
+   ```
+
+</Steps>
+
+Each environment maintains completely separate state — different resource groups, different secrets, different configuration. The AppHost receives the environment name through `DOTNET_ENVIRONMENT`, so any environment-based branching in your AppHost code (resource topology, parameter defaults) applies automatically.
+
 ## Deployment manifest
 
 The `azd` tool relies on the [deployment manifest format](/deployment/azure/manifest-format/) to understand your application topology. The manifest is a JSON document generated from the AppHost that describes resources, bindings, and parameters. It's produced automatically when `azd` invokes the AppHost during deployment.

--- a/src/frontend/src/content/docs/deployment/docker-compose.mdx
+++ b/src/frontend/src/content/docs/deployment/docker-compose.mdx
@@ -117,6 +117,46 @@ aspire do docker-compose-down-env
 
 This command stops and removes all containers, networks, and volumes created by the Docker Compose deployment.
 
+## Multi-environment deployments
+
+Docker Compose deployments support multiple environments through the `--environment` flag. Each environment produces its own `.env.{environment}` file with environment-specific parameter values, while sharing the same `docker-compose.yaml`.
+
+### Deploy to staging and production
+
+Use the `--environment` flag to deploy the same application to different environments on the same or different Docker hosts:
+
+```bash title="Deploy to staging"
+aspire deploy --environment staging
+```
+
+```bash title="Deploy to production"
+aspire deploy --environment production
+```
+
+Each deployment:
+
+- Runs the AppHost with the specified environment, so `builder.Environment.EnvironmentName` reflects `staging` or `production`. Any environment-based branching in your AppHost applies automatically.
+- Generates an `.env.staging` or `.env.production` file with filled-in parameter values.
+- Maintains a separate [deployment state cache](/deployment/deployment-state-caching/) per environment.
+
+### Publish artifacts for multiple environments
+
+To generate artifacts without deploying, use `aspire do prepare-{resource-name}` with the `--environment` flag:
+
+```bash title="Prepare staging and production artifacts"
+aspire do prepare-env --environment staging
+aspire do prepare-env --environment production
+```
+
+This generates environment-specific `.env` files that you can deploy independently, for example from a CI pipeline that targets different Docker hosts per environment.
+
+<LearnMore>
+  For more on how environments work across all deployment targets, see the
+  [Environments](/deployment/environments/) guide. For command details on
+  `prepare-*` steps, see the [CLI reference: `aspire
+  do`](/reference/cli/commands/aspire-do/).
+</LearnMore>
+
 ## Output artifacts
 
 When you publish or deploy, Aspire generates the following artifacts in the `aspire-output` directory:

--- a/src/frontend/src/content/docs/deployment/environments.mdx
+++ b/src/frontend/src/content/docs/deployment/environments.mdx
@@ -1,0 +1,396 @@
+---
+title: Environments
+description: Learn how to use Aspire environments to configure your application for development, staging, and production deployments.
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+When you run or deploy an Aspire application, the **environment** determines how the AppHost configures resources, what parameter values are used, and how your deployment is organized. Environments let you use the same AppHost to target different deployment contexts — development, staging, production, or any custom name — without duplicating your application model.
+
+## How environments work
+
+The Aspire environment is a single named value — like `Development`, `Staging`, or `Production` — that the AppHost receives as input. Environment names are case-insensitive strings; you can use any name that makes sense for your workflow. Your AppHost code can branch on this value to change resource topology, resolve different parameter values, or set environment variables on child services.
+
+The environment name flows through the system in three stages:
+
+1. **Input**: You pass the environment name to the AppHost. Deployment commands such as `aspire deploy`, `aspire publish`, and `aspire do` expose `--environment` directly, and `aspire start` can forward it to the AppHost with `-- --environment <name>`.
+2. **AppHost evaluation**: Your AppHost code reads the environment to branch logic, resolve parameters, or configure resources.
+3. **Downstream configuration**: Your AppHost explicitly sets framework-specific environment variables (like `DOTNET_ENVIRONMENT` or `NODE_ENV`) on child resources as needed.
+
+<Aside type="note">
+  The Aspire environment is an **AppHost concept** — it controls how the AppHost
+  configures your application. Framework-specific runtime variables like
+  `DOTNET_ENVIRONMENT` and `NODE_ENV` are separate and must be set explicitly on
+  each resource. Aspire does not automatically propagate the environment name to
+  child services.
+</Aside>
+
+## Set the environment
+
+### During local development
+
+`aspire run` is a development-oriented command, so the AppHost runs in development mode by default. If you want to evaluate a different AppHost environment locally, start the AppHost explicitly and pass the environment through:
+
+```bash title="Start locally with a staging environment"
+aspire start -- --environment Staging
+```
+
+### During deployment
+
+Deployment-oriented commands such as `aspire publish`, `aspire deploy`, and `aspire do` default to `Production`. Override them with the `--environment` flag:
+
+```bash title="Deploy to staging"
+aspire deploy --environment staging
+```
+
+```bash title="Publish for production"
+aspire publish --environment production
+```
+
+Each environment maintains its own [deployment state cache](/deployment/deployment-state-caching/), so staging and production deployments track their provisioning settings independently.
+
+### Environment vs execution context
+
+The environment name and the execution context are independent concepts:
+
+| Concept           | What it answers                | Default for `aspire run` | Default for `aspire publish` |
+| ----------------- | ------------------------------ | ------------------------ | ---------------------------- |
+| Environment       | _Where_ is the app targeting?  | `Development`            | `Production`                 |
+| Execution context | _How_ was the AppHost invoked? | Run mode                 | Publish mode                 |
+
+You can start an AppHost locally with `aspire start -- --environment Staging` for validation, or publish to a `Development` cloud environment if your workflow needs that. The two axes are independent — environment names are arbitrary strings, not tied to run vs publish.
+
+## Read the environment in your AppHost
+
+Your AppHost code can check the current environment to change behavior. The environment is available through the builder's host environment API:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Check for specific environments
+if (builder.Environment.IsDevelopment())
+{
+    // Development-specific configuration
+}
+
+// Check for a custom environment name
+if (builder.Environment.IsEnvironment("Testing"))
+{
+    // Testing-specific configuration
+}
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+const env = await builder.environment.get();
+
+// Check for specific environments
+if (await env.isDevelopment()) {
+  // Development-specific configuration
+}
+
+// Check for a custom environment name
+if (await env.isEnvironment('Testing')) {
+  // Testing-specific configuration
+}
+```
+
+</TabItem>
+</Tabs>
+
+The following convenience methods are available:
+
+| Method                                        | Returns `true` when environment is |
+| --------------------------------------------- | ---------------------------------- |
+| `IsDevelopment()` / `isDevelopment()`         | `Development`                      |
+| `IsStaging()` / `isStaging()`                 | `Staging`                          |
+| `IsProduction()` / `isProduction()`           | `Production`                       |
+| `IsEnvironment(name)` / `isEnvironment(name)` | Any custom name                    |
+
+## Common patterns
+
+### Set environment variables on child resources
+
+Your services often need to know which environment they're running in. Different frameworks use different environment variables — use `WithEnvironment` to set the appropriate one for each service:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var isDevelopment = builder.Environment.IsDevelopment();
+var dotnetEnvironment = isDevelopment ? "Development" : "Production";
+var appEnvironment = isDevelopment ? "development" : "production";
+
+// .NET services use DOTNET_ENVIRONMENT
+builder.AddProject<Projects.Api>("api")
+    .WithEnvironment("DOTNET_ENVIRONMENT", dotnetEnvironment);
+
+// Node.js services use NODE_ENV
+builder.AddNodeApp("frontend", "../frontend", "server.js")
+    .WithEnvironment("NODE_ENV", appEnvironment);
+
+// Any container can receive custom env vars
+builder.AddContainer("worker", "myorg/worker")
+    .WithEnvironment("APP_ENV", appEnvironment);
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+const env = await builder.environment.get();
+const isDevelopment = await env.isDevelopment();
+const dotnetEnvironment = isDevelopment ? 'Development' : 'Production';
+const appEnvironment = isDevelopment ? 'development' : 'production';
+
+// .NET services use DOTNET_ENVIRONMENT
+const api = await builder.addProject('api', '../Api/Api.csproj');
+await api.withEnvironment('DOTNET_ENVIRONMENT', dotnetEnvironment);
+
+// Node.js services use NODE_ENV
+const frontend = await builder.addNodeApp(
+  'frontend',
+  '../frontend',
+  'server.js'
+);
+await frontend.withEnvironment('NODE_ENV', appEnvironment);
+
+// Any container can receive custom env vars
+const worker = await builder.addContainer('worker', 'myorg/worker');
+await worker.withEnvironment('APP_ENV', appEnvironment);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+Common environment variable conventions by framework and ecosystem:
+
+| Framework       | Environment variable       | Typical values                         |
+| --------------- | -------------------------- | -------------------------------------- |
+| ASP.NET Core    | `ASPNETCORE_ENVIRONMENT`   | `Development`, `Staging`, `Production` |
+| .NET (non-web)  | `DOTNET_ENVIRONMENT`       | `Development`, `Staging`, `Production` |
+| Node.js         | `NODE_ENV`                 | `development`, `production`            |
+| Python (Flask)  | `FLASK_ENV` _(deprecated)_ | `development`, `production`            |
+| Python (Django) | `DJANGO_SETTINGS_MODULE`   | Module path                            |
+| Ruby on Rails   | `RAILS_ENV`                | `development`, `staging`, `production` |
+| Go              | `APP_ENV`                  | `development`, `staging`, `production` |
+| Rust            | `APP_ENV` / `RUST_ENV`     | `development`, `staging`, `production` |
+| Java (Spring)   | `SPRING_PROFILES_ACTIVE`   | `dev`, `test`, `prod`                  |
+
+<Aside type="tip">
+  `AddNodeApp` automatically sets `NODE_ENV` to `development` or `production`
+  based on whether the AppHost environment is `Development`. If you need a
+  different value (such as `staging`), override it with an explicit
+  `WithEnvironment("NODE_ENV", ...)` call as shown above.
+</Aside>
+
+### Use parameters for per-environment values
+
+Use [parameters](/fundamentals/external-parameters/) to externalize values that change between environments, such as SKU tiers, replica counts, or API endpoints:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var apiKey = builder.AddParameter("apiKey", secret: true);
+
+builder.AddProject<Projects.Api>("api")
+    .WithEnvironment("API_KEY", apiKey);
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const apiKey = await builder.addParameter('apiKey', { secret: true });
+
+const api = await builder.addProject('api', '../Api/Api.csproj');
+await api.withEnvironment('API_KEY', apiKey);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+#### How parameter values are resolved
+
+When you call `AddParameter("apiKey")`, Aspire looks for a value under the configuration key `Parameters:apiKey`. The value can come from multiple sources:
+
+**All AppHost languages:**
+
+| Source                     | Example                         | When to use                 |
+| -------------------------- | ------------------------------- | --------------------------- |
+| **Environment variables**  | `Parameters__apiKey=value`      | CI/CD pipelines, containers |
+| **Command-line arguments** | `--Parameters:apiKey=value`     | Quick overrides             |
+| **Interactive prompt**     | Prompted during `aspire deploy` | First-time setup            |
+
+**C# AppHosts only** (via .NET configuration):
+
+| Source                       | Example                                               | When to use                                |
+| ---------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| **`appsettings.{env}.json`** | `{ "Parameters": { "apiKey": "value" } }`             | Per-environment defaults in source control |
+| **`appsettings.json`**       | Same structure                                        | Baseline defaults                          |
+| **User secrets**             | `dotnet user-secrets set "Parameters:apiKey" "value"` | Local development secrets                  |
+
+The double-underscore (`__`) in environment variable names replaces the colon (`:`) used in configuration keys. So the parameter `apiKey` maps to the environment variable `Parameters__apiKey`.
+
+#### Per-environment defaults with config files (C# AppHosts)
+
+C# AppHosts can use `appsettings.{environment}.json` files to set different parameter values per environment:
+
+```json title="appsettings.json"
+{
+  "Parameters": {
+    "apiKey": "dev-key-for-local-testing"
+  }
+}
+```
+
+```json title="appsettings.Staging.json"
+{
+  "Parameters": {
+    "apiKey": "staging-key-value"
+  }
+}
+```
+
+When the AppHost runs with `--environment Staging`, the staging file overrides the base values automatically. This is standard [.NET configuration layering](https://learn.microsoft.com/dotnet/core/extensions/configuration) — no Aspire-specific mechanism is needed.
+
+#### Providing parameters in CI/CD
+
+In CI/CD pipelines, set parameters as environment variables. This works for any AppHost language:
+
+```yaml title=".github/workflows/deploy.yml"
+- name: Deploy to production
+  run: aspire deploy --environment production
+  env:
+    Parameters__apiKey: ${{ secrets.API_KEY }}
+    Parameters__replicas: '3'
+    Parameters__sku: 'Premium'
+```
+
+Environment variables take the highest priority, so they override any values from config files or defaults.
+
+### Use execution context for run vs publish decisions
+
+Use the [execution context](#environment-vs-execution-context) for choices that differ between local orchestration and publish/deploy workflows. For example, use a local Redis container in run mode and an Azure Managed Redis resource when publishing:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var cache = builder.ExecutionContext.IsRunMode
+    ? builder.AddRedis("cache")
+    : builder.AddAzureManagedRedis("cache");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(cache);
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+const isRunMode = await builder.executionContext.isRunMode();
+
+const cache = isRunMode
+  ? await builder.addRedis('cache')
+  : await builder.addAzureManagedRedis('cache');
+
+const api = await builder.addProject('api', '../Api/Api.csproj');
+await api.withReference(cache);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+## Environments in CI/CD
+
+In a CI/CD pipeline, you typically pass the environment name as part of the deployment command. Many CI systems have their own environment concepts that map naturally to Aspire environments.
+
+### GitHub Actions
+
+GitHub Environments provide scoped secrets and protection rules. Map them to Aspire environments by passing the environment name to the CLI:
+
+```yaml title=".github/workflows/deploy.yml"
+jobs:
+  deploy-staging:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to staging
+        run: aspire deploy --environment staging
+        env:
+          Parameters__apiKey: ${{ secrets.API_KEY }}
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    environment: production
+    needs: deploy-staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy to production
+        run: aspire deploy --environment production
+        env:
+          Parameters__apiKey: ${{ secrets.API_KEY }}
+```
+
+With this approach:
+
+- Each GitHub Environment scopes its own secrets (the `API_KEY` secret has different values in staging and production).
+- Protection rules on the `production` environment can require approvals before deployment.
+- The `--environment` flag ensures Aspire uses the correct deployment state cache and passes the environment name to your AppHost.
+
+<LearnMore>
+  For more information on deployment lifecycle, see [App lifecycle
+  (CI/CD)](/deployment/app-lifecycle/). For GitHub workflow guidance that
+  complements this page, see [Deployment state
+  caching](/deployment/deployment-state-caching/#github-actions-example).
+</LearnMore>
+
+## See also
+
+- [Deployment state caching](/deployment/deployment-state-caching/) — how environment-specific state is persisted
+- [AppHost configuration](/app-host/configuration/) — launch profile and environment variable configuration
+- [External parameters](/fundamentals/external-parameters/) — parameterize values that change between environments
+- [Deploy to Docker Compose](/deployment/docker-compose/) — environment-specific `.env` files
+- [CLI reference: `aspire deploy`](/reference/cli/commands/aspire-deploy/) — `--environment` flag details


### PR DESCRIPTION
## Summary

Adds deployment docs for Aspire environments and updates related deployment guides so environment-specific behavior is easier to discover.

### New page: /deployment/environments/

- Explains the Aspire environment as an AppHost concept
- Shows how to pass environment names to the AppHost for local start and deployment commands
- Shows how to read the environment in C# and TypeScript AppHosts
- Covers common patterns for:
  - setting runtime environment variables on child resources
  - parameter resolution and per-environment values
  - using execution context for run vs publish decisions
  - mapping GitHub Environments to Aspire environments

### Updated: /deployment/azure/azure-developer-cli/

- Clarifies that azd env select does not automatically set DOTNET_ENVIRONMENT
- Clarifies the difference between Aspire parameters and azd infrastructure inputs

### Updated: /deployment/docker-compose/

- Adds multi-environment deployment guidance
- Adds a command-reference link for aspire do prepare-* steps

### Sidebar

- Adds Environments to the Deployment section
