### PR TITLE
Document Azure HTTPS endpoint upgrades

### DIFF
--- a/src/frontend/src/content/docs/deployment/azure/app-service.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/app-service.mdx
@@ -99,6 +99,51 @@ Start with the common case:
 
 App Service routes public traffic to the app's target port, even if the app listens on a development port such as `8080`.
 
+### Automatic HTTPS upgrade
+
+Azure App Service redirects HTTP traffic to HTTPS at the platform level. To match the deployed serving scheme, Aspire upgrades external HTTP endpoints in an App Service environment to HTTPS on port 443 when it generates endpoint URLs and service discovery connection strings for dependent resources.
+
+This behavior is enabled by default. If you intentionally need generated endpoint URLs and connection strings to preserve `http://`, disable the upgrade on the App Service environment:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureAppServiceEnvironment("app-service-env")
+    .WithHttpsUpgrade(false);
+
+builder.AddDockerfile("web", "./web")
+    .WithHttpEndpoint(port: 8080, targetPort: 8080, name: "http")
+    .WithExternalHttpEndpoints();
+
+builder.Build().Run();
+
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts" twoslash
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+await builder
+    .addAzureAppServiceEnvironment("app-service-env")
+    .withHttpsUpgrade(false);
+
+await builder
+    .addDockerfile("web", "./web")
+    .withHttpEndpoint({ port: 8080, targetPort: 8080, name: "http" })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+Disabling the upgrade primarily affects generated endpoint configuration for dependent resources. Azure App Service can still redirect HTTP requests to HTTPS after deployment.
+
 ### Constraints
 
 Azure App Service uses a public website model:

--- a/src/frontend/src/content/docs/deployment/azure/container-apps.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/container-apps.mdx
@@ -114,7 +114,45 @@ Azure Container Apps uses an Envoy-based HTTP edge proxy for HTTP ingress:
 
 - public HTTP-style ingress is exposed through the platform HTTPS endpoint by default
 - HTTP requests sent to the app are redirected to HTTPS
-- you can turn off that default upgrade behavior on the environment if you need to keep HTTP behavior
+
+To match the deployed serving scheme, Aspire upgrades external HTTP endpoints in an Azure Container Apps environment to HTTPS when it generates endpoint URLs and service discovery connection strings for dependent resources. If you intentionally need generated endpoint URLs and connection strings to preserve `http://`, disable the upgrade on the environment:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("aca-env")
+    .WithHttpsUpgrade(false);
+
+builder.AddDockerfile("web", "./web")
+    .WithHttpEndpoint(port: 8080, targetPort: 8080, name: "http")
+    .WithExternalHttpEndpoints();
+
+builder.Build().Run();
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.ts" twoslash
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+await builder
+    .addAzureContainerAppEnvironment("aca-env")
+    .withHttpsUpgrade(false);
+
+await builder
+    .addDockerfile("web", "./web")
+    .withHttpEndpoint({ port: 8080, targetPort: 8080, name: "http" })
+    .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+Disabling the upgrade primarily affects generated endpoint configuration for dependent resources. Azure Container Apps can still redirect HTTP requests to HTTPS after deployment.
 
 ### Constraints and edge cases
 


### PR DESCRIPTION
Docs update for microsoft/aspire.dev#833 item 19.

Covers the WithHttpsUpgrade behavior introduced by microsoft/aspire#16060 for Azure App Service endpoints and adds matching Azure Container Apps deployment guidance for the same opt-out behavior.

Validation:
- pnpm --dir .\src\frontend run test:unit:docs
- pnpm --dir .\src\frontend run build:skip-search (fails on release/13.3 baseline: missing @assets/get-started/install-aspire-code-extension.png from src/frontend/src/content/docs/ja/get-started/aspire-vscode-extension.mdx; unrelated to this diff)