### PR TITLE
Fix release build diagnostics sidebar

### DIFF
--- a/src/frontend/config/sidebar/reference.topics.ts
+++ b/src/frontend/config/sidebar/reference.topics.ts
@@ -705,6 +705,10 @@ export const referenceTopics: StarlightSidebarTopicsUserConfig[number] = {
             { label: 'ASPIREAZURE001', link: '/diagnostics/aspireazure001' },
             { label: 'ASPIREAZURE002', link: '/diagnostics/aspireazure002' },
             { label: 'ASPIREAZURE003', link: '/diagnostics/aspireazure003' },
+            {
+              label: 'ASPIREBROWSERLOGS001',
+              link: '/diagnostics/aspirebrowserlogs001',
+            },
           ],
         },
       ],


### PR DESCRIPTION
## Summary
- Add the missing ASPIREBROWSERLOGS001 diagnostics page to the Reference > Diagnostics sidebar topics config.
- Fix the starlight-sidebar-topics prerender failure for /diagnostics/aspirebrowserlogs001/.

## Validation
- pnpm --dir .\src\frontend run build