### PR TITLE
Add Kubernetes Ingress and Gateway API documentation

### DIFF
--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -129,12 +129,12 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
           slug: 'deployment/kubernetes-ingress',
         },
         {
-          label: 'Ingress on AKS',
-          slug: 'deployment/kubernetes-ingress-aks',
-        },
-        {
           label: 'Gateway API on AKS',
           slug: 'deployment/kubernetes-gateway-aks',
+        },
+        {
+          label: 'Ingress on AKS',
+          slug: 'deployment/kubernetes-ingress-aks',
         },
       ],
     },

--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -124,6 +124,18 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
           label: 'Azure Kubernetes Service (AKS)',
           slug: 'deployment/kubernetes/aks',
         },
+        {
+          label: 'Ingress & Gateway API',
+          slug: 'deployment/kubernetes-ingress',
+        },
+        {
+          label: 'Ingress on AKS',
+          slug: 'deployment/kubernetes-ingress-aks',
+        },
+        {
+          label: 'Gateway API on AKS',
+          slug: 'deployment/kubernetes-gateway-aks',
+        },
       ],
     },
     {

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -1,0 +1,396 @@
+---
+title: Configure Gateway API on AKS
+description: Learn how to expose .NET Aspire services on AKS using Kubernetes Gateway API with Application Gateway for Containers (AGC).
+sidebar:
+  badge:
+    text: Preview
+    variant: caution
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on Azure Kubernetes Service (AKS) with Application Gateway for Containers (AGC). Gateway API is the recommended approach over Ingress for AKS deployments because it supports cert-manager HTTP-01 challenges natively — no DNS API access is required for automated TLS certificate provisioning.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+- An **AKS cluster** with the ALB controller addon enabled.
+- The **ApplicationLoadBalancer** CRD deployed in your cluster.
+- An **Azure Container Registry (ACR)** attached to the cluster.
+- **cert-manager** installed with Gateway API support enabled:
+  ```bash
+  helm install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
+  ```
+
+Depending on your TLS certificate strategy, you may also need:
+
+- **For DNS-01**: An Azure DNS zone and a managed identity with **DNS Zone Contributor** role.
+- **For HTTP-01**: No DNS infrastructure needed — this is the key advantage of using Gateway API.
+
+## Configure the AppHost
+
+Add a Kubernetes Gateway to your AppHost project to expose your frontend service through AGC. The gateway configuration includes the gateway class, ALB annotations, routing, hostname, and TLS settings.
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Parameters for deployment configuration
+var gatewayClassName = builder.AddParameter("gatewayClassName");
+var loadBalancerName = builder.AddParameter("loadBalancerName");
+var loadBalancerNamespace = builder.AddParameter("loadBalancerNamespace");
+var externalFqdn = builder.AddParameter("externalFqdn");
+
+var frontend = builder.AddProject<Projects.MyApp_Frontend>("frontend");
+
+var k8s = builder.AddKubernetes("k8s");
+
+var gateway = k8s.AddGateway("gateway")
+    .WithGatewayClass(gatewayClassName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithRoute("/", frontend.GetEndpoint("http"))
+    .WithHostname(externalFqdn)
+    .WithTls();
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+import { DistributedApplication } from "@aspire/hosting";
+
+const builder = DistributedApplication.createBuilder();
+
+// Parameters for deployment configuration
+const gatewayClassName = builder.addParameter("gatewayClassName");
+const loadBalancerName = builder.addParameter("loadBalancerName");
+const loadBalancerNamespace = builder.addParameter("loadBalancerNamespace");
+const externalFqdn = builder.addParameter("externalFqdn");
+
+const frontend = builder.addProject("frontend", "../MyApp.Frontend");
+
+const k8s = builder.addKubernetes("k8s");
+
+const gateway = k8s.addGateway("gateway")
+    .withGatewayClass(gatewayClassName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withRoute("/", frontend.getEndpoint("http"))
+    .withHostname(externalFqdn)
+    .withTls();
+
+builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+## Choose a TLS certificate strategy
+
+There are two approaches for automating TLS certificates with cert-manager when using Gateway API on AKS.
+
+### Option A: HTTP-01 with Gateway API (Recommended)
+
+HTTP-01 validation is the recommended approach because it requires **no DNS API access**. cert-manager creates a temporary `HTTPRoute` on the existing Gateway to respond to ACME HTTP-01 challenges. This means:
+
+- The challenge is served from the **same frontend and IP** as your application.
+- There is **no hairpin NAT** issue — the ACME server reaches the same public endpoint.
+- You don't need an Azure DNS zone or managed identity for DNS.
+
+Create a `ClusterIssuer` that uses the `gatewayHTTPRoute` solver:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          parentRefs:
+          - name: gateway
+            namespace: <your-namespace>
+            kind: Gateway
+```
+
+<Aside type="note">
+cert-manager must be installed with `--set config.enableGatewayAPI=true` for the `gatewayHTTPRoute` solver to work. If cert-manager was installed without this flag, upgrade the release with the flag enabled.
+</Aside>
+
+### Option B: DNS-01 with Azure DNS
+
+If you already have an Azure DNS zone configured, you can use DNS-01 validation. This approach requires a managed identity with the **DNS Zone Contributor** role on your Azure DNS zone.
+
+Create a `ClusterIssuer` that uses the `azureDNS` solver:
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+    - dns01:
+        azureDNS:
+          subscriptionID: <your-subscription-id>
+          resourceGroupName: <your-resource-group>
+          hostedZoneName: <your-domain.com>
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: <your-managed-identity-client-id>
+```
+
+## Deploy
+
+Run `aspire deploy` and provide the required parameter values:
+
+```bash
+aspire deploy \
+  --parameter gatewayClassName=azure-alb-external \
+  --parameter loadBalancerName=my-alb \
+  --parameter loadBalancerNamespace=alb-infra \
+  --parameter externalFqdn=myapp.example.com
+```
+
+## Verify
+
+After deployment, verify that your Gateway is configured correctly and TLS is working.
+
+<Steps>
+
+1. **Check the Gateway address:**
+
+   ```bash
+   kubectl get gateway gateway -o wide
+   ```
+
+   The `ADDRESS` column should show the public IP or hostname assigned by AGC. If the address is empty, see the [Troubleshooting](#troubleshooting) section.
+
+2. **Check the certificate status:**
+
+   ```bash
+   kubectl get certificate
+   kubectl describe certificate gateway-tls
+   ```
+
+   The certificate should show `Ready: True` once cert-manager has completed the ACME challenge.
+
+3. **Test HTTPS access:**
+
+   ```bash
+   curl https://myapp.example.com
+   ```
+
+   You should receive a valid response with a trusted TLS certificate.
+
+</Steps>
+
+## How Gateway API differs from Ingress
+
+If you're familiar with the Ingress-based approach, here are the key differences when using Gateway API:
+
+- **Separate resources**: Gateway API uses a `Gateway` resource (defines listeners and TLS) and one or more `HTTPRoute` resources (define routing rules). Ingress combines both into a single resource.
+- **TLS on the Gateway**: TLS is configured on the Gateway's listener, not on individual routes. `WithTls()` adds an HTTPS listener to the Gateway — it does **not** create a separate route.
+- **Shared frontend**: Multiple `HTTPRoute` resources share one Gateway. This means one frontend IP address, avoiding the 5-frontend limit that AGC imposes per Ingress resource.
+- **HTTP-01 works**: cert-manager HTTP-01 validation works with Gateway API because the solver creates a temporary `HTTPRoute` on the same Gateway — no additional frontend or IP is needed.
+
+### cert-manager comparison
+
+| Approach | Works with Ingress? | Works with Gateway? | Needs DNS API? |
+|---|---|---|---|
+| DNS-01 (Azure DNS) | ✅ | ✅ | Yes |
+| HTTP-01 (`gatewayHTTPRoute`) | ❌ (AGC creates separate frontends per Ingress) | ✅ | No |
+| Manual (`acme.sh` / `openssl`) | ✅ | ✅ | Manual DNS TXT |
+
+## Deploy without TLS
+
+<details>
+<summary>Deploy without TLS (not recommended)</summary>
+
+<Aside type="danger">
+Deploying without TLS exposes all traffic in plaintext. This is only appropriate for development or internal-only clusters with network-level encryption. **Never use this in production with public-facing services.**
+</Aside>
+
+To deploy without TLS, omit `WithTls()` from your Gateway configuration:
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var gateway = k8s.AddGateway("gateway")
+    .WithGatewayClass(gatewayClassName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithRoute("/", frontend.GetEndpoint("http"))
+    .WithHostname(externalFqdn);
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+const gateway = k8s.addGateway("gateway")
+    .withGatewayClass(gatewayClassName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withRoute("/", frontend.getEndpoint("http"))
+    .withHostname(externalFqdn);
+```
+
+</TabItem>
+</Tabs>
+
+</details>
+
+## Deploy without hostname
+
+<details>
+<summary>Deploy without a hostname</summary>
+
+<Aside type="caution">
+Deploying without a hostname means the Gateway accepts traffic for **any** hostname. This prevents TLS from working (no SNI match) and is not recommended for production. Use this only for quick testing with the raw IP address.
+</Aside>
+
+To deploy without a hostname, omit `WithHostname()` and `WithTls()`:
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var gateway = k8s.AddGateway("gateway")
+    .WithGatewayClass(gatewayClassName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithRoute("/", frontend.GetEndpoint("http"));
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+const gateway = k8s.addGateway("gateway")
+    .withGatewayClass(gatewayClassName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withGatewayAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withRoute("/", frontend.getEndpoint("http"));
+```
+
+</TabItem>
+</Tabs>
+
+After deployment, get the Gateway's assigned address:
+
+```bash
+kubectl get gateway gateway -o jsonpath='{.status.addresses[0].value}'
+```
+
+</details>
+
+## Troubleshooting
+
+### Gateway not getting an address
+
+If `kubectl get gateway` shows no address:
+
+1. **Verify GatewayClassName**: Ensure the `gatewayClassName` parameter matches a valid `GatewayClass` in your cluster:
+   ```bash
+   kubectl get gatewayclass
+   ```
+2. **Check ALB annotations**: The `alb.networking.azure.io/alb-name` and `alb.networking.azure.io/alb-namespace` annotations must reference an existing `ApplicationLoadBalancer` resource:
+   ```bash
+   kubectl get applicationloadbalancer -A
+   ```
+3. **Check ALB controller logs**: Look for errors in the ALB controller pod:
+   ```bash
+   kubectl logs -n kube-system -l app=alb-controller --tail=50
+   ```
+
+### cert-manager HTTP-01 challenge not resolving
+
+The HTTP-01 solver requires the Gateway to be in a valid state. AGC will not program the frontend if any listener references a TLS secret that doesn't exist yet.
+
+<Aside type="tip">
+Create a **bootstrap self-signed certificate** before deploying. This ensures the Gateway's HTTPS listener is valid while cert-manager obtains the real certificate. Once the ACME certificate is issued, it replaces the bootstrap certificate automatically.
+</Aside>
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gateway-tls-bootstrap
+spec:
+  secretName: gateway-tls
+  issuerRef:
+    name: selfsigned
+    kind: ClusterIssuer
+  dnsNames:
+  - myapp.example.com
+---
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: selfsigned
+spec:
+  selfSigned: {}
+```
+
+### Certificate order stuck in "errored" state
+
+If a cert-manager `Order` resource is stuck with `state: errored`, the simplest recovery is to delete and recreate the `Certificate` resource:
+
+```bash
+# Check the order status
+kubectl get order
+kubectl describe order <order-name>
+
+# Delete the certificate to trigger re-issuance
+kubectl delete certificate gateway-tls
+
+# Recreate by reapplying your Certificate manifest
+kubectl apply -f certificate.yaml
+```
+
+<Aside type="note">
+Deleting the `Certificate` resource also cleans up the associated `CertificateRequest` and `Order` resources. cert-manager will start a fresh ACME flow when the `Certificate` is recreated.
+</Aside>
+
+<LearnMore>
+- [Kubernetes Gateway API documentation](https://gateway-api.sigs.k8s.io/)
+- [Application Gateway for Containers documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
+- [cert-manager Gateway API support](https://cert-manager.io/docs/usage/gateway/)
+- [ALB controller for AKS](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller)
+</LearnMore>

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure Gateway API on AKS
-description: Learn how to expose .NET Aspire services on AKS using Kubernetes Gateway API with Application Gateway for Containers (AGC).
+description: Learn how to expose .NET Aspire services on AKS using Kubernetes Gateway API with Application Gateway for Containers (AGC) and automatic TLS via HTTP-01.
 sidebar:
   badge:
     text: Preview
@@ -10,32 +10,395 @@ sidebar:
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 
-This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on Azure Kubernetes Service (AKS) with Application Gateway for Containers (AGC). Gateway API is the recommended approach over Ingress for AKS deployments because it supports cert-manager HTTP-01 challenges natively — no DNS API access is required for automated TLS certificate provisioning.
+This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on Azure Kubernetes Service (AKS) with **Application Gateway for Containers (AGC)** and automatic TLS certificate provisioning via **cert-manager HTTP-01** challenges.
+
+Gateway API with HTTP-01 is the **recommended approach** for TLS on AKS because:
+
+- **No DNS API access required** — cert-manager validates domain ownership via HTTP, not DNS TXT records.
+- **No Azure DNS zone or managed identity needed** — significantly simpler infrastructure than DNS-01.
+- **Works with any domain** — including the auto-assigned AGC FQDN (`*.alb.azure.com`), your own custom domain, or even without a pre-existing DNS zone.
 
 <Aside type="note">
   This guide uses a **bring-your-own-cluster** model where you provision and
-  manage the AKS cluster, container registry, and DNS zone yourself. If you
-  want Aspire to provision the AKS cluster and registry as part of your
-  application model, use
+  manage the AKS cluster and container registry yourself. If you want Aspire to
+  provision the AKS cluster and registry as part of your application model, use
   [`AddAzureKubernetesEnvironment`](/deployment/kubernetes/aks/) instead.
 </Aside>
 
-## Prerequisites
+## Set up the AKS environment
 
-The AKS environment setup is the same as for the Ingress walkthrough. If you
-haven't already configured your cluster, follow the full setup steps in
-[Configure Ingress on AKS — Set up the AKS environment](/deployment/kubernetes-ingress-aks/#set-up-the-aks-environment).
+The following steps create the Azure infrastructure needed for Gateway API with HTTP-01 TLS. If you already have an AKS cluster with ALB and cert-manager configured, skip to [Configure the AppHost](#configure-the-apphost).
 
-You need:
-- An AKS cluster with ALB controller, OIDC issuer, and workload identity
-- An ApplicationLoadBalancer CRD deployed
-- An Azure Container Registry attached to the cluster
-- cert-manager installed with Gateway API support (`--set config.enableGatewayAPI=true`)
+### Register resource providers and features
 
-Depending on your TLS certificate strategy:
+Application Gateway for Containers requires several resource providers and preview features to be registered in your Azure subscription:
 
-- **For DNS-01**: An Azure DNS zone and a managed identity with **DNS Zone Contributor** role (covered in the setup steps above)
-- **For HTTP-01 (Gateway API only)**: No DNS infrastructure needed — cert-manager creates a temporary `HTTPRoute` on the existing Gateway
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Register required resource providers
+az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.Network
+az provider register --namespace Microsoft.NetworkFunction
+az provider register --namespace Microsoft.ServiceNetworking
+
+# Register preview features for ALB controller and Gateway API
+az feature register --namespace Microsoft.ContainerService \
+  --name ManagedGatewayAPIPreview
+az feature register --namespace Microsoft.ContainerService \
+  --name ApplicationLoadBalancerPreview
+
+# Wait for registration to complete (may take a few minutes)
+az feature show --namespace Microsoft.ContainerService \
+  --name ApplicationLoadBalancerPreview --query properties.state -o tsv
+
+# Re-register the provider after feature registration
+az provider register --namespace Microsoft.ContainerService
+
+# Install required CLI extensions
+az extension add --name alb
+az extension add --name aks-preview
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Register required resource providers
+az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.Network
+az provider register --namespace Microsoft.NetworkFunction
+az provider register --namespace Microsoft.ServiceNetworking
+
+# Register preview features for ALB controller and Gateway API
+az feature register --namespace Microsoft.ContainerService `
+  --name ManagedGatewayAPIPreview
+az feature register --namespace Microsoft.ContainerService `
+  --name ApplicationLoadBalancerPreview
+
+# Wait for registration to complete (may take a few minutes)
+az feature show --namespace Microsoft.ContainerService `
+  --name ApplicationLoadBalancerPreview --query properties.state -o tsv
+
+# Re-register the provider after feature registration
+az provider register --namespace Microsoft.ContainerService
+
+# Install required CLI extensions
+az extension add --name alb
+az extension add --name aks-preview
+```
+
+</TabItem>
+</Tabs>
+
+<Aside type="note">
+  Feature registration can take several minutes. Use `az feature show` to check
+  the status. For the latest prerequisites and supported regions, see the
+  [Application Gateway for Containers
+  documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/).
+</Aside>
+
+### Create the resource group and cluster
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Variables — customize these for your environment
+RESOURCE_GROUP=my-aspire-aks
+LOCATION=westus3
+CLUSTER_NAME=my-aspire-aks
+ACR_NAME=myaspireacr
+
+# Create resource group
+az group create --name $RESOURCE_GROUP --location $LOCATION
+
+# Create AKS cluster with ALB controller, OIDC issuer, and workload identity
+az aks create \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --location $LOCATION \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --generate-ssh-keys
+
+# Enable the ALB controller addon
+az aks update \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --enable-alb
+
+# Get cluster credentials
+az aks get-credentials \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Variables — customize these for your environment
+$RESOURCE_GROUP = "my-aspire-aks"
+$LOCATION = "westus3"
+$CLUSTER_NAME = "my-aspire-aks"
+$ACR_NAME = "myaspireacr"
+
+# Create resource group
+az group create --name $RESOURCE_GROUP --location $LOCATION
+
+# Create AKS cluster with ALB controller, OIDC issuer, and workload identity
+az aks create `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --location $LOCATION `
+  --enable-oidc-issuer `
+  --enable-workload-identity `
+  --generate-ssh-keys
+
+# Enable the ALB controller addon
+az aks update `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --enable-alb
+
+# Get cluster credentials
+az aks get-credentials `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME
+```
+
+</TabItem>
+</Tabs>
+
+### Create and attach a container registry
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Create Azure Container Registry
+az acr create \
+  --resource-group $RESOURCE_GROUP \
+  --name $ACR_NAME \
+  --sku Basic
+
+# Attach ACR to AKS (grants AcrPull access)
+az aks update \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --attach-acr $ACR_NAME
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Create Azure Container Registry
+az acr create `
+  --resource-group $RESOURCE_GROUP `
+  --name $ACR_NAME `
+  --sku Basic
+
+# Attach ACR to AKS (grants AcrPull access)
+az aks update `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --attach-acr $ACR_NAME
+```
+
+</TabItem>
+</Tabs>
+
+### Create the ApplicationLoadBalancer
+
+Create a dedicated subnet for AGC in the cluster's VNet, then deploy the `ApplicationLoadBalancer` custom resource:
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Get the managed cluster resource group and VNet
+MC_RG=$(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \
+  --query nodeResourceGroup -o tsv)
+VNET_NAME=$(az network vnet list --resource-group $MC_RG --query "[0].name" -o tsv)
+
+# Create a subnet for the ALB (delegated to ServiceNetworking)
+az network vnet subnet create \
+  --resource-group $MC_RG \
+  --vnet-name $VNET_NAME \
+  --name subnet-alb \
+  --address-prefix 10.237.0.0/24 \
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+
+# Get the full subnet ID
+SUBNET_ID=$(az network vnet subnet show \
+  --resource-group $MC_RG \
+  --vnet-name $VNET_NAME \
+  --name subnet-alb \
+  --query id -o tsv)
+
+# Deploy the ApplicationLoadBalancer CRD
+kubectl apply -f - <<EOF
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-aspire
+  namespace: default
+spec:
+  associations:
+  - $SUBNET_ID
+EOF
+
+# Wait for it to become ready
+kubectl get applicationloadbalancer alb-aspire --watch
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Get the managed cluster resource group and VNet
+$MC_RG = $(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME `
+  --query nodeResourceGroup -o tsv)
+$VNET_NAME = $(az network vnet list --resource-group $MC_RG --query "[0].name" -o tsv)
+
+# Create a subnet for the ALB (delegated to ServiceNetworking)
+az network vnet subnet create `
+  --resource-group $MC_RG `
+  --vnet-name $VNET_NAME `
+  --name subnet-alb `
+  --address-prefix 10.237.0.0/24 `
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+
+# Get the full subnet ID
+$SUBNET_ID = $(az network vnet subnet show `
+  --resource-group $MC_RG `
+  --vnet-name $VNET_NAME `
+  --name subnet-alb `
+  --query id -o tsv)
+
+# Deploy the ApplicationLoadBalancer CRD
+@"
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-aspire
+  namespace: default
+spec:
+  associations:
+  - $SUBNET_ID
+"@ | kubectl apply -f -
+
+# Wait for it to become ready
+kubectl get applicationloadbalancer alb-aspire --watch
+```
+
+</TabItem>
+</Tabs>
+
+### Install cert-manager
+
+Install cert-manager with Gateway API support enabled. Unlike DNS-01 validation, HTTP-01 does **not** require a managed identity, federated credentials, or workload identity configuration — cert-manager only needs to create a temporary `HTTPRoute` on the Gateway.
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Install cert-manager with Gateway API support
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --set config.enableGatewayAPI=true \
+  --wait
+
+# Verify cert-manager is running
+kubectl get pods -n cert-manager
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Install cert-manager with Gateway API support
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager `
+  --namespace cert-manager `
+  --create-namespace `
+  --set crds.enabled=true `
+  --set config.enableGatewayAPI=true `
+  --wait
+
+# Verify cert-manager is running
+kubectl get pods -n cert-manager
+```
+
+</TabItem>
+</Tabs>
+
+### Create the HTTP-01 ClusterIssuer
+
+Create a `ClusterIssuer` that uses the `gatewayHTTPRoute` solver. This tells cert-manager to respond to ACME HTTP-01 challenges by creating a temporary `HTTPRoute` on the Gateway — the challenge is served from the **same frontend and IP** as your application.
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-http01
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-http01-account-key
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          parentRefs:
+          - kind: Gateway
+EOF
+
+# Verify the issuer is ready
+kubectl get clusterissuer letsencrypt-http01
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+@"
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-http01
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-http01-account-key
+    solvers:
+    - http01:
+        gatewayHTTPRoute:
+          parentRefs:
+          - kind: Gateway
+"@ | kubectl apply -f -
+
+# Verify the issuer is ready
+kubectl get clusterissuer letsencrypt-http01
+```
+
+</TabItem>
+</Tabs>
+
+<Aside type="note">
+The `parentRefs` in the `ClusterIssuer` specifies `kind: Gateway` without a specific name or namespace. This allows the solver to attach to whichever Gateway owns the `Certificate` resource. cert-manager discovers the correct Gateway automatically.
+</Aside>
 
 ## Configure the AppHost
 
@@ -48,16 +411,27 @@ Add a Kubernetes Gateway to your AppHost project to expose your frontend service
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Parameters for deployment configuration
+var registryEndpoint = builder.AddParameter("registryEndpoint");
 var gatewayClassName = builder.AddParameter("gatewayClassName");
 var loadBalancerName = builder.AddParameter("loadBalancerName");
 var loadBalancerNamespace = builder.AddParameter("loadBalancerNamespace");
+var clusterIssuer = builder.AddParameter("clusterIssuer");
 var externalFqdn = builder.AddParameter("externalFqdn");
 
-var frontend = builder.AddProject<Projects.MyApp_Frontend>("frontend");
+// Kubernetes environment
+var k8s = builder.AddKubernetesEnvironment("k8s");
 
-var k8s = builder.AddKubernetes("k8s");
+// Container registry
+var acr = builder.AddContainerRegistry("acr", registryEndpoint);
 
-var gateway = k8s.AddGateway("gateway")
+// Application services
+var api = builder.AddProject<Projects.ApiService>("api");
+
+var frontend = builder.AddProject<Projects.Frontend>("frontend")
+    .WithReference(api);
+
+// Gateway with TLS
+var gateway = k8s.AddGateway("ingress")
     .WithGatewayClass(gatewayClassName)
     .WithGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -74,21 +448,32 @@ builder.Build().Run();
 <TabItem label="TypeScript">
 
 ```typescript
-import { DistributedApplication } from "@aspire/hosting";
+import { DistributedApplication } from "@aspire/apphost";
 
 const builder = DistributedApplication.createBuilder();
 
 // Parameters for deployment configuration
+const registryEndpoint = builder.addParameter("registryEndpoint");
 const gatewayClassName = builder.addParameter("gatewayClassName");
 const loadBalancerName = builder.addParameter("loadBalancerName");
 const loadBalancerNamespace = builder.addParameter("loadBalancerNamespace");
+const clusterIssuer = builder.addParameter("clusterIssuer");
 const externalFqdn = builder.addParameter("externalFqdn");
 
-const frontend = builder.addProject("frontend", "../MyApp.Frontend");
+// Kubernetes environment
+const k8s = builder.addKubernetesEnvironment("k8s");
 
-const k8s = builder.addKubernetes("k8s");
+// Container registry
+const acr = builder.addContainerRegistry("acr", registryEndpoint);
 
-const gateway = k8s.addGateway("gateway")
+// Application services
+const api = builder.addProject("api");
+
+const frontend = builder.addProject("frontend")
+    .withReference(api);
+
+// Gateway with TLS
+const gateway = k8s.addGateway("ingress")
     .withGatewayClass(gatewayClassName)
     .withGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -104,114 +489,129 @@ builder.build().run();
 </TabItem>
 </Tabs>
 
-## Choose a TLS certificate strategy
-
-There are two approaches for automating TLS certificates with cert-manager when using Gateway API on AKS.
-
-### Option A: HTTP-01 with Gateway API (Recommended)
-
-HTTP-01 validation is the recommended approach because it requires **no DNS API access**. cert-manager creates a temporary `HTTPRoute` on the existing Gateway to respond to ACME HTTP-01 challenges. This means:
-
-- The challenge is served from the **same frontend and IP** as your application.
-- There is **no hairpin NAT** issue — the ACME server reaches the same public endpoint.
-- You don't need an Azure DNS zone or managed identity for DNS.
-
-Create a `ClusterIssuer` that uses the `gatewayHTTPRoute` solver:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt-prod
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: your-email@example.com
-    privateKeySecretRef:
-      name: letsencrypt-prod-account-key
-    solvers:
-    - http01:
-        gatewayHTTPRoute:
-          parentRefs:
-          - name: gateway
-            namespace: <your-namespace>
-            kind: Gateway
-```
-
-<Aside type="note">
-cert-manager must be installed with `--set config.enableGatewayAPI=true` for the `gatewayHTTPRoute` solver to work. If cert-manager was installed without this flag, upgrade the release with the flag enabled.
-</Aside>
-
-### Option B: DNS-01 with Azure DNS
-
-If you already have an Azure DNS zone configured, you can use DNS-01 validation. This approach requires a managed identity with the **DNS Zone Contributor** role on your Azure DNS zone.
-
-Create a `ClusterIssuer` that uses the `azureDNS` solver:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: letsencrypt-prod
-spec:
-  acme:
-    server: https://acme-v02.api.letsencrypt.org/directory
-    email: your-email@example.com
-    privateKeySecretRef:
-      name: letsencrypt-prod-account-key
-    solvers:
-    - dns01:
-        azureDNS:
-          subscriptionID: <your-subscription-id>
-          resourceGroupName: <your-resource-group>
-          hostedZoneName: <your-domain.com>
-          environment: AzurePublicCloud
-          managedIdentity:
-            clientID: <your-managed-identity-client-id>
-```
+The `WithTls()` call with no arguments auto-generates the TLS secret name (`ingress-tls`) and adds a cert-manager annotation to the Gateway referencing the `ClusterIssuer` specified via the `clusterIssuer` parameter.
 
 ## Deploy
 
 Set environment variables to provide parameter values, then run `aspire deploy`:
 
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
 ```bash
+export Parameters__registryEndpoint=myaspireacr.azurecr.io
 export Parameters__gatewayClassName=azure-alb-external
-export Parameters__loadBalancerName=my-alb
-export Parameters__loadBalancerNamespace=alb-infra
+export Parameters__loadBalancerName=alb-aspire
+export Parameters__loadBalancerNamespace=default
+export Parameters__clusterIssuer=letsencrypt-http01
 export Parameters__externalFqdn=myapp.example.com
 
 aspire deploy
 ```
 
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+$env:Parameters__registryEndpoint = "myaspireacr.azurecr.io"
+$env:Parameters__gatewayClassName = "azure-alb-external"
+$env:Parameters__loadBalancerName = "alb-aspire"
+$env:Parameters__loadBalancerNamespace = "default"
+$env:Parameters__clusterIssuer = "letsencrypt-http01"
+$env:Parameters__externalFqdn = "myapp.example.com"
+
+aspire deploy
+```
+
+</TabItem>
+</Tabs>
+
 <Aside type="note">
   Parameter values are provided via environment variables using the naming
-  convention `Parameters__<name>`. You can also set these in a
+  convention `Parameters__<name>`. You can also set these in an
   `appsettings.json` or user secrets file. The Aspire CLI will prompt for any
   missing parameter values interactively.
 </Aside>
 
-## Verify
+## Point DNS to the Gateway
 
-After deployment, verify that your Gateway is configured correctly and TLS is working.
+After deployment, the Gateway is assigned a public FQDN by AGC. Create a DNS record pointing your hostname to this address.
 
 <Steps>
 
-1. **Check the Gateway address:**
+1. **Get the Gateway address:**
 
    ```bash
-   kubectl get gateway gateway -o wide
+   kubectl get gateway ingress -o jsonpath='{.status.addresses[0].value}'
    ```
 
-   The `ADDRESS` column should show the public IP or hostname assigned by AGC. If the address is empty, see the [Troubleshooting](#troubleshooting) section.
+   This returns the AGC frontend FQDN, for example: `abc123.fz50.alb.azure.com`.
+
+2. **Create a CNAME record** at your DNS provider pointing your hostname (e.g., `myapp.example.com`) to the AGC FQDN.
+
+   If using Azure DNS:
+
+   <Tabs syncKey="shell-lang">
+   <TabItem label="bash">
+
+   ```bash
+   AGC_FQDN=$(kubectl get gateway ingress \
+     -o jsonpath='{.status.addresses[0].value}')
+
+   az network dns record-set cname set-record \
+     --resource-group $RESOURCE_GROUP \
+     --zone-name example.com \
+     --record-set-name myapp \
+     --cname $AGC_FQDN
+   ```
+
+   </TabItem>
+   <TabItem label="PowerShell">
+
+   ```powershell
+   $AGC_FQDN = $(kubectl get gateway ingress `
+     -o jsonpath='{.status.addresses[0].value}')
+
+   az network dns record-set cname set-record `
+     --resource-group $RESOURCE_GROUP `
+     --zone-name example.com `
+     --record-set-name myapp `
+     --cname $AGC_FQDN
+   ```
+
+   </TabItem>
+   </Tabs>
+
+3. **Wait for cert-manager** to complete the HTTP-01 challenge. cert-manager starts the challenge immediately on deployment and retries with exponential backoff until DNS resolves. This typically takes 5–10 minutes once the DNS record is active.
+
+</Steps>
+
+<Aside type="tip">
+**Using the AGC auto-assigned FQDN:** If you don't have a custom domain, you can use the AGC-assigned FQDN directly (e.g., `abc123.fz50.alb.azure.com`) as your `externalFqdn` parameter. cert-manager HTTP-01 works with these addresses — no custom domain or DNS zone is required. Deploy once without a hostname to discover the FQDN, then redeploy with it as `externalFqdn`.
+</Aside>
+
+## Verify
+
+After deployment and DNS propagation, verify that your Gateway is configured correctly and TLS is working.
+
+<Steps>
+
+1. **Check the Gateway status:**
+
+   ```bash
+   kubectl get gateway ingress -o wide
+   ```
+
+   The `ADDRESS` column should show the public FQDN assigned by AGC. If the address is empty, see the [Troubleshooting](#troubleshooting) section.
 
 2. **Check the certificate status:**
 
    ```bash
    kubectl get certificate
-   kubectl describe certificate gateway-tls
+   kubectl describe certificate ingress-tls
    ```
 
-   The certificate should show `Ready: True` once cert-manager has completed the ACME challenge.
+   The certificate should show `Ready: True` once cert-manager has completed the HTTP-01 challenge. This typically takes 5–10 minutes after DNS is pointed to the Gateway.
 
 3. **Test HTTPS access:**
 
@@ -219,26 +619,47 @@ After deployment, verify that your Gateway is configured correctly and TLS is wo
    curl https://myapp.example.com
    ```
 
-   You should receive a valid response with a trusted TLS certificate.
+   You should receive a valid response with a trusted TLS certificate from Let's Encrypt.
 
 </Steps>
 
-## How Gateway API differs from Ingress
+## How it works
 
-If you're familiar with the Ingress-based approach, here are the key differences when using Gateway API:
+When you deploy a Gateway with `WithHostname()` and `WithTls()`, the following sequence occurs:
 
-- **Separate resources**: Gateway API uses a `Gateway` resource (defines listeners and TLS) and one or more `HTTPRoute` resources (define routing rules). Ingress combines both into a single resource.
-- **TLS on the Gateway**: TLS is configured on the Gateway's listener, not on individual routes. `WithTls()` adds an HTTPS listener to the Gateway — it does **not** create a separate route.
-- **Shared frontend**: Multiple `HTTPRoute` resources share one Gateway. This means one frontend IP address, avoiding the 5-frontend limit that AGC imposes per Ingress resource.
-- **HTTP-01 works**: cert-manager HTTP-01 validation works with Gateway API because the solver creates a temporary `HTTPRoute` on the same Gateway — no additional frontend or IP is needed.
+<Steps>
+
+1. **Bootstrap TLS.** On the first deploy, Aspire generates a self-signed placeholder certificate and creates the Kubernetes Secret referenced by the Gateway's HTTPS listener. This makes the listener valid immediately so AGC can start programming the frontend.
+
+2. **Gateway programming.** AGC detects the Gateway resource and provisions a frontend with a public FQDN. The HTTPS listener is valid (using the bootstrap certificate) so AGC begins routing traffic.
+
+3. **HTTP-01 challenge.** cert-manager detects the Gateway's `cert-manager.io/issuer` annotation and creates a `Certificate` resource. The HTTP-01 solver creates a temporary `HTTPRoute` on the **same Gateway**, responding to the ACME challenge at `/.well-known/acme-challenge/<token>`. Because the `HTTPRoute` shares the same frontend and IP, the ACME server's validation request reaches the solver directly.
+
+4. **Certificate issuance.** Once the ACME server verifies the challenge response, Let's Encrypt issues a trusted certificate. cert-manager stores it in the Kubernetes Secret, replacing the bootstrap certificate. AGC picks up the new certificate automatically.
+
+5. **Automatic renewal.** cert-manager renews the certificate before expiry (default: 30 days before). The HTTP-01 flow repeats transparently.
+
+</Steps>
+
+## Why HTTP-01 works with Gateway API but not Ingress
+
+AGC creates a **separate frontend** (with its own FQDN and IP) for each Ingress resource. When cert-manager creates a solver Ingress for an HTTP-01 challenge, AGC assigns it a **different** frontend — the ACME server's validation request goes to the wrong IP and fails.
+
+With Gateway API, multiple `HTTPRoute` resources share a **single Gateway** and therefore a single frontend. When cert-manager creates a temporary solver `HTTPRoute`, it attaches to the same Gateway and is served from the same IP. The ACME validation request reaches the solver, and the challenge succeeds.
 
 ### cert-manager comparison
 
 | Approach | Works with Ingress? | Works with Gateway? | Needs DNS API? |
 |---|---|---|---|
+| HTTP-01 (`gatewayHTTPRoute`) | ❌ (separate frontends per Ingress) | ✅ | No |
 | DNS-01 (Azure DNS) | ✅ | ✅ | Yes |
-| HTTP-01 (`gatewayHTTPRoute`) | ❌ (AGC creates separate frontends per Ingress) | ✅ | No |
 | Manual (`acme.sh` / `openssl`) | ✅ | ✅ | Manual DNS TXT |
+
+## Alternative: DNS-01 with Azure DNS
+
+If you already have an Azure DNS zone and prefer DNS-based validation, you can use DNS-01 instead of HTTP-01. This requires additional infrastructure: a managed identity with the **DNS Zone Contributor** role, federated credentials for workload identity, and patching the cert-manager deployment.
+
+For the full DNS-01 setup steps, see the cert-manager section of [Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/#install-cert-manager-with-azure-dns-support). The AppHost configuration is the same — only the `ClusterIssuer` and `clusterIssuer` parameter value differ.
 
 ## Deploy without TLS
 
@@ -255,7 +676,7 @@ To deploy without TLS, omit `WithTls()` from your Gateway configuration:
 <TabItem label="C#">
 
 ```csharp
-var gateway = k8s.AddGateway("gateway")
+var gateway = k8s.AddGateway("ingress")
     .WithGatewayClass(gatewayClassName)
     .WithGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -269,7 +690,7 @@ var gateway = k8s.AddGateway("gateway")
 <TabItem label="TypeScript">
 
 ```typescript
-const gateway = k8s.addGateway("gateway")
+const gateway = k8s.addGateway("ingress")
     .withGatewayClass(gatewayClassName)
     .withGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -299,7 +720,7 @@ To deploy without a hostname, omit `WithHostname()` and `WithTls()`:
 <TabItem label="C#">
 
 ```csharp
-var gateway = k8s.AddGateway("gateway")
+var gateway = k8s.AddGateway("ingress")
     .WithGatewayClass(gatewayClassName)
     .WithGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -312,7 +733,7 @@ var gateway = k8s.AddGateway("gateway")
 <TabItem label="TypeScript">
 
 ```typescript
-const gateway = k8s.addGateway("gateway")
+const gateway = k8s.addGateway("ingress")
     .withGatewayClass(gatewayClassName)
     .withGatewayAnnotation(
         "alb.networking.azure.io/alb-name", loadBalancerName)
@@ -327,7 +748,7 @@ const gateway = k8s.addGateway("gateway")
 After deployment, get the Gateway's assigned address:
 
 ```bash
-kubectl get gateway gateway -o jsonpath='{.status.addresses[0].value}'
+kubectl get gateway ingress -o jsonpath='{.status.addresses[0].value}'
 ```
 
 </details>
@@ -351,38 +772,37 @@ If `kubectl get gateway` shows no address:
    kubectl logs -n kube-system -l app=alb-controller --tail=50
    ```
 
-### cert-manager HTTP-01 challenge not resolving
+### cert-manager HTTP-01 challenge not completing
 
-The HTTP-01 solver requires the Gateway to be in a valid state. AGC will not program the frontend if any listener references a TLS secret that doesn't exist yet.
+If the certificate stays in a `Pending` state:
 
-<Aside type="tip">
-Create a **bootstrap self-signed certificate** before deploying. This ensures the Gateway's HTTPS listener is valid while cert-manager obtains the real certificate. Once the ACME certificate is issued, it replaces the bootstrap certificate automatically.
-</Aside>
+1. **Check the challenge status:**
+   ```bash
+   kubectl get challenge
+   kubectl describe challenge
+   ```
 
-```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: gateway-tls-bootstrap
-spec:
-  secretName: gateway-tls
-  issuerRef:
-    name: selfsigned
-    kind: ClusterIssuer
-  dnsNames:
-  - myapp.example.com
----
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: selfsigned
-spec:
-  selfSigned: {}
-```
+2. **Verify DNS resolves to the Gateway.** The ACME server must be able to reach `http://<your-hostname>/.well-known/acme-challenge/<token>`. If DNS doesn't point to the Gateway's AGC address yet, the challenge will fail and retry with exponential backoff (starting at ~1 minute, up to ~32 minutes).
+
+3. **Ensure the Gateway has a valid HTTPS listener.** AGC won't program the frontend if any listener references a TLS secret that doesn't exist. Aspire creates a bootstrap self-signed certificate automatically on first deploy. If the secret was manually deleted, recreate it:
+
+   ```bash
+   # Check if the secret exists
+   kubectl get secret ingress-tls
+
+   # If missing, redeploy with aspire deploy to recreate the bootstrap cert
+   ```
+
+4. **Verify cert-manager has Gateway API support enabled:**
+   ```bash
+   kubectl get deployment cert-manager -n cert-manager \
+     -o jsonpath='{.spec.template.spec.containers[0].args}'
+   ```
+   Look for `--enable-gateway-api-routes=true` in the args. If missing, upgrade the Helm release with `--set config.enableGatewayAPI=true`.
 
 ### Certificate order stuck in "errored" state
 
-If a cert-manager `Order` resource is stuck with `state: errored`, the simplest recovery is to delete and recreate the `Certificate` resource:
+If a cert-manager `Order` resource shows `state: errored`, delete the `Certificate` to trigger a fresh ACME flow:
 
 ```bash
 # Check the order status
@@ -390,14 +810,14 @@ kubectl get order
 kubectl describe order <order-name>
 
 # Delete the certificate to trigger re-issuance
-kubectl delete certificate gateway-tls
+kubectl delete certificate ingress-tls
 
-# Recreate by reapplying your Certificate manifest
-kubectl apply -f certificate.yaml
+# Redeploy to recreate
+aspire deploy
 ```
 
 <Aside type="note">
-Deleting the `Certificate` resource also cleans up the associated `CertificateRequest` and `Order` resources. cert-manager will start a fresh ACME flow when the `Certificate` is recreated.
+Deleting the `Certificate` resource also cleans up the associated `CertificateRequest` and `Order` resources. cert-manager starts a fresh ACME flow when the `Certificate` is recreated by the next deployment.
 </Aside>
 
 <LearnMore>
@@ -406,6 +826,7 @@ Deleting the `Certificate` resource also cleans up the associated `CertificateRe
 - [Quickstart: Deploy ALB Controller (AKS add-on)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
 - [cert-manager Gateway API support](https://cert-manager.io/docs/usage/gateway/)
 - [cert-manager with Let's Encrypt on AKS (Gateway API)](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api)
+- [Register resource providers for AGC](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller#register-the-required-resource-providers)
 - [.NET Aspire deployment overview](/deployment/overview/)
 - [Deploy to AKS with Aspire](/deployment/kubernetes/aks/)
 </LearnMore>

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -168,15 +168,23 @@ spec:
 
 ## Deploy
 
-Run `aspire deploy` and provide the required parameter values:
+Set environment variables to provide parameter values, then run `aspire deploy`:
 
 ```bash
-aspire deploy \
-  --parameter gatewayClassName=azure-alb-external \
-  --parameter loadBalancerName=my-alb \
-  --parameter loadBalancerNamespace=alb-infra \
-  --parameter externalFqdn=myapp.example.com
+export Parameters__gatewayClassName=azure-alb-external
+export Parameters__loadBalancerName=my-alb
+export Parameters__loadBalancerNamespace=alb-infra
+export Parameters__externalFqdn=myapp.example.com
+
+aspire deploy
 ```
+
+<Aside type="note">
+  Parameter values are provided via environment variables using the naming
+  convention `Parameters__<name>`. You can also set these in a
+  `appsettings.json` or user secrets file. The Aspire CLI will prompt for any
+  missing parameter values interactively.
+</Aside>
 
 ## Verify
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -402,7 +402,10 @@ Deleting the `Certificate` resource also cleans up the associated `CertificateRe
 
 <LearnMore>
 - [Kubernetes Gateway API documentation](https://gateway-api.sigs.k8s.io/)
-- [Application Gateway for Containers documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/overview)
+- [Application Gateway for Containers documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/)
+- [Quickstart: Deploy ALB Controller (AKS add-on)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
 - [cert-manager Gateway API support](https://cert-manager.io/docs/usage/gateway/)
-- [ALB controller for AKS](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller)
+- [cert-manager with Let's Encrypt on AKS (Gateway API)](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-gateway-api)
+- [.NET Aspire deployment overview](/deployment/overview/)
+- [Deploy to AKS with Aspire](/deployment/kubernetes/aks/)
 </LearnMore>

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -12,9 +12,15 @@ import LearnMore from '@components/LearnMore.astro';
 
 This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on Azure Kubernetes Service (AKS) with Application Gateway for Containers (AGC). Gateway API is the recommended approach over Ingress for AKS deployments because it supports cert-manager HTTP-01 challenges natively — no DNS API access is required for automated TLS certificate provisioning.
 
-## Prerequisites
+<Aside type="note">
+  This guide uses a **bring-your-own-cluster** model where you provision and
+  manage the AKS cluster, container registry, and DNS zone yourself. If you
+  want Aspire to provision the AKS cluster and registry as part of your
+  application model, use
+  [`AddAzureKubernetesEnvironment`](/deployment/kubernetes/aks/) instead.
+</Aside>
 
-Before you begin, ensure you have the following:
+## Prerequisites
 
 The AKS environment setup is the same as for the Ingress walkthrough. If you
 haven't already configured your cluster, follow the full setup steps in

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -16,22 +16,20 @@ This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on
 
 Before you begin, ensure you have the following:
 
-- An **AKS cluster** with the ALB controller addon enabled.
-- The **ApplicationLoadBalancer** CRD deployed in your cluster.
-- An **Azure Container Registry (ACR)** attached to the cluster.
-- **cert-manager** installed with Gateway API support enabled:
-  ```bash
-  helm install cert-manager jetstack/cert-manager \
-    --namespace cert-manager \
-    --create-namespace \
-    --set crds.enabled=true \
-    --set config.enableGatewayAPI=true
-  ```
+The AKS environment setup is the same as for the Ingress walkthrough. If you
+haven't already configured your cluster, follow the full setup steps in
+[Configure Ingress on AKS — Set up the AKS environment](/deployment/kubernetes-ingress-aks/#set-up-the-aks-environment).
 
-Depending on your TLS certificate strategy, you may also need:
+You need:
+- An AKS cluster with ALB controller, OIDC issuer, and workload identity
+- An ApplicationLoadBalancer CRD deployed
+- An Azure Container Registry attached to the cluster
+- cert-manager installed with Gateway API support (`--set config.enableGatewayAPI=true`)
 
-- **For DNS-01**: An Azure DNS zone and a managed identity with **DNS Zone Contributor** role.
-- **For HTTP-01**: No DNS infrastructure needed — this is the key advantage of using Gateway API.
+Depending on your TLS certificate strategy:
+
+- **For DNS-01**: An Azure DNS zone and a managed identity with **DNS Zone Contributor** role (covered in the setup steps above)
+- **For HTTP-01 (Gateway API only)**: No DNS infrastructure needed — cert-manager creates a temporary `HTTPRoute` on the existing Gateway
 
 ## Configure the AppHost
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -18,23 +18,223 @@ and automatic TLS certificate provisioning via **cert-manager** DNS-01 challenge
 
 Before you begin, ensure you have the following:
 
-- An **AKS cluster** with the [ALB controller addon](/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) enabled.
-- An **ApplicationLoadBalancer** custom resource deployed in your cluster.
-- An **Azure Container Registry (ACR)** [attached to the cluster](/azure/aks/cluster-container-registry-integration).
-- An **Azure DNS zone** for your domain.
-- **cert-manager** installed in the cluster with Gateway API support enabled:
+## Set up the AKS environment
 
-  ```bash
-  helm install cert-manager jetstack/cert-manager \
-    --namespace cert-manager \
-    --create-namespace \
-    --set crds.enabled=true \
-    --set config.enableGatewayAPI=true
-  ```
+The following steps create all the Azure infrastructure needed for this walkthrough. If you already have an AKS cluster with ALB and cert-manager configured, skip to [Configure the AppHost](#configure-the-apphost).
 
-- A **managed identity** for cert-manager with the **DNS Zone Contributor** role
-  on your Azure DNS zone, and a **federated credential** bound to the
-  cert-manager service account.
+### Create the resource group and cluster
+
+```bash
+# Variables — customize these for your environment
+RESOURCE_GROUP=my-aspire-aks
+LOCATION=westus3
+CLUSTER_NAME=my-aspire-aks
+ACR_NAME=myaspireacr
+DNS_ZONE=myapp.example.com
+
+# Create resource group
+az group create --name $RESOURCE_GROUP --location $LOCATION
+
+# Create AKS cluster with ALB controller, OIDC issuer, and workload identity
+az aks create \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --location $LOCATION \
+  --enable-oidc-issuer \
+  --enable-workload-identity \
+  --generate-ssh-keys
+
+# Enable the ALB controller addon
+az aks update \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --enable-alb
+
+# Get cluster credentials
+az aks get-credentials \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME
+```
+
+### Create and attach a container registry
+
+```bash
+# Create Azure Container Registry
+az acr create \
+  --resource-group $RESOURCE_GROUP \
+  --name $ACR_NAME \
+  --sku Basic
+
+# Attach ACR to AKS (grants AcrPull access)
+az aks update \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --attach-acr $ACR_NAME
+```
+
+### Create the ApplicationLoadBalancer
+
+Create a dedicated subnet for AGC in the cluster's VNet, then deploy the `ApplicationLoadBalancer` custom resource:
+
+```bash
+# Get the managed cluster resource group and VNet
+MC_RG=$(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME \
+  --query nodeResourceGroup -o tsv)
+VNET_NAME=$(az network vnet list --resource-group $MC_RG --query "[0].name" -o tsv)
+
+# Create a subnet for the ALB (delegated to ServiceNetworking)
+az network vnet subnet create \
+  --resource-group $MC_RG \
+  --vnet-name $VNET_NAME \
+  --name subnet-alb \
+  --address-prefix 10.237.0.0/24 \
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+
+# Get the full subnet ID
+SUBNET_ID=$(az network vnet subnet show \
+  --resource-group $MC_RG \
+  --vnet-name $VNET_NAME \
+  --name subnet-alb \
+  --query id -o tsv)
+
+# Deploy the ApplicationLoadBalancer CRD
+kubectl apply -f - <<EOF
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-aspire
+  namespace: default
+spec:
+  associations:
+  - $SUBNET_ID
+EOF
+
+# Wait for it to become ready
+kubectl get applicationloadbalancer alb-aspire --watch
+```
+
+### Create an Azure DNS zone
+
+```bash
+# Create the DNS zone
+az network dns zone create \
+  --resource-group $RESOURCE_GROUP \
+  --name $DNS_ZONE
+
+# List the name servers — delegate these in your domain registrar
+az network dns zone show \
+  --resource-group $RESOURCE_GROUP \
+  --name $DNS_ZONE \
+  --query nameServers -o tsv
+```
+
+<Aside type="note">
+  You need to add NS records for `$DNS_ZONE` at your domain registrar pointing
+  to the name servers listed above. DNS delegation may take up to 48 hours to
+  propagate, though it's typically much faster.
+</Aside>
+
+### Install cert-manager with Azure DNS support
+
+```bash
+# Install cert-manager with Gateway API support
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true \
+  --set config.enableGatewayAPI=true \
+  --wait
+
+# Create a managed identity for cert-manager
+az identity create \
+  --name cert-manager-identity \
+  --resource-group $RESOURCE_GROUP
+
+IDENTITY_CLIENT_ID=$(az identity show \
+  --name cert-manager-identity \
+  --resource-group $RESOURCE_GROUP \
+  --query clientId -o tsv)
+
+IDENTITY_PRINCIPAL_ID=$(az identity show \
+  --name cert-manager-identity \
+  --resource-group $RESOURCE_GROUP \
+  --query principalId -o tsv)
+
+# Grant DNS Zone Contributor role on the DNS zone
+DNS_ZONE_ID=$(az network dns zone show \
+  --resource-group $RESOURCE_GROUP \
+  --name $DNS_ZONE \
+  --query id -o tsv)
+
+az role assignment create \
+  --assignee-object-id $IDENTITY_PRINCIPAL_ID \
+  --assignee-principal-type ServicePrincipal \
+  --role "DNS Zone Contributor" \
+  --scope $DNS_ZONE_ID
+
+# Create a federated credential for cert-manager's service account
+OIDC_ISSUER=$(az aks show \
+  --resource-group $RESOURCE_GROUP \
+  --name $CLUSTER_NAME \
+  --query oidcIssuerProfile.issuerUrl -o tsv)
+
+az identity federated-credential create \
+  --name cert-manager-fedcred \
+  --identity-name cert-manager-identity \
+  --resource-group $RESOURCE_GROUP \
+  --issuer $OIDC_ISSUER \
+  --subject "system:serviceaccount:cert-manager:cert-manager" \
+  --audiences "api://AzureADTokenExchange"
+
+# Annotate and label the cert-manager service account for workload identity
+kubectl annotate serviceaccount cert-manager \
+  --namespace cert-manager \
+  azure.workload.identity/client-id=$IDENTITY_CLIENT_ID \
+  --overwrite
+
+kubectl label serviceaccount cert-manager \
+  --namespace cert-manager \
+  azure.workload.identity/use=true \
+  --overwrite
+
+# Patch the deployment to inject workload identity env vars
+kubectl patch deployment cert-manager \
+  --namespace cert-manager \
+  --type=json \
+  -p='[{"op":"add","path":"/spec/template/metadata/labels/azure.workload.identity~1use","value":"true"}]'
+
+# Wait for rollout
+kubectl rollout status deployment cert-manager --namespace cert-manager
+
+# Get the subscription ID for the ClusterIssuer
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+
+# Create a ClusterIssuer using Azure DNS for DNS-01 challenges
+kubectl apply -f - <<EOF
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: $DNS_ZONE
+          resourceGroupName: $RESOURCE_GROUP
+          subscriptionID: $SUBSCRIPTION_ID
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: $IDENTITY_CLIENT_ID
+EOF
+
+# Verify the issuer is ready
+kubectl get clusterissuer letsencrypt-prod
+```
 
 ## Configure the AppHost
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -1,0 +1,388 @@
+---
+title: Configure Ingress on AKS
+description: Learn how to configure Kubernetes Ingress on AKS with Application Gateway for Containers and automatic TLS via cert-manager.
+sidebar:
+  badge:
+    text: Preview
+    variant: caution
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+This walkthrough shows how to use `AddIngress` to expose .NET Aspire services on
+Azure Kubernetes Service (AKS) with **Application Gateway for Containers (AGC)**
+and automatic TLS certificate provisioning via **cert-manager** DNS-01 challenges.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+- An **AKS cluster** with the [ALB controller addon](/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller) enabled.
+- An **ApplicationLoadBalancer** custom resource deployed in your cluster.
+- An **Azure Container Registry (ACR)** [attached to the cluster](/azure/aks/cluster-container-registry-integration).
+- An **Azure DNS zone** for your domain.
+- **cert-manager** installed in the cluster with Gateway API support enabled:
+
+  ```bash
+  helm install cert-manager jetstack/cert-manager \
+    --namespace cert-manager \
+    --create-namespace \
+    --set crds.enabled=true \
+    --set config.enableGatewayAPI=true
+  ```
+
+- A **managed identity** for cert-manager with the **DNS Zone Contributor** role
+  on your Azure DNS zone, and a **federated credential** bound to the
+  cert-manager service account.
+
+## Configure the AppHost
+
+Define your Kubernetes environment, container registry, and ingress in the
+AppHost project. The example below uses parameters so that environment-specific
+values are supplied at deploy time.
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Parameters
+var registryEndpoint = builder.AddParameter("registryEndpoint");
+var helmNamespace = builder.AddParameter("helmNamespace");
+var helmChartVersion = builder.AddParameter("helmChartVersion");
+var helmChartReleaseName = builder.AddParameter("helmChartReleaseName");
+var ingressClassName = builder.AddParameter("ingressClassName");
+var loadBalancerName = builder.AddParameter("loadBalancerName");
+var loadBalancerNamespace = builder.AddParameter("loadBalancerNamespace");
+var clusterIssuer = builder.AddParameter("clusterIssuer");
+var externalFqdn = builder.AddParameter("externalFqdn");
+
+// Kubernetes environment
+var k8s = builder.AddKubernetesEnvironment("k8s")
+    .WithHelm(helm =>
+    {
+        helm.Namespace = helmNamespace;
+        helm.ChartVersion = helmChartVersion;
+        helm.ReleaseName = helmChartReleaseName;
+    });
+
+// Container registry
+var acr = builder.AddContainerRegistry("acr", registryEndpoint);
+
+// Application services
+var api = builder.AddProject<Projects.ApiService>("api");
+
+var frontend = builder.AddProject<Projects.Frontend>("frontend")
+    .WithReference(api);
+
+// Ingress
+var ingress = k8s.AddIngress("ingress")
+    .WithIngressClass(ingressClassName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithIngressAnnotation(
+        "cert-manager.io/cluster-issuer", clusterIssuer)
+    .WithDefaultBackend(frontend.GetEndpoint("http"))
+    .WithHostname(externalFqdn)
+    .WithTls();
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+import { DistributedApplication } from "@aspire/apphost";
+
+const builder = DistributedApplication.createBuilder();
+
+// Parameters
+const registryEndpoint = builder.addParameter("registryEndpoint");
+const helmNamespace = builder.addParameter("helmNamespace");
+const helmChartVersion = builder.addParameter("helmChartVersion");
+const helmChartReleaseName = builder.addParameter("helmChartReleaseName");
+const ingressClassName = builder.addParameter("ingressClassName");
+const loadBalancerName = builder.addParameter("loadBalancerName");
+const loadBalancerNamespace = builder.addParameter("loadBalancerNamespace");
+const clusterIssuer = builder.addParameter("clusterIssuer");
+const externalFqdn = builder.addParameter("externalFqdn");
+
+// Kubernetes environment
+const k8s = builder.addKubernetesEnvironment("k8s")
+    .withHelm((helm) => {
+        helm.namespace = helmNamespace;
+        helm.chartVersion = helmChartVersion;
+        helm.releaseName = helmChartReleaseName;
+    });
+
+// Container registry
+const acr = builder.addContainerRegistry("acr", registryEndpoint);
+
+// Application services
+const api = builder.addProject("api");
+
+const frontend = builder.addProject("frontend")
+    .withReference(api);
+
+// Ingress
+const ingress = k8s.addIngress("ingress")
+    .withIngressClass(ingressClassName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withIngressAnnotation(
+        "cert-manager.io/cluster-issuer", clusterIssuer)
+    .withDefaultBackend(frontend.getEndpoint("http"))
+    .withHostname(externalFqdn)
+    .withTls();
+
+builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+## Deploy
+
+Run `aspire deploy` from the AppHost project directory and supply the parameter
+values for your environment:
+
+```bash
+aspire deploy \
+  --parameter registryEndpoint=myregistry.azurecr.io \
+  --parameter helmNamespace=my-app \
+  --parameter helmChartVersion=0.1.0 \
+  --parameter helmChartReleaseName=my-app \
+  --parameter ingressClassName=azure-alb-external \
+  --parameter loadBalancerName=my-alb \
+  --parameter loadBalancerNamespace=alb-infra \
+  --parameter clusterIssuer=letsencrypt-dns \
+  --parameter externalFqdn=myapp.example.com
+```
+
+## Verify
+
+After the deployment completes, verify the ingress is working:
+
+<Steps>
+
+1. **Check the ingress address.** Wait for AGC to assign an IP or FQDN to the
+   ingress:
+
+   ```bash
+   kubectl get ingress -n my-app
+   ```
+
+   The `ADDRESS` column should show the AGC frontend address.
+
+2. **Check the certificate status.** Verify that cert-manager has issued a
+   certificate for your domain:
+
+   ```bash
+   kubectl get certificate -n my-app
+   ```
+
+   The `READY` column should show `True` once the certificate is issued.
+
+3. **Access the application.** Open `https://myapp.example.com` in your browser
+   and confirm you see a valid TLS certificate.
+
+</Steps>
+
+## How TLS works with Ingress on AGC
+
+When you deploy an ingress with the `cert-manager.io/cluster-issuer` annotation
+and `WithTls`, the following sequence occurs:
+
+<Steps>
+
+1. **Self-signed bootstrap certificate.** On the first deploy, cert-manager
+   creates a temporary self-signed certificate so AGC can start serving traffic
+   immediately.
+
+2. **Annotation detection.** cert-manager detects the
+   `cert-manager.io/cluster-issuer` annotation on the ingress resource and
+   creates a `Certificate` resource targeting the configured `ClusterIssuer`.
+
+3. **DNS-01 challenge.** The `ClusterIssuer` uses the DNS-01 solver to validate
+   domain ownership. cert-manager creates a `TXT` record in your Azure DNS zone,
+   the ACME server validates it, and a real certificate is issued.
+
+4. **Certificate rotation.** cert-manager stores the issued certificate in a
+   Kubernetes secret referenced by the ingress TLS configuration and
+   automatically renews it before expiry.
+
+</Steps>
+
+<Aside type="note">
+HTTP-01 challenges don't work with AGC Ingress because AGC creates a separate
+frontend for each Ingress resource. The ACME HTTP-01 validation request is
+routed to the AGC frontend, which may not reach the cert-manager solver pod.
+Use DNS-01 challenges instead.
+</Aside>
+
+## Deploy without TLS
+
+<details>
+<summary>Deploy without TLS (not recommended for production)</summary>
+
+<Aside type="danger">
+Deploying without TLS exposes your application over plain HTTP. This is not
+recommended for production workloads. Only use this approach for development or
+testing scenarios.
+</Aside>
+
+Remove the `WithTls` call and the `cert-manager.io/cluster-issuer` annotation:
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var ingress = k8s.AddIngress("ingress")
+    .WithIngressClass(ingressClassName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithDefaultBackend(frontend.GetEndpoint("http"))
+    .WithHostname(externalFqdn);
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+const ingress = k8s.addIngress("ingress")
+    .withIngressClass(ingressClassName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withDefaultBackend(frontend.getEndpoint("http"))
+    .withHostname(externalFqdn);
+```
+
+</TabItem>
+</Tabs>
+
+</details>
+
+## Deploy without hostname
+
+<details>
+<summary>Deploy without a custom hostname</summary>
+
+<Aside type="caution">
+When you omit `WithHostname`, AGC automatically assigns a generated FQDN to the
+ingress. You won't be able to use cert-manager for TLS because you don't control
+the domain. The AGC-assigned FQDN uses a wildcard certificate managed by Azure.
+</Aside>
+
+Remove the `WithHostname`, `WithTls`, and cert-manager annotation calls:
+
+<Tabs syncKey="aspire-lang">
+<TabItem label="C#">
+
+```csharp
+var ingress = k8s.AddIngress("ingress")
+    .WithIngressClass(ingressClassName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .WithIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .WithDefaultBackend(frontend.GetEndpoint("http"));
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```typescript
+const ingress = k8s.addIngress("ingress")
+    .withIngressClass(ingressClassName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-name", loadBalancerName)
+    .withIngressAnnotation(
+        "alb.networking.azure.io/alb-namespace", loadBalancerNamespace)
+    .withDefaultBackend(frontend.getEndpoint("http"));
+```
+
+</TabItem>
+</Tabs>
+
+</details>
+
+## Troubleshooting
+
+### AGC frontend limit
+
+AGC has a limit of **5 frontends** per Application Gateway for Containers
+instance. Each Ingress resource creates its own frontend. If you exceed this
+limit, new ingress resources remain in a pending state.
+
+To check your current frontend count:
+
+```bash
+kubectl get ingress -A -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.status.loadBalancer.ingress[0].hostname}{"\n"}{end}'
+```
+
+Consider consolidating multiple services behind a single ingress with path-based
+routing, or request a quota increase from Azure support.
+
+### Certificate not issuing
+
+If the certificate `READY` status remains `False`, check the following:
+
+<Steps>
+
+1. **cert-manager logs.** Look for errors related to DNS-01 challenge creation:
+
+   ```bash
+   kubectl logs -n cert-manager deploy/cert-manager -f
+   ```
+
+2. **Challenge status.** Check if the ACME challenge is progressing:
+
+   ```bash
+   kubectl get challenges -n my-app
+   ```
+
+3. **Workload identity.** Verify that the cert-manager service account has the
+   correct federated credential and that the managed identity has
+   **DNS Zone Contributor** permissions on the Azure DNS zone:
+
+   ```bash
+   kubectl describe serviceaccount cert-manager -n cert-manager
+   ```
+
+4. **ClusterIssuer status.** Confirm the issuer is ready:
+
+   ```bash
+   kubectl get clusterissuer letsencrypt-dns -o yaml
+   ```
+
+</Steps>
+
+### Browser showing HSTS redirect to HTTPS
+
+If your browser automatically redirects HTTP URLs to HTTPS even when you haven't
+configured TLS, this is due to **HTTP Strict Transport Security (HSTS)**. Modern
+browsers cache HSTS policies for domains, including subdomains of `.com` and
+other top-level domains.
+
+To work around this during development:
+
+- Clear your browser's HSTS cache for the domain.
+- Use a private/incognito browser window.
+- Deploy with TLS enabled to avoid the issue entirely.
+
+<LearnMore>
+- [Application Gateway for Containers documentation](/azure/application-gateway/for-containers/overview)
+- [cert-manager documentation](https://cert-manager.io/docs/)
+- [.NET Aspire deployment overview](/dotnet/aspire/deployment/overview)
+</LearnMore>

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -150,21 +150,28 @@ builder.build().run();
 
 ## Deploy
 
-Run `aspire deploy` from the AppHost project directory and supply the parameter
-values for your environment:
+Set environment variables to provide parameter values, then run `aspire deploy`:
 
 ```bash
-aspire deploy \
-  --parameter registryEndpoint=myregistry.azurecr.io \
-  --parameter helmNamespace=my-app \
-  --parameter helmChartVersion=0.1.0 \
-  --parameter helmChartReleaseName=my-app \
-  --parameter ingressClassName=azure-alb-external \
-  --parameter loadBalancerName=my-alb \
-  --parameter loadBalancerNamespace=alb-infra \
-  --parameter clusterIssuer=letsencrypt-dns \
-  --parameter externalFqdn=myapp.example.com
+export Parameters__registryEndpoint=myregistry.azurecr.io
+export Parameters__helmNamespace=my-app
+export Parameters__helmChartVersion=0.1.0
+export Parameters__helmChartReleaseName=my-app
+export Parameters__ingressClassName=azure-alb-external
+export Parameters__loadBalancerName=my-alb
+export Parameters__loadBalancerNamespace=alb-infra
+export Parameters__clusterIssuer=letsencrypt-dns
+export Parameters__externalFqdn=myapp.example.com
+
+aspire deploy
 ```
+
+<Aside type="note">
+  Parameter values are provided via environment variables using the naming
+  convention `Parameters__<name>`. You can also set these in a
+  `appsettings.json` or user secrets file. The Aspire CLI will prompt for any
+  missing parameter values interactively.
+</Aside>
 
 ## Verify
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -14,9 +14,13 @@ This walkthrough shows how to use `AddIngress` to expose .NET Aspire services on
 Azure Kubernetes Service (AKS) with **Application Gateway for Containers (AGC)**
 and automatic TLS certificate provisioning via **cert-manager** DNS-01 challenges.
 
-## Prerequisites
-
-Before you begin, ensure you have the following:
+<Aside type="note">
+  This guide uses a **bring-your-own-cluster** model where you provision and
+  manage the AKS cluster, container registry, and DNS zone yourself. If you
+  want Aspire to provision the AKS cluster and registry as part of your
+  application model, use
+  [`AddAzureKubernetesEnvironment`](/deployment/kubernetes/aks/) instead.
+</Aside>
 
 ## Set up the AKS environment
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -26,7 +26,80 @@ and automatic TLS certificate provisioning via **cert-manager** DNS-01 challenge
 
 The following steps create all the Azure infrastructure needed for this walkthrough. If you already have an AKS cluster with ALB and cert-manager configured, skip to [Configure the AppHost](#configure-the-apphost).
 
+### Register resource providers and features
+
+Application Gateway for Containers requires several resource providers and preview features to be registered in your Azure subscription:
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
+
+```bash
+# Register required resource providers
+az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.Network
+az provider register --namespace Microsoft.NetworkFunction
+az provider register --namespace Microsoft.ServiceNetworking
+
+# Register preview features for ALB controller and Gateway API
+az feature register --namespace Microsoft.ContainerService \
+  --name ManagedGatewayAPIPreview
+az feature register --namespace Microsoft.ContainerService \
+  --name ApplicationLoadBalancerPreview
+
+# Wait for registration to complete (may take a few minutes)
+az feature show --namespace Microsoft.ContainerService \
+  --name ApplicationLoadBalancerPreview --query properties.state -o tsv
+
+# Re-register the provider after feature registration
+az provider register --namespace Microsoft.ContainerService
+
+# Install required CLI extensions
+az extension add --name alb
+az extension add --name aks-preview
+```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Register required resource providers
+az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.Network
+az provider register --namespace Microsoft.NetworkFunction
+az provider register --namespace Microsoft.ServiceNetworking
+
+# Register preview features for ALB controller and Gateway API
+az feature register --namespace Microsoft.ContainerService `
+  --name ManagedGatewayAPIPreview
+az feature register --namespace Microsoft.ContainerService `
+  --name ApplicationLoadBalancerPreview
+
+# Wait for registration to complete (may take a few minutes)
+az feature show --namespace Microsoft.ContainerService `
+  --name ApplicationLoadBalancerPreview --query properties.state -o tsv
+
+# Re-register the provider after feature registration
+az provider register --namespace Microsoft.ContainerService
+
+# Install required CLI extensions
+az extension add --name alb
+az extension add --name aks-preview
+```
+
+</TabItem>
+</Tabs>
+
+<Aside type="note">
+  Feature registration can take several minutes. Use `az feature show` to check
+  the status. For the latest prerequisites and supported regions, see the
+  [Application Gateway for Containers
+  documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/).
+</Aside>
+
 ### Create the resource group and cluster
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
 
 ```bash
 # Variables — customize these for your environment
@@ -60,7 +133,48 @@ az aks get-credentials \
   --name $CLUSTER_NAME
 ```
 
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Variables — customize these for your environment
+$RESOURCE_GROUP = "my-aspire-aks"
+$LOCATION = "westus3"
+$CLUSTER_NAME = "my-aspire-aks"
+$ACR_NAME = "myaspireacr"
+$DNS_ZONE = "myapp.example.com"
+
+# Create resource group
+az group create --name $RESOURCE_GROUP --location $LOCATION
+
+# Create AKS cluster with ALB controller, OIDC issuer, and workload identity
+az aks create `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --location $LOCATION `
+  --enable-oidc-issuer `
+  --enable-workload-identity `
+  --generate-ssh-keys
+
+# Enable the ALB controller addon
+az aks update `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --enable-alb
+
+# Get cluster credentials
+az aks get-credentials `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME
+```
+
+</TabItem>
+</Tabs>
+
 ### Create and attach a container registry
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
 
 ```bash
 # Create Azure Container Registry
@@ -76,9 +190,32 @@ az aks update \
   --attach-acr $ACR_NAME
 ```
 
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Create Azure Container Registry
+az acr create `
+  --resource-group $RESOURCE_GROUP `
+  --name $ACR_NAME `
+  --sku Basic
+
+# Attach ACR to AKS (grants AcrPull access)
+az aks update `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --attach-acr $ACR_NAME
+```
+
+</TabItem>
+</Tabs>
+
 ### Create the ApplicationLoadBalancer
 
 Create a dedicated subnet for AGC in the cluster's VNet, then deploy the `ApplicationLoadBalancer` custom resource:
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
 
 ```bash
 # Get the managed cluster resource group and VNet
@@ -117,7 +254,53 @@ EOF
 kubectl get applicationloadbalancer alb-aspire --watch
 ```
 
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Get the managed cluster resource group and VNet
+$MC_RG = $(az aks show --resource-group $RESOURCE_GROUP --name $CLUSTER_NAME `
+  --query nodeResourceGroup -o tsv)
+$VNET_NAME = $(az network vnet list --resource-group $MC_RG --query "[0].name" -o tsv)
+
+# Create a subnet for the ALB (delegated to ServiceNetworking)
+az network vnet subnet create `
+  --resource-group $MC_RG `
+  --vnet-name $VNET_NAME `
+  --name subnet-alb `
+  --address-prefix 10.237.0.0/24 `
+  --delegations Microsoft.ServiceNetworking/trafficControllers
+
+# Get the full subnet ID
+$SUBNET_ID = $(az network vnet subnet show `
+  --resource-group $MC_RG `
+  --vnet-name $VNET_NAME `
+  --name subnet-alb `
+  --query id -o tsv)
+
+# Deploy the ApplicationLoadBalancer CRD
+@"
+apiVersion: alb.networking.azure.io/v1
+kind: ApplicationLoadBalancer
+metadata:
+  name: alb-aspire
+  namespace: default
+spec:
+  associations:
+  - $SUBNET_ID
+"@ | kubectl apply -f -
+
+# Wait for it to become ready
+kubectl get applicationloadbalancer alb-aspire --watch
+```
+
+</TabItem>
+</Tabs>
+
 ### Create an Azure DNS zone
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
 
 ```bash
 # Create the DNS zone
@@ -132,6 +315,25 @@ az network dns zone show \
   --query nameServers -o tsv
 ```
 
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Create the DNS zone
+az network dns zone create `
+  --resource-group $RESOURCE_GROUP `
+  --name $DNS_ZONE
+
+# List the name servers — delegate these in your domain registrar
+az network dns zone show `
+  --resource-group $RESOURCE_GROUP `
+  --name $DNS_ZONE `
+  --query nameServers -o tsv
+```
+
+</TabItem>
+</Tabs>
+
 <Aside type="note">
   You need to add NS records for `$DNS_ZONE` at your domain registrar pointing
   to the name servers listed above. DNS delegation may take up to 48 hours to
@@ -139,6 +341,9 @@ az network dns zone show \
 </Aside>
 
 ### Install cert-manager with Azure DNS support
+
+<Tabs syncKey="shell-lang">
+<TabItem label="bash">
 
 ```bash
 # Install cert-manager with Gateway API support
@@ -239,6 +444,112 @@ EOF
 # Verify the issuer is ready
 kubectl get clusterissuer letsencrypt-prod
 ```
+
+</TabItem>
+<TabItem label="PowerShell">
+
+```powershell
+# Install cert-manager with Gateway API support
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager `
+  --namespace cert-manager `
+  --create-namespace `
+  --set crds.enabled=true `
+  --set config.enableGatewayAPI=true `
+  --wait
+
+# Create a managed identity for cert-manager
+az identity create `
+  --name cert-manager-identity `
+  --resource-group $RESOURCE_GROUP
+
+$IDENTITY_CLIENT_ID = $(az identity show `
+  --name cert-manager-identity `
+  --resource-group $RESOURCE_GROUP `
+  --query clientId -o tsv)
+
+$IDENTITY_PRINCIPAL_ID = $(az identity show `
+  --name cert-manager-identity `
+  --resource-group $RESOURCE_GROUP `
+  --query principalId -o tsv)
+
+# Grant DNS Zone Contributor role on the DNS zone
+$DNS_ZONE_ID = $(az network dns zone show `
+  --resource-group $RESOURCE_GROUP `
+  --name $DNS_ZONE `
+  --query id -o tsv)
+
+az role assignment create `
+  --assignee-object-id $IDENTITY_PRINCIPAL_ID `
+  --assignee-principal-type ServicePrincipal `
+  --role "DNS Zone Contributor" `
+  --scope $DNS_ZONE_ID
+
+# Create a federated credential for cert-manager's service account
+$OIDC_ISSUER = $(az aks show `
+  --resource-group $RESOURCE_GROUP `
+  --name $CLUSTER_NAME `
+  --query oidcIssuerProfile.issuerUrl -o tsv)
+
+az identity federated-credential create `
+  --name cert-manager-fedcred `
+  --identity-name cert-manager-identity `
+  --resource-group $RESOURCE_GROUP `
+  --issuer $OIDC_ISSUER `
+  --subject "system:serviceaccount:cert-manager:cert-manager" `
+  --audiences "api://AzureADTokenExchange"
+
+# Annotate and label the cert-manager service account for workload identity
+kubectl annotate serviceaccount cert-manager `
+  --namespace cert-manager `
+  azure.workload.identity/client-id=$IDENTITY_CLIENT_ID `
+  --overwrite
+
+kubectl label serviceaccount cert-manager `
+  --namespace cert-manager `
+  azure.workload.identity/use=true `
+  --overwrite
+
+# Patch the deployment to inject workload identity env vars
+kubectl patch deployment cert-manager `
+  --namespace cert-manager `
+  --type=json `
+  -p='[{"op":"add","path":"/spec/template/metadata/labels/azure.workload.identity~1use","value":"true"}]'
+
+# Wait for rollout
+kubectl rollout status deployment cert-manager --namespace cert-manager
+
+# Get the subscription ID for the ClusterIssuer
+$SUBSCRIPTION_ID = $(az account show --query id -o tsv)
+
+# Create a ClusterIssuer using Azure DNS for DNS-01 challenges
+@"
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: your-email@example.com
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    solvers:
+    - dns01:
+        azureDNS:
+          hostedZoneName: $DNS_ZONE
+          resourceGroupName: $RESOURCE_GROUP
+          subscriptionID: $SUBSCRIPTION_ID
+          environment: AzurePublicCloud
+          managedIdentity:
+            clientID: $IDENTITY_CLIENT_ID
+"@ | kubectl apply -f -
+
+# Verify the issuer is ready
+kubectl get clusterissuer letsencrypt-prod
+```
+
+</TabItem>
+</Tabs>
 
 ## Configure the AppHost
 
@@ -593,7 +904,10 @@ To work around this during development:
 - Deploy with TLS enabled to avoid the issue entirely.
 
 <LearnMore>
-- [Application Gateway for Containers documentation](/azure/application-gateway/for-containers/overview)
+- [Application Gateway for Containers documentation](https://learn.microsoft.com/azure/application-gateway/for-containers/)
+- [Quickstart: Deploy ALB Controller (AKS add-on)](https://learn.microsoft.com/azure/application-gateway/for-containers/quickstart-deploy-application-gateway-for-containers-alb-controller-addon)
 - [cert-manager documentation](https://cert-manager.io/docs/)
-- [.NET Aspire deployment overview](/dotnet/aspire/deployment/overview)
+- [cert-manager with Let's Encrypt on AKS (Ingress API)](https://learn.microsoft.com/azure/application-gateway/for-containers/how-to-cert-manager-lets-encrypt-ingress-api)
+- [.NET Aspire deployment overview](/deployment/overview/)
+- [Deploy to AKS with Aspire](/deployment/kubernetes/aks/)
 </LearnMore>

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
@@ -34,13 +34,7 @@ Kubernetes offers two approaches for routing external traffic to your services:
 
 **Recommendation:** Use **Gateway API** for new deployments. It's the future direction of Kubernetes traffic management and offers richer routing capabilities with better portability across providers. Use **Ingress** when your cluster or ingress controller doesn't support the Gateway API yet.
 
-<Aside type="tip">
-  On AKS with Application Gateway for Containers (AGC), both Ingress and
-  Gateway API are supported. Gateway API is recommended because cert-manager's
-  HTTP-01 challenge solver works natively with it — creating a temporary
-  `HTTPRoute` on the existing Gateway without requiring a separate frontend or
-  DNS API access.
-</Aside>
+
 
 ## What Aspire generates
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
@@ -111,9 +111,9 @@ You can omit `WithTls()` to deploy without TLS. The Ingress/Gateway will serve t
 
 Choose the walkthrough that matches your deployment approach:
 
-- **[Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/)** — Use the Kubernetes Ingress API with Application Gateway for Containers on AKS. Requires cert-manager with DNS-01 for automatic TLS.
+- **[Configure Gateway API on AKS](/deployment/kubernetes-gateway-aks/) (Recommended)** — Use the Kubernetes Gateway API with Application Gateway for Containers on AKS. Supports cert-manager HTTP-01 for automatic TLS with **no DNS API or DNS zone required**.
 
-- **[Configure Gateway API on AKS](/deployment/kubernetes-gateway-aks/)** — Use the Kubernetes Gateway API with Application Gateway for Containers on AKS. Supports cert-manager HTTP-01 (no DNS API needed) or DNS-01 for automatic TLS.
+- **[Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/)** — Use the Kubernetes Ingress API with Application Gateway for Containers on AKS. Requires cert-manager with DNS-01 for automatic TLS.
 
 <Aside type="note">
   These walkthroughs use AKS with Application Gateway for Containers as the

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
@@ -1,0 +1,131 @@
+---
+title: Expose services with Ingress and Gateway API
+description: Learn how to expose your Aspire application services to external traffic using Kubernetes Ingress or Gateway API resources.
+sidebar:
+  badge: Preview
+---
+
+import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+
+When you deploy an Aspire application to Kubernetes, your services are accessible only within the cluster by default. To expose services to external traffic — such as a web frontend that users access from the internet — you need to configure an **Ingress** or **Gateway** resource that routes traffic from outside the cluster to your services.
+
+Aspire provides first-class APIs for defining Ingress and Gateway API resources directly in your AppHost, generating the appropriate Kubernetes YAML as part of the Helm chart output.
+
+<Aside type="note">
+  This guide covers exposing services to external traffic. For the basics of
+  deploying to Kubernetes with Aspire, see [Deploy to
+  Kubernetes](/deployment/kubernetes/).
+</Aside>
+
+## Ingress vs. Gateway API
+
+Kubernetes offers two approaches for routing external traffic to your services:
+
+| | **Ingress** | **Gateway API** |
+|---|---|---|
+| **Maturity** | Legacy (stable since K8S 1.19) | Modern (GA since K8S 1.27) |
+| **Resource model** | Single `Ingress` resource | Three-tier: `GatewayClass` → `Gateway` → `HTTPRoute` |
+| **Protocol support** | HTTP/HTTPS only | HTTP, HTTPS, TCP, UDP, gRPC |
+| **Routing features** | Host and path matching | Host, path, header, query, method matching |
+| **Extensibility** | Controller-specific annotations | Standardized filters and policies |
+| **Traffic splitting** | Not standardized | First-class weighted backends |
+| **Aspire API** | `AddIngress()` | `AddGateway()` |
+
+**Recommendation:** Use **Gateway API** for new deployments. It's the future direction of Kubernetes traffic management and offers richer routing capabilities with better portability across providers. Use **Ingress** when your cluster or ingress controller doesn't support the Gateway API yet.
+
+<Aside type="tip">
+  On AKS with Application Gateway for Containers (AGC), both Ingress and
+  Gateway API are supported. Gateway API is recommended because cert-manager's
+  HTTP-01 challenge solver works natively with it — creating a temporary
+  `HTTPRoute` on the existing Gateway without requiring a separate frontend or
+  DNS API access.
+</Aside>
+
+## What Aspire generates
+
+When you use `AddIngress()` or `AddGateway()`, Aspire generates additional Kubernetes resources in the Helm chart output:
+
+**For Ingress (`AddIngress`):**
+- A `networking.k8s.io/v1 Ingress` resource with rules, TLS configuration, and controller annotations
+
+**For Gateway API (`AddGateway`):**
+- A `gateway.networking.k8s.io/v1 Gateway` resource with listeners (HTTP on port 80, HTTPS on port 443 if TLS is configured)
+- One or more `HTTPRoute` resources attached to the Gateway, grouped by hostname
+
+## TLS and certificates
+
+When you configure TLS with `WithTls()`, Aspire handles the initial bootstrapping:
+
+<Steps>
+1. **First deploy**: Aspire generates a self-signed placeholder TLS certificate and creates the Kubernetes Secret. This makes the Ingress/Gateway valid immediately so the load balancer can start routing traffic.
+
+2. **Certificate replacement**: You then configure a certificate management solution (such as [cert-manager](https://cert-manager.io/)) to replace the self-signed certificate with a real one from a trusted CA like Let's Encrypt or ZeroSSL.
+
+3. **Subsequent deploys**: The existing Secret (with the real certificate) is preserved — the bootstrap step only creates the Secret if it doesn't already exist.
+</Steps>
+
+<Aside type="caution">
+  The self-signed bootstrap certificate is a placeholder only. Browsers will
+  show security warnings when accessing your site with this certificate.
+  Configure cert-manager or provide your own certificate for production use.
+</Aside>
+
+## Using parameters for deployment configuration
+
+Aspire's Ingress and Gateway APIs accept parameters, allowing you to reuse the same AppHost across multiple deployment environments (development, staging, production) with different hostnames, TLS secrets, and controller configurations:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var hostname = builder.AddParameter("hostname");
+var ingressClass = builder.AddParameter("ingressclass");
+
+var ingress = k8s.AddIngress("ingress")
+    .WithIngressClass(ingressClass)
+    .WithHostname(hostname)
+    .WithTls();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts"
+const hostname = builder.addParameter('hostname');
+const ingressClass = builder.addParameter('ingressclass');
+
+const ingress = await k8s.addIngress('ingress');
+ingress.withIngressClass(ingressClass);
+ingress.withHostname(hostname);
+ingress.withTls();
+```
+</TabItem>
+</Tabs>
+
+Parameter values are provided at deploy time via the Aspire CLI or configuration files, keeping environment-specific details out of your source code.
+
+## Deploying without TLS
+
+<Aside type="danger">
+  Deploying without TLS exposes all traffic in plaintext, including
+  authentication tokens, session cookies, and user data. Only use this for
+  development clusters or internal services that are not accessible from the
+  internet.
+</Aside>
+
+You can omit `WithTls()` to deploy without TLS. The Ingress/Gateway will serve traffic over HTTP only. This is useful for quick testing but should never be used in production.
+
+## Next steps
+
+Choose the walkthrough that matches your deployment approach:
+
+- **[Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/)** — Use the Kubernetes Ingress API with Application Gateway for Containers on AKS. Requires cert-manager with DNS-01 for automatic TLS.
+
+- **[Configure Gateway API on AKS](/deployment/kubernetes-gateway-aks/)** — Use the Kubernetes Gateway API with Application Gateway for Containers on AKS. Supports cert-manager HTTP-01 (no DNS API needed) or DNS-01 for automatic TLS.
+
+<Aside type="note">
+  These walkthroughs use AKS with Application Gateway for Containers as the
+  reference implementation. The Aspire APIs (`AddIngress`, `AddGateway`) work
+  with any Kubernetes cluster that has an ingress controller or Gateway API
+  implementation. Controller-specific annotations (such as
+  `alb.networking.azure.io/alb-name`) will differ for other providers (NGINX,
+  Traefik, Istio, etc.).
+</Aside>

--- a/src/frontend/src/content/docs/deployment/kubernetes.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes.mdx
@@ -236,6 +236,9 @@ In Kubernetes, services discover each other using the cluster's built-in DNS. A 
 
 ## See also
 
+- [Expose services with Ingress and Gateway API](/deployment/kubernetes-ingress/)
+- [Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/)
+- [Configure Gateway API on AKS](/deployment/kubernetes-gateway-aks/)
 - [Kubernetes integration](/integrations/compute/kubernetes/)
 - [Pipelines and app topology](/deployment/pipelines/)
 - [Publishing and deployment overview](/deployment/overview/)

--- a/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
@@ -159,6 +159,9 @@ For complete walkthroughs, see [Deploy to Kubernetes clusters](/deployment/kuber
 ## See also
 
 - [Deploy to Kubernetes](/deployment/kubernetes/)
+- [Expose services with Ingress and Gateway API](/deployment/kubernetes-ingress/)
+- [Configure Ingress on AKS](/deployment/kubernetes-ingress-aks/)
+- [Configure Gateway API on AKS](/deployment/kubernetes-gateway-aks/)
 - [Deploy to AKS](/deployment/kubernetes/aks/)
 - [AKS integration](/integrations/cloud/azure/aks/)
 - [Kubernetes documentation](https://kubernetes.io/docs/)


### PR DESCRIPTION
## Summary

Adds three new documentation pages for exposing Aspire services on Kubernetes using Ingress and Gateway API, plus sidebar registration and cross-links.

### New pages

1. **Expose services with Ingress and Gateway API** (\kubernetes-ingress.mdx\)
   - Overview with Ingress vs Gateway API comparison table
   - TLS bootstrap flow explanation
   - Parameter usage for multi-environment deployments
   - Links to the two walkthroughs

2. **Configure Gateway API on AKS** (\kubernetes-gateway-aks.mdx\) — *Recommended*
   - Standalone walkthrough with full AKS setup (resource providers, cluster, ACR, ALB, cert-manager)
   - HTTP-01 focused — no DNS zone or managed identity needed
   - Complete ClusterIssuer setup with \gatewayHTTPRoute\ solver
   - Deploy section with bash/PowerShell tabs
   - Detailed 'How it works' and 'Why HTTP-01 works with Gateway but not Ingress' sections
   - Troubleshooting guide

3. **Configure Ingress on AKS** (\kubernetes-ingress-aks.mdx\)
   - Full BYO cluster setup with az CLI commands (bash/PowerShell tabs)
   - DNS-01 with Azure DNS + workload identity + cert-manager
   - Complete AppHost configuration with parameters

### Other changes

- **Sidebar** (\deployment.topics.ts\): Registered all 3 pages under Kubernetes section, Gateway before Ingress
- **Cross-links**: Added links from \kubernetes.mdx\ and \integrations/compute/kubernetes.mdx\
- **BYO cluster callout**: Each walkthrough notes the bring-your-own-cluster model with link to \AddAzureKubernetesEnvironment\

### Validation

- Lint: ✅
- Unit tests: ✅
- Resource provider registrations and feature flags documented per Azure docs