### PR TITLE
docs: clarify AppHost language pivot guidance

### DIFF
--- a/.github/agents/community-toolkit-integration-doc-writer.agent.md
+++ b/.github/agents/community-toolkit-integration-doc-writer.agent.md
@@ -88,6 +88,7 @@ This step ensures that the documentation you've created is properly indexed and 
 ### Required components and imports
 * Import `Badge` from '@astrojs/starlight/components' and add `<Badge text="⭐ Community Toolkit" variant="tip" size="large" />` at the top
 * Import and use the `Aside` component for notes, tips, cautions, and warnings
+* Import and use `AppHostLangPivot` for AppHost examples when both C# and TypeScript AppHost APIs are available
 * Import and use `InstallPackage` for hosting packages
 * Import and use `InstallDotNetPackage` for client packages
 * Import `Image` from 'astro:assets' for icons
@@ -137,6 +138,13 @@ This step ensures that the documentation you've created is properly indexed and 
 * For C# code in AppHost, always end with `// After adding all resources, run the app...` comment
 * Show complete, runnable examples
 * Use proper formatting and indentation
+
+### AppHost language parity
+* Follow the `doc-writer` skill's AppHost language parity guidance for all AppHost and hosting-integration examples.
+* Always show both C# AppHost (`AppHost.cs`) and TypeScript AppHost (`apphost.ts`) variants inside `AppHostLangPivot` unless the feature is genuinely language-specific or TypeScript AppHost support does not exist yet.
+* Before writing a TypeScript AppHost example, verify the API exists in the TypeScript AppHost SDK. Do not invent TypeScript samples.
+* If TypeScript AppHost support is not available, show only the C# example without `AppHostLangPivot` and add a note that TypeScript AppHost support for the integration is not yet available.
+* Use language-neutral prose around AppHost examples, such as "Add a resource to your AppHost" instead of C#-specific method instructions.
 
 ### Writing style
 * Use imperative mood for instructions ("call the method", not "you call the method")

--- a/.github/skills/doc-writer/SKILL.md
+++ b/.github/skills/doc-writer/SKILL.md
@@ -87,6 +87,7 @@ Additional commonly used imports:
 ```tsx
 import { Kbd } from 'starlight-kbd/components';
 import LearnMore from '@components/LearnMore.astro';
+import AppHostLangPivot from '@components/AppHostLangPivot.astro';
 import PivotSelector from '@components/PivotSelector.astro';
 import Pivot from '@components/Pivot.astro';
 import ThemeImage from '@components/ThemeImage.astro';
@@ -175,7 +176,7 @@ If a heading should appear in the **On this page** table of contents, keep that 
 
 #### Pivot/PivotSelector
 
-Use for programming language selection that persists across page:
+Use for programming language selection that persists across a page. For Aspire AppHost C# and TypeScript content, use `AppHostLangPivot` instead; see [AppHost Language Parity (C# and TypeScript)](#apphost-language-parity-c-and-typescript).
 
 ```mdx
 <PivotSelector
@@ -203,20 +204,6 @@ If a heading needs to appear in the **On this page** table of contents, keep the
 When a page shows the **On this page** table of contents (the default behavior unless `tableOfContents: false` is set), do **not** add an `Overview` heading at any level (`##`, `###`, etc.). The docs site already provides an implicit overview link to the top of the page, so an explicit `Overview` heading becomes redundant.
 
 If your opening section is truly introductory, keep it as body copy without an `Overview` heading. If that section has a more specific purpose, use a descriptive heading such as `Key concepts`, `Prerequisites`, or another topic-specific label.
-
-For Aspire AppHost docs, use a single page-level `PivotSelector` with `key="aspire-lang"` when the surrounding section flow should switch as one unit. If a page would otherwise need multiple `aspire-lang` selectors, keep the page-level selector for the main flow and use synced `Tabs`/`TabItem` with `syncKey='aspire-lang'` for repeated language-specific examples later on the page.
-
-```mdx
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-C# example content here.
-</TabItem>
-
-<TabItem id='typescript' label='TypeScript'>
-TypeScript example content here.
-</TabItem>
-</Tabs>
-```
 
 #### CardGrid and LinkCard
 

--- a/.github/skills/doc-writer/SKILL.md
+++ b/.github/skills/doc-writer/SKILL.md
@@ -176,7 +176,7 @@ If a heading should appear in the **On this page** table of contents, keep that 
 
 #### Pivot/PivotSelector
 
-Use for programming language selection that persists across a page. For Aspire AppHost C# and TypeScript content, use `AppHostLangPivot` instead; see [AppHost Language Parity (C# and TypeScript)](#apphost-language-parity-c-and-typescript).
+Use for programming language selection that persists across page navigations (for example, site-wide via query string and local storage). For Aspire AppHost C# and TypeScript content, use `AppHostLangPivot` instead; see [AppHost Language Parity (C# and TypeScript)](#apphost-language-parity-c-and-typescript).
 
 ```mdx
 <PivotSelector


### PR DESCRIPTION
## Summary

- Remove stale AppHost guidance that recommended `PivotSelector`/synced tabs for C# and TypeScript AppHost content.
- Clarify that `AppHostLangPivot` is the default for AppHost language-specific docs content.
- Add AppHost language parity guidance to the Community Toolkit integration doc writer agent.

## Notes

Documentation-only guidance update; no site behavior changes.