### PR TITLE
Update MCP docs for Aspire 13.3

### DIFF
--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -16,7 +16,7 @@ Aspire provides a first-class setup experience for AI coding agents. Run `aspire
 
 Aspire gives coding agents the same visibility into your running application that a developer has. The resource data, structured logs, and distributed traces you see in the [Aspire Dashboard](/dashboard/overview/) are exposed to agents through the [Aspire MCP server](/get-started/aspire-mcp-server/) and the [Aspire CLI](/get-started/install-cli/). Whether a person is debugging in the dashboard or an agent is diagnosing through MCP, they see the same picture.
 
-The Aspire CLI is built for agent-driven workflows — every command works non-interactively to not block and prompts and supports `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
+The Aspire CLI is built for agent-driven workflows — commands support non-interactive execution to avoid blocking on prompts, and many commands support `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
 
 The Aspire skill file (installed by `aspire agent init`) teaches agents all of these patterns automatically.
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-init.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-init.mdx
@@ -1,6 +1,6 @@
 ---
 title: aspire agent init command
-description: Learn about the aspire agent init command and its usage. This command initializes MCP server configuration for detected agent environments.
+description: Learn about the aspire agent init command and its usage. This command initializes AI agent configuration for detected agent environments.
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
@@ -9,7 +9,7 @@ import Include from '@components/Include.astro';
 
 ## Name
 
-`aspire agent init` - Initialize <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr> server configuration for detected agent environments.
+`aspire agent init` - Initialize AI agent configuration for detected agent environments.
 
 ## Synopsis
 
@@ -33,17 +33,17 @@ The command also removes skill files from any locations that were deselected, ke
 
 The following options are available:
 
-- **`--workspace-root`**
+- **`--workspace-root <workspace-root>`**
 
   Path to the workspace root directory. When not specified, the current directory is used as the workspace root.
 
-- **`--skill-locations`**
+- **`--skill-locations <skill-locations>`**
 
-  Comma-separated list of skill locations to configure (for example, `vscode,github`). Use `all` to configure all detected locations, or `none` to skip. When not specified, the command prompts interactively.
+  Comma-separated list of skill locations to configure, such as `standard`, `claudecode`, `github`, or `opencode`. Use `all` to configure all supported locations or `none` to skip skill location configuration. When not specified, the command prompts interactively.
 
-- **`--skills`**
+- **`--skills <skills>`**
 
-  Comma-separated list of skills to enable (for example, `mcp,cli`). Use `all` to enable all available skills, or `none` to skip. When not specified, the command prompts interactively.
+  Comma-separated list of skills to enable, such as `aspire`, `aspireify`, `playwright-cli`, or `dotnet-inspect`. Use `all` to enable all available skills or `none` to skip skill installation. When not specified, the command prompts interactively.
 
 - <Include relativePath="reference/cli/includes/option-help.md" />
 
@@ -59,10 +59,22 @@ The following options are available:
 
 ## Examples
 
-- Initialize MCP configuration for detected agent environments:
+- Initialize AI agent configuration for detected agent environments:
 
   ```bash title="Aspire CLI"
   aspire agent init
+  ```
+
+- Install all supported Aspire skills in all supported skill locations:
+
+  ```bash title="Aspire CLI"
+  aspire agent init --skills all --skill-locations all
+  ```
+
+- Initialize agent configuration from a specific workspace root:
+
+  ```bash title="Aspire CLI"
+  aspire agent init --workspace-root ./src
   ```
 
 ## See also

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-mcp.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-mcp.mdx
@@ -36,21 +36,17 @@ When the server is running, MCP-compatible clients can connect to it to:
 - Execute resource commands (start, stop, restart)
 - Query integration information
 
-You can also connect directly to a standalone Aspire Dashboard (one not managed by an AppHost) by providing `--dashboard-url`. In this dashboard-only mode, only the three telemetry tools (`list_structured_logs`, `list_traces`, `list_trace_structured_logs`) are exposed; AppHost-specific tools are not available.
+By default, the server discovers running AppHosts from the current workspace. You can also connect directly to a standalone Aspire Dashboard (one not managed by an AppHost) by providing `--dashboard-url`. In this dashboard-only mode, only the three telemetry tools (`list_structured_logs`, `list_traces`, `list_trace_structured_logs`) are exposed; AppHost-specific tools are not available.
 
 ## Options
 
 The following options are available:
 
-- **`--apphost <apphost>`**
+- **`--dashboard-url <dashboard-url>`**
 
-  The path to the Aspire AppHost project file. Mutually exclusive with `--dashboard-url`.
+  The URL of a standalone Aspire Dashboard to connect to instead of discovering one from an AppHost. Accepts a base URL (for example, `http://localhost:18888`) or a full login URL including a browser token (for example, `http://localhost:18888/login?t=<token>`). When a login URL is provided, the token is automatically exchanged for an API key.
 
-- **`--dashboard-url <url>`**
-
-  The URL of a standalone Aspire Dashboard to connect to instead of discovering one from an AppHost. Accepts a base URL (for example, `http://localhost:18888`) or a full login URL including a browser token (for example, `http://localhost:18888/login?t=<token>`). When a login URL is provided, the token is automatically exchanged for an API key. Mutually exclusive with `--apphost`.
-
-- **`--api-key <key>`**
+- **`--api-key <api-key>`**
 
   The API key used to authenticate with the dashboard's Telemetry API. Only required when `--dashboard-url` is specified and the dashboard is configured with `ApiKey` authentication and no login URL is provided.
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-agent.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: aspire agent command
-description: Learn about the aspire agent command and its usage. This command driver is used to manage AI agent integrations and MCP (Model Context Protocol) server operations.
+description: Learn about the aspire agent command and its usage. This command driver manages AI agent integrations, Aspire skill files, and MCP (Model Context Protocol) server operations.
 ---
 
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
@@ -21,7 +21,7 @@ aspire agent [command] [options]
 
 ## Description
 
-The `aspire agent` command manages AI agent integrations for Aspire. This includes starting the <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr> (Model Context Protocol) server and initializing agent environment configurations. The MCP server enables AI assistants and development tools to interact with your Aspire AppHost, providing capabilities such as resource management, diagnostics, and observability.
+The `aspire agent` command manages AI agent integrations for Aspire. This includes initializing agent environment configuration, installing Aspire skill files, and starting the <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr> server. The MCP server enables AI assistants and development tools to interact with your Aspire AppHost, providing capabilities such as resource management, diagnostics, and observability.
 
 ## Options
 
@@ -46,7 +46,7 @@ The following commands are available:
 | Command                                      | Status | Function                                                             |
 | -------------------------------------------- | ------ | -------------------------------------------------------------------- |
 | [`aspire agent mcp`](../aspire-agent-mcp/)   | Stable | Start the MCP (Model Context Protocol) server.                       |
-| [`aspire agent init`](../aspire-agent-init/) | Stable | Initialize MCP server configuration for detected agent environments. |
+| [`aspire agent init`](../aspire-agent-init/) | Stable | Initialize AI agent configuration for detected agent environments.   |
 
 ## See also
 


### PR DESCRIPTION
## Summary
- align Aspire MCP and AI agent CLI reference docs with the Aspire 13.3 command surface
- document current skill and skill-location option values for `aspire agent init`
- remove stale `--apphost` guidance from `aspire agent mcp` and clarify standalone dashboard MCP usage

## Validation
- `aspire --version` confirmed 13.3.0
- `git diff --check`

Closes #334