### PR TITLE
Clarify first-run setup choices

### DIFF
--- a/src/frontend/config/sidebar/docs.topics.ts
+++ b/src/frontend/config/sidebar/docs.topics.ts
@@ -211,7 +211,7 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
       items: [
         {
           label: 'Setup and tooling',
-          collapsed: true,
+          collapsed: false,
           translations: {
             da: 'Opsætning og værktøjer',
             de: 'Einrichtung und Werkzeuge',
@@ -292,14 +292,6 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
                 'zh-CN': 'VS Code 扩展',
               },
               slug: 'get-started/aspire-vscode-extension',
-            },
-            {
-              label: 'Dev Containers',
-              slug: 'get-started/dev-containers',
-            },
-            {
-              label: 'GitHub Codespaces',
-              slug: 'get-started/github-codespaces',
             },
           ],
         },
@@ -1336,6 +1328,37 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
             'zh-CN': '资源示例',
           },
           slug: 'architecture/resource-examples',
+        },
+      ],
+    },
+    {
+      label: 'Non-local dev environments',
+      translations: {
+        da: 'Ikke-lokale udviklingsmiljøer',
+        de: 'Nicht-lokale Entwicklungsumgebungen',
+        en: 'Non-local dev environments',
+        es: 'Entornos de desarrollo no locales',
+        fr: 'Environnements de développement non locaux',
+        hi: 'गैर-स्थानीय विकास वातावरण',
+        id: 'Lingkungan pengembangan non-lokal',
+        it: 'Ambienti di sviluppo non locali',
+        ja: '非ローカル開発環境',
+        ko: '비로컬 개발 환경',
+        'pt-BR': 'Ambientes de desenvolvimento não locais',
+        ru: 'Нелокальные среды разработки',
+        tr: 'Yerel olmayan geliştirme ortamları',
+        uk: 'Нелокальні середовища розробки',
+        'zh-CN': '非本地开发环境',
+      },
+      collapsed: true,
+      items: [
+        {
+          label: 'Dev Containers',
+          slug: 'get-started/dev-containers',
+        },
+        {
+          label: 'GitHub Codespaces',
+          slug: 'get-started/github-codespaces',
         },
       ],
     },

--- a/src/frontend/src/components/ContainerRuntimeChoices.astro
+++ b/src/frontend/src/components/ContainerRuntimeChoices.astro
@@ -1,0 +1,189 @@
+---
+import { Code, TabItem, Tabs } from '@astrojs/starlight/components';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
+
+interface RuntimeChoice {
+  id: string;
+  title: string;
+  href: string;
+  linkLabel: string;
+  statusLabel: string;
+  description: string;
+}
+
+interface PodmanSetup {
+  heading: string;
+  body: string;
+  bashTitle: string;
+  powershellTitle: string;
+}
+
+interface Props {
+  heading?: string;
+  intro: string;
+  ariaLabel: string;
+  choices: RuntimeChoice[];
+  podmanSetup: PodmanSetup;
+}
+
+const { heading, intro, ariaLabel, choices, podmanSetup } = Astro.props;
+const podmanRuntimeVariable = 'ASPIRE_CONTAINER_RUNTIME';
+const podmanBodyParts = podmanSetup.body.split(podmanRuntimeVariable);
+---
+
+<section class="runtime-choices" aria-label={ariaLabel}>
+  {heading && <h3 class="runtime-heading">{heading}</h3>}
+  <p class="runtime-intro">{intro}</p>
+  <div class="runtime-tabs">
+    <Tabs>
+      {
+        choices.map((choice) => (
+          <TabItem label={choice.title} icon={choice.id === 'docker' ? 'seti:docker' : undefined}>
+            <div class:list={['runtime-panel', `runtime-${choice.id}`]}>
+              <div class="runtime-panel-actions">
+                <span class="runtime-status">{choice.statusLabel}</span>
+                <a class="runtime-link" href={choice.href} target="_blank" rel="noopener noreferrer">
+                  {choice.linkLabel}
+                </a>
+              </div>
+              <p class="runtime-description">{choice.description}</p>
+              {
+                choice.id === 'podman' && (
+                  <div class="podman-setup">
+                    <div class="podman-setup-copy">
+                      <h5>{podmanSetup.heading}</h5>
+                      <p class="podman-copy">
+                        {
+                          podmanBodyParts.map((part, index) => (
+                            <>
+                              {part}
+                              {index < podmanBodyParts.length - 1 && (
+                                <code>{podmanRuntimeVariable}</code>
+                              )}
+                            </>
+                          ))
+                        }
+                      </p>
+                    </div>
+                    <OsAwareTabs syncKey="terminal">
+                      <Code
+                        slot="unix"
+                        title={podmanSetup.bashTitle}
+                        code="export ASPIRE_CONTAINER_RUNTIME=podman"
+                        lang="bash"
+                      />
+                      <Code
+                        slot="windows"
+                        title={podmanSetup.powershellTitle}
+                        code={[
+                          '[System.Environment]::SetEnvironmentVariable(',
+                          '    "ASPIRE_CONTAINER_RUNTIME",',
+                          '    "podman",',
+                          '    "User"',
+                          ')',
+                        ].join('\n')}
+                        lang="powershell"
+                      />
+                    </OsAwareTabs>
+                  </div>
+                )
+              }
+            </div>
+          </TabItem>
+        ))
+      }
+    </Tabs>
+  </div>
+</section>
+
+<style>
+  .runtime-choices {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin: 1rem 0;
+    color: var(--sl-color-text);
+    font-size: var(--sl-text-base);
+  }
+
+  .runtime-heading {
+    margin: 0;
+    color: var(--sl-color-text);
+    font-size: var(--sl-text-lg);
+    line-height: 1.3;
+  }
+
+  .runtime-intro {
+    margin: 0;
+    color: inherit;
+    font-size: inherit;
+    line-height: 1.6;
+  }
+
+  .runtime-tabs :global(starlight-tabs) {
+    margin: 0;
+  }
+
+  .runtime-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.7rem;
+    padding-top: 0.1rem;
+  }
+
+  .runtime-panel-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.8rem;
+  }
+
+  .runtime-status {
+    color: var(--sl-color-text-accent);
+    font-size: inherit;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  .runtime-link {
+    color: inherit;
+    font-size: inherit;
+    font-weight: 400;
+    line-height: 1.6;
+    text-underline-offset: 0.18em;
+  }
+
+  .runtime-description,
+  .podman-copy {
+    margin: 0;
+    color: inherit;
+    font-size: inherit;
+    line-height: 1.6;
+  }
+
+  .podman-setup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 0.1rem;
+  }
+
+  .podman-setup-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .podman-setup-copy h5 {
+    margin: 0;
+  }
+
+  .podman-setup :global(starlight-tabs) {
+    margin: 0;
+  }
+
+  .podman-setup :global(figure.frame) {
+    margin: 0;
+  }
+
+</style>

--- a/src/frontend/src/components/ContainerRuntimeChoices.astro
+++ b/src/frontend/src/components/ContainerRuntimeChoices.astro
@@ -1,5 +1,5 @@
 ---
-import { Code, TabItem, Tabs } from '@astrojs/starlight/components';
+import { Badge, Code, TabItem, Tabs } from '@astrojs/starlight/components';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 
 interface RuntimeChoice {
@@ -41,7 +41,7 @@ const podmanBodyParts = podmanSetup.body.split(podmanRuntimeVariable);
           <TabItem label={choice.title} icon={choice.id === 'docker' ? 'seti:docker' : undefined}>
             <div class:list={['runtime-panel', `runtime-${choice.id}`]}>
               <div class="runtime-panel-actions">
-                <span class="runtime-status">{choice.statusLabel}</span>
+                <Badge variant={choice.id === 'docker' ? 'default' : 'note'} text={choice.statusLabel} size='large' />
                 <a class="runtime-link" href={choice.href} target="_blank" rel="noopener noreferrer">
                   {choice.linkLabel}
                 </a>
@@ -146,7 +146,6 @@ const podmanBodyParts = podmanSetup.body.split(podmanRuntimeVariable);
   }
 
   .runtime-link {
-    color: inherit;
     font-size: inherit;
     font-weight: 400;
     line-height: 1.6;

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -5,11 +5,9 @@ lastUpdated: true
 tableOfContents: true
 ---
 
-import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
-import InstallAspireCLI from '@components/InstallAspireCLI.astro';
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
-import { Aside, Code, Steps } from '@astrojs/starlight/components';
+import { Aside, Code, Icon } from '@astrojs/starlight/components';
 
 Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system.
 
@@ -20,10 +18,7 @@ Aspire provides a command-line interface (CLI) tool to help you create and manag
 
 ## Install the Aspire CLI
 
-To install the Aspire CLI download and run the install script:
-
-<Aside type="note" title="Download and install" icon="download">
-You can download and run the installation script in a single command to install the Aspire CLI:
+To install the Aspire CLI, download and run the installation script in a single command:
 
 <OsAwareTabs syncKey="terminal">
   <Code
@@ -40,70 +35,13 @@ You can download and run the installation script in a single command to install 
   />
 </OsAwareTabs>
 
-The script installs the latest stable release of Aspire CLI. See [Validation](#validation) to verify the installation.
+The script installs the latest stable release of Aspire CLI. During installation, you might be asked `Do you want to continue?`. Reply with `Y` for Yes or `A` for Yes to All to continue downloading and running the install script. See [Validation](#validation) to verify the installation.
 
-</Aside>
+:::tip
+At any time, you can reopen the **Install Aspire CLI** command modal from the top navigation (download icon <Icon name='download' class='d-inline' size='large' />). The modal shows the download-and-install command for your OS, so you can run the installer again when needed.
+:::
 
-### Two-step installation process
-
-Alternatively, you can download the script and run it as a two-step process:
-
-<Steps>
-
-1.  Open a terminal.
-1.  Download the script and save it as a file:
-
-    <OsAwareTabs syncKey="terminal">
-      <Code
-        slot="unix"
-        lang="bash"
-        title="Download script (macOS/Linux)"
-        code="curl -sSL https://aspire.dev/install.sh -o aspire-install.sh"
-      />
-      <Code
-        slot="windows"
-        lang="powershell"
-        title="Download script (Windows)"
-        code="irm https://aspire.dev/install.ps1 -OutFile aspire-install.ps1"
-      />
-    </OsAwareTabs>
-
-1.  Run the script to install the stable release build of Aspire.
-
-        You should see output similar to the following snippet:
-
-    <OsAwareTabs syncKey="terminal">
-      <Code
-        slot="unix"
-        lang="txt"
-        title="Installation output (macOS/Linux)"
-        frame="terminal"
-        code={
-          'Downloading from:\n' +
-          'https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-linux-x64.tar.gz\n' +
-          'Aspire CLI successfully installed to: /home/username/.aspire/bin/aspire\n' +
-          'Added /home/username/.aspire/bin to PATH for current session Added\n' +
-          '/home/username/.aspire/bin to PATH in /home/username/.bashrc The aspire\n' +
-          'cli is now available for use in this and new sessions.'
-        }
-      />
-      <Code
-        slot="windows"
-        lang="txt"
-        title="Installation output (Windows)"
-        frame="terminal"
-        code={
-          'Downloading from: https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-win-x64.zip\n' +
-          'Aspire CLI successfully installed to:\n' +
-          'C:\\Users\\name\\.aspire\\bin\\aspire.exe Added C:\\Users\\username\\.aspire\\bin\n' +
-          'to PATH for current session Added C:\\Users\\username\\.aspire\\bin to user\n' +
-          'PATH environment variable The aspire cli is now available for use in\n' +
-          'this and new sessions.'
-        }
-      />
-    </OsAwareTabs>
-
-</Steps>
+You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
 
 ## Validation
 
@@ -112,16 +50,6 @@ To validate that the Aspire CLI is installed, use `aspire --version` to query As
 ```bash title="Check installed version"
 aspire --version
 ```
-
-Consider the following example of running the command:
-
-<AsciinemaPlayer
-  src="/casts/aspire-version.cast"
-  poster="npt:0:01"
-  rows="5"
-  autoPlay={true}
-  loop={false}
-/>
 
 If that command works, you're presented with the version of the Aspire CLI tool:
 

--- a/src/frontend/src/content/docs/get-started/prerequisites.mdx
+++ b/src/frontend/src/content/docs/get-started/prerequisites.mdx
@@ -8,11 +8,9 @@ tableOfContents:
 lastUpdated: true
 ---
 
-import { Aside, Icon, Code, CardGrid, Card, LinkCard, LinkButton, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import IconAside from '@components/IconAside.astro';
-import IconLinkCard from '@components/IconLinkCard.astro';
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import CodespacesButton from '@components/CodespacesButton.astro';
-import OsAwareTabs from '@components/OsAwareTabs.astro';
+import ContainerRuntimeChoices from '@components/ContainerRuntimeChoices.astro';
 
 Ready to dive into Aspire? Before you begin, make sure your development environment is set up with a few essential tools. This guide walks you through everything you need to start building and running Aspire solutions with confidence.
 
@@ -25,7 +23,7 @@ Ready to dive into Aspire? Before you begin, make sure your development environm
 
     Aspire's C# AppHost is built on .NET, a free, open-source, cross-platform framework for building modern apps and cloud services. You'll need the [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) installed—no prior C# experience is required.
 
-    <Aside type="tip" title="Important">
+    <Aside type="caution" title="Important">
     The .NET 10.0 SDK is required for C# AppHosts. However, Aspire can run applications targeting .NET 8.0 or later.
     </Aside>
 
@@ -43,28 +41,49 @@ Ready to dive into Aspire? Before you begin, make sure your development environm
 
 1. #### Install an OCI-compliant container runtime
 
-    Aspire can run containers using several OCI-compatible runtimes, including Docker Desktop and Podman.
+    <ContainerRuntimeChoices
+      ariaLabel="Container runtime choices"
+      intro="Choose one runtime for local container support. Docker Desktop is the recommended default for most Aspire developers."
+      choices={[
+        {
+          id: 'docker',
+          title: 'Docker Desktop',
+          href: 'https://www.docker.com/products/docker-desktop',
+          linkLabel: 'Install Docker Desktop',
+          statusLabel: 'Recommended default',
+          description:
+            'A familiar and widely supported environment for building and running containers.',
+        },
+        {
+          id: 'podman',
+          title: 'Podman',
+          href: 'https://podman.io/',
+          linkLabel: 'Install Podman',
+          statusLabel: 'Supported alternative',
+          description:
+            'An open-source, daemonless runtime for building and running Open Container Initiative (OCI) containers.',
+        },
+        {
+          id: 'rancher',
+          title: 'Rancher Desktop',
+          href: 'https://rancherdesktop.io/',
+          linkLabel: 'Learn about Rancher Desktop',
+          statusLabel: 'Community reported',
+          description:
+            'Reported by users as a successful alternative, especially when configured to use the Docker CLI. Rancher Desktop is not an officially supported or regularly tested Aspire scenario.',
+        },
+      ]}
+      podmanSetup={{
+        heading: 'Use Podman with Aspire',
+        body: 'After installing Podman, set ASPIRE_CONTAINER_RUNTIME to podman.',
+        bashTitle: 'Set Podman runtime',
+        powershellTitle: 'Set Podman runtime',
+      }}
+    />
 
-    - <a href="https://www.docker.com/products/docker-desktop" target="_blank">Docker Desktop</a> is the most popular container runtime among Aspire developers, offering a familiar and widely supported environment for building and running containers.
-
-    - <a href="https://podman.io/" target="_blank">Podman</a> is an open-source, daemonless alternative to Docker. It supports building and running Open Container Initiative (OCI) containers, making it a flexible choice for developers who prefer a lightweight solution.
-
-      <OsAwareTabs syncKey="terminal">
-        <Code
-          slot="unix"
-          title='Set the ASPIRE_CONTAINER_RUNTIME environment variable to podman'
-          code={`export ASPIRE_CONTAINER_RUNTIME=podman`}
-          lang="bash"
-        />
-        <Code
-          slot="windows"
-          title='Set the ASPIRE_CONTAINER_RUNTIME environment variable to podman'
-          code={`[System.Environment]::SetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME", "podman", "User")`}
-          lang="powershell"
-        />
-      </OsAwareTabs>
-
-    - <a href="https://rancherdesktop.io/" target="_blank">Rancher Desktop</a> has been reported by users as a successful alternative—particularly when configured to use the Docker CLI. However, Rancher Desktop is not an officially supported or regularly tested scenario for Aspire. If you encounter issues with Rancher Desktop, please let us know, but fixes may not be prioritized.
+    :::tip[Choose one runtime]{icon='approve-check-circle'}
+    Install one option from the tabs above. For most users, choose **Docker Desktop**; don't install Podman or Rancher Desktop unless you specifically want to use one of them instead.
+    :::
 
 1. #### Install an integrated development environment (IDE)
 
@@ -94,12 +113,12 @@ Ready to dive into Aspire? Before you begin, make sure your development environm
     </TabItem>
     </Tabs>
 
-1. #### Consider alternatives to local installation
-
-    If you prefer not to install the prerequisites on your local machine, you can develop Aspire solutions using cloud-based options like [GitHub Codespaces](/get-started/github-codespaces/) or [Dev Containers](/get-started/dev-containers/). These options allow you to work in a cloud-based environment, eliminating the need for local installations, but may not provide the same performance as local installations.
-
-    The Aspire team maintains a GitHub Codespaces (with preconfigured Dev Container) configuration to help you get started quickly:
-
-    <CodespacesButton owner='microsoft' repo='aspire-devcontainer'  />
-
 </Steps>
+
+#### Consider alternatives to local installation (Optional)
+
+If you prefer not to install the prerequisites on your local machine, you can develop Aspire solutions using cloud-based options like [GitHub Codespaces](/get-started/github-codespaces/) or [Dev Containers](/get-started/dev-containers/). These options allow you to work in a cloud-based environment, eliminating the need for local installations, but may not provide the same performance as local installations.
+
+The Aspire team maintains a GitHub Codespaces (with preconfigured Dev Container) configuration to help you get started quickly:
+
+<CodespacesButton owner='microsoft' repo='aspire-devcontainer'  />

--- a/src/frontend/src/content/docs/ja/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/ja/get-started/install-cli.mdx
@@ -5,11 +5,9 @@ lastUpdated: true
 tableOfContents: true
 ---
 
-import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
-import InstallAspireCLI from '@components/InstallAspireCLI.astro';
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
-import { Aside, Code, Steps } from '@astrojs/starlight/components';
+import { Aside, Code, Icon } from '@astrojs/starlight/components';
 
 Aspire には、Aspire ベースのアプリを作成・管理するためのコマンドラインインターフェイス（CLI）ツールが用意されています。
 この CLI は、インタラクティブな操作を中心とした体験により、開発ワークフローを効率化します。
@@ -25,86 +23,30 @@ Aspire には、Aspire ベースのアプリを作成・管理するためのコ
 
 ## Aspire CLI をインストール
 
-Aspire CLI をインストールするには、インストールスクリプトをダウンロードして実行してください:
-
-<Aside type="note" title="ダウンロード & インストール" icon="download">
-1 つのコマンドでインストールスクリプトをダウンロードして実行し、Aspire CLI をインストールできます:
+Aspire CLI をインストールするには、インストールスクリプトを 1 つのコマンドでダウンロードして実行します:
 
 <OsAwareTabs syncKey="terminal">
   <Code
     slot="unix"
     lang="bash"
+    title="インストール スクリプト (macOS/Linux)"
     code="curl -sSL https://aspire.dev/install.sh | bash"
   />
   <Code
     slot="windows"
     lang="powershell"
+    title="インストール スクリプト (Windows)"
     code="irm https://aspire.dev/install.ps1 | iex"
   />
 </OsAwareTabs>
 
-このスクリプトは、Aspire CLI インストールを確認するには、 [検証](#検証) をご覧ください。
+このスクリプトは Aspire CLI の最新安定版をインストールします。インストール中に `Do you want to continue?` と表示される場合があります。その場合は、ダウンロードとインストールスクリプトの実行を続行するために `Y`（Yes）または `A`（Yes to All）で応答してください。インストールを確認するには、 [検証](#検証) をご覧ください。
 
-</Aside>
+:::tip
+いつでも上部ナビゲーションの **Install Aspire CLI** コマンド モーダル（ダウンロード アイコン <Icon name='download' class='d-inline' size='large' />）を再度開けます。このモーダルには、お使いの OS 向けのダウンロード兼インストール コマンドが表示されるため、必要に応じてインストーラーを再実行できます。
+:::
 
-### 2 段階のインストール手順
-
-別の方法として、スクリプトをダウンロードしてから実行するという 2 段階の手順でインストールすることもできます:
-
-<Steps>
-
-1.  ターミナルを開きます。
-1.  スクリプトをダウンロードしてファイルとして保存します:
-
-    <OsAwareTabs syncKey="terminal">
-      <Code
-        slot="unix"
-        lang="bash"
-        code="curl -sSL https://aspire.dev/install.sh -o aspire-install.sh"
-      />
-      <Code
-        slot="windows"
-        lang="powershell"
-        code="irm https://aspire.dev/install.ps1 -OutFile aspire-install.ps1"
-      />
-    </OsAwareTabs>
-
-1.  安定版の Aspire をインストールするためにスクリプトを実行してください。
-
-        次のような出力が表示されるはずです。:
-
-    <OsAwareTabs syncKey="terminal">
-      <Code
-        slot="unix"
-        lang="txt"
-        title="Output"
-        frame="terminal"
-        code={
-          'Downloading from:\n' +
-          'https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-linux-x64.tar.gz\n' +
-          'Aspire CLI successfully installed to: /home/username/.aspire/bin/aspire\n' +
-          'Added /home/username/.aspire/bin to PATH for current session Added\n' +
-          '/home/username/.aspire/bin to PATH in /home/username/.bashrc The aspire\n' +
-          'cli is now available for use in this and new sessions.'
-        }
-      />
-      <Code
-        slot="windows"
-        lang="txt"
-        title="Output"
-        frame="terminal"
-        code={
-          'Downloading from:\n' +
-          'https://aka.ms/dotnet/9/aspire/ga/daily/aspire-cli-win-x64.zip\n' +
-          'Aspire CLI successfully installed to: C:\\Users\\name\\.aspire\\bin\\aspire.exe\n' +
-          'Added C:\\Users\\username\\.aspire\\bin to PATH for current session Added\n' +
-          'C:\\Users\\username\\.aspire\\bin to user PATH environment variable The aspire\n' +
-          'cli is now available for use in this and new sessions.'
-        }
-      />
-    </OsAwareTabs>
-
-</Steps>
+スクリプトを確認したい場合や、ダウンロードと実行を分けて行いたい場合にのみ、スクリプトを個別にダウンロードしてください。詳しくは [aspire-install スクリプト リファレンス](/reference/cli/install-script/) をご覧ください。
 
 ## 検証
 
@@ -114,24 +56,13 @@ Aspire CLI が正しくインストールされているか確認するには、
 aspire --version
 ```
 
-次は、そのコマンドを実行した例です:
-
-<AsciinemaPlayer
-  src="/casts/aspire-version.cast"
-  poster="npt:0:01"
-  rows="5"
-  autoPlay={true}
-  loop={false}
-/>
-
 そのコマンドが正常に動作すれば、Aspire CLI ツールのバージョンが表示されます:
 
-```bash title="Aspire CLI — Output"
+```bash title="Aspire CLI — Output" data-disable-copy
 13.2.0+{commitSHA}
 ```
 
 `+{commitSHA}` というサフィックスは、Aspire CLI がどのコミットからビルドされたかを示しています。
-このサフィックスはプレリリース版に含まれ、安定版リリースでは表示されない場合があります。
 
 <LearnMore>
   もっと詳しく知るには、[Aspire CLI のリファレンス](/reference/cli/overview/)
@@ -149,3 +80,4 @@ aspire --version
 
 - [aspire-install スクリプト リファレンス](/reference/cli/install-script/)
 - [`aspire` コマンド リファレンス](/reference/cli/commands/aspire/)
+- [Aspire VS Code 拡張機能](/ja/get-started/aspire-vscode-extension/) — CLI をインストールし、VS Code から Aspire コマンドを使用できます

--- a/src/frontend/src/content/docs/ja/get-started/prerequisites.mdx
+++ b/src/frontend/src/content/docs/ja/get-started/prerequisites.mdx
@@ -9,11 +9,9 @@ lastUpdated: true
 prev: false
 ---
 
-import { Aside, Icon, Code, CardGrid, Card, LinkCard, LinkButton, Steps } from '@astrojs/starlight/components';
-import IconAside from '@components/IconAside.astro';
-import IconLinkCard from '@components/IconLinkCard.astro';
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import CodespacesButton from '@components/CodespacesButton.astro';
-import OsAwareTabs from '@components/OsAwareTabs.astro';
+import ContainerRuntimeChoices from '@components/ContainerRuntimeChoices.astro';
 
 Aspire に取り組む準備はできましたか？
 始める前に、開発環境にいくつかの必須ツールが整っていることを確認してください。
@@ -21,74 +19,110 @@ Aspire に取り組む準備はできましたか？
 
 <Steps>
 
-1. #### .NET SDK のインストール
+1. #### 言語ランタイムをインストール
 
-    Aspire は .NET を基盤として構築されています。.NET は、モダンなアプリやクラウドサービスを開発するための、無料・オープンソース・クロスプラットフォームのフレームワークです。
-利用するには [.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) をインストールする必要がありますが... — C# の経験は不要です。
+    <Tabs syncKey='aspire-lang'>
+    <TabItem id='csharp' label='C#'>
 
-    <Aside type="tip" title="Important">
-    Aspire CLI を使用するには、お使いのマシンに .NET 10.0 SDK がインストールされている必要があります。
-ただし、Aspire 自体は .NET 8.0 以降をターゲットとしたアプリケーションを実行できます。
+    Aspire の C# AppHost は .NET を基盤としています。.NET は、モダンなアプリやクラウドサービスを開発するための、無料・オープンソース・クロスプラットフォームのフレームワークです。[.NET 10.0 SDK](https://dotnet.microsoft.com/download/dotnet/10.0) をインストールする必要がありますが、C# の経験は不要です。
+
+    <Aside type="caution" title="重要">
+    C# AppHost には .NET 10.0 SDK が必要です。ただし、Aspire は .NET 8.0 以降をターゲットとしたアプリケーションを実行できます。
     </Aside>
 
     お使いのオペレーティングシステム（Windows、macOS、Linux）に応じた [インストール手順](https://dotnet.microsoft.com/download/dotnet/10.0) に従って、セットアップを完了してください。
 
+    </TabItem>
+    <TabItem id='typescript' label='TypeScript'>
+
+    Aspire の TypeScript AppHost には、[Node.js](https://nodejs.org/) 20 以降（LTS 推奨）と、npm や pnpm などのパッケージマネージャーが必要です。
+
+    お使いのオペレーティングシステム（Windows、macOS、Linux）に応じた [Node.js のインストール手順](https://nodejs.org/) に従って、セットアップを完了してください。
+
+    </TabItem>
+    </Tabs>
+
 1. #### OCI 準拠のコンテナーランタイムをインストール
 
-    Aspire は、Docker Desktop や Podman を含む複数の OCI 互換ランタイムを利用してコンテナーを実行できます。
+    <ContainerRuntimeChoices
+      ariaLabel="コンテナーランタイムの選択肢"
+      intro="ローカルでコンテナーを利用するためのランタイムを 1 つ選択してください。多くの Aspire 開発者には Docker Desktop を既定の推奨パスとしておすすめします。"
+      choices={[
+        {
+          id: 'docker',
+          title: 'Docker Desktop',
+          href: 'https://www.docker.com/products/docker-desktop',
+          linkLabel: 'Docker Desktop をインストール',
+          statusLabel: '推奨される既定の選択肢',
+          description:
+            'コンテナーのビルドと実行において、馴染みやすく広くサポートされた環境を提供します。',
+        },
+        {
+          id: 'podman',
+          title: 'Podman',
+          href: 'https://podman.io/',
+          linkLabel: 'Podman をインストール',
+          statusLabel: 'サポートされる代替手段',
+          description:
+            'Open Container Initiative（OCI）コンテナーのビルドと実行に対応した、オープンソースでデーモンを必要としないランタイムです。',
+        },
+        {
+          id: 'rancher',
+          title: 'Rancher Desktop',
+          href: 'https://rancherdesktop.io/',
+          linkLabel: 'Rancher Desktop について確認',
+          statusLabel: 'コミュニティからの報告あり',
+          description:
+            'Docker CLI を使用するよう設定した場合に利用できたという報告があります。ただし、Rancher Desktop は Aspire の正式サポート対象でも、定期的にテストされている環境でもありません。',
+        },
+      ]}
+      podmanSetup={{
+        heading: 'Aspire で Podman を使用する',
+        body: 'Podman をインストールしたら、ASPIRE_CONTAINER_RUNTIME を podman に設定します。',
+        bashTitle: 'Podman ランタイムを設定',
+        powershellTitle: 'Podman ランタイムを設定',
+      }}
+    />
 
-    - <a href="https://www.docker.com/products/docker-desktop" target="_blank">Docker Desktop</a> は Aspire 開発者のあいだで最も一般的に使われているコンテナーランタイムで、コンテナーの構築と実行において、馴染みやすく広くサポートされた環境を提供します。
-
-    - <a href="https://podman.io/" target="_blank">Podman</a> はオープンソースで、デーモンを必要としない Docker の代替手段です。
-Open Container Initiative（OCI）に準拠したコンテナーのビルドと実行をサポートしており、軽量なソリューションを好む開発者にとって柔軟な選択肢となります。
-
-      <OsAwareTabs syncKey="terminal">
-        <Code
-          slot="unix"
-          title='ASPIRE_CONTAINER_RUNTIME 環境変数を podman に設定'
-          code={`export ASPIRE_CONTAINER_RUNTIME=podman`}
-          lang="bash"
-        />
-        <Code
-          slot="windows"
-          title='ASPIRE_CONTAINER_RUNTIME 環境変数を podman に設定'
-          code={`[System.Environment]::SetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME", "podman", "User")`}
-          lang="powershell"
-        />
-      </OsAwareTabs>
-
-    - <a href="https://rancherdesktop.io/" target="_blank">Rancher Desktop</a> は、Docker CLI を使用するよう設定した場合に、代替手段として問題なく利用できたという報告があります。
-ただし、Rancher Desktop は Aspire の正式サポート対象でも、定期的にテストされている環境でもありません。
-もし Rancher Desktop で問題が発生した場合はお知らせいただければ幸いですが、修正が優先されない場合がありますのでご了承ください。
+    :::tip[ランタイムを 1 つ選択]{icon='approve-check-circle'}
+    上のタブから 1 つだけインストールしてください。ほとんどのユーザーには **Docker Desktop** をおすすめします。Podman または Rancher Desktop を使いたい明確な理由がある場合にのみ、それらを代わりに選択してください。
+    :::
 
 1. #### 統合開発環境（IDE）をインストール
 
     Aspire は複数の IDE やコードエディターをサポートしています。
-ご自身のワークフローに最も適したものをお選びいただけます:
+    ご自身のワークフローに最も適したものをお選びいただけます:
 
-    <Aside type="note" title="Visual Studio Code" icon="vscode">
-    最適な利用体験のためには [Visual Studio Code](https://code.visualstudio.com/) をおすすめします — 軽量でクロスプラットフォームに対応したコードエディターであり、Aspire との相性もとても良好です。利用を始めるには、次の拡張機能をインストールしてください。:
+    :::note[Visual Studio Code]{icon="vscode"}
+    最適な利用体験のためには [Visual Studio Code](https://code.visualstudio.com/) をおすすめします。軽量でクロスプラットフォームに対応したコードエディターであり、Aspire との相性も良好です。利用を始めるには、次の拡張機能をインストールしてください:
 
-    <Steps>
+    Aspire 固有のコマンドや機能を利用するための [Aspire 拡張機能](/ja/get-started/aspire-vscode-extension/) 。
+    :::
 
-    1. C# 言語サポート用の [C# 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) 。
-    2. Aspire 固有のコマンドや機能を利用するための [Aspire 拡張機能](https://marketplace.visualstudio.com/items?itemName=microsoft-aspire.aspire-vscode) 。
+    <Tabs syncKey='aspire-lang'>
+    <TabItem id='csharp' label='C#'>
 
-    </Steps>
-    </Aside>
+    さらに、C# 言語サポート用の [C# 拡張機能](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) をインストールしてください。
 
     Aspire は次の IDE とも相性良く動作します:
 
     - [Visual Studio](https://visualstudio.microsoft.com/vs/): C# 開発向けのフル機能 IDE で、デバッグ、IntelliSense、Git サポートなどを備えています。
     - [JetBrains Rider](https://plugins.jetbrains.com/plugin/23289--net-aspire): 高度なコード分析、リファクタリング、デバッグなどの機能を備えた、クロスプラットフォーム対応の強力な C# IDE です。
-    <br/>
 
-1. #### ローカルインストール以外の選択肢も検討する
+    </TabItem>
+    <TabItem id='typescript' label='TypeScript'>
 
-    ローカルマシンにインストールしたくない場合は、 [GitHub Codespaces](/get-started/github-codespaces/) や [Dev Containers](/get-started/dev-containers/)などのクラウドベースの選択肢を利用して Aspire ソリューションを開発することもできます。 これらを使えば、ローカル環境を構築せずにクラウド上で開発できますが、パフォーマンスはローカル環境に比べて劣る場合があります。
+    TypeScript AppHost には、Aspire 拡張機能をインストールした Visual Studio Code をおすすめします。
 
-    Aspire チームは、すぐに開発を始められるよう、事前設定済みの Dev Container を含む GitHub Codespaces の構成を提供しています:
-
-    <CodespacesButton owner='microsoft' repo='aspire-devcontainer'  />
+    </TabItem>
+    </Tabs>
 
 </Steps>
+
+1. #### ローカルインストール以外の選択肢も検討する（任意）
+
+ローカルマシンにインストールしたくない場合は、 [GitHub Codespaces](/get-started/github-codespaces/) や [Dev Containers](/get-started/dev-containers/)などのクラウドベースの選択肢を利用して Aspire ソリューションを開発することもできます。 これらを使えば、ローカル環境を構築せずにクラウド上で開発できますが、パフォーマンスはローカル環境に比べて劣る場合があります。
+
+Aspire チームは、すぐに開発を始められるよう、事前設定済みの Dev Container を含む GitHub Codespaces の構成を提供しています:
+
+<CodespacesButton owner='microsoft' repo='aspire-devcontainer'  />

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -510,6 +510,11 @@ figure.frame {
   min-height: 1rem;
 }
 
+.expressive-code .copy button:not([data-disable-copy]) {
+  opacity: 1;
+  visibility: visible;
+}
+
 a:focus-visible,
 button:focus-visible,
 input:focus-visible,
@@ -539,14 +544,6 @@ textarea:focus-visible {
   .expressive-code .copy button:not([data-disable-copy]) {
     width: 2rem;
     height: 2rem;
-  }
-}
-
-/* Show copy button on mobile for better accessibility */
-@media (max-width: 768px) {
-  .expressive-code .copy button:not([data-disable-copy]) {
-    opacity: 1;
-    visibility: visible;
   }
 }
 

--- a/src/frontend/tests/e2e/custom-components.spec.ts
+++ b/src/frontend/tests/e2e/custom-components.spec.ts
@@ -39,11 +39,46 @@ test('accessible code enhancements label code regions and remove disabled copy b
   await expect(labelledRegion).toBeVisible();
   await expect(labelledRegion).toHaveAttribute('aria-label', /install/i);
   await expect(copyButton).toHaveAttribute('aria-label', /(copy|copied)/i);
+  await expect(copyButton).toHaveCSS('opacity', '1');
+  await expect(copyButton).toHaveCSS('visibility', 'visible');
 
   await page.goto('/');
   await dismissCookieConsentIfVisible(page);
 
   await expect(page.locator('.code-display[data-disable-copy] .copy')).toHaveCount(0);
+});
+
+test('prerequisites presents container runtimes as one choice with Podman setup inline', async ({
+  page,
+}) => {
+  await page.goto('/get-started/prerequisites/');
+  await dismissCookieConsentIfVisible(page);
+
+  const main = page.locator('main');
+  const runtimeChoices = page.locator('.runtime-choices');
+  const podmanChoice = runtimeChoices.locator('.runtime-podman');
+
+  await expect(main).toContainText('Install an OCI-compliant container runtime');
+  await expect(main).toContainText('Install one option from the tabs above.');
+  await expect(main).toContainText('Podman or Rancher Desktop unless you specifically want');
+  await expect(runtimeChoices).toBeVisible();
+  await expect(runtimeChoices).toContainText('Docker Desktop');
+  await expect(runtimeChoices).toContainText('Podman');
+  await expect(runtimeChoices).toContainText('Rancher Desktop');
+
+  await expect(runtimeChoices.getByRole('tab', { name: 'Docker Desktop' })).toHaveAttribute(
+    'aria-selected',
+    'true'
+  );
+  await expect(podmanChoice).toBeHidden();
+
+  await runtimeChoices.getByRole('tab', { name: 'Podman' }).click();
+
+  await expect(podmanChoice).toBeVisible();
+  await expect(podmanChoice).toContainText('Use Podman with Aspire');
+  await expect(podmanChoice).toContainText('ASPIRE_CONTAINER_RUNTIME');
+  await expect(podmanChoice).toContainText('podman');
+  await expect(podmanChoice.locator('starlight-tabs[data-sync-key="terminal"]')).toBeVisible();
 });
 
 test('testimonial carousel advances cards and enables the previous control', async ({ page }) => {

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -9,6 +9,7 @@ import Breadcrumb from '@components/Breadcrumb.astro';
 import CTABanner from '@components/CTABanner.astro';
 import CapabilityGrid from '@components/CapabilityGrid.astro';
 import CodespacesButton from '@components/CodespacesButton.astro';
+import ContainerRuntimeChoices from '@components/ContainerRuntimeChoices.astro';
 import Expand from '@components/Expand.astro';
 import FooterLinks from '@components/FooterLinks.astro';
 import FeatureShowcase from '@components/FeatureShowcase.astro';
@@ -156,6 +157,47 @@ const basicRenderCases: BasicRenderCase[] = [
     Component: CodespacesButton,
     props: { owner: 'dotnet', repo: 'aspire' },
     includes: ['https://codespaces.new/dotnet/aspire', 'github.com/codespaces/badge.svg'],
+  },
+  {
+    name: 'ContainerRuntimeChoices renders localized runtime options and Podman setup',
+    Component: ContainerRuntimeChoices,
+    props: {
+      ariaLabel: 'コンテナーランタイムの選択肢',
+      intro: 'ランタイムを 1 つ選択してください。',
+      choices: [
+        {
+          id: 'docker',
+          title: 'Docker Desktop',
+          href: 'https://www.docker.com/products/docker-desktop',
+          linkLabel: 'Docker Desktop をインストール',
+          statusLabel: '推奨',
+          description: 'Supported container runtime.',
+        },
+        {
+          id: 'podman',
+          title: 'Podman',
+          href: 'https://podman.io/',
+          linkLabel: 'Podman をインストール',
+          statusLabel: '代替手段',
+          description: 'Daemonless OCI runtime.',
+        },
+      ],
+      podmanSetup: {
+        heading: 'Aspire で Podman を使用する',
+        body: 'ASPIRE_CONTAINER_RUNTIME を podman に設定します。',
+        bashTitle: 'Bash で設定',
+        powershellTitle: 'PowerShell で設定',
+      },
+    },
+    includes: [
+      'コンテナーランタイムの選択肢',
+      'ランタイムを 1 つ選択してください。',
+      'Docker Desktop',
+      'Docker Desktop をインストール',
+      'Podman',
+      'ASPIRE_CONTAINER_RUNTIME=podman',
+      'PowerShell で設定',
+    ],
   },
   {
     name: 'FluidGrid renders slot content',


### PR DESCRIPTION
This PR applies user study observations from the first-run setup flow to make required choices more obvious and reduce uncertainty for new Aspire users.

## Summary
- Replace the prerequisites runtime list with a tabbed choose-one experience for Docker Desktop, Podman, and Rancher Desktop.
- Emphasize Docker Desktop as the recommended default while keeping supported alternatives discoverable.
- Keep Podman-specific setup inline only in the Podman tab, including the required `ASPIRE_CONTAINER_RUNTIME` command.
- Simplify the Aspire CLI install page around the single download-and-run command and clarify the `Do you want to continue?` prompt.
- Mirror the English prerequisite and CLI install updates in the Japanese docs.
- Make code-block copy buttons visible by default and add targeted component/e2e coverage.

## User Study Context
These changes are based on user study observations where first-time users needed clearer signals about which setup path to choose. The goal is to make the primary decisions feel explicit, especially choosing one OCI runtime and understanding the recommended default path.

## Validation
- `pnpm test:unit`
- `pnpm test:e2e`
- `git diff --check`

A full frontend build was not run locally.