### PR TITLE
Use pnpm instead of npm in check-data-files.mjs

### DIFF
--- a/src/frontend/scripts/check-data-files.mjs
+++ b/src/frontend/scripts/check-data-files.mjs
@@ -21,7 +21,7 @@ function checkDataFiles() {
     console.log('\n🔄 Running update:all to generate missing files...\n');
 
     try {
-      execSync('npm run update:all', { stdio: 'inherit' });
+      execSync('pnpm run update:all', { stdio: 'inherit' });
       console.log('\n✅ Data files generated successfully');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';


### PR DESCRIPTION
## Summary

Fixes #872

The repository is configured as a `pnpm` workspace (`pnpm-workspace.yaml`, `pnpm-lock.yaml`, `"packageManager": "pnpm@10.30.1"`), but `src/frontend/scripts/check-data-files.mjs` hardcoded:

```js
execSync('npm run update:all', { stdio: 'inherit' });
```

When `pnpm dev` is run and missing data files are detected, the script jumps out of the active `pnpm` environment and forces `npm run update:all`. Running `npm` inside a `pnpm` workspace:

- Ignores `pnpm-lock.yaml`
- Creates an unnecessary `package-lock.json`
- Generates an incompatible flat `node_modules` structure
- Can corrupt or destabilize the local development environment
- Breaks workspace dependency consistency

## Change

This repo is intended to strictly use `pnpm` (it ships a `pnpm-workspace.yaml` and pins `packageManager` to `pnpm@10.30.1`), so the script now invokes `pnpm` directly:

```js
execSync('pnpm run update:all', { stdio: 'inherit' });
```

This keeps the call site simple and matches every other script invocation in `src/frontend/package.json` (`dev`, `start`, `build`, `lint`, `test`, `update:all`, etc. all use `pnpm`).