### PR TITLE
Document duplicate polyglot capability analyzer

### DIFF
--- a/src/frontend/config/sidebar/reference.topics.ts
+++ b/src/frontend/config/sidebar/reference.topics.ts
@@ -577,6 +577,10 @@ export const referenceTopics: StarlightSidebarTopicsUserConfig[number] = {
               link: '/diagnostics/aspireexport010',
             },
             {
+              label: 'ASPIREEXPORT013',
+              link: '/diagnostics/aspireexport013',
+            },
+            {
               label: 'ASPIRECERTIFICATES001',
               link: '/diagnostics/aspirecertificates001',
             },

--- a/src/frontend/src/content/docs/diagnostics/aspireexport013.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport013.mdx
@@ -1,0 +1,106 @@
+---
+title: Compiler Warning ASPIREEXPORT013
+description: Learn more about compiler Warning ASPIREEXPORT013. A polyglot capability ID is defined by multiple exports in the same assembly.
+---
+
+import { Badge } from '@astrojs/starlight/components';
+
+<Badge
+  text="Version introduced: 13.3"
+  variant="note"
+  size="large"
+  class:list={'mb-1'}
+/>
+
+> Polyglot capability ID '{0}' is defined by multiple exports in this assembly: {1}. Use unique AspireExport IDs for overloaded or colliding members.
+
+This diagnostic warning is reported when two or more Aspire Type System (ATS) exports in the same assembly generate the same runtime capability ID. The capability ID is used to dispatch calls from TypeScript, Python, Java, and other AppHost runtimes back to the hosting integration. Unlike C# method signatures, a capability ID doesn't include the receiver type, parameter list, or overload signature, so exports that are distinct in C# can still collide at runtime.
+
+## Example
+
+The following code generates `ASPIREEXPORT013`:
+
+```csharp title="C# — Integration.cs"
+[AspireExport("configure")]
+public static void ConfigureBuilder(
+    this IDistributedApplicationBuilder builder,
+    string name)
+{
+    // ...
+}
+
+[AspireExport("configure")]
+public static IResourceBuilder<MyResource> ConfigureResource(
+    this IResourceBuilder<MyResource> builder,
+    string value)
+{
+    return builder;
+}
+```
+
+Both exports generate the same capability ID, such as `MyCompany.Hosting.MyIntegration/configure`, even though they target different C# receiver types.
+
+The diagnostic can also be reported for public instance members exposed through `[AspireExport(ExposeMethods = true)]`:
+
+```csharp title="C# — Context.cs"
+[AspireExport(ExposeMethods = true)]
+public sealed class HelmChartOptions
+{
+    public void WithNamespace(string namespaceName)
+    {
+        // ...
+    }
+
+    public void WithNamespace(int namespaceNumber)
+    {
+        // ...
+    }
+}
+```
+
+Both overloads generate the same default member capability ID because the overload signature isn't part of the capability ID.
+
+## To correct this warning
+
+Use unique export IDs for members that would otherwise generate the same capability ID:
+
+```csharp title="C# — Integration.cs"
+[AspireExport("configureBuilder", MethodName = "configure")]
+public static void ConfigureBuilder(
+    this IDistributedApplicationBuilder builder,
+    string name)
+{
+    // ...
+}
+
+[AspireExport("configureResource", MethodName = "configure")]
+public static IResourceBuilder<MyResource> ConfigureResource(
+    this IResourceBuilder<MyResource> builder,
+    string value)
+{
+    return builder;
+}
+```
+
+Use `MethodName` when separate target types can still expose the same friendly method name in the generated SDK while keeping the underlying capability IDs unique. For overloads on the same context type, prefer a single ATS-friendly overload, mark unsupported overloads with `[AspireExportIgnore]`, or give each exported overload a unique SDK method name.
+
+## Suppress the warning
+
+Suppress the warning with either of the following methods:
+
+- Set the severity of the rule in the _.editorconfig_ file.
+
+  ```ini title=".editorconfig"
+  [*.{cs,vb}]
+  dotnet_diagnostic.ASPIREEXPORT013.severity = none
+  ```
+
+  For more information about editor config files, see [Configuration files for code analysis rules](/diagnostics/overview/#suppress-in-the-editorconfig-file).
+
+- Add the following `PropertyGroup` to your project file:
+
+  ```xml title="C# project file"
+  <PropertyGroup>
+      <NoWarn>$(NoWarn);ASPIREEXPORT013</NoWarn>
+  </PropertyGroup>
+  ```

--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -44,13 +44,13 @@ Your C# code runs as-is — the TypeScript SDK is a thin client that calls into 
 The [`📦 Aspire.Hosting.Integration.Analyzers`](https://www.nuget.org/packages/Aspire.Hosting.Integration.Analyzers) package provides build-time validation that catches common export mistakes. Add it to your integration project:
 
 ```xml title="XML — MyIntegration.csproj"
-<PackageReference Include="Aspire.Hosting.Integration.Analyzers" Version="13.2.0">
+<PackageReference Include="Aspire.Hosting.Integration.Analyzers" Version="13.3.0">
     <PrivateAssets>all</PrivateAssets>
     <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 </PackageReference>
 ```
 
-The analyzer reports diagnostics that help you get your exports right before users encounter runtime errors. Common scenarios include detecting incompatible parameter types, missing export annotations on public methods, duplicate export IDs, and synchronous callbacks that could deadlock in multi-language app hosts.
+The analyzer reports diagnostics that help you get your exports right before users encounter runtime errors. Common scenarios include detecting incompatible parameter types, missing export annotations on public methods, duplicate export or capability IDs, and synchronous callbacks that could deadlock in multi-language app hosts.
 
 ## Export extension methods
 
@@ -109,8 +109,54 @@ await app.run();
 ```
 
 <Aside type="tip" title="Naming convention">
-The export ID becomes the method name in generated SDKs. Use camelCase (e.g., `addMyDatabase`, `withDataVolume`). The full capability ID is computed as `{AssemblyName}/{methodName}` — for example, `MyCompany.Hosting.MyDatabase/addMyDatabase`.
+The export ID usually becomes the method name in generated SDKs. Use camelCase (e.g., `addMyDatabase`, `withDataVolume`), or set `MethodName` when the runtime capability ID and SDK method name need to differ. For static exports, the full capability ID is computed as `{AssemblyName}/{exportId}` — for example, `MyCompany.Hosting.MyDatabase/addMyDatabase`.
 </Aside>
+
+### Keep capability IDs unique
+
+The runtime dispatches multi-language calls by **capability ID**. A capability ID is more restrictive than a C# method signature: it doesn't include the C# receiver type, parameter list, or overload signature. Starting in Aspire 13.3, the analyzer reports `ASPIREEXPORT013` when two exports in the same assembly generate the same capability ID.
+
+For static exports, the generated capability ID uses the assembly name and effective export ID. The following methods collide even though they target different C# types:
+
+```csharp title="C# — Duplicate capability ID"
+[AspireExport("configure")]
+public static void ConfigureBuilder(
+    this IDistributedApplicationBuilder builder,
+    string name)
+{
+    // ...
+}
+
+[AspireExport("configure")]
+public static IResourceBuilder<MyDatabaseResource> ConfigureDatabase(
+    this IResourceBuilder<MyDatabaseResource> builder,
+    string value)
+{
+    return builder;
+}
+```
+
+Use distinct export IDs for the runtime capability, and use `MethodName` when you want the generated SDK method name to stay concise on different target types:
+
+```csharp title="C# — Unique capability IDs with SDK method names"
+[AspireExport("configureBuilder", MethodName = "configure")]
+public static void ConfigureBuilder(
+    this IDistributedApplicationBuilder builder,
+    string name)
+{
+    // ...
+}
+
+[AspireExport("configureDatabase", MethodName = "configure")]
+public static IResourceBuilder<MyDatabaseResource> ConfigureDatabase(
+    this IResourceBuilder<MyDatabaseResource> builder,
+    string value)
+{
+    return builder;
+}
+```
+
+When you set `ExposeMethods = true` or `ExposeProperties = true` on a context type, the analyzer also checks the capabilities generated for public instance members. Overloaded instance methods with the same name generate the same default capability ID, so either expose a single ATS-friendly overload, mark unsupported overloads with `[AspireExportIgnore]`, or give each exported member a unique `[AspireExport]` ID and generated `MethodName`.
 
 ## Export resource types
 
@@ -341,6 +387,9 @@ The `Aspire.Hosting.Integration.Analyzers` package reports these diagnostics:
 | ASPIREEXPORT008 | Warning  | Public extension method on exported type missing `[AspireExport]` or `[AspireExportIgnore]` |
 | ASPIREEXPORT009 | Warning  | Export name may collide with other integrations                                             |
 | ASPIREEXPORT010 | Warning  | Synchronous callback invoked inline — may deadlock in multi-language app hosts              |
+| ASPIREEXPORT011 | Warning  | Explicit export ID matches the convention-derived name                                      |
+| ASPIREEXPORT012 | Warning  | Callback context type missing `[AspireExport]`                                              |
+| ASPIREEXPORT013 | Warning  | Duplicate polyglot capability ID across exports in the same assembly                        |
 
 A clean build with zero analyzer warnings means your integration is ready for multi-language use.
 


### PR DESCRIPTION
## Summary
- Document ASPIREEXPORT013 for duplicate polyglot capability IDs
- Update the multi-language integration authoring article with capability ID uniqueness guidance
- Add ASPIREEXPORT013 to the diagnostics sidebar
