### PR TITLE
fix: fetch PR head history for Lunaria builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
     uses: ./.github/workflows/frontend-build.yml
     with:
       node_version: '24.x'
+      pull_number: ${{ github.event_name == 'pull_request' && github.event.pull_request.number || '' }}
 
   apphost-build:
     needs: changes

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -34,13 +34,22 @@ jobs:
           PULL_NUMBER: ${{ inputs.pull_number }}
         run: |
           if [ -n "$PULL_NUMBER" ]; then
-            git fetch origin \
-              "+refs/pull/${PULL_NUMBER}/head:refs/remotes/pull/${PULL_NUMBER}/head" \
-              --unshallow 2>/dev/null || \
-            git fetch origin \
-              "+refs/pull/${PULL_NUMBER}/head:refs/remotes/pull/${PULL_NUMBER}/head"
-          else
-            git fetch --unshallow 2>/dev/null || true
+            case "$PULL_NUMBER" in
+              (*[!0-9]*)
+                echo "Invalid pull_number input: '$PULL_NUMBER'" >&2
+                exit 1
+                ;;
+            esac
+
+            pull_ref="+refs/pull/${PULL_NUMBER}/head:refs/remotes/origin/pull/${PULL_NUMBER}/head"
+
+            if [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+              git fetch origin "$pull_ref" --unshallow
+            else
+              git fetch origin "$pull_ref"
+            fi
+          elif [ "$(git rev-parse --is-shallow-repository)" = "true" ]; then
+            git fetch --unshallow
           fi
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: "24.x"
         type: string
+      pull_number:
+        description: Pull request number when available
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -25,7 +30,18 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure full git history for Lunaria
-        run: git fetch --unshallow 2>/dev/null || true
+        env:
+          PULL_NUMBER: ${{ inputs.pull_number }}
+        run: |
+          if [ -n "$PULL_NUMBER" ]; then
+            git fetch origin \
+              "+refs/pull/${PULL_NUMBER}/head:refs/remotes/pull/${PULL_NUMBER}/head" \
+              --unshallow 2>/dev/null || \
+            git fetch origin \
+              "+refs/pull/${PULL_NUMBER}/head:refs/remotes/pull/${PULL_NUMBER}/head"
+          else
+            git fetch --unshallow 2>/dev/null || true
+          fi
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
         with:


### PR DESCRIPTION
## Summary

Follow up to #707 by fetching the PR head ref in the reusable frontend workflow before the Lunaria build.

## Why

The earlier `git fetch --unshallow` change was necessary, but not sufficient for all pull request checkouts. We still have failing `frontend-build` runs where Lunaria logs:

```text
[info] Shallow repository detected. A clone of your repository's history will be downloaded and used.
```

and then fails on a newly added docs page such as:

- `/src/frontend/src/content/docs/get-started/faq.mdx` in #701
- `/src/frontend/src/content/docs/deployment/environments.mdx` in #705

## Root cause

On some PR merge checkouts (`refs/pull/<n>/merge`), Lunaria still sees the repository as shallow and switches into its fallback history path. That path cannot resolve git history for docs pages that only exist on the PR branch.

## Fix

When this reusable workflow is running for a pull request, fetch:

```bash
refs/pull/<n>/head
```

explicitly, with `--unshallow`, before the frontend build. This makes the PR head history available even when the checkout was created from the merge ref.

For non-PR builds, keep the existing `git fetch --unshallow` fallback.

## Validation

Simulated PR merge checkouts for the known failing cases:

- PR #701: shallow `true` -> `false`, `faq.mdx` history restored
- PR #705: shallow `true` -> `false`, `environments.mdx` history restored
