### PR TITLE
Port AppHost path config docs to release/13.3

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-config-set.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-config-set.mdx
@@ -51,6 +51,7 @@ The following options are available:
 
   Set the configuration value in user-scoped global Aspire configuration
   instead of the rooted `aspire.config.json` file.
+  Project-specific values such as `appHost.path` can't be set globally.
 
 - <Include relativePath="reference/cli/includes/option-help.md" />
 

--- a/src/frontend/src/content/docs/reference/cli/configuration.mdx
+++ b/src/frontend/src/content/docs/reference/cli/configuration.mdx
@@ -107,6 +107,33 @@ can configure.
 
 <Include relativePath="reference/cli/includes/config-settings-table.md" />
 
+### Configure the AppHost path
+
+Use `appHost.path` to set the default AppHost entry point for the current
+configuration root:
+
+```bash title="Set the local AppHost path"
+aspire config set appHost.path ./apphost.ts
+```
+
+The CLI writes this value to the local `aspire.config.json` file:
+
+```json title="aspire.config.json"
+{
+  "appHost": {
+    "path": "./apphost.ts"
+  }
+}
+```
+
+The AppHost path can point to the entry point used by your AppHost language, such
+as `apphost.ts`, `Program.cs`, or an AppHost project file. The path is
+project-specific and can't be configured globally. If a global settings file
+contains `appHost.path` or the legacy `appHostPath` key, the CLI ignores that
+value and warns that AppHost paths must be configured locally. The legacy
+`appHostPath` key is also blocked by `aspire config set`; use `appHost.path`
+instead.
+
 :::tip
 Some feature flags shown by `aspire config list --all` may correspond to
 preview, migration, or hidden functionality. Treat the output of your
@@ -156,7 +183,7 @@ CLI supports.
   installed CLI can configure.
 
 - Use `aspire config get <key>` to inspect a specific setting such as
-  `channel` or `appHostPath`.
+  `channel` or `appHost.path`.
 
 - Use `aspire config set <key> <value>` to update a setting, and
   `aspire config set --global ...` when you want a user-scoped default.

--- a/src/frontend/src/content/docs/reference/cli/includes/config-file-description.md
+++ b/src/frontend/src/content/docs/reference/cli/includes/config-file-description.md
@@ -15,3 +15,5 @@ defaults.
 
   User-scoped defaults can be set with `aspire config set --global ...`.
   Project-scoped settings override global values when both are present.
+  Project-specific values such as `appHost.path` must be configured locally in
+  `aspire.config.json`.

--- a/src/frontend/src/content/docs/reference/cli/includes/config-settings-table.md
+++ b/src/frontend/src/content/docs/reference/cli/includes/config-settings-table.md
@@ -2,16 +2,16 @@
 title: Config Settings Table
 ---
 
-| Logical key                            | Stored in `aspire.config.json` as      | Description                                                                                                      |
-| -------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `appHostPath`                          | `appHost.path`                         | Path to the default AppHost project for the rooted configuration.                                                |
-| `channel`                              | `channel`                              | Default Aspire channel used by channel-aware commands such as `aspire new`, `aspire init`, and `aspire update`.  |
-| `features.defaultWatchEnabled`         | `features.defaultWatchEnabled`         | Enable or disable watch mode by default when running Aspire applications for automatic restarts on file changes. |
-| `features.execCommandEnabled`          | `features.execCommandEnabled`          | Enable or disable the legacy `aspire exec` command for executing commands inside running resources.              |
-| `features.experimentalPolyglot:go`     | `features.experimentalPolyglot:go`     | Enable or disable experimental Go language support for polyglot Aspire applications.                             |
-| `features.experimentalPolyglot:java`   | `features.experimentalPolyglot:java`   | Enable or disable experimental Java language support for polyglot Aspire applications.                           |
-| `features.experimentalPolyglot:python` | `features.experimentalPolyglot:python` | Enable or disable experimental Python language support for polyglot Aspire applications.                         |
-| `features.experimentalPolyglot:rust`   | `features.experimentalPolyglot:rust`   | Enable or disable experimental Rust language support for polyglot Aspire applications.                           |
-| `features.showAllTemplates`            | `features.showAllTemplates`            | Show all available templates, including experimental ones, in `aspire new` and `aspire init`.                    |
-| `features.showDeprecatedPackages`      | `features.showDeprecatedPackages`      | Show or hide deprecated packages in `aspire add` search results.                                                 |
-| `features.updateNotificationsEnabled`  | `features.updateNotificationsEnabled`  | Enable or disable Aspire CLI update notifications.                                                               |
+| Logical key                            | Stored in `aspire.config.json` as      | Description                                                                                                                                         |
+| -------------------------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `appHost.path`                         | `appHost.path`                         | Project-scoped path to the default AppHost entry point. This setting must be configured in the local `aspire.config.json` file.                     |
+| `channel`                              | `channel`                              | Default Aspire channel used by channel-aware commands such as `aspire new`, `aspire init`, and `aspire update`.                                     |
+| `features.defaultWatchEnabled`         | `features.defaultWatchEnabled`         | Enable or disable watch mode by default when running Aspire applications for automatic restarts on file changes.                                    |
+| `features.execCommandEnabled`          | `features.execCommandEnabled`          | Enable or disable the legacy `aspire exec` command for executing commands inside running resources.                                                 |
+| `features.experimentalPolyglot:go`     | `features.experimentalPolyglot:go`     | Enable or disable experimental Go language support for polyglot Aspire applications.                                                                |
+| `features.experimentalPolyglot:java`   | `features.experimentalPolyglot:java`   | Enable or disable experimental Java language support for polyglot Aspire applications.                                                              |
+| `features.experimentalPolyglot:python` | `features.experimentalPolyglot:python` | Enable or disable experimental Python language support for polyglot Aspire applications.                                                            |
+| `features.experimentalPolyglot:rust`   | `features.experimentalPolyglot:rust`   | Enable or disable experimental Rust language support for polyglot Aspire applications.                                                              |
+| `features.showAllTemplates`            | `features.showAllTemplates`            | Show all available templates, including experimental ones, in `aspire new` and `aspire init`.                                                       |
+| `features.showDeprecatedPackages`      | `features.showDeprecatedPackages`      | Show or hide deprecated packages in `aspire add` search results.                                                                                    |
+| `features.updateNotificationsEnabled`  | `features.updateNotificationsEnabled`  | Enable or disable Aspire CLI update notifications.                                                                                                  |


### PR DESCRIPTION
## Summary
- Ports #862 to release/13.3.
- Documents `appHost.path` as the supported local AppHost path setting.
- Clarifies that AppHost paths can't be configured globally and that legacy `appHostPath` is blocked by `aspire config set`.

## Validation
- pnpm --dir ./src/frontend run lint
- pnpm --dir ./src/frontend run test:unit:docs
