### PR TITLE
Strip locale prefix from API reference sidebar links

### DIFF
--- a/src/frontend/src/route-data-middleware.ts
+++ b/src/frontend/src/route-data-middleware.ts
@@ -1,4 +1,5 @@
 import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+import { stripApiReferenceLocale } from './utils/api-reference-routes';
 
 /**
  * Custom route middleware that applies implicit pagination rules:
@@ -21,6 +22,15 @@ export const onRequest = defineRouteMiddleware((context) => {
   if (!routeData) return;
 
   const { entry, pagination, sidebar } = routeData;
+
+  // --- Step 0: Canonicalize API reference sidebar links ---
+  // API reference pages under /reference/api/ are only generated for the default
+  // (English) locale because they're produced from package metadata rather than
+  // translated content. Starlight auto-prefixes the active locale to sidebar
+  // links, which produces 404s for non-default locales (e.g.
+  // /it/reference/api/csharp/). Rewrite those hrefs to point to the canonical
+  // English path so the sidebar never emits a link that 404s.
+  canonicalizeApiReferenceLinks(sidebar);
 
   // --- Step 1: Group boundary rules ---
   const location = findCurrentPage(sidebar);
@@ -81,8 +91,31 @@ export const onRequest = defineRouteMiddleware((context) => {
 interface SidebarEntry {
   type: string;
   label: string;
+  href?: string;
   isCurrent?: boolean;
   entries?: SidebarEntry[];
+}
+
+/**
+ * Walk the sidebar tree and rewrite any link whose href is a localized API
+ * reference path (e.g. `/it/reference/api/csharp/`) to the canonical,
+ * locale-stripped path (e.g. `/reference/api/csharp/`).
+ */
+function canonicalizeApiReferenceLinks(entries: SidebarEntry[]): void {
+  for (const entry of entries) {
+    if (!entry) continue;
+
+    if (entry.type === 'link' && typeof entry.href === 'string') {
+      const canonical = stripApiReferenceLocale(entry.href);
+      if (canonical) {
+        entry.href = canonical;
+      }
+    }
+
+    if (entry.entries) {
+      canonicalizeApiReferenceLinks(entry.entries);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
## Problem

Sidebar links to the API reference pages (e.g. **Search C# APIs**, **Search TypeScript APIs**) 404 in any non-default locale. For example: <https://aspire.dev/it/reference/api/csharp/>.

The API reference pages under `/reference/api/` are generated only for the default (English) locale because they're built from package metadata rather than translated content. However, Starlight's i18n layer auto-prepends the active locale to every sidebar `link`, producing URLs like `/it/reference/api/csharp/` that have no corresponding generated page.

## Why fix at the sidebar instead of redirecting?

[#754](https://github.com/microsoft/aspire.dev/pull/754) introduced a redirect via Astro's `src/middleware.ts`, but Astro is built as a fully static bundle (no SSR adapter) and the production site is served by the ASP.NET Core `StaticHost` project — that middleware never runs at request time in production, so the 404 persists.

The cleanest fix is at the source: **the sidebar shouldn't generate links that 404 in the first place**. Strip the locale prefix from API-reference sidebar hrefs before they're rendered, so the sidebar always points to the canonical, English-only API reference path regardless of active locale.

## Change

Extend the existing `route-data-middleware.ts` (which already mutates sidebar/pagination data) to walk the sidebar tree and rewrite any link whose href matches the localized API reference pattern (`/<locale>/reference/api/...`) to its canonical, locale-stripped form. Reuses `stripApiReferenceLocale` from `src/utils/api-reference-routes` (added in #754) so locale detection stays in one place.

## Verification

- `pnpm exec vitest run tests/unit/api-reference-routes.vitest.test.ts tests/unit/locale-routes.vitest.test.ts` → all 7 tests pass.
- `pnpm exec eslint src/route-data-middleware.ts --max-warnings 0` → clean.
- After this change, the sidebar items "Search C# APIs" and "Search TypeScript APIs" emit `/reference/api/csharp/` and `/reference/api/typescript/` (without a locale prefix) on every page, so they no longer 404 from non-English contexts.

## Follow-up

The Astro middleware redirect added in #754 is still useful as a defense-in-depth (e.g. for deep-linked or copy-pasted localized URLs), but it does not run in production today. A separate change can either remove that middleware or move equivalent logic to `StaticHost` if we want bookmarked localized URLs to redirect instead of 404. Out of scope for this PR.
