### PR TITLE
Mark aspire dashboard commands as preview

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-dashboard-run.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-dashboard-run.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire dashboard run command
 description: Learn about the aspire dashboard run command and its usage. This command starts a standalone Aspire Dashboard instance.
+sidebar:
+  badge: Preview
 ---
 
 import Include from '@components/Include.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-dashboard.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-dashboard.mdx
@@ -1,6 +1,8 @@
 ---
 title: aspire dashboard command
 description: Learn about the aspire dashboard command and its usage. This command is used to manage the Aspire dashboard.
+sidebar:
+  badge: Preview
 ---
 
 import Include from '@components/Include.astro';

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire.mdx
@@ -76,6 +76,7 @@ The following commands are available:
 | [`aspire doctor`](../aspire-doctor/)       | Stable  | Diagnose Aspire environment issues and verify setup.                  |
 | [`aspire mcp`](../aspire-mcp/)             | Stable  | Interact with <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr> tools exposed by Aspire resources.                  |
 | [`aspire secret`](../aspire-secret/)       | Stable  | Manage apphost user secrets.                                          |
+| [`aspire dashboard`](../aspire-dashboard/) | Preview | Manage the Aspire dashboard.                                          |
 
 ## Examples
 


### PR DESCRIPTION
Adds the **Preview** badge to the `aspire dashboard` and `aspire dashboard run` CLI command pages and lists `aspire dashboard` with Preview status in the main command table.

### Changes

- `aspire-dashboard.mdx` — added `sidebar: badge: Preview` frontmatter
- `aspire-dashboard-run.mdx` — added `sidebar: badge: Preview` frontmatter
- `aspire.mdx` — added `aspire dashboard` row with Preview status to the commands table