### PR TITLE
Fix AppHost builder code preview clipping on narrow phones

### DIFF
--- a/src/frontend/src/components/AppHostBuilder.astro
+++ b/src/frontend/src/components/AppHostBuilder.astro
@@ -1347,12 +1347,43 @@ await builder.build().run();`,
       padding: 0.5rem 0.25rem;
       font-size: 0.75rem;
     }
+
+    .header,
+    .code-display {
+      padding: 1rem;
+    }
   }
 
   @media (max-width: 480px) {
     .toggles {
       grid-template-columns: 1fr;
       gap: 0.5rem;
+    }
+
+    .header,
+    .code-display {
+      padding: 0.75rem;
+    }
+
+    .header h3 {
+      font-size: 1.1rem;
+    }
+
+    /* On narrow phones, soft-wrap the AppHost preview code rather than
+       requiring horizontal swipe-scrolling. These are illustrative
+       samples, not copy/paste targets, so readability beats fidelity to
+       the original line breaks. The :global() escape hatch is required
+       because Expressive Code's markup is rendered via set:html and
+       therefore not reachable from this component's scoped styles. */
+    .code-display :global(.expressive-code pre) {
+      overflow-x: hidden;
+    }
+
+    .code-display :global(.expressive-code pre > code),
+    .code-display :global(.expressive-code .ec-line),
+    .code-display :global(.expressive-code .ec-line > .code) {
+      white-space: pre-wrap;
+      word-break: break-word;
     }
   }
 </style>


### PR DESCRIPTION
## What

The `Build your AppHost` interactive preview on the splash page renders each AppHost variant via Expressive Code. On phone-portrait viewports (e.g. Galaxy S24 Ultra at ~412 CSS px -- which corresponds to the 1440 x 3120 device-pixel screenshot the reporter shared, since Chrome on the S24 Ultra runs at ~3.5x DPR by default) the longest sample lines get clipped on the right edge of the frame.

## Why

Two compounding issues:

1. `.header` and `.code-display` keep their 1.5rem padding even at the existing `max-width: 480px` breakpoint, eating ~48px of horizontal space.
2. Expressive Code's `pre` falls back to `overflow-x: auto`, so the remaining characters are only reachable by swipe-scrolling -- and on the splash, the floating scroll-to-top button sits roughly where that affordance would surface.

Net effect: long lines such as `var builder = DistributedApplication.CreateBuilder(args);` look truncated.

## How

Tighten the chrome and soft-wrap the code at narrow widths in `AppHostBuilder.astro`:

- `@media (max-width: 768px)` -- shrink `.header` / `.code-display` padding from 1.5rem to 1rem.
- `@media (max-width: 480px)` -- shrink further to 0.75rem, drop the heading to 1.1rem, and force `white-space: pre-wrap` on the EC-rendered `.ec-line` / `code` nodes via `:global()` so the illustrative samples break to the next line instead of clipping.

These previews are illustrative -- not copy/paste targets -- so wrapping beats fidelity to the original line breaks at phone widths.

## Validation

Reproduced the original clipping (against `upstream/main`) and verified the fix with Playwright/Chromium (`Galaxy S24` user agent, `colorScheme: dark`) at the CSS viewport widths the S24 family actually presents to a browser:

| CSS viewport | Scenario | Before | After |
|--------------|----------|--------|-------|
| **360 x 780** | Galaxy S24 default | code clipped | wraps cleanly |
| **412 x 891** | S24 Ultra default (DPR 3.5, matches reporter's 1440 x 3120 panel screenshot) | code clipped (matches the reporter's screenshot exactly) | wraps cleanly |
| **480 x 1040** | Samsung "Display zoom: Small" edge case | code clipped | wraps cleanly |
| **1440 x 900** | Desktop regression baseline | unchanged | unchanged |

Toggling features (Front end / Database / API service / Container / Deployment options) continues to switch the active variant correctly with wrap in place.

Run locally:

```
cd src/frontend
pnpm dev
```

`pnpm lint`, `pnpm test:unit:components`, and `pnpm build:skip-search` all pass against this change.
