### PR TITLE
[docs] Document installing the Aspire CLI as a .NET tool

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Aspire CLI
-description: Learn how to install the Aspire CLI as a native executable or .NET global tool to manage your cloud-native applications.
+description: Learn how to install the Aspire CLI as a native executable or .NET tool to manage your cloud-native applications.
 lastUpdated: true
 tableOfContents: true
 ---
@@ -43,6 +43,24 @@ At any time, you can reopen the **Install Aspire CLI** command modal from the to
 
 You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
 
+## Install as a .NET tool
+
+<Aside type="note">
+This install method was introduced in Aspire 13.3.
+</Aside>
+
+The Aspire CLI is also published as a NativeAOT [.NET tool](https://learn.microsoft.com/dotnet/core/tools/global-tools). This install method requires the .NET SDK 10.0.100 or later.
+
+```bash title="Install the Aspire CLI as a .NET tool"
+dotnet tool install -g Aspire.Cli
+```
+
+Self-update via `aspire update --self` is disabled for .NET tool installs. Update the CLI through the .NET SDK instead:
+
+```bash title="Update the Aspire CLI"
+dotnet tool update -g Aspire.Cli
+```
+
 ## Validation
 
 To validate that the Aspire CLI is installed, use `aspire --version` to query Aspire CLI for a version number:
@@ -75,4 +93,5 @@ The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CL
 
 - [aspire-install script reference](/reference/cli/install-script/)
 - [`aspire` command reference](/reference/cli/commands/aspire/)
+- [Upgrade Aspire](/whats-new/upgrade-aspire/)
 - [Aspire VS Code extension](/get-started/aspire-vscode-extension/) — install the CLI and use Aspire commands from within VS Code


### PR DESCRIPTION
Documents the new `dotnet tool install -g Aspire.Cli` install path introduced in Aspire 13.3.

**Source PRs:** microsoft/aspire#16496 (ships the CLI as a NativeAOT .NET tool) and microsoft/aspire#16611 (servicing backport to `release/13.3`).

**Issue:** Addresses item 1 of microsoft/aspire.dev#837 (CLI conceptual docs gap for 13.3).

## What changed

In `src/frontend/src/content/docs/get-started/install-cli.mdx`:

- New `## Install as a .NET tool` section between the existing install-script section and Validation, with:
  - 13.3 introduction note.
  - `dotnet tool install -g Aspire.Cli` install command.
  - `.NET SDK 10.0.100` prerequisite mention.
  - `dotnet tool update -g Aspire.Cli` update command, plus a note that `aspire update --self` is disabled for .NET tool installs (per `microsoft/aspire#16496` — the CLI prints the equivalent `dotnet tool update` command instead).
- Page description no longer says "global tool" — heading and body use ".NET tool" consistently.
- Added a link to **Upgrade Aspire** in See also.

## Out of scope

- The 13.3 What's New entry for this feature is already covered by #838.
- Japanese localization (`ja/get-started/install-cli.mdx`) — left for the translation pipeline.

