### PR TITLE
docs: update TypeScript endpoint property samples

### DIFF
--- a/src/frontend/src/content/docs/app-host/executable-resources.mdx
+++ b/src/frontend/src/content/docs/app-host/executable-resources.mdx
@@ -43,7 +43,7 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.ts" twoslash
+```typescript title="apphost.ts"
 import { createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
@@ -147,16 +147,19 @@ var app = builder.AddExecutable("app", "node", ".", "app.js")
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 ```typescript title="apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder, EndpointProperty } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 
 const redis = await builder.addRedis("cache");
+const redisEndpoint = await redis.getEndpoint("tcp");
+const redisHost = await redisEndpoint.property(EndpointProperty.Host);
+const redisPort = await redisEndpoint.property(EndpointProperty.Port);
 
 const app = await builder.addExecutable("app", "node", ".", ["app.js"])
     .withReference(redis)
-    .withEnvironment("REDIS_HOST", redis.host)
-    .withEnvironment("REDIS_PORT", redis.port);
+    .withEnvironment("REDIS_HOST", redisHost)
+    .withEnvironment("REDIS_PORT", redisPort);
 ```
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/architecture/resource-hierarchies.mdx
+++ b/src/frontend/src/content/docs/architecture/resource-hierarchies.mdx
@@ -4,6 +4,7 @@ description: Learn how Aspire manages resources and their dependencies in your a
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import AppHostLangPivot from '@components/AppHostLangPivot.astro';
 
 Aspire supports modeling **parent-child relationships** between resources to express ownership, containment, and grouping.
 
@@ -407,14 +408,17 @@ builder.Build().Run();
 ## `EndpointReferenceExpression` — Accessing Endpoint Parts
 
 `EndpointReferenceExpression` represents **one field** of an endpoint (`Host`, `Port`, `Scheme`, etc.).
-Call `endpoint.Property(...)` to get that field; the result is still a structured value and stays deferred until publish/run time.
+In C#, call `endpoint.Property(...)` to get that field. In TypeScript AppHosts, call `await endpoint.property(...)`. The result is still a structured value and stays deferred until publish/run time.
 
 | Need                                    | Pattern                                                |
 | --------------------------------------- | ------------------------------------------------------ |
-| Only one part (e.g., host)              | `endpoint.Property(EndpointProperty.Host)`             |
+| Only one part (e.g., host)              | C#: `endpoint.Property(EndpointProperty.Host)`<br />TypeScript: `await endpoint.property(EndpointProperty.Host)` |
 | Compose multiple parts into one setting | Build a `ReferenceExpression` (see dedicated section). |
 
-```csharp title="Example — Expose Redis Host and Port"
+<AppHostLangPivot>
+  <div slot="csharp">
+
+```csharp title="C# — AppHost.cs"
 var redis = builder.AddContainer("redis", "redis")
                    .WithEndpoint("tcp", 6379);
 
@@ -427,7 +431,32 @@ builder.AddProject("worker")
        });
 ```
 
-In this pattern, `ep.Property(...)` returns an `EndpointReferenceExpression`, which is a structured value that will be resolved at runtime.
+  </div>
+  <div slot="typescript">
+
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder, EndpointProperty } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const redis = await builder.addContainer("redis", "redis");
+await redis.withEndpoint({ name: "tcp", targetPort: 6379 });
+
+const ep = await redis.getEndpoint("tcp");
+const redisHost = await ep.property(EndpointProperty.Host);
+const redisPort = await ep.property(EndpointProperty.Port);
+
+await builder.addProject("worker", "../Worker/Worker.csproj")
+    .withEnvironment("REDIS_HOST", redisHost)
+    .withEnvironment("REDIS_PORT", redisPort);
+
+await builder.build().run();
+```
+
+  </div>
+</AppHostLangPivot>
+
+In this pattern, the endpoint property call returns an `EndpointReferenceExpression`, which is a structured value that will be resolved at runtime.
 
 ```csharp title="Example — Build a Full Redis URL"
 var ep = redis.GetEndpoint("tcp");

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -89,7 +89,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.ts"
 import { createBuilder } from './.modules/aspire.js';
 
 const builder = await createBuilder();
@@ -565,15 +565,20 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder, EndpointProperty } from './.modules/aspire.js';
 
 const builder = await createBuilder();
 
 const postgres = await builder.addPostgres("postgres");
 const database = await postgres.addDatabase("myDatabase");
+const postgresEndpoint = await postgres.getEndpoint("tcp");
+const postgresHost = await postgresEndpoint.property(EndpointProperty.Host);
+const postgresPort = await postgresEndpoint.property(EndpointProperty.Port);
 
 await builder.addNodeApp("my-app", "./app", "index.js")
     .withReference(database)
+    .withEnvironment("POSTGRES_HOST", postgresHost)
+    .withEnvironment("POSTGRES_PORT", postgresPort)
     .withEnvironment("POSTGRES_USER", postgres.userNameParameter)
     .withEnvironment("POSTGRES_PASSWORD", postgres.passwordParameter)
     .withEnvironment("POSTGRES_DATABASE", "myDatabase");


### PR DESCRIPTION
## Summary
- Document the new TypeScript endpoint property expression API from microsoft/aspire#16540
- Update TypeScript samples that pass endpoint host and port values into app resources
- Add TypeScript parity to the EndpointReferenceExpression docs
