### PR TITLE
Document publish summary output

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-deploy.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-deploy.mdx
@@ -8,7 +8,6 @@ sidebar:
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
 
 import Include from '@components/Include.astro';
-import LearnMore from '@components/LearnMore.astro';
 
 ## Name
 
@@ -44,13 +43,38 @@ The command performs the following steps to deploy an app orchestrated with Aspi
 - Starts the AppHost and its resources.
 - Executes the `deploy` pipeline step, and any dependent steps, registered in the app model.
 
+## Pipeline summary output
+
+After the pipeline finishes, `aspire deploy` prints a result summary and a step-by-step breakdown. The summary shows how many steps succeeded, the total pipeline duration, and a `Steps Summary:` table.
+
+The `Steps Summary:` table lists pipeline steps in their execution hierarchy. Top-level steps appear at the left edge of the step-name column, and child steps are indented under their parent steps. Each row includes the step duration, final status, step name, and, when the terminal is wide enough, a timeline bar that shows when the step started and finished relative to the whole pipeline.
+
+```text title="Output"
+------------------------------------------------------------
+✅ 5/5 steps succeeded • Total time: 0.43s
+
+Steps Summary:
+                Step timeline:                 0s                       0.41s
+                                               │───────┬──────┬─────┬───────│
+      0.73ms  ✓ validate-compute-environments  │╴                           │
+      0.21ms  ✓   before-start                 │╴                           │
+       0.41s  ✓ pipeline-execution             │╶──────────────────────────╴│
+       0.41s  ✓ custom-deploy-prereq           │╶──────────────────────────╴│
+      0.33ms  ✓   deploy                       │                           ╴│
+
+✅ Pipeline succeeded
+------------------------------------------------------------
+```
+
+The `Step timeline:` header shows the start and end of the overall pipeline duration. The ruler divides that duration into equal intervals, and each step row uses a bar to show the step's relative start and end times. Very short steps can appear as a single point marker (`╴`). If the terminal isn't wide enough to preserve readable step names, Aspire omits the timeline columns and keeps the hierarchical step list.
+
 ## Options
 
 The following options are available:
 
 - **`--`**
 
-  Delimits arguments to `aspire publish` from arguments for the AppHost. All arguments after this delimiter are passed to the apphost.
+  Delimits arguments to `aspire deploy` from arguments for the AppHost. All arguments after this delimiter are passed to the AppHost.
 
 - <Include relativePath="reference/cli/includes/option-project.md" />
 
@@ -98,7 +122,7 @@ The following options are available:
   aspire deploy
   ```
 
-- Publish and deploy an Aspire apphost and its dependencies:
+- Publish and deploy an Aspire AppHost and its dependencies:
 
   ```bash title="Aspire CLI"
   aspire deploy --apphost './projects/apphost/orchestration.AppHost.csproj'

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-publish.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-publish.mdx
@@ -8,8 +8,6 @@ sidebar:
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
 
 import Include from '@components/Include.astro';
-import LearnMore from '@components/LearnMore.astro';
-import { Aside } from '@astrojs/starlight/components';
 
 ## Name
 
@@ -44,6 +42,31 @@ The command performs the following steps to run an Aspire AppHost:
 - Builds the AppHost project and its resources.
 - Starts the AppHost and its resources.
 - Executes all publishing pipeline steps registered in the app model.
+
+## Pipeline summary output
+
+After the pipeline finishes, `aspire publish` prints a result summary and a step-by-step breakdown. The summary shows how many steps succeeded, the total pipeline duration, and a `Steps Summary:` table.
+
+The `Steps Summary:` table lists pipeline steps in their execution hierarchy. Top-level steps appear at the left edge of the step-name column, and child steps are indented under their parent steps. Each row includes the step duration, final status, step name, and, when the terminal is wide enough, a timeline bar that shows when the step started and finished relative to the whole pipeline.
+
+```text title="Output"
+------------------------------------------------------------
+✅ 5/5 steps succeeded • Total time: 0.43s
+
+Steps Summary:
+                Step timeline:                 0s                       0.41s
+                                               │───────┬──────┬─────┬───────│
+      0.57ms  ✓ validate-compute-environments  │╴                           │
+      0.16ms  ✓   before-start                 │╴                           │
+       0.41s  ✓ pipeline-execution             │╶──────────────────────────╴│
+       0.41s  ✓ custom-publish-prereq          │╶──────────────────────────╴│
+      0.55ms  ✓   publish                      │                           ╴│
+
+✅ Pipeline succeeded
+------------------------------------------------------------
+```
+
+The `Step timeline:` header shows the start and end of the overall pipeline duration. The ruler divides that duration into equal intervals, and each step row uses a bar to show the step's relative start and end times. Very short steps can appear as a single point marker (`╴`). If the terminal isn't wide enough to preserve readable step names, Aspire omits the timeline columns and keeps the hierarchical step list.
 
 ## Options
 


### PR DESCRIPTION
## Summary

- Document the new hierarchical publish/deploy pipeline summary output.
- Explain the timeline ruler, per-step bars, indentation, and narrow-terminal fallback.
- Include sample outputs for `aspire publish` and `aspire deploy`.
