### PR TITLE
style: update padding and border-radius for topic-hero subtitle code

### DIFF
--- a/src/frontend/src/components/TopicHero.astro
+++ b/src/frontend/src/components/TopicHero.astro
@@ -192,14 +192,13 @@ const subtitleSegments = subtitle
 
   .topic-hero-subtitle code {
     display: inline-block;
-    padding: 0.12em 0.45em;
+    padding: 0 0.25rem;
     margin-inline: 0.08em;
-    border-radius: 0.4rem;
+    border-radius: 0.5rem;
     border: 1px solid color-mix(in srgb, var(--topic-accent) 28%, transparent);
     background: color-mix(in srgb, var(--topic-accent) 16%, var(--sl-color-black));
     color: color-mix(in srgb, var(--topic-accent) 72%, white);
     font-size: 0.95em;
-    font-weight: 600;
     box-shadow: inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
   }
 


### PR DESCRIPTION
Minor tweak - styling inline accented code, before:

<img width="1387" height="653" alt="image" src="https://github.com/user-attachments/assets/02f3c9f5-df5c-4fc7-9ed5-2a5316ec7e2e" />

After:

<img width="1399" height="608" alt="image" src="https://github.com/user-attachments/assets/5679adf1-2f1e-4163-994d-4d12e8a8c256" />
