### PR TITLE
[docs] Document installing the Aspire CLI as a NativeAOT .NET tool

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,10 +1,11 @@
 ---
 title: Install Aspire CLI
-description: Learn how to install the Aspire CLI as a native executable or NativeAOT .NET tool to manage your cloud-native applications.
+description: Learn how to install the Aspire CLI as a native executable or .NET global tool to manage your cloud-native applications.
 lastUpdated: true
 tableOfContents: true
 ---
 
+import Expand from '@components/Expand.astro';
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 import { Aside, Code, Icon } from '@astrojs/starlight/components';
@@ -43,15 +44,15 @@ At any time, you can reopen the **Install Aspire CLI** command modal from the to
 
 You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
 
-## Install as a NativeAOT .NET tool
+<Expand summary="Install as a NativeAOT .NET global tool">
 
 <Aside type="note">
 This install method was introduced in Aspire 13.3.
 </Aside>
 
-The Aspire CLI is also published as a NativeAOT [.NET tool](https://learn.microsoft.com/dotnet/core/tools/global-tools). This install method requires the .NET SDK 10.0.100 or later.
+The Aspire CLI is also published as a NativeAOT [.NET global tool](https://learn.microsoft.com/dotnet/core/tools/global-tools). This install method requires the .NET SDK 10.0.100 or later.
 
-```bash title="Install the Aspire CLI as a NativeAOT .NET tool"
+```bash title="Install the Aspire CLI as a NativeAOT .NET global tool"
 dotnet tool install -g Aspire.Cli
 ```
 
@@ -60,6 +61,8 @@ Self-update via `aspire update --self` is disabled for .NET tool installs. Updat
 ```bash title="Update the Aspire CLI"
 dotnet tool update -g Aspire.Cli
 ```
+
+</Expand>
 
 ## Validation
 

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: Install Aspire CLI
-description: Learn how to install the Aspire CLI as a native executable or .NET global tool to manage your cloud-native applications.
+description: Learn how to install the Aspire CLI as a native executable or NativeAOT .NET tool to manage your cloud-native applications.
 lastUpdated: true
 tableOfContents: true
 ---
@@ -42,6 +42,24 @@ At any time, you can reopen the **Install Aspire CLI** command modal from the to
 :::
 
 You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
+
+## Install as a NativeAOT .NET tool
+
+<Aside type="note">
+This install method was introduced in Aspire 13.3.
+</Aside>
+
+The Aspire CLI is also published as a NativeAOT [.NET tool](https://learn.microsoft.com/dotnet/core/tools/global-tools). This install method requires the .NET SDK 10.0.100 or later.
+
+```bash title="Install the Aspire CLI as a NativeAOT .NET tool"
+dotnet tool install -g Aspire.Cli
+```
+
+Self-update via `aspire update --self` is disabled for .NET tool installs. Update the CLI through the .NET SDK instead:
+
+```bash title="Update the Aspire CLI"
+dotnet tool update -g Aspire.Cli
+```
 
 ## Validation
 


### PR DESCRIPTION
Documents the new `dotnet tool install -g Aspire.Cli` install path introduced in Aspire 13.3.

**Source PRs:** microsoft/aspire#16496 (ships the CLI as a NativeAOT .NET tool) and microsoft/aspire#16611 (servicing backport to `release/13.3`).

**Issue:** Addresses item 1 of microsoft/aspire.dev#837 (CLI conceptual docs gap for 13.3).

## What changed

In `src/frontend/src/content/docs/get-started/install-cli.mdx`:

- New `## Install as a NativeAOT .NET tool` section between the existing install-script section and Validation, with:
  - 13.3 introduction note.
  - `dotnet tool install -g Aspire.Cli` install command.
  - `.NET SDK 10.0.100` prerequisite mention.
  - `dotnet tool update -g Aspire.Cli` update command, plus a note that `aspire update --self` is disabled for .NET tool installs (per `microsoft/aspire#16496` — the CLI prints the equivalent `dotnet tool update` command instead).
- Page description updated: `.NET global tool` → `NativeAOT .NET tool`, matching the new heading and body.

## Out of scope

- The 13.3 What's New entry for this feature is already covered by #838.
- Japanese localization (`ja/get-started/install-cli.mdx`) — left for the translation pipeline.

