### PR TITLE
Update standalone dashboard docs for Aspire CLI

### DIFF
--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -17,6 +17,7 @@ import FeatureShowcase from '@components/FeatureShowcase.astro';
 import ImageShowcase from '@components/ImageShowcase.astro';
 import CapabilityGrid from '@components/CapabilityGrid.astro';
 import CTABanner from '@components/CTABanner.astro';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
 
 import projectsImage from '@assets/dashboard/explore/resources-filtered-containers.png';
 import tracesImage from '@assets/dashboard/explore/trace-span-details.png';
@@ -72,15 +73,34 @@ The Aspire Dashboard is your command center during development. Powered by [Open
 
 ## Run the dashboard standalone
 
-The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Choose the startup option that fits your workflow.
+The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data.
+
+Install the Aspire CLI, then start the dashboard:
 
 ```bash title="Aspire CLI"
 aspire dashboard run
 ```
 
-```bash title="Container image"
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest
+Or run the same standalone dashboard from its container image:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard \
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
 ```
+
+</div>
+<div slot="windows">
+
+```powershell
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard `
+    mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+</div>
+</OsAwareTabs>
 
 Open the dashboard URL, then point your apps' OTLP exporter to `http://localhost:4317`. For prerequisites, login details, and additional options, see the [standalone dashboard guide](/dashboard/standalone/).
 

--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -18,8 +18,6 @@ import ImageShowcase from '@components/ImageShowcase.astro';
 import CapabilityGrid from '@components/CapabilityGrid.astro';
 import CTABanner from '@components/CTABanner.astro';
 
-import OsAwareTabs from '@components/OsAwareTabs.astro';
-
 import projectsImage from '@assets/dashboard/explore/resources-filtered-containers.png';
 import tracesImage from '@assets/dashboard/explore/trace-span-details.png';
 import metricsImage from '@assets/dashboard/explore/metrics-view.png';
@@ -74,28 +72,7 @@ The Aspire Dashboard is your command center during development. Powered by [Open
 
 ## Run the dashboard standalone
 
-The dashboard starts automatically with your Aspire app, but it can also run standalone as a Docker container to monitor any application that sends OpenTelemetry data. Start it with a single command:
-
-<OsAwareTabs syncKey="terminal">
-<div slot="unix">
-
-```bash
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-<div slot="windows">
-
-```powershell
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard `
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-</OsAwareTabs>
-
-Navigate to `http://localhost:18888` to open the dashboard, and point your apps' OTLP exporter to `http://localhost:4317`. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
+The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Run it with the Aspire CLI or the standalone container image. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
 
 ## AI-powered debugging
 
@@ -151,7 +128,7 @@ Navigate to `http://localhost:18888` to open the dashboard, and point your apps'
       icon: 'laptop',
       title: 'Standalone mode',
       description:
-        'Use the dashboard independently as a Docker container to monitor any application that sends OpenTelemetry data.',
+        'Use the dashboard independently to monitor any application that sends OpenTelemetry data.',
       href: '/dashboard/standalone/',
     },
   ]}

--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -72,13 +72,17 @@ The Aspire Dashboard is your command center during development. Powered by [Open
 
 ## Run the dashboard standalone
 
-The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Install the Aspire CLI, then start the dashboard:
+The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Choose the startup option that fits your workflow.
 
 ```bash title="Aspire CLI"
 aspire dashboard run
 ```
 
-Open the dashboard URL printed by the CLI, then point your apps' OTLP exporter to `http://localhost:4317`. You can also run the same standalone dashboard from its container image. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
+```bash title="Container image"
+docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard mcr.microsoft.com/dotnet/aspire-dashboard:latest
+```
+
+Open the dashboard URL, then point your apps' OTLP exporter to `http://localhost:4317`. For prerequisites, login details, and additional options, see the [standalone dashboard guide](/dashboard/standalone/).
 
 ## AI-powered debugging
 

--- a/src/frontend/src/content/docs/dashboard/index.mdx
+++ b/src/frontend/src/content/docs/dashboard/index.mdx
@@ -72,7 +72,13 @@ The Aspire Dashboard is your command center during development. Powered by [Open
 
 ## Run the dashboard standalone
 
-The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Run it with the Aspire CLI or the standalone container image. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
+The dashboard starts automatically with your Aspire app, but it can also run standalone to monitor any application that sends OpenTelemetry data. Install the Aspire CLI, then start the dashboard:
+
+```bash title="Aspire CLI"
+aspire dashboard run
+```
+
+Open the dashboard URL printed by the CLI, then point your apps' OTLP exporter to `http://localhost:4317`. You can also run the same standalone dashboard from its container image. For more details, see the [standalone dashboard guide](/dashboard/standalone/).
 
 ## AI-powered debugging
 

--- a/src/frontend/src/content/docs/dashboard/overview.mdx
+++ b/src/frontend/src/content/docs/dashboard/overview.mdx
@@ -4,7 +4,6 @@ description: Overview of Aspire dashboard and getting started.
 ---
 
 import { Image } from 'astro:assets';
-import OsAwareTabs from '@components/OsAwareTabs.astro';
 import ThemeImage from '@components/ThemeImage.astro';
 import projectsImage from '@assets/dashboard/explore/projects.png';
 import architectureDiagramDark from '@assets/dashboard/architecture-diagram-dark.svg';
@@ -31,36 +30,7 @@ For more information about using the dashboard during Aspire development, see [E
 
 ## Standalone mode
 
-The Aspire dashboard is also shipped as a Docker image and can be used standalone, without the rest of Aspire. The standalone dashboard provides a great UI for viewing telemetry and can be used by any application.
-
-<OsAwareTabs syncKey="terminal">
-<div slot="unix">
-
-```bash
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-<div slot="windows">
-
-```powershell
-docker run --rm -it -p 18888:18888 -p 4317:18889 -p 4318:18890 -d --name aspire-dashboard `
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-</OsAwareTabs>
-
-The preceding Docker command:
-
-- Starts a container from the `mcr.microsoft.com/dotnet/aspire-dashboard:latest` image.
-- The container instance exposing three ports:
-  - Maps the dashboard's port `18888` to the host's port `18888`. Port `18888` has the dashboard UI. Navigate to `http://localhost:18888` in the browser to view the dashboard.
-  - Maps the dashboard's OTLP/gRPC port `18889` to the host's port `4317`. Port `4317` receives OpenTelemetry data from apps using [OTLP/gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc).
-  - Maps the dashboard's OTLP/HTTP port `18890` to the host's port `4318`. Port `4318` receives OpenTelemetry data from apps using [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp).
-
-For more information, see the [Standalone Aspire dashboard](/dashboard/standalone/).
+The Aspire dashboard can run standalone, without the rest of Aspire. The standalone dashboard provides a great UI for viewing telemetry and can be used by any application that sends OpenTelemetry data. You can start it with the Aspire CLI or run it from the standalone container image. For more information, see the [Standalone Aspire dashboard](/dashboard/standalone/).
 
 ## Configuration
 

--- a/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
@@ -3,10 +3,9 @@ title: Use the Aspire dashboard with Node.js apps
 description: How to use the Aspire Dashboard in a Node.js application.
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
-import OsAwareTabs from '@components/OsAwareTabs.astro';
+import { Steps } from '@astrojs/starlight/components';
 
-The [Aspire dashboard](/dashboard/overview/) provides a great user experience for viewing telemetry, and is available as a standalone container image that can be used with any OpenTelemetry-enabled app. In this article, you'll learn how to:
+The [Aspire dashboard](/dashboard/overview/) provides a great user experience for viewing telemetry. You can run it standalone with the [Aspire CLI](/reference/cli/overview/) or the standalone dashboard container image for any OpenTelemetry-enabled app. In this article, you'll learn how to:
 
 - Start the Aspire dashboard in standalone mode.
 - Use the Aspire dashboard with a Node.js app.
@@ -15,8 +14,7 @@ The [Aspire dashboard](/dashboard/overview/) provides a great user experience fo
 
 To complete this tutorial, you need the following:
 
-- [Container runtime](/get-started/prerequisites/#install-an-oci-compliant-container-runtime).
-  - You can use an alternative container runtime, but the commands in this article are for Docker.
+- A way to run the standalone dashboard: [Aspire CLI](/get-started/install-cli/) or a [container runtime](/get-started/prerequisites/#install-an-oci-compliant-container-runtime).
 - [Node.js 18 or higher](https://nodejs.org/en/download/package-manager) locally installed.
 
 ## Create a sample application
@@ -202,28 +200,7 @@ Now let's add OpenTelemetry instrumentation to send telemetry data to the Aspire
 
 ## Start the Aspire dashboard
 
-To start the Aspire dashboard in standalone mode, run the following Docker command:
-
-<OsAwareTabs syncKey="terminal">
-<div slot="unix">
-
-```bash
-docker run --rm -it -p 18888:18888 -p 4317:18889 --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-<div slot="windows">
-
-```powershell
-docker run --rm -it -p 18888:18888 -p 4317:18889 --name aspire-dashboard `
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-</div>
-</OsAwareTabs>
-
-In the Docker logs, the endpoint and key for the dashboard are displayed. Copy the key and navigate to `http://localhost:18888` in a web browser. Enter the key to log in to the dashboard.
+Start the Aspire dashboard in standalone mode so it's ready to receive telemetry data from the Node.js app. You can start it with the Aspire CLI or the standalone container image. For details, see [Start the dashboard](/dashboard/standalone/#start-the-dashboard).
 
 ## View telemetry in the dashboard
 

--- a/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone-for-nodejs.mdx
@@ -14,7 +14,7 @@ The [Aspire dashboard](/dashboard/overview/) provides a great user experience fo
 
 To complete this tutorial, you need the following:
 
-- A way to run the standalone dashboard: [Aspire CLI](/get-started/install-cli/) or a [container runtime](/get-started/prerequisites/#install-an-oci-compliant-container-runtime).
+- A running standalone dashboard. For dashboard prerequisites and startup options, see [Standalone Aspire dashboard](/dashboard/standalone/#start-the-dashboard).
 - [Node.js 18 or higher](https://nodejs.org/en/download/package-manager) locally installed.
 
 ## Create a sample application

--- a/src/frontend/src/content/docs/dashboard/standalone-for-python.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone-for-python.mdx
@@ -21,7 +21,8 @@ The [Aspire dashboard](/dashboard/overview/) provides a great user experience fo
 
 To complete this tutorial, you need the following:
 
-- [Aspire 13.0 or later](/get-started/install-cli/) installed.
+- A running standalone dashboard. For dashboard prerequisites and startup options, see [Standalone Aspire dashboard](/dashboard/standalone/#start-the-dashboard).
+- [Aspire 13.0 or later](/get-started/install-cli/) installed to create the sample app.
 - [Python 3.10 or higher](https://www.python.org/downloads/) with [uv](https://docs.astral.sh/uv/) installed.
 
 ## Create a sample application

--- a/src/frontend/src/content/docs/dashboard/standalone-for-python.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone-for-python.mdx
@@ -12,7 +12,7 @@ import ThemeImage from '@components/ThemeImage.astro';
 import aspireDashboardPythonLogs from '@assets/dashboard/standalone/aspire-dashboard-python-logs.png';
 import aspireDashboardPythonLogsLight from '@assets/dashboard/standalone/aspire-dashboard-python-logs-light.png';
 
-The [Aspire dashboard](/dashboard/overview/) provides a great user experience for viewing telemetry, and is available as a standalone container image that can be used with any OpenTelemetry-enabled app. In this article, you'll learn how to:
+The [Aspire dashboard](/dashboard/overview/) provides a great user experience for viewing telemetry. You can run it standalone with the [Aspire CLI](/reference/cli/overview/) or the standalone dashboard container image for any OpenTelemetry-enabled app. In this article, you'll learn how to:
 
 - Start the Aspire dashboard in standalone mode.
 - Use the Aspire dashboard with a Python app.
@@ -21,8 +21,6 @@ The [Aspire dashboard](/dashboard/overview/) provides a great user experience fo
 
 To complete this tutorial, you need the following:
 
-- [Container runtime](/get-started/prerequisites/#install-an-oci-compliant-container-runtime).
-  - You can use an alternative container runtime, but the commands in this article are for Docker.
 - [Aspire 13.0 or later](/get-started/install-cli/) installed.
 - [Python 3.10 or higher](https://www.python.org/downloads/) with [uv](https://docs.astral.sh/uv/) installed.
 
@@ -66,14 +64,7 @@ This tutorial uses the Aspire 13.0 Python starter template which includes a Fast
 
 ## Start the Aspire dashboard
 
-Before running the Python app, start the Aspire dashboard in standalone mode so it's ready to receive telemetry data:
-
-```bash
-docker run --rm -it -p 18888:18888 -p 4317:18889 --name aspire-dashboard \
-    mcr.microsoft.com/dotnet/aspire-dashboard:latest
-```
-
-In the Docker logs, the endpoint and key for the dashboard are displayed. Copy the key and navigate to `http://localhost:18888` in a web browser. Enter the key to log in to the dashboard.
+Before running the Python app, start the Aspire dashboard in standalone mode so it's ready to receive telemetry data. You can start it with the Aspire CLI or the standalone container image. For details, see [Start the dashboard](/dashboard/standalone/#start-the-dashboard).
 
 Leave the dashboard running and open a new terminal for the next steps.
 
@@ -236,7 +227,7 @@ When you're done exploring the Aspire dashboard with your Python app, stop both 
 <Steps>
 
 1. Stop the FastAPI application by pressing <Kbd windows='Ctrl+C' mac='⌘+C' /> in the terminal where it's running.
-2. Stop the Aspire dashboard by pressing <Kbd windows='Ctrl+C' mac='⌘ + C' /> in the terminal where the Docker container is running.
+2. Stop the Aspire dashboard by pressing <Kbd windows='Ctrl+C' mac='⌘+C' /> in the terminal where the dashboard is running.
 
 </Steps>
 

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -132,7 +132,7 @@ The dashboard offers a UI for viewing telemetry. Refer to the documentation to e
 
 Although there is no restriction on where the dashboard is run, the dashboard is designed as a development and short-term diagnostic tool. The dashboard persists telemetry in-memory which creates some limitations:
 
-- Telemetry is automatically removed if [telemetry limits](configuration#telemetry-limits) are exceeded.
+- Telemetry is automatically removed if [telemetry limits](/dashboard/configuration/#telemetry-limits) are exceeded.
 - No telemetry is persisted when the dashboard is restarted.
 
 ### Unavailable features when standalone

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -11,10 +11,12 @@ import standaloneModeImage from '@assets/dashboard/standalone/standalone-mode.pn
 import standaloneModeImageLight from '@assets/dashboard/standalone/standalone-mode-light.png';
 import containerLogImage from '@assets/dashboard/standalone/aspire-dashboard-container-log.png';
 
-The [Aspire dashboard](/dashboard/overview/) provides a great UI for viewing telemetry. The dashboard:
+The [Aspire dashboard](/dashboard/overview/) provides a great UI for viewing telemetry. You can run the dashboard in standalone mode in two ways:
 
-- Ships as a container image that can be used with any OpenTelemetry enabled app.
-- Can be used standalone, without the rest of Aspire.
+- Use the [Aspire CLI](/reference/cli/overview/) to start the dashboard with default local endpoints.
+- Use the standalone dashboard container image when you want to run it with Docker or another OCI-compliant container runtime.
+
+Both options work without the rest of Aspire and can receive telemetry from any OpenTelemetry-enabled app.
 
 <ThemeImage
   light={standaloneModeImageLight}
@@ -23,9 +25,27 @@ The [Aspire dashboard](/dashboard/overview/) provides a great UI for viewing tel
 
 ## Start the dashboard
 
-### Docker
+### Aspire CLI
 
-The dashboard is started using the Docker command line.
+Install the [Aspire CLI](/get-started/install-cli/), then start the dashboard:
+
+```bash title="Aspire CLI"
+aspire dashboard run
+```
+
+The dashboard starts with the following defaults:
+
+- **Frontend UI** at `http://localhost:18888`
+- **OTLP/gRPC** endpoint at `http://localhost:4317`
+- **OTLP/HTTP** endpoint at `http://localhost:4318`
+
+The dashboard is secured with a browser token by default. A login URL with the token is displayed in the terminal output. Use `--allow-anonymous` to disable authentication during local development.
+
+For all available options, see the [`aspire dashboard run`](/reference/cli/commands/aspire-dashboard-run/) command reference.
+
+### Container image
+
+The dashboard also ships as a standalone container image. Use this option when a container workflow fits your environment or you want to manage dashboard hosting with your existing container tooling.
 
 <OsAwareTabs syncKey="terminal">
 <div slot="unix">
@@ -54,27 +74,11 @@ The preceding Docker command:
   - Mapping the dashboard's OTLP/gRPC port `18889` to the host's port `4317`. Port `4317` receives OpenTelemetry data from apps using [OTLP/gRPC](https://opentelemetry.io/docs/specs/otlp/#otlpgrpc).
   - Mapping the dashboard's OTLP/HTTP port `18890` to the host's port `4318`. Port `4318` receives OpenTelemetry data from apps using [OTLP/HTTP](https://opentelemetry.io/docs/specs/otlp/#otlphttp).
 
-### Aspire CLI
-
-If you have the [Aspire CLI](/reference/cli/overview/) installed, you can start the dashboard with a single command:
-
-```bash title="Aspire CLI"
-aspire dashboard run
-```
-
-The dashboard starts with the following defaults:
-
-- **Frontend UI** at `http://localhost:18888`
-- **OTLP/gRPC** endpoint at `http://localhost:4317`
-- **OTLP/HTTP** endpoint at `http://localhost:4318`
-
-The dashboard is secured with a browser token by default. A login URL with the token is displayed in the terminal output. Use `--allow-anonymous` to disable authentication during local development.
-
-For all available options, see the [`aspire dashboard run`](/reference/cli/commands/aspire-dashboard-run/) command reference.
-
 ## Login to the dashboard
 
 Data displayed in the dashboard can be sensitive. By default, the dashboard is secured with authentication that requires a token to login.
+
+When the dashboard is run with `aspire dashboard run`, the Aspire CLI prints the login URL directly in the terminal. Open that URL in your browser to log in.
 
 When the dashboard is run from a standalone container, the login token is printed to the container logs. The logs are displayed in the Docker Desktop user interface on the **Logs** tab for the **aspire-dashboard** container:
 
@@ -113,7 +117,7 @@ echo $matches.Value
 </OsAwareTabs>
 
 <Aside type="tip">
-To avoid the login, you can disable the authentication requirement by setting the `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` environment variable to `true`. Additional configuration is available, see [Dashboard configuration](/dashboard/configuration/).
+To avoid the login during local development, start the dashboard with `aspire dashboard run --allow-anonymous`. If you're running the dashboard container, set the `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` environment variable to `true`. Additional configuration is available, see [Dashboard configuration](/dashboard/configuration/).
 </Aside>
 
 For more information about logging into the dashboard, see [Dashboard authentication](/dashboard/explore/#dashboard-authentication).
@@ -141,7 +145,7 @@ AI coding agents can still use the standalone dashboard via the Aspire CLI and M
 
 Apps send telemetry to the dashboard using [OpenTelemetry Protocol (OTLP)](https://opentelemetry.io/docs/specs/otlp/). The dashboard must expose a port for receiving OpenTelemetry data, and apps are configured to send data to that address.
 
-A Docker command was shown earlier to [start the dashboard](#start-the-dashboard). It configured the container to receive OpenTelemetry data on port `4317` (gRPC) and port `4318` (HTTP). The <abbr title="OpenTelemetry Protocol" data-tooltip-placement="top">OTLP</abbr> endpoint addresses are `http://localhost:4317` for gRPC and `http://localhost:4318` for HTTP.
+Both startup options shown earlier configure the dashboard to receive OpenTelemetry data on port `4317` (gRPC) and port `4318` (HTTP). The <abbr title="OpenTelemetry Protocol" data-tooltip-placement="top">OTLP</abbr> endpoint addresses are `http://localhost:4317` for gRPC and `http://localhost:4318` for HTTP. The Docker command maps the container's OTLP ports to the same host ports.
 
 ### Configure OpenTelemetry SDK
 

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -25,6 +25,8 @@ Both options work without the rest of Aspire and can receive telemetry from any 
 
 ## Start the dashboard
 
+Choose the startup path that best fits your workflow. The Aspire CLI provides the shortest local setup, while the container image works well when you already manage tools through a container runtime.
+
 ### Aspire CLI
 
 Install the [Aspire CLI](/get-started/install-cli/), then start the dashboard:

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -266,7 +266,7 @@ test('footer preferences persist theme and keyboard style selections', async ({ 
 });
 
 test('terminal tabs stay synced between pages', async ({ page }) => {
-  await page.goto('/dashboard/overview/');
+  await page.goto('/dashboard/standalone/');
   await dismissCookieConsentIfVisible(page);
 
   const sourceTabs = page.locator('starlight-tabs[data-sync-key="terminal"]').first();


### PR DESCRIPTION
The standalone dashboard docs still emphasized the container-image workflow in several entry points, which made the new `aspire dashboard run` path less discoverable. This updates the docs to recommend installing the Aspire CLI for the primary standalone workflow while preserving the container image as the second supported way to run the dashboard.

## Summary

- Make `/dashboard/standalone/` the source of truth for starting the standalone dashboard.
- Document both supported startup paths there: Aspire CLI and standalone container image.
- Trim repeated startup commands from the dashboard landing, overview, Python, and Node.js pages and link them back to the standalone guide.
- Keep the language guides focused on app telemetry setup instead of repeating dashboard startup details.

## Validation

- Validated the affected pages against the running local Aspire app.
- Confirmed only `/dashboard/standalone/` contains the `aspire dashboard run` and `docker run --rm` examples.
- Confirmed the other affected pages link back to the standalone guide.
- Ran `git diff --check`.