### PR TITLE
Remove .NET 10 prerequisite from VS Code extension page

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
@@ -30,7 +30,6 @@ The official Aspire extension for VS Code. Run, debug, and deploy your Aspire ap
 ## Prerequisites
 
 - **Aspire CLI** — Install via the **Aspire: Install Aspire CLI (stable)** command in VS Code, or follow the [installation guide](/get-started/install-cli/).
-- **.NET 10** or later — [Download .NET](https://dotnet.microsoft.com/download).
 - **VS Code 1.98** or later.
 
 ## Install the extension


### PR DESCRIPTION
The Aspire VS Code extension itself only requires the Aspire CLI and VS Code 1.98+. Language runtimes like .NET are an AppHost concern, not an extension prerequisite — TypeScript AppHosts don't need .NET at all.