### PR TITLE
Update Microsoft Foundry docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started.mdx
@@ -20,7 +20,7 @@ import aiFoundryIcon from '@assets/icons/azure-ai-foundry-icon.png';
 
 <Badge text="🧪 Preview" variant="note" size="large" />
 
-[Microsoft Foundry](https://learn.microsoft.com/ai-studio) provides a unified platform for developing, testing, and deploying AI applications. The Aspire Microsoft Foundry integration enables you to connect to Microsoft Foundry services from your applications, providing access to various AI capabilities including model deployments, prompt flow, and more.
+[Microsoft Foundry](https://learn.microsoft.com/azure/foundry/what-is-foundry) provides a unified platform for developing, testing, and deploying AI applications. The Aspire Microsoft Foundry integration enables you to connect to Microsoft Foundry services from your applications, providing access to AI capabilities including model deployments, Foundry projects, and hosted agents.
 
 In this introduction, you'll see how to install and use the Aspire Microsoft Foundry integrations in a simple configuration. If you already have this knowledge, see [Microsoft Foundry Hosting integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host/) for full reference details.
 
@@ -64,7 +64,7 @@ The preceding code adds a Microsoft Foundry resource named `foundry` with a depl
 
 ## Set up client integration
 
-The client integration for Azure AI Foundry is the [Azure AI Inference](/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started/) integration. To use Azure AI Foundry from your client applications, install the Azure AI Inference integration in your client project.
+The client integration for Microsoft Foundry is the [Azure AI Inference](/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started/) integration. To use Microsoft Foundry from your client applications, install the Azure AI Inference integration in your client project.
 
 For more information on using the client integration, see the [Azure AI Inference integration documentation](/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started/).
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
@@ -76,7 +76,7 @@ The preceding code:
 - Adds a Microsoft Foundry resource named `foundry`.
 - Adds a Microsoft Foundry deployment resource named `chat` using the generated `FoundryModel.OpenAI.Gpt5Mini` descriptor.
 
-For more information about the generated model descriptors, see the [FoundryModel API reference](https://learn.microsoft.com/dotnet/api/aspire.hosting.foundrymodel).
+For more information about the generated model descriptors, see the [FoundryModel API reference](/reference/api/csharp/aspire.hosting.foundry/foundrymodel/).
 
 If you need a different generated model descriptor, use the corresponding nested type, such as `FoundryModel.Microsoft.Phi4Reasoning`:
 


### PR DESCRIPTION
## Summary
- Keep Microsoft Foundry as the product name in the Foundry integration docs
- Update the overview link to the current Microsoft Foundry documentation
- Point the `FoundryModel` link to the generated Aspire API reference for `Aspire.Hosting.Foundry`

## Validation
- `pnpm --dir ./src/frontend run test:unit:docs`
