### PR TITLE
fix: build frontend before tests to prevent Lunaria CI failures

### DIFF
--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -65,6 +65,45 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
+      # Build BEFORE tests so that Lunaria (i18n status) runs against a
+      # pristine working tree.  The lint step inside test:all calls
+      # `astro sync` which can leave generated artifacts on disk; when
+      # the build ran second, Lunaria would see those as uncommitted
+      # changes and fail with a doubled rootDir path
+      # (src/frontend/src/frontend/…).
+      - name: Build frontend
+        env:
+          MODE: production
+          ASTRO_TELEMETRY_DISABLED: 1
+        run: pnpm build:production
+
+      # Upload before the dist sanity-check so the artifact is always
+      # available for debugging, even when the check step fails.
+      # Note: `uses` actions ignore the job-level working-directory,
+      # so the path is repo-root-relative (src/frontend/dist).
+      - name: Upload build artifact
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: frontend-dist
+          path: src/frontend/dist
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Check dist
+        run: |
+          if [ ! -d "dist" ]; then
+            echo "Frontend build failed - dist directory not found"
+            exit 1
+          fi
+
+          if [ ! -f "dist/index.html" ]; then
+            echo "Frontend build incomplete - index.html not found"
+            exit 1
+          fi
+
+          ls -la dist
+
       - name: Install Playwright Chromium
         run: pnpm exec playwright install --with-deps chromium
 
@@ -109,32 +148,3 @@ jobs:
             echo '- `frontend-playwright-report`'
             echo '- `frontend-test-results`'
           } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Build frontend
-        env:
-          MODE: production
-          ASTRO_TELEMETRY_DISABLED: 1
-        run: pnpm build:production
-
-      - name: Check dist
-        run: |
-          if [ ! -d "dist" ]; then
-            echo "Frontend build failed - dist directory not found"
-            exit 1
-          fi
-
-          if [ ! -f "dist/index.html" ]; then
-            echo "Frontend build incomplete - index.html not found"
-            exit 1
-          fi
-
-          ls -la dist
-
-      - name: Upload artifact
-        if: ${{ always() }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: frontend-dist
-          path: src/frontend/dist
-          if-no-files-found: warn
-          retention-days: 7


### PR DESCRIPTION
## Problem

The frontend CI keeps failing with:

```
[error] Failed to retrieve last commit data from
.../src/frontend/src/frontend/src/content/docs/deployment/environments.mdx.
Your working copy should not contain uncommitted changes to tracked files
when running Lunaria.
```

The `src/frontend` segment is **doubled** in the resolved path, and Lunaria reports uncommitted changes even on a fresh checkout.

## Root cause

The workflow ran `pnpm test:all` **before** `pnpm build:production`. The lint step inside `test:all` calls `astro sync`, which generates TypeScript artifacts on disk. By the time the build ran and Lunaria tried to resolve i18n file paths, the working tree was no longer pristine — causing Lunaria's `rootDir` resolution in `@lunariajs/starlight` to double the `src/frontend` prefix.

## Fix

Reorder the workflow so the **build runs first** against a clean working tree, then tests run afterward. This also defers the Playwright browser install until just before the test step (since only tests need it).

### Before

```
install → Playwright install → test:all → build → dist check
```

### After

```
install → build → upload artifact → dist check → Playwright install → test:all
```

The build artifact upload is also moved **before** the dist sanity-check so the artifact is always captured for debugging, even when the check fails.

## Why this matters

- PRs branched from older `main` (before the custom `lunaria-starlight.mjs` was added) still use the default `@lunariajs/starlight` npm plugin, which has this path-doubling bug
- Even with the custom plugin on `main`, building first is a defensive measure — no Lunaria integration should ever run against a polluted working tree
- Deferring Playwright install until after the build also saves ~30s of CI time if the build fails early