### PR TITLE
Document Azure:CredentialProcessTimeoutSeconds option

### DIFF
--- a/src/frontend/src/content/docs/deployment/azure/index.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/index.mdx
@@ -53,6 +53,7 @@ After authentication succeeds, `aspire deploy` still needs a small set of shared
 | `Azure:SubscriptionId` | `Azure__SubscriptionId` | Target Azure subscription |
 | `Azure:Location` | `Azure__Location` | Default Azure region for provisioned resources |
 | `Azure:ResourceGroup` | `Azure__ResourceGroup` | Resource group to create or reuse |
+| `Azure:CredentialProcessTimeoutSeconds` | `Azure__CredentialProcessTimeoutSeconds` | Override the credential subprocess timeout (5–600 seconds) when `az login` validation is slow |
 
 ### Local settings
 
@@ -79,6 +80,7 @@ After your CI/CD system authenticates to Azure, provide the shared Azure setting
 | Azure subscription | `Azure__SubscriptionId` | Select the target Azure subscription |
 | Azure location | `Azure__Location` | Set the default region for provisioned resources |
 | Azure resource group | `Azure__ResourceGroup` | Select the resource group to create or reuse |
+| Credential process timeout | `Azure__CredentialProcessTimeoutSeconds` | Override the credential subprocess timeout (5–600 seconds) when `az login` validation is slow on the build agent |
 | AppHost parameters | `Parameters__*` environment variables | Supply any required AppHost inputs |
 | Aspire environment | `aspire deploy --environment <name>` | Select the Aspire environment, such as `Production`, for environment-scoped parameter resolution |
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
@@ -101,6 +101,7 @@ The following configuration options are available:
 | `Azure:ResourceGroupPrefix` | Prefix used when Aspire generates a resource group name | `rg-aspire` |
 | `Azure:CredentialSource` | Authentication method for local provisioning | `Default` |
 | `Azure:AllowResourceGroupCreation` | Allow creating resource groups | `true` |
+| `Azure:CredentialProcessTimeoutSeconds` | Timeout in seconds for credential subprocess operations (must be between 5 and 600) | Azure SDK default |
 
 ## Resource group management
 
@@ -191,6 +192,22 @@ If you want to force a specific local credential, set `Azure:CredentialSource` t
 | `VisualStudioCode` | Visual Studio Code Azure account |
 | `AzurePowerShell` | Azure PowerShell sign-in |
 | `InteractiveBrowser` | Browser-based sign-in prompt |
+
+### Credential process timeout
+
+Most local credential sources (Azure CLI, Azure PowerShell, Visual Studio, Azure Developer CLI, and the development `Default` chain) acquire tokens by invoking a subprocess. On machines where these tools are slow to respond — for example, due to antivirus scanning or network latency — credential validation can time out before authentication completes.
+
+Use `Azure:CredentialProcessTimeoutSeconds` to override the credential subprocess timeout. The value must be between **5** and **600** seconds. When unset, the Azure SDK's default timeout is used.
+
+```json title="appsettings.Development.json"
+{
+  "Azure": {
+    "CredentialProcessTimeoutSeconds": 120
+  }
+}
+```
+
+This setting applies to the `AzureCli`, `AzurePowerShell`, `VisualStudio`, and `AzureDeveloperCli` credential sources, and to the development credential chain used when `CredentialSource` isn't explicitly set. It has no effect on `InteractiveBrowser`, which doesn't shell out to a subprocess.
 
 ## Provisioned resource naming
 


### PR DESCRIPTION
Documents the new `Azure:CredentialProcessTimeoutSeconds` configuration option introduced in microsoft/aspire#16175. The option lets users override the credential subprocess timeout (range 5-600) when `az login` validation is slow due to antivirus, network latency, etc.

## Changes

- **deployment/azure/index.mdx**: adds the option to the *Shared Azure settings* table and the *CI/CD settings* table.
- **integrations/cloud/azure/local-provisioning.mdx**: adds the option to the configuration table and a new *Credential process timeout* section under Authentication.

A companion PR (#731) targets `release/13.3`.