### PR TITLE
Fix aspire start environment docs

### DIFF
--- a/src/frontend/src/content/docs/deployment/environments.mdx
+++ b/src/frontend/src/content/docs/deployment/environments.mdx
@@ -14,7 +14,7 @@ The Aspire environment is a single named value — like `Development`, `Staging`
 
 The environment name flows through the system in three stages:
 
-1. **Input**: You pass the environment name to the AppHost. Deployment commands such as `aspire deploy`, `aspire publish`, and `aspire do` expose `--environment` directly, and `aspire start` can forward it to the AppHost with `-- --environment <name>`.
+1. **Input**: You pass the environment name to the AppHost. Deployment commands such as `aspire deploy`, `aspire publish`, and `aspire do` expose `--environment` directly, and `aspire start` also accepts `--environment <name>`.
 2. **AppHost evaluation**: Your AppHost code reads the environment to branch logic, resolve parameters, or configure resources.
 3. **Downstream configuration**: Your AppHost explicitly sets framework-specific environment variables (like `DOTNET_ENVIRONMENT` or `NODE_ENV`) on child resources as needed.
 
@@ -30,10 +30,10 @@ The environment name flows through the system in three stages:
 
 ### During local development
 
-`aspire run` is a development-oriented command, so the AppHost runs in development mode by default. If you want to evaluate a different AppHost environment locally, start the AppHost explicitly and pass the environment through:
+`aspire run` is a development-oriented command, so the AppHost runs in development mode by default. If you want to evaluate a different AppHost environment locally, start the AppHost explicitly and specify the environment:
 
 ```bash title="Start locally with a staging environment"
-aspire start -- --environment Staging
+aspire start --environment Staging
 ```
 
 ### During deployment
@@ -59,7 +59,7 @@ The environment name and the execution context are independent concepts:
 | Environment       | _Where_ is the app targeting?  | `Development`            | `Production`                 |
 | Execution context | _How_ was the AppHost invoked? | Run mode                 | Publish mode                 |
 
-You can start an AppHost locally with `aspire start -- --environment Staging` for validation, or publish to a `Development` cloud environment if your workflow needs that. The two axes are independent — environment names are arbitrary strings, not tied to run vs publish.
+You can start an AppHost locally with `aspire start --environment Staging` for validation, or publish to a `Development` cloud environment if your workflow needs that. The two axes are independent — environment names are arbitrary strings, not tied to run vs publish.
 
 ## Read the environment in your AppHost
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-start.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-start.mdx
@@ -83,10 +83,10 @@ The following options are available:
   aspire start --isolated
   ```
 
-- Pass additional arguments to the AppHost:
+- Start the AppHost with a specific environment:
 
   ```bash title="Aspire CLI"
-  aspire start -- --environment Development
+  aspire start --environment Development
   ```
 
 ## See also


### PR DESCRIPTION
## Summary
- update the environments guide to use `aspire start --environment <name>`
- update the `aspire start` command reference example to match actual CLI behavior
- clarify that `aspire start` accepts the environment flag directly

## Testing
- docs-only change
- verified CLI behavior with disposable AppHosts using `aspire start` and `aspire deploy`