### PR TITLE
Fix method name for Bun package installation

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -55,13 +55,13 @@ By default, the integration looks for an `index.ts` file as the entrypoint.
 
 ### Package installation
 
-To ensure packages are installed before running your Bun application, use the `WithBunPackageInstaller` method:
+To ensure packages are installed before running your Bun application, use the `WithBunPackageInstallation` method:
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var bunApp = builder.AddBunApp("bun-api", "../bun-app")
-    .WithBunPackageInstaller()
+    .WithBunPackageInstallation()
     .WithHttpEndpoint(port: 3000, env: "PORT");
 
 // After adding all resources, run the app...


### PR DESCRIPTION
Documentation was incorrect, referring to this extension method as `.WithBunPackageInstaller()`. The actual API provides `.WithBunPackageInstallation()`