### PR TITLE
Rewrite Kubernetes docs for Aspire 13.3

### DIFF
--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -110,10 +110,45 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
     },
     {
       label: 'Kubernetes',
-      slug: 'deployment/kubernetes',
+      collapsed: false,
+      items: [
+        {
+          label: 'Overview',
+          slug: 'deployment/kubernetes',
+        },
+        {
+          label: 'Kubernetes clusters',
+          slug: 'deployment/kubernetes/kubernetes',
+        },
+        {
+          label: 'Azure Kubernetes Service (AKS)',
+          slug: 'deployment/kubernetes/aks',
+        },
+      ],
     },
     {
-      label: 'Azure',
+      label: 'Custom deployment pipelines',
+      translations: {
+        da: 'Brugerdefinerede implementeringspipelines',
+        de: 'Benutzerdefinierte Bereitstellungspipelines',
+        en: 'Custom deployment pipelines',
+        es: 'Canalizaciones de despliegue personalizadas',
+        fr: 'Pipelines de déploiement personnalisés',
+        hi: 'कस्टम तैनाती पाइपलाइन',
+        id: 'Pipeline penyebaran kustom',
+        it: 'Pipeline di distribuzione personalizzate',
+        ja: 'カスタム デプロイ パイプライン',
+        ko: '사용자 지정 배포 파이프라인',
+        'pt-BR': 'Pipelines de implantação personalizados',
+        ru: 'Пользовательские конвейеры развертывания',
+        tr: 'Özel dağıtım işlem hatları',
+        uk: 'Користувацькі конвеєри розгортання',
+        'zh-CN': '自定义部署管道',
+      },
+      slug: 'deployment/custom-deployments',
+    },
+    {
+      label: 'Deploy to Azure',
       collapsed: false,
       items: [
         {

--- a/src/frontend/config/sidebar/integrations.topics.ts
+++ b/src/frontend/config/sidebar/integrations.topics.ts
@@ -485,6 +485,10 @@ export const integrationTopics: StarlightSidebarTopicsUserConfig = {
               ],
             },
             {
+              label: 'Azure Kubernetes Service (AKS)',
+              slug: 'integrations/cloud/azure/aks',
+            },
+            {
               label: 'Azure Cosmos DB',
               collapsed: true,
               items: [

--- a/src/frontend/src/content/docs/deployment/index.mdx
+++ b/src/frontend/src/content/docs/deployment/index.mdx
@@ -99,7 +99,7 @@ Aspire is not locked to a single cloud. Your local dev topology translates direc
       icon: 'seti:config',
       title: 'Kubernetes',
       description:
-        'Produce Kubernetes Helm charts that reflect your AppHost model. Deploy to any K8s cluster with your existing toolchain.',
+        'Publish Helm charts or deploy directly to any Kubernetes cluster — self-managed or AKS — with full publish and deploy support.',
       href: '/deployment/kubernetes/',
     },
     {

--- a/src/frontend/src/content/docs/deployment/kubernetes/aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/aks.mdx
@@ -1,0 +1,242 @@
+---
+title: Deploy to Azure Kubernetes Service (AKS)
+description: Learn how to deploy your Aspire application to Azure Kubernetes Service with full provisioning of AKS, ACR, and Azure resources.
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+Deploy your Aspire application to Azure Kubernetes Service (AKS). Aspire provisions the AKS cluster, Azure Container Registry (ACR), and any Azure resources your app depends on — then deploys your application in a single command.
+
+<LearnMore>
+Start with [Deploy to Kubernetes](/deployment/kubernetes/) for the shared Kubernetes deployment model and target selection. For AKS hosting integration details, see [AKS integration](/integrations/cloud/azure/aks/).
+</LearnMore>
+
+## Prerequisites
+
+- [Aspire prerequisites](/get-started/prerequisites/)
+- [Aspire CLI](/get-started/install-cli/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and available on your `PATH`
+- [Helm](https://helm.sh/docs/intro/install/) installed and available on your `PATH`
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) installed and available on your `PATH`
+- An active Azure account and subscription
+
+By default, local deployment uses Azure CLI credentials. Authenticate with Azure CLI before deploying:
+
+```bash title="Authenticate with Azure CLI"
+az login
+```
+
+## Configure your AppHost for AKS
+
+Add the AKS hosting integration to your AppHost:
+
+```bash title="Aspire CLI — Add Azure Kubernetes"
+aspire add azure-kubernetes
+```
+
+The Aspire CLI adds the [📦 Aspire.Hosting.Azure.Kubernetes](https://www.nuget.org/packages/Aspire.Hosting.Azure.Kubernetes) integration to your AppHost.
+
+Then add the AKS environment in your AppHost:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs" {3}
+var builder = DistributedApplication.CreateBuilder(args);
+
+var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+var api = builder.AddProject<Projects.MyApi>("api");
+
+builder.Build().Run();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts" {5}
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+When an AKS environment is present, all compute resources are automatically deployed to AKS — no additional opt-in is required.
+
+## What Aspire provisions
+
+When you run `aspire deploy`, Aspire provisions the following Azure resources:
+
+- **AKS cluster** — a managed Kubernetes cluster
+- **Azure Container Registry (ACR)** — to store container images for your application
+- **Managed identity** — for secure, credential-free access between AKS and ACR
+- **Azure resources** — any Azure resources referenced in your AppHost (databases, caches, messaging, etc.)
+
+Aspire builds your container images, pushes them to ACR, generates Helm charts, and installs them to the AKS cluster.
+
+## Configure node pools
+
+### System node pool
+
+Customize the system node pool VM size and scaling using `WithSystemNodePool`:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+await aks.withSystemNodePool('Standard_D4s_v5', 1, 5);
+```
+</TabItem>
+</Tabs>
+
+### Additional node pools
+
+Add additional node pools for workload isolation or specialized hardware, then use `WithNodePool` to schedule workloads on them:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var aks = builder.AddAzureKubernetesEnvironment("aks");
+var gpuPool = aks.AddNodePool("gpupool", "Standard_NC6s_v3", minCount: 0, maxCount: 5);
+
+builder.AddContainer("ml-worker", "my-ml-image")
+    .WithNodePool(gpuPool);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+const gpuPool = await aks.addNodePool('gpupool', 'Standard_NC6s_v3', 0, 5);
+
+const worker = await builder.addContainer('ml-worker', 'my-ml-image');
+await worker.withNodePool(gpuPool);
+```
+</TabItem>
+</Tabs>
+
+## Deploy to AKS
+
+Deploy your application to AKS with a single command:
+
+```bash title="Deploy to AKS"
+aspire deploy
+```
+
+Aspire performs the following steps:
+
+<Steps>
+
+1. **Provisions Azure infrastructure** — creates the AKS cluster, ACR, managed identity, and any Azure resources defined in your AppHost.
+
+2. **Builds container images** — builds Docker images for your project and container resources.
+
+3. **Pushes images to ACR** — tags and pushes the built images to the provisioned Azure Container Registry.
+
+4. **Generates and installs Helm charts** — creates Kubernetes manifests from your app model and installs them to the AKS cluster using Helm.
+
+</Steps>
+
+:::note
+The first deployment may take several minutes while the AKS cluster and ACR are provisioned. Subsequent deployments are faster as Aspire reuses existing infrastructure.
+:::
+
+## Publish AKS artifacts
+
+To generate deployment artifacts without deploying, use `aspire publish`:
+
+```bash title="Publish AKS artifacts"
+aspire publish -o aks-artifacts
+```
+
+This generates Helm charts and Bicep infrastructure templates that you can review, customize, and deploy using your own CI/CD pipeline or GitOps workflow.
+
+## Azure-specific considerations
+
+### Authentication
+
+By default, local `aspire deploy` uses Azure CLI credentials. If you want a different credential source, set `Azure:CredentialSource` to one of the supported values: `AzureCli`, `AzureDeveloperCli`, `VisualStudio`, `VisualStudioCode`, `AzurePowerShell`, `InteractiveBrowser`, or `Default`.
+
+<LearnMore>
+For detailed Azure authentication configuration, see [Deploy to Azure](/deployment/azure/).
+</LearnMore>
+
+### Azure settings
+
+After authentication, `aspire deploy` needs a target subscription and location. These are configured via external parameters or environment variables:
+
+- `Azure:SubscriptionId` — the Azure subscription to deploy to
+- `Azure:Location` — the Azure region for resource provisioning (for example, `eastus2`)
+
+### Customizing Azure resources
+
+Use `PublishAsKubernetesService` to customize the Kubernetes resources generated for individual services:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+using Aspire.Hosting.Kubernetes.Resources;
+
+builder.AddProject<Projects.MyApi>("api")
+    .PublishAsKubernetesService(resource =>
+    {
+        // Scale to 3 replicas
+        if (resource.Workload is Deployment deployment)
+        {
+            deployment.Spec.Replicas = 3;
+        }
+    });
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' });
+await api.publishAsKubernetesService(async (resource) => {
+  // Scale to 3 replicas
+  await resource.workload.spec.replicas.set(3);
+});
+```
+</TabItem>
+</Tabs>
+
+## Troubleshooting
+
+### AKS cluster not reachable after deploy
+
+After `aspire deploy` provisions the AKS cluster, your local `kubectl` context is configured automatically. If you can't reach the cluster, ensure your Azure CLI session is active and fetch credentials:
+
+```bash title="Get AKS credentials"
+az aks get-credentials --resource-group <resource-group> --name <cluster-name>
+```
+
+### Image pull failures
+
+If pods fail with `ImagePullBackOff`, verify that the AKS cluster has the correct role assignment to pull from the provisioned ACR:
+
+```bash title="Check ACR pull access"
+az aks check-acr --resource-group <resource-group> --name <cluster-name> --acr <acr-name>.azurecr.io
+```
+
+## See also
+
+- [AKS integration](/integrations/cloud/azure/aks/)
+- [Kubernetes integration](/integrations/compute/kubernetes/)
+- [Deploy to Kubernetes](/deployment/kubernetes/)
+- [Deploy to Azure](/deployment/azure/)
+- [Pipelines and app topology](/deployment/pipelines/)
+- [Azure Kubernetes Service documentation](https://learn.microsoft.com/azure/aks/)

--- a/src/frontend/src/content/docs/deployment/kubernetes/index.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/index.mdx
@@ -1,0 +1,88 @@
+---
+title: Deploy to Kubernetes
+description: Learn how to deploy Aspire applications to Kubernetes — whether you manage your own cluster or use Azure Kubernetes Service (AKS).
+---
+
+import { CardGrid, LinkCard, Steps } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+Use `aspire publish` or `aspire deploy` to take your Aspire application to Kubernetes. Aspire uses the Kubernetes-targeted environments in your AppHost to determine how each compute resource maps to Kubernetes objects, then generates Helm charts or provisions infrastructure depending on the target you choose.
+
+<LearnMore>
+To understand how Aspire deployment works across all targets, see the [Deployment overview](/deployment/overview/).
+</LearnMore>
+
+## Choose your target
+
+Aspire supports two Kubernetes deployment targets:
+
+<CardGrid>
+  <LinkCard
+    title="Kubernetes"
+    description="Deploy to any existing Kubernetes cluster using Helm charts generated from your AppHost model."
+    href="/deployment/kubernetes/kubernetes/"
+  />
+  <LinkCard
+    title="Azure Kubernetes Service (AKS)"
+    description="Deploy to AKS with full provisioning — Aspire creates the cluster, container registry, and Azure resources for you."
+    href="/deployment/kubernetes/aks/"
+  />
+</CardGrid>
+
+## Shared prerequisites
+
+- [Aspire prerequisites](/get-started/prerequisites/)
+- [Aspire CLI](/get-started/install-cli/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed and available on your `PATH`
+- [Helm](https://helm.sh/docs/intro/install/) installed and available on your `PATH`
+
+## How Aspire maps resources to Kubernetes
+
+When you publish or deploy, Aspire translates your application model into Kubernetes-native resources:
+
+| Aspire resource       | Kubernetes resource                          |
+| --------------------- | -------------------------------------------- |
+| Project resources     | Deployments or StatefulSets                  |
+| Container resources   | Deployments or StatefulSets                  |
+| Connection strings    | ConfigMaps and Secrets                       |
+| Environment variables | ConfigMaps and Secrets                       |
+| Endpoints             | Services                                     |
+| Volumes               | PersistentVolumes and PersistentVolumeClaims |
+
+## Publish vs deploy
+
+Both Kubernetes targets support `aspire publish`. The key difference is whether the target also supports `aspire deploy`:
+
+| Target     | `aspire publish`                                   | `aspire deploy`                                                    |
+| ---------- | -------------------------------------------------- | ------------------------------------------------------------------ |
+| Kubernetes | Generates Helm charts you apply with `helm` or CI  | Deploys to the current `kubectl` context using `helm install`      |
+| AKS        | Generates Helm charts and Bicep infrastructure     | Provisions Azure resources and deploys in a single command         |
+
+<LearnMore>
+For more on the pipeline model and how publish and deploy relate, see [Pipelines and app topology](/deployment/pipelines/).
+</LearnMore>
+
+## Continue learning
+
+<CardGrid>
+  <LinkCard
+    title="Deploy to Kubernetes"
+    description="Step-by-step guide for deploying to an existing Kubernetes cluster."
+    href="/deployment/kubernetes/kubernetes/"
+  />
+  <LinkCard
+    title="Deploy to AKS"
+    description="Step-by-step guide for deploying to Azure Kubernetes Service."
+    href="/deployment/kubernetes/aks/"
+  />
+  <LinkCard
+    title="Kubernetes integration"
+    description="Hosting integration reference for Aspire.Hosting.Kubernetes."
+    href="/integrations/compute/kubernetes/"
+  />
+  <LinkCard
+    title="AKS integration"
+    description="Hosting integration reference for Aspire.Hosting.Azure.Kubernetes."
+    href="/integrations/cloud/azure/aks/"
+  />
+</CardGrid>

--- a/src/frontend/src/content/docs/deployment/kubernetes/kubernetes.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/kubernetes.mdx
@@ -1,0 +1,345 @@
+---
+title: Deploy to Kubernetes clusters
+description: Learn how to publish and deploy your Aspire application to an existing Kubernetes cluster using Helm charts.
+---
+
+import { Aside, FileTree, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+Deploy your Aspire application to any existing Kubernetes cluster. Aspire generates a complete Helm chart from your application model, and you can either apply it yourself or let `aspire deploy` install it directly using your current `kubectl` context.
+
+<LearnMore>
+For hosting integration setup and configuration, see [Kubernetes integration](/integrations/compute/kubernetes/).
+</LearnMore>
+
+## Prerequisites
+
+- [Aspire prerequisites](/get-started/prerequisites/)
+- [Aspire CLI](/get-started/install-cli/) installed
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) installed with a configured cluster context
+- [Helm](https://helm.sh/docs/intro/install/) installed and available on your `PATH`
+- An existing Kubernetes cluster (local or remote)
+
+## Configure your AppHost
+
+Add the Kubernetes hosting integration to your AppHost and configure a Kubernetes environment:
+
+```bash title="Aspire CLI — Add Kubernetes"
+aspire add kubernetes
+```
+
+The Aspire CLI adds the [📦 Aspire.Hosting.Kubernetes](https://www.nuget.org/packages/Aspire.Hosting.Kubernetes) integration to your AppHost.
+
+Then add the Kubernetes environment in your AppHost:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs" {3}
+var builder = DistributedApplication.CreateBuilder(args);
+
+var k8s = builder.AddKubernetesEnvironment("k8s");
+
+var api = builder.AddProject<Projects.MyApi>("api");
+
+builder.Build().Run();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts" {5}
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const k8s = await builder.addKubernetesEnvironment('k8s');
+
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+When a Kubernetes environment is present, all compute resources are automatically published as Kubernetes workloads — no additional opt-in is required.
+
+## Configure a container registry
+
+Unlike managed targets such as AKS, a vanilla Kubernetes cluster doesn't know which container registry to use for your application images. Without a registry, Aspire has no way to make your locally-built images available to cluster nodes. You must provide a container registry that is accessible from both your local machine (to push images) and from the cluster (to pull images):
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs" {3-4}
+var builder = DistributedApplication.CreateBuilder(args);
+
+var registry = builder.AddContainerRegistry("registry", "myregistry.example.com:5000");
+builder.AddKubernetesEnvironment("k8s").WithContainerRegistry(registry);
+
+var api = builder.AddProject<Projects.MyApi>("api");
+
+builder.Build().Run();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts" {5-6}
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const registry = await builder.addContainerRegistry('registry', 'myregistry.example.com:5000');
+const k8s = await builder.addKubernetesEnvironment('k8s');
+await k8s.withContainerRegistry(registry);
+
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+The registry endpoint must be reachable from both your local machine and from the Kubernetes cluster nodes. When you run `aspire deploy`, Aspire builds your container images, pushes them to this registry, and configures the Helm chart to pull from it.
+
+:::note
+The container registry APIs are currently in preview. In C#, you need to suppress the `ASPIRECOMPUTE003` diagnostic to use them:
+
+```csharp
+#pragma warning disable ASPIRECOMPUTE003
+```
+:::
+
+:::note
+If you're using a local development cluster like Docker Desktop or kind, you may need to configure the cluster to trust or access your registry. See your cluster's documentation for details.
+:::
+
+## Publish Helm chart artifacts
+
+To generate Kubernetes deployment artifacts without deploying, use `aspire publish`:
+
+```bash title="Generate Kubernetes artifacts"
+aspire publish -o k8s-artifacts
+```
+
+This command analyzes your application model and produces a complete Helm chart in the specified output directory:
+
+<FileTree>
+- k8s-artifacts/
+  - Chart.yaml Chart metadata (name, version, etc.)
+  - values.yaml Configurable values for the chart
+  - templates/
+    - \<resource\>/
+      - deployment.yaml Deployment or StatefulSet
+      - service.yaml Service for connectivity
+      - config.yaml Configuration data (ConfigMap)
+</FileTree>
+
+The publisher generates the following Kubernetes resources from your application model:
+
+- **Deployments** or **StatefulSets** for your application services
+- **Services** for network connectivity between resources
+- **ConfigMaps** for application configuration, connection strings, and environment variables
+
+You can then deploy these artifacts using `helm`, `kubectl`, or your existing GitOps workflow.
+
+## Deploy to a cluster
+
+To deploy directly to your current Kubernetes cluster, use `aspire deploy`:
+
+```bash title="Deploy to Kubernetes"
+aspire deploy
+```
+
+`aspire deploy` uses your current `kubectl` context and deploys the application using `helm install`. Aspire builds container images, generates the Helm chart, and installs it to the cluster in a single command.
+
+:::tip
+Verify your target cluster context before deploying:
+
+```bash title="Check kubectl context"
+kubectl config current-context
+```
+:::
+
+For subsequent deployments, `aspire deploy` automatically upgrades the existing Helm release.
+
+## Deploy published artifacts with Helm
+
+If you prefer to publish first and deploy separately — for example, in a CI/CD pipeline — use Helm to install the generated chart:
+
+<Steps>
+
+1. Install the chart to your cluster:
+
+   ```bash title="Install with Helm"
+   helm install my-app ./k8s-artifacts
+   ```
+
+2. For subsequent deployments, upgrade the existing release:
+
+   ```bash title="Upgrade with Helm"
+   helm upgrade my-app ./k8s-artifacts
+   ```
+
+3. Override default values using `--set` flags or a custom values file:
+
+   ```bash title="Override values"
+   helm upgrade my-app ./k8s-artifacts \
+       --set api.image.repository=myregistry.azurecr.io/api \
+       --set api.image.tag=v1.2.0
+   ```
+
+   Alternatively, create a custom values file for your environment:
+
+   ```yaml title="values.production.yaml"
+   api:
+     image:
+       repository: myregistry.azurecr.io/api
+       tag: v1.2.0
+   ```
+
+   ```bash title="Deploy with custom values file"
+   helm upgrade my-app ./k8s-artifacts -f values.production.yaml
+   ```
+
+</Steps>
+
+## Customize the Kubernetes environment
+
+### Helm settings
+
+Use `WithHelm` to configure Helm chart settings such as namespace, release name, and chart version:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+builder.AddKubernetesEnvironment("k8s")
+    .WithHelm(helm =>
+    {
+        helm.WithNamespace("my-namespace");
+        helm.WithReleaseName("my-release");
+        helm.WithChartVersion("1.0.0");
+    });
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const k8s = await builder.addKubernetesEnvironment('k8s');
+await k8s.withHelm(async (helm) => {
+  await helm.withNamespace('my-namespace');
+  await helm.withReleaseName('my-release');
+  await helm.withChartVersion('1.0.0');
+});
+```
+</TabItem>
+</Tabs>
+
+Helm is the default deployment engine. Call `WithHelm` only when you need to customize the defaults.
+
+### Node pools
+
+Use `AddNodePool` to reference an existing node pool in your cluster, then `WithNodePool` to schedule specific workloads on it:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var k8s = builder.AddKubernetesEnvironment("k8s");
+var gpuPool = k8s.AddNodePool("gpu");
+
+builder.AddContainer("ml-worker", "my-ml-image")
+    .WithNodePool(gpuPool);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const k8s = await builder.addKubernetesEnvironment('k8s');
+const gpuPool = await k8s.addNodePool('gpu');
+
+const worker = await builder.addContainer('ml-worker', 'my-ml-image');
+await worker.withNodePool(gpuPool);
+```
+</TabItem>
+</Tabs>
+
+:::note
+For vanilla Kubernetes, `AddNodePool` creates a named reference to a node pool that already exists in your cluster. It does not provision a new pool — use your cluster's tooling to create the pool first.
+:::
+
+### Per-resource customization
+
+Use `PublishAsKubernetesService` to modify the generated Kubernetes resources for individual services:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+using Aspire.Hosting.Kubernetes.Resources;
+
+builder.AddContainer("service", "nginx")
+    .WithEnvironment("MY_ENV", "value")
+    .PublishAsKubernetesService(resource =>
+    {
+        // Scale to 3 replicas
+        if (resource.Workload is Deployment deployment)
+        {
+            deployment.Spec.Replicas = 3;
+        }
+    });
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const service = await builder.addContainer('service', 'nginx');
+await service.withEnvironment('MY_ENV', 'value');
+await service.publishAsKubernetesService(async (resource) => {
+  // Scale to 3 replicas
+  await resource.workload.spec.replicas.set(3);
+});
+```
+</TabItem>
+</Tabs>
+
+:::tip
+Use `WithHelm` on the Kubernetes environment for global Helm settings, and `PublishAsKubernetesService` on individual resources for per-resource customization.
+:::
+
+## Deployment considerations
+
+### Container images
+
+The publisher generates parameterized Helm values for container image references. If you haven't specified custom container images, the generated `values.yaml` contains placeholders that you override at deployment time using `--set` or a custom values file.
+
+### Resource names
+
+Resource names in Kubernetes must follow DNS naming conventions. The integration automatically normalizes Aspire resource names by:
+
+- Converting to lowercase
+- Replacing invalid characters with hyphens
+- Ensuring names don't start or end with hyphens
+
+### Environment-specific configuration
+
+Use [external parameters](/fundamentals/external-parameters/) to configure values that differ between development and production environments.
+
+### Service discovery
+
+In Kubernetes, services discover each other using the cluster's built-in DNS. A service named `api` is reachable at `api.<namespace>.svc.cluster.local`. The generated Helm charts configure service references automatically using Kubernetes-native DNS resolution.
+
+## Troubleshooting
+
+### Connection strings empty in Kubernetes
+
+If your application can't find connection strings at runtime, verify that the generated ConfigMaps and Secrets are correctly mounted as environment variables in your pod specifications. Check that the resource names in your Helm values match the expected connection string names.
+
+### Password and authentication issues
+
+Kubernetes Secrets store values as base64-encoded strings. Verify that your Secrets are properly encoded and that the generated templates reference them correctly. Use `kubectl get secret <name> -o yaml` to inspect Secret contents.
+
+## See also
+
+- [Kubernetes integration](/integrations/compute/kubernetes/)
+- [Deploy to AKS](/deployment/kubernetes/aks/)
+- [Pipelines and app topology](/deployment/pipelines/)
+- [Publishing and deployment overview](/deployment/overview/)
+- [Kubernetes documentation](https://kubernetes.io/docs/)
+- [Helm documentation](https://helm.sh/docs/)

--- a/src/frontend/src/content/docs/deployment/overview.mdx
+++ b/src/frontend/src/content/docs/deployment/overview.mdx
@@ -198,7 +198,8 @@ aspire do publish --environment staging
 | Integration                                                                                                      | Target                  | Publish | Deploy | Notes                                                   |
 | ---------------------------------------------------------------------------------------------------------------- | ----------------------- | ------- | ------ | ------------------------------------------------------- |
 | [📦 Aspire.Hosting.Docker](/integrations/compute/docker/)                                                        | Docker / Docker Compose | ✅ Yes  | ✅ Yes | Use generated Compose with your own scripts or tooling. |
-| [📦 Aspire.Hosting.Kubernetes](/integrations/compute/kubernetes/)                                                | Kubernetes              | ✅ Yes  | ❌ No  | Apply with `kubectl`, GitOps, or other controllers.     |
+| [📦 Aspire.Hosting.Kubernetes](/integrations/compute/kubernetes/)                                                | Kubernetes              | ✅ Yes  | ✅ Yes | Deploy to any cluster via current `kubectl` context.    |
+| [📦 Aspire.Hosting.Azure.Kubernetes](/integrations/cloud/azure/aks/)                                            | Azure Kubernetes (AKS)  | ✅ Yes  | ✅ Yes | Full AKS provisioning and deploy via `aspire deploy`.   |
 | [📦 Aspire.Hosting.Azure.AppContainers](/integrations/cloud/azure/configure-container-apps/)                     | Azure Container Apps    | ✅ Yes  | ✅ Yes | Full publish and deploy support via `aspire deploy`.    |
 | [📦 Aspire.Hosting.Azure.AppService](/integrations/cloud/azure/azure-app-service/azure-app-service-get-started/) | Azure App Service       | ✅ Yes  | ✅ Yes | Full publish and deploy support via `aspire deploy`.    |
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
@@ -1,0 +1,110 @@
+---
+title: Azure Kubernetes Service (AKS) integration
+description: Learn how to add Azure Kubernetes Service deployment support to your Aspire application using the Aspire.Hosting.Azure.Kubernetes hosting integration.
+---
+
+import InstallPackage from '@components/InstallPackage.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+The Aspire AKS hosting integration enables you to deploy your Aspire application to Azure Kubernetes Service (AKS) with full provisioning. Aspire creates the AKS cluster, Azure Container Registry (ACR), managed identity, and any Azure resources your app depends on — all from your AppHost definition.
+
+## Hosting integration
+
+To get started with the Aspire AKS hosting integration, install the [📦 Aspire.Hosting.Azure.Kubernetes](https://www.nuget.org/packages/Aspire.Hosting.Azure.Kubernetes) NuGet package in the AppHost project:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.Kubernetes" />
+
+## Add AKS environment
+
+After installing the package, add an AKS environment to your AppHost:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var aks = builder.AddAzureKubernetesEnvironment("aks");
+
+var api = builder.AddProject<Projects.MyApi>("api");
+
+builder.Build().Run();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+When an AKS environment is present, all compute resources are automatically deployed to AKS — no additional opt-in is required.
+
+## Configure the system node pool
+
+Customize the system node pool VM size and scaling using `WithSystemNodePool`:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+await aks.withSystemNodePool('Standard_D4s_v5', 1, 5);
+```
+</TabItem>
+</Tabs>
+
+## Add node pools
+
+Add additional node pools for workload isolation, GPU workloads, or specialized hardware requirements:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var aks = builder.AddAzureKubernetesEnvironment("aks");
+var gpuPool = aks.AddNodePool("gpupool", "Standard_NC6s_v3", minCount: 0, maxCount: 5);
+
+builder.AddContainer("ml-worker", "my-ml-image")
+    .WithNodePool(gpuPool);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+const gpuPool = await aks.addNodePool('gpupool', 'Standard_NC6s_v3', 0, 5);
+
+const worker = await builder.addContainer('ml-worker', 'my-ml-image');
+await worker.withNodePool(gpuPool);
+```
+</TabItem>
+</Tabs>
+
+## Publishing and deployment
+
+The AKS integration supports both `aspire publish` (generate Helm chart and Bicep artifacts) and `aspire deploy` (provision Azure infrastructure and deploy in a single command).
+
+For a complete end-to-end walkthrough, see [Deploy to AKS](/deployment/kubernetes/aks/).
+
+## See also
+
+- [Deploy to AKS](/deployment/kubernetes/aks/)
+- [Deploy to Kubernetes](/deployment/kubernetes/)
+- [Kubernetes integration](/integrations/compute/kubernetes/)
+- [Deploy to Azure](/deployment/azure/)
+- [Azure Kubernetes Service documentation](https://learn.microsoft.com/azure/aks/)

--- a/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
@@ -1,10 +1,10 @@
 ---
 title: Kubernetes integration
-description: Learn how to add Kubernetes resources to your Aspire application.
+description: Learn how to add Kubernetes deployment support to your Aspire application using the Aspire.Hosting.Kubernetes hosting integration.
 ---
 
 import InstallPackage from '@components/InstallPackage.astro';
-import { Aside } from '@astrojs/starlight/components';
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import kubernetesIcon from '@assets/icons/kubernetes.svg';
 
@@ -17,7 +17,7 @@ import kubernetesIcon from '@assets/icons/kubernetes.svg';
   data-zoom-off
 />
 
-The Aspire Kubernetes hosting integration enables you to generate Kubernetes deployment manifests from your Aspire application model. This integration allows you to define your application's infrastructure and deployment configuration using the familiar Aspire AppHost and then publish it as Kubernetes YAML manifests for deployment to any Kubernetes cluster.
+The Aspire Kubernetes hosting integration enables you to publish and deploy your Aspire application to any Kubernetes cluster. Add a Kubernetes environment to your AppHost, and Aspire generates Helm charts from your application model — or deploys directly to a cluster using your current `kubectl` context.
 
 ## Hosting integration
 
@@ -27,9 +27,11 @@ To get started with the Aspire Kubernetes hosting integration, install the [📦
 
 ## Add Kubernetes environment
 
-After installing the package, add a Kubernetes environment to your AppHost project using the `AddKubernetesEnvironment` method:
+After installing the package, add a Kubernetes environment to your AppHost:
 
-```csharp title="C# — AppHost.cs"
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var k8s = builder.AddKubernetesEnvironment("k8s");
@@ -38,6 +40,24 @@ var api = builder.AddProject<Projects.MyApi>("api");
 
 builder.Build().Run();
 ```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const k8s = await builder.addKubernetesEnvironment('k8s');
+
+const api = await builder
+    .addNodeApp('api', './api', 'src/index.ts')
+    .withHttpEndpoint({ env: 'PORT' })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
 
 <Aside type="tip">
   With the `k8s` variable assigned, you can pass that to the
@@ -45,33 +65,101 @@ builder.Build().Run();
   that define more than one. Otherwise, the `k8s` variable isn't required.
 </Aside>
 
-## Configure Kubernetes environment properties
+## Configure Helm settings
 
-You can customize the Kubernetes environment using the `WithProperties` method:
+Use `WithHelm` to customize Helm chart settings such as namespace, release name, and chart version:
 
-```csharp title="C# — AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var api = builder.AddProject<Projects.MyApi>("api");
-
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
 builder.AddKubernetesEnvironment("k8s")
-       .WithProperties(k8s =>
-       {
-           k8s.HelmChartName = "my-aspire-app";
-       });
-
-builder.Build().Run();
+    .WithHelm(helm =>
+    {
+        helm.WithNamespace("my-namespace");
+        helm.WithReleaseName("my-release");
+        helm.WithChartVersion("1.0.0");
+    });
 ```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const k8s = await builder.addKubernetesEnvironment('k8s');
+await k8s.withHelm(async (helm) => {
+  await helm.withNamespace('my-namespace');
+  await helm.withReleaseName('my-release');
+  await helm.withChartVersion('1.0.0');
+});
+```
+</TabItem>
+</Tabs>
 
-The `WithProperties` method allows you to configure various aspects of the Kubernetes deployment, including the Helm chart name that will be used for generating the Kubernetes resources.
+Helm is the default deployment engine. Call `WithHelm` only when you need to customize the defaults.
+
+## Configure a container registry
+
+A vanilla Kubernetes cluster doesn't know which container registry to use for your application images. Use `AddContainerRegistry` and `WithContainerRegistry` to specify a registry that is accessible from both your local machine and from the cluster:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var registry = builder.AddContainerRegistry("registry", "myregistry.example.com:5000");
+builder.AddKubernetesEnvironment("k8s").WithContainerRegistry(registry);
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const registry = await builder.addContainerRegistry('registry', 'myregistry.example.com:5000');
+const k8s = await builder.addKubernetesEnvironment('k8s');
+await k8s.withContainerRegistry(registry);
+```
+</TabItem>
+</Tabs>
+
+:::note
+The container registry APIs are currently in preview. In C#, suppress the `ASPIRECOMPUTE003` diagnostic to use them.
+:::
+
+## Customize individual resources
+
+Use `PublishAsKubernetesService` to modify the generated Kubernetes resources for individual services:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+using Aspire.Hosting.Kubernetes.Resources;
+
+builder.AddContainer("service", "nginx")
+    .PublishAsKubernetesService(resource =>
+    {
+        // Scale to 3 replicas
+        if (resource.Workload is Deployment deployment)
+        {
+            deployment.Spec.Replicas = 3;
+        }
+    });
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const service = await builder.addContainer('service', 'nginx');
+await service.publishAsKubernetesService(async (resource) => {
+  // Scale to 3 replicas
+  await resource.workload.spec.replicas.set(3);
+});
+```
+</TabItem>
+</Tabs>
 
 ## Publishing and deployment
 
-For a complete guide on generating Kubernetes Helm charts, deploying with Helm, resource mappings, and troubleshooting — see [Deploy to Kubernetes](/deployment/kubernetes/).
+The Kubernetes integration supports both `aspire publish` (generate Helm chart artifacts) and `aspire deploy` (deploy directly to your current cluster context).
+
+For complete walkthroughs, see [Deploy to Kubernetes clusters](/deployment/kubernetes/kubernetes/).
 
 ## See also
 
 - [Deploy to Kubernetes](/deployment/kubernetes/)
-- [Aspire GitHub repo](https://github.com/microsoft/aspire)
+- [Deploy to AKS](/deployment/kubernetes/aks/)
+- [AKS integration](/integrations/cloud/azure/aks/)
 - [Kubernetes documentation](https://kubernetes.io/docs/)
 - [Helm documentation](https://helm.sh/docs/)

--- a/src/frontend/src/data/integration-docs.json
+++ b/src/frontend/src/data/integration-docs.json
@@ -196,6 +196,10 @@
     "href": "/integrations/compute/kubernetes/"
   },
   {
+    "match": "Aspire.Hosting.Azure.Kubernetes",
+    "href": "/integrations/cloud/azure/aks/"
+  },
+  {
     "match": "Aspire.Hosting.Maui",
     "href": "/integrations/dotnet/maui/"
   },


### PR DESCRIPTION
## Summary

Comprehensive rewrite of Kubernetes documentation for the 13.3 release, covering the new \spire deploy\ support for vanilla Kubernetes and the new \Aspire.Hosting.Azure.Kubernetes\ (AKS) integration.

### New pages (3)
- **\deployment/kubernetes/index.mdx\** — K8s deployment overview with shared prereqs, resource mapping table, publish vs deploy comparison
- **\deployment/kubernetes/kubernetes.mdx\** — Vanilla K8s walkthrough: container registry config, \spire publish\ + \spire deploy\, Helm settings, node pools, troubleshooting
- **\deployment/kubernetes/aks.mdx\** — AKS walkthrough: \AddAzureKubernetesEnvironment\, node pools with scheduling, full provisioning + deploy

### New integration page (1)
- **\integrations/cloud/azure/aks/index.mdx\** — \Aspire.Hosting.Azure.Kubernetes\ package APIs

### Updated pages (1)
- **\integrations/compute/kubernetes.mdx\** — Added TypeScript tabs, container registry API, deploy support, \WithHelm\ config

### Supporting changes
- Sidebar: expanded Kubernetes into folder with Overview, Kubernetes clusters, AKS sub-pages
- Deployment overview: added capabilities table with K8s Deploy and AKS rows
- Deployment index: updated K8s card description
- \integration-docs.json\: added AKS mapping
- \integrations.topics.ts\: added AKS to Azure sidebar

### Validated
- All APIs verified against \microsoft/aspire\ source (\WithHelm\, \WithSystemNodePool\, \AddNodePool\, \WithNodePool\, \PublishAsKubernetesService\)
- End-to-end tested: vanilla K8s deploy to Docker Desktop + AKS deploy to Azure (midenn subscription)
- All C# and TypeScript examples use idiomatic patterns (C# starter template / Express+React template)
- Playwright-tested all 5 pages: links, tabs, sidebar, content rendering