### PR TITLE
fix: update keyboard shortcut for stopping AppHost in documentation

### DIFF
--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -680,7 +680,7 @@ Once the AppHost captures the resources and relationships you care about, start 
 
 4. Exercise the actual app flows you care about, such as frontend-to-API calls, worker jobs, or database access.
 
-5. Stop the system by pressing <Kbd windows="Ctrl+C" mac="⌘+C" /> in your terminal.
+5. Stop the system by pressing <Kbd windows="Ctrl+C" mac="⌃+C" /> in your terminal.
 
 </Steps>
 

--- a/src/frontend/src/content/docs/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/first-app.mdx
@@ -408,7 +408,7 @@ To create your first Aspire application, use the [Aspire CLI](/get-started/insta
 <Pivot id="csharp">
 <Steps>
 
-1. Stop the AppHost and close the dashboard by pressing <Kbd windows="Ctrl+C" mac="⌘+C" /> in your terminal.
+1. Stop the AppHost and close the dashboard by pressing <Kbd windows="Ctrl+C" mac="⌃+C" /> in your terminal.
 
     ```bash title="Stop dev-time orchestration"
     🛑  Stopping Aspire.
@@ -428,7 +428,7 @@ To create your first Aspire application, use the [Aspire CLI](/get-started/insta
 
 <Steps>
 
-1. Stop the AppHost and close the dashboard by pressing <Kbd windows="Ctrl+C" mac="⌘+C" /> in your terminal.
+1. Stop the AppHost and close the dashboard by pressing <Kbd windows="Ctrl+C" mac="⌃+C" /> in your terminal.
 
     ```bash title="Stop dev-time orchestration"
     🛑  Stopping Aspire.

--- a/src/frontend/src/content/docs/get-started/troubleshooting.mdx
+++ b/src/frontend/src/content/docs/get-started/troubleshooting.mdx
@@ -28,7 +28,7 @@ Having issues getting started with Aspire? This page covers solutions to the mos
 **Solution**:
 
 - Stop any other applications using the same ports
-- If you have another Aspire app running, stop it first with <Kbd windows="Ctrl+C" mac="⌘+C" />
+- If you have another Aspire app running, stop it first with <Kbd windows="Ctrl+C" mac="⌃+C" />
 
 ### How to find processes using a port
 

--- a/src/frontend/src/content/docs/ja/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/ja/get-started/first-app.mdx
@@ -364,7 +364,7 @@ import pythonDashboardDark from '@assets/get-started/python-aspire-dashboard-dar
 
 <Steps>
 
-1. ターミナルで <Kbd windows="Ctrl+C" mac="⌘+C" /> を押すと、AppHost が停止し、ダッシュボードも閉じられます。
+1. ターミナルで <Kbd windows="Ctrl+C" mac="⌃+C" /> を押すと、AppHost が停止し、ダッシュボードも閉じられます。
 
     ```bash title="開発時オーケストレーションを停止する"
     🛑  Stopping Aspire.


### PR DESCRIPTION
Stopping the apphost is done with  ⌃ (control) + c on mac instead of ⌘ + c