### PR TITLE
[docs] Add --list-steps sample output to aspire do and pipelines pages

### DIFF
--- a/src/frontend/src/content/docs/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/deployment/pipelines.mdx
@@ -440,7 +440,26 @@ Before executing pipeline steps, you can discover what steps would run for a giv
 aspire deploy --list-steps
 ```
 
-This lists the pipeline steps that would be executed by the chosen command, in execution order, without running them. Pair `--list-steps` with the command you intend to run (for example, `aspire publish --list-steps` or `aspire do build --list-steps`) to see exactly which steps a given invocation would trigger.
+Example output:
+
+```text title="Output"
+1. parameter-prompt
+   └─ No dependencies
+
+2. provision-redis-infra
+   ├─ Depends on: parameter-prompt
+   └─ Tags: provision-infra
+
+3. build-webapi
+   ├─ Depends on: parameter-prompt
+   └─ Tags: build-compute
+
+4. deploy-webapi
+   ├─ Depends on: provision-redis-infra, build-webapi
+   └─ Tags: deploy-compute
+```
+
+This lists the pipeline steps that would be executed by the chosen command, in execution order, without running them. Each entry shows the step's position, the steps it depends on, and any tags it carries. Pair `--list-steps` with the command you intend to run (for example, `aspire publish --list-steps` or `aspire do build --list-steps`) to see exactly which steps a given invocation would trigger.
 
 ## Custom pipeline steps
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-do.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-do.mdx
@@ -106,6 +106,27 @@ Running `aspire do --list-steps` produces a numbered list of every step in the p
 aspire do --list-steps
 ```
 
+Example output:
+
+```text title="Output"
+1. parameter-prompt
+   └─ No dependencies
+
+2. provision-redis-infra
+   ├─ Depends on: parameter-prompt
+   └─ Tags: provision-infra
+
+3. build-webapi
+   ├─ Depends on: parameter-prompt
+   └─ Tags: build-compute
+
+4. deploy-webapi
+   ├─ Depends on: provision-redis-infra, build-webapi
+   └─ Tags: deploy-compute
+```
+
+Each entry shows the step's position in execution order, the steps it depends on, and any tags it declares. Steps with no dependencies and no tags are shown as `└─ No dependencies`.
+
 Use this when you just need to confirm a step exists or check its direct dependencies.
 
 ### In-depth report with `aspire do diagnostics`


### PR DESCRIPTION
Adds a short example output block for the `--list-steps` flag to the two pages where it gets the most attention:

- `src/frontend/src/content/docs/reference/cli/commands/aspire-do.mdx` — in the existing **Quick listing with `--list-steps`** subsection.
- `src/frontend/src/content/docs/deployment/pipelines.mdx` — in the existing **Discovering available steps** subsection under `aspire do`.

The sample matches the actual formatter introduced in microsoft/aspire#16085 (verified against `PipelineCommandBase.PrintPipelineSteps` and `PipelineCommandListStepsTests.cs`) so the page accurately reflects what users see in the terminal — including the `├─` / `└─` connectors used for steps with deps only, deps and tags, or no dependencies at all.

This is a small follow-up polish on top of #801 (which originally documented `--list-steps`) and closes out item **#2** of microsoft/aspire.dev#837.

### Validation

- `pnpm --dir ./src/frontend run lint` — clean
- `pnpm --dir ./src/frontend run test:unit:docs` — 2/2 passed

### Notes

- Targets `release/13.3` because `--list-steps` shipped in 13.3 and the existing `--list-steps` documentation lives there.
- A separate, minor expansion of the corresponding Whats New bullet in `aspire-13-3.mdx` was pushed to #838.