### PR TITLE
Improve AI-powered debugging section on dashboard pages

### DIFF
--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -17,6 +17,7 @@ import FeatureShowcase from '@components/FeatureShowcase.astro';
 import ImageShowcase from '@components/ImageShowcase.astro';
 import CapabilityGrid from '@components/CapabilityGrid.astro';
 import CTABanner from '@components/CTABanner.astro';
+import TerminalShowcase from '@components/TerminalShowcase.astro';
 
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 
@@ -24,7 +25,6 @@ import projectsImage from '@assets/dashboard/explore/resources-filtered-containe
 import tracesImage from '@assets/dashboard/explore/trace-span-details.png';
 import metricsImage from '@assets/dashboard/explore/metrics-view.png';
 import structuredLogsImage from '@assets/dashboard/explore/structured-logs-errors-view.png';
-import mcpDialogImage from '@assets/dashboard/mcp-server/mcp-dialog.png';
 
 <TopicHero
   icon="seti:happenings"
@@ -99,13 +99,14 @@ Navigate to `http://localhost:18888` to open the dashboard, and point your apps'
 
 ## AI-powered debugging
 
-<ImageShowcase
-  title="MCP server for AI agents"
-  description="Expose your app's telemetry, resources, and logs to AI coding agents via the Model Context Protocol. Give your coding assistants full observability context for smarter debugging."
-  image={mcpDialogImage}
-  imageAlt="Aspire Dashboard MCP server configuration dialog showing connection details for AI assistants."
-  imagePosition="left"
-  cta={{ label: 'Configure MCP server', href: '/get-started/aspire-mcp-server/' }}
+<TerminalShowcase
+  title="Your AI agent sees what you see —"
+  highlight="logs, traces, and resources."
+  description="AI coding agents read the same dashboard telemetry you do through the Aspire CLI and the Aspire MCP server. Agents call commands like aspire describe, aspire otel logs, and aspire otel traces — or MCP tools such as list_structured_logs and list_traces — to diagnose issues, verify fixes, and reason over real running-app data."
+  cast="/casts/mcp-copilot-cli.cast"
+  poster="npt:0:22"
+  rows={20}
+  cta={{ label: 'Use AI coding agents with the dashboard', href: '/dashboard/ai-coding-agents/' }}
 />
 
 ## Key capabilities
@@ -163,11 +164,11 @@ Navigate to `http://localhost:18888` to open the dashboard, and point your apps'
   features={[
     {
       icon: 'puzzle',
-      title: 'MCP server',
+      title: 'AI coding agents',
       description:
-        'Expose dashboard data to AI agents and coding assistants via the Model Context Protocol. Your AI tools get full observability context.',
-      href: '/get-started/aspire-mcp-server/',
-      label: 'Configure MCP',
+        'Give AI coding agents the same observability context you have. Aspire CLI commands and the Aspire MCP server expose dashboard logs, traces, and resource state to any MCP-compatible assistant.',
+      href: '/dashboard/ai-coding-agents/',
+      label: 'Set up agents',
       accent: 'purple',
     },
     {

--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -105,7 +105,7 @@ Navigate to `http://localhost:18888` to open the dashboard, and point your apps'
   description="AI coding agents read the same dashboard telemetry you do through the Aspire CLI and the Aspire MCP server. Agents call commands like aspire describe, aspire otel logs, and aspire otel traces — or MCP tools such as list_structured_logs and list_traces — to diagnose issues, verify fixes, and reason over real running-app data."
   cast="/casts/mcp-copilot-cli.cast"
   poster="npt:0:22"
-  rows={20}
+  rows={15}
   cta={{ label: 'Use AI coding agents with the dashboard', href: '/dashboard/ai-coding-agents/' }}
 />
 

--- a/src/frontend/src/content/docs/dashboard/overview.mdx
+++ b/src/frontend/src/content/docs/dashboard/overview.mdx
@@ -29,6 +29,14 @@ The dashboard is integrated into the [Aspire _*.AppHost_](/get-started/app-host/
 
 For more information about using the dashboard during Aspire development, see [Explore dashboard features](/dashboard/explore/).
 
+## Use the dashboard with AI coding agents
+
+The dashboard isn't just a UI for developers — its data is also available to AI coding agents through the [Aspire CLI](/reference/cli/overview/) and the [Aspire MCP server](/get-started/aspire-mcp-server/). Agents read the same structured logs, distributed traces, console output, and resource state that you see in the dashboard, so they can diagnose issues, verify fixes, and add features with full runtime context.
+
+CLI commands like [`aspire describe`](/reference/cli/commands/aspire-describe/), [`aspire otel logs`](/reference/cli/commands/aspire-otel-logs/), and [`aspire otel traces`](/reference/cli/commands/aspire-otel-traces/) all support `--format Json` for machine-readable output. The MCP server exposes equivalent tools — `list_resources`, `list_structured_logs`, `list_traces`, and `list_console_logs` — to any MCP-compatible assistant.
+
+For setup steps, supported assistants, and a sample agent workflow, see [Dashboard and AI coding agents](/dashboard/ai-coding-agents/).
+
 ## Standalone mode
 
 The Aspire dashboard is also shipped as a Docker image and can be used standalone, without the rest of Aspire. The standalone dashboard provides a great UI for viewing telemetry and can be used by any application.
@@ -88,3 +96,4 @@ For more information, see [Aspire dashboard security considerations](/dashboard/
 ## Next steps
 
 - [Explore the Aspire dashboard](/dashboard/explore/)
+- [Use AI coding agents with the dashboard](/dashboard/ai-coding-agents/)


### PR DESCRIPTION
## Summary

Closes #874.

The dashboard landing page (`/dashboard/`) had an "AI-powered debugging" section showing an outdated screenshot of the **in-dashboard MCP server configuration dialog** — a UI that was removed in 13.3 (see #784, #808, #825). The card also linked only to MCP server configuration with no path to the new [Dashboard and AI coding agents](/dashboard/ai-coding-agents/) topic.

The dashboard overview page (`/dashboard/overview/`) had shrunk to a single bullet about agents + MCP and didn't have the "content section on using agents with the dashboard" the issue calls for.

## Before / after

**Before** — outdated `ImageShowcase` of the removed in-dashboard MCP dialog:

![Before — AI-powered debugging section showing the outdated in-dashboard MCP server configuration dialog screenshot with an MCP server for AI agents card on the right.](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/assets-issue-874/before.png)

**After** — `TerminalShowcase` playing the existing `mcp-copilot-cli.cast`:

![After — AI-powered debugging section showing a TerminalShowcase with GitHub Copilot CLI calling Aspire and showing reasoning over running app data, plus a Use AI coding agents with the dashboard CTA.](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/assets-issue-874/after.png)

## Changes

`src/frontend/src/content/docs/dashboard/index.mdx`

- Replaced the outdated `ImageShowcase` (using `mcpDialogImage`) with a `TerminalShowcase` that plays the existing `/casts/mcp-copilot-cli.cast` recording — which shows GitHub Copilot CLI calling Aspire MCP / CLI tools to fetch dashboard data and reason over the results, exactly the kind of screenshot the issue suggests.
- Updated the section copy to call out that agents read the same telemetry through the Aspire CLI **and** the Aspire MCP server, with concrete command and tool examples.
- Pointed the CTA at `/dashboard/ai-coding-agents/`.
- Refocused the matching "Beyond development" card from "MCP server" to "AI coding agents" (still mentions MCP) and re-pointed it at `/dashboard/ai-coding-agents/`.
- Removed the now-unused `mcpDialogImage` import.

`src/frontend/src/content/docs/dashboard/overview.mdx`

- Added a new **Use the dashboard with AI coding agents** section between "Use the dashboard with Aspire projects" and "Standalone mode". It explains how agents access the dashboard's logs, traces, console output, and resource state through the Aspire CLI (`aspire describe`, `aspire otel logs`, `aspire otel traces`) and equivalent MCP tools (`list_resources`, `list_structured_logs`, `list_traces`, `list_console_logs`), and links to the full setup guide on `/dashboard/ai-coding-agents/`.
- Added a corresponding entry in the "Next steps" list.

## Notes

- `TerminalShowcase` is already used on `reference/overview.mdx` for the `aspire-new.cast` hero, so the visual treatment is consistent with the rest of the site.
- The `mcp-copilot-cli.cast` recording is also embedded on `get-started/ai-coding-agents.mdx`, so we're reusing existing assets — no new captures required.
- No sidebar or navigation changes — `/dashboard/ai-coding-agents/` is already wired up.
