### PR TITLE
Document Azure:CredentialProcessTimeoutSeconds option

### DIFF
--- a/src/frontend/src/content/docs/deployment/azure/aca-deployment-aspire-cli.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/aca-deployment-aspire-cli.mdx
@@ -100,6 +100,8 @@ aspire deploy
   - `Azure__SubscriptionId`: Target Azure subscription ID.
   - `Azure__Location`: Azure region (for example, `eastus`).
   - `Azure__ResourceGroup`: Resource group name to create or reuse.
+
+  If credential validation is slow on your machine (for example, due to antivirus or network latency), you can also set `Azure__CredentialProcessTimeoutSeconds` (a value between 5 and 600) to extend the credential subprocess timeout. For more information, see [Credential process timeout](/integrations/cloud/azure/local-provisioning/#credential-process-timeout).
 </Aside>
 
 ## Deployment process

--- a/src/frontend/src/content/docs/get-started/deploy-first-app-csharp.mdx
+++ b/src/frontend/src/content/docs/get-started/deploy-first-app-csharp.mdx
@@ -418,6 +418,8 @@ Now that you've added the deployment package and updated your AppHost, you can d
     - `Azure__Location`: Azure region (for example, eastus).
     - `Azure__ResourceGroup`: Resource group name to create or reuse.
 
+    If credential validation is slow on your machine (for example, due to antivirus or network latency), you can also set `Azure__CredentialProcessTimeoutSeconds` (a value between 5 and 600) to extend the credential subprocess timeout. For more information, see [Credential process timeout](/integrations/cloud/azure/local-provisioning/#credential-process-timeout).
+
     Deploying to Azure App Containers builds the container images and deploys the services to Azure App Containers.
     
     ```bash title="Aspire CLI — Deploy your app"

--- a/src/frontend/src/content/docs/get-started/deploy-first-app-typescript.mdx
+++ b/src/frontend/src/content/docs/get-started/deploy-first-app-typescript.mdx
@@ -302,6 +302,8 @@ Now that you've added the deployment package and updated your AppHost, you can d
     - `Azure__Location`: Azure region (for example, eastus).
     - `Azure__ResourceGroup`: Resource group name to create or reuse.
 
+    If credential validation is slow on your machine (for example, due to antivirus or network latency), you can also set `Azure__CredentialProcessTimeoutSeconds` (a value between 5 and 600) to extend the credential subprocess timeout. For more information, see [Credential process timeout](/integrations/cloud/azure/local-provisioning/#credential-process-timeout).
+
     Deploying to Azure App Containers builds the container images and deploys the services to Azure App Containers.
 
     ```bash title="Aspire CLI — Deploy your app"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
@@ -95,12 +95,13 @@ You can also use environment variables:
 
 The following configuration options are available:
 
-| Setting                            | Description                    | Default    |
-| ---------------------------------- | ------------------------------ | ---------- |
-| `Azure:SubscriptionId`             | Your Azure subscription ID     | (required) |
-| `Azure:Location`                   | Azure region for resources     | (required) |
-| `Azure:CredentialSource`           | Authentication method          | `AzureCli` |
-| `Azure:AllowResourceGroupCreation` | Allow creating resource groups | `true`     |
+| Setting                                  | Description                                                                       | Default       |
+| ---------------------------------------- | --------------------------------------------------------------------------------- | ------------- |
+| `Azure:SubscriptionId`                   | Your Azure subscription ID                                                        | (required)    |
+| `Azure:Location`                         | Azure region for resources                                                        | (required)    |
+| `Azure:CredentialSource`                 | Authentication method                                                             | `AzureCli`    |
+| `Azure:AllowResourceGroupCreation`       | Allow creating resource groups                                                    | `true`        |
+| `Azure:CredentialProcessTimeoutSeconds`  | Timeout in seconds for credential subprocess operations (must be between 5 and 600) | Azure SDK default |
 
 ## Resource group management
 
@@ -221,6 +222,22 @@ Uses Visual Studio's Azure account:
   }
 }
 ```
+
+### Credential process timeout
+
+Most local credential sources (Azure CLI, Azure PowerShell, Visual Studio, and Azure Developer CLI) acquire tokens by invoking a subprocess. On machines where these tools are slow to respond — for example, due to antivirus scanning or network latency — credential validation can time out before authentication completes.
+
+Use `Azure:CredentialProcessTimeoutSeconds` to override the credential subprocess timeout. The value must be between **5** and **600** seconds. When unset, the Azure SDK's default timeout is used.
+
+```json title="appsettings.Development.json"
+{
+  "Azure": {
+    "CredentialProcessTimeoutSeconds": 120
+  }
+}
+```
+
+This setting applies to the `AzureCli`, `AzurePowerShell`, `VisualStudio`, and `AzureDeveloperCli` credential sources, and to the development credential chain used when `CredentialSource` isn't explicitly set. It has no effect on `InteractiveBrowser` or `ManagedIdentity` credentials, which don't shell out to a subprocess.
 
 ## Provisioned resource naming
 


### PR DESCRIPTION
Documents the new `Azure:CredentialProcessTimeoutSeconds` configuration option added in microsoft/aspire#16175.

Targets `release/13.3`.

## Changes

- `src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx`
  - Adds `Azure:CredentialProcessTimeoutSeconds` to the configuration options table.
  - Adds a new `Credential process timeout` subsection under `Authentication` covering when to use the setting, how to set it (appsettings + env var), which credential sources it applies to, and the user-facing timeout error message.
- `src/frontend/src/content/docs/whats-new/aspire-13-3.mdx`
  - Adds a `Configurable Azure credential timeout` section under the NSP section.