### PR TITLE
Improve site search UX with keyboard navigation, footer hints, and query-forwarding API buttons

### DIFF
--- a/src/frontend/src/components/starlight/Search.astro
+++ b/src/frontend/src/components/starlight/Search.astro
@@ -120,6 +120,10 @@ const typescriptHref = `${base}/reference/api/typescript/`;
         input.setAttribute('role', 'combobox');
         input.setAttribute('aria-autocomplete', 'list');
         input.setAttribute('aria-controls', this.resultsContainerId);
+        // Seed `aria-expanded` so it's always present once the combobox
+        // role is set; the line below this `if` will refresh it to the
+        // real dialog state on every render.
+        input.setAttribute('aria-expanded', 'false');
         // Capture-phase keydown on the dialog catches arrows whether the
         // user is in the input or already on a focused result/button.
         this.dialog.addEventListener('keydown', this.keydownHandler, true);
@@ -168,9 +172,23 @@ const typescriptHref = `${base}/reference/api/typescript/`;
           ? (this.targets[this.activeIndex] as HTMLAnchorElement)
           : null;
 
+      // Clean up only the elements that are leaving the target list.
+      // Elements that survive into `newTargets` keep their attributes so
+      // a transient Pagefind re-render (which can briefly emit a target
+      // list without the result links) doesn't permanently wipe the
+      // active highlight — `setActive` below will re-establish state on
+      // the surviving element if appropriate.
+      const newSet = new Set(newTargets);
       for (const stale of this.targets) {
+        if (newSet.has(stale)) continue;
         stale.removeAttribute('data-search-active');
-        stale.setAttribute('aria-selected', 'false');
+        // `aria-selected` is only valid on roles in the listbox family
+        // (option/row/tab/gridcell/treeitem). The load-more / API buttons
+        // sit outside the listbox, so we never write the attribute on
+        // them — and we don't clear it on them either.
+        if (stale.getAttribute('role') === 'option') {
+          stale.setAttribute('aria-selected', 'false');
+        }
       }
       this.targets = newTargets;
 
@@ -222,7 +240,9 @@ const typescriptHref = `${base}/reference/api/typescript/`;
       if (this.activeIndex >= 0 && this.targets[this.activeIndex]) {
         const prev = this.targets[this.activeIndex];
         prev.removeAttribute('data-search-active');
-        prev.setAttribute('aria-selected', 'false');
+        if (prev.getAttribute('role') === 'option') {
+          prev.setAttribute('aria-selected', 'false');
+        }
       }
       this.activeIndex = index;
       if (index < 0 || !this.targets[index]) {
@@ -231,10 +251,14 @@ const typescriptHref = `${base}/reference/api/typescript/`;
       }
       const el = this.targets[index];
       el.setAttribute('data-search-active', 'true');
-      el.setAttribute('aria-selected', 'true');
-      // Only point aria-activedescendant at result links; the API/load-more
-      // buttons aren't part of the listbox.
+      // `aria-selected` and `aria-activedescendant` are only meaningful
+      // when the target lives inside the listbox (role="option"). The
+      // load-more button and the API reference buttons are plain
+      // focusable controls, so we deliberately leave both attributes
+      // off them — otherwise screen readers may announce them as
+      // "selected" listbox options.
       if (el.getAttribute('role') === 'option') {
+        el.setAttribute('aria-selected', 'true');
         this.input?.setAttribute('aria-activedescendant', el.id);
       } else {
         this.input?.removeAttribute('aria-activedescendant');
@@ -261,10 +285,14 @@ const typescriptHref = `${base}/reference/api/typescript/`;
         e.preventDefault();
         const prev = this.activeIndex <= 0 ? this.targets.length - 1 : this.activeIndex - 1;
         this.setActive(prev, true);
-      } else if (e.key === 'Home' && this.targets.length > 0) {
+      } else if (e.key === 'Home' && this.targets.length > 0 && e.target !== this.input) {
+        // Home/End are intercepted only when focus has already moved out
+        // of the input. While the caret is in the search field, the
+        // browser's native cursor behaviour (jump to start/end of the
+        // query text) takes priority over list navigation.
         e.preventDefault();
         this.setActive(0, true);
-      } else if (e.key === 'End' && this.targets.length > 0) {
+      } else if (e.key === 'End' && this.targets.length > 0 && e.target !== this.input) {
         e.preventDefault();
         this.setActive(this.targets.length - 1, true);
       } else if (e.key === 'Enter' && this.activeIndex >= 0 && this.targets[this.activeIndex]) {
@@ -515,6 +543,15 @@ const typescriptHref = `${base}/reference/api/typescript/`;
   }
 
   /* ── Keyboard hints footer ─────────────────────────────────────── */
+  /*
+   * The footer is rendered inside Starlight's `.dialog-frame`, which
+   * applies `padding: 1rem` (and `1.5rem` at >= 50rem). The negative
+   * `margin-inline` / `margin-block-end` values and the matching sticky
+   * `bottom` offset below "bleed" the footer back to the dialog edges so
+   * the border-top runs full width. If Starlight changes those padding
+   * tokens, update these values to match — otherwise the footer will
+   * appear visually inset from the dialog frame.
+   */
   .search-keyboard-footer {
     display: flex;
     flex-wrap: wrap;

--- a/src/frontend/src/components/starlight/Search.astro
+++ b/src/frontend/src/components/starlight/Search.astro
@@ -9,6 +9,8 @@ const pageId = routeData?.id ?? '';
 const isApiRefPage = pageId.startsWith('reference/api') || Astro.url.pathname.startsWith('/reference/api');
 const hideSearch = isApiRefPage;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
+const csharpHref = `${base}/reference/api/csharp/`;
+const typescriptHref = `${base}/reference/api/typescript/`;
 ---
 
 { hideSearch ? <></> : <DefaultSearch><slot /></DefaultSearch> }
@@ -17,11 +19,23 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   <div class="api-search-notice">
     <p class="api-search-notice-text">API references are intentionally omitted from this search. To find API references, please search these dedicated API pages instead:</p>
     <div class="api-search-notice-buttons">
-      <a href={`${base}/reference/api/csharp/`} class="api-search-btn">
+      <a
+        href={csharpHref}
+        class="api-search-btn"
+        data-api-search-link
+        data-api-lang="csharp"
+        data-api-base-href={csharpHref}
+      >
         <Image src={csharpIcon} alt="" width={50} height={50} />
         <span>C# API Reference</span>
       </a>
-      <a href={`${base}/reference/api/typescript/`} class="api-search-btn">
+      <a
+        href={typescriptHref}
+        class="api-search-btn"
+        data-api-search-link
+        data-api-lang="typescript"
+        data-api-base-href={typescriptHref}
+      >
         <Image src={typescriptIcon} alt="" width={50} height={50} />
         <span>TypeScript API Reference</span>
       </a>
@@ -29,40 +43,249 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   </div>
 </template>
 
+<template id="search-keyboard-footer-tpl">
+  <div class="search-keyboard-footer" data-testid="search-keyboard-footer" aria-hidden="true">
+    <span class="search-kb-hint">
+      <kbd class="search-kb-key">↑</kbd>
+      <kbd class="search-kb-key">↓</kbd>
+      <span class="search-kb-label">Navigate</span>
+    </span>
+    <span class="search-kb-hint">
+      <kbd class="search-kb-key">↵</kbd>
+      <span class="search-kb-label">Open</span>
+    </span>
+    <span class="search-kb-hint">
+      <kbd class="search-kb-key">Esc</kbd>
+      <span class="search-kb-label">Close</span>
+    </span>
+  </div>
+</template>
+
 <script>
-  // Inject an API search notice into the Starlight/Pagefind search dialog
-  let currentObserver: MutationObserver | undefined;
+  /**
+   * Layered enhancements for the Starlight/Pagefind search dialog:
+   *   1. Injects the C#/TypeScript "API search notice" template.
+   *   2. Injects the keyboard-shortcut footer (↑ ↓ ↵ Esc).
+   *   3. Wires keyboard navigation across Pagefind result links with
+   *      aria-activedescendant for screen-reader users.
+   *   4. Forwards the typed query into the API notice buttons as `?q=`,
+   *      so a user who searches and falls back to the API listings keeps
+   *      their query.
+   *
+   * Pagefind UI is rendered lazily (and not at all in `astro dev`), so we
+   * use a single MutationObserver on the <site-search> custom element to
+   * pick up newly mounted pieces and keep the active result list in sync
+   * as the user types.
+   */
+  let cleanup: (() => void) | undefined;
 
-  function injectApiNotice() {
-    const siteSearch = document.querySelector('site-search');
-    if (!siteSearch) return;
-
-    // Disconnect any existing observer before creating a new one to avoid accumulation
-    currentObserver?.disconnect();
-
-    const observer = new MutationObserver(() => {
-      const dialog = siteSearch.querySelector('dialog');
-      if (!dialog) return;
-
-      // Only inject once
-      if (dialog.querySelector('.api-search-notice')) return;
-
-      const inner = dialog.querySelector('.dialog-frame');
-      if (!inner) return;
-
-      const tpl = document.getElementById('api-search-notice-tpl');
-      if (!(tpl instanceof HTMLTemplateElement)) return;
-
-      inner.appendChild(tpl.content.cloneNode(true));
-    });
-
-    observer.observe(siteSearch, { childList: true, subtree: true });
-    currentObserver = observer;
+  function injectTemplate(parent: Element, templateId: string, existingSelector: string): void {
+    if (parent.querySelector(existingSelector)) return;
+    const tpl = document.getElementById(templateId);
+    if (!(tpl instanceof HTMLTemplateElement)) return;
+    parent.appendChild(tpl.content.cloneNode(true));
   }
 
-  // Run on load and after Astro client-side navigation
-  injectApiNotice();
-  document.addEventListener('astro:after-swap', injectApiNotice);
+  class SearchKeyboardNav {
+    private dialog: HTMLDialogElement;
+    private input: HTMLInputElement | null = null;
+    private results: HTMLAnchorElement[] = [];
+    private activeIndex = -1;
+    private wired = false;
+    private readonly keydownHandler: (e: KeyboardEvent) => void;
+    private readonly resultsContainerId = 'aspire-search-results';
+
+    constructor(dialog: HTMLDialogElement) {
+      this.dialog = dialog;
+      this.keydownHandler = (e) => this.handleKey(e);
+    }
+
+    refresh(): void {
+      const input = this.dialog.querySelector<HTMLInputElement>('.pagefind-ui__search-input');
+      if (input && !this.wired) {
+        this.input = input;
+        input.setAttribute('role', 'combobox');
+        input.setAttribute('aria-autocomplete', 'list');
+        input.setAttribute('aria-controls', this.resultsContainerId);
+        input.setAttribute('aria-expanded', 'true');
+        input.addEventListener('keydown', this.keydownHandler);
+        this.wired = true;
+      }
+
+      const resultsContainer = this.dialog.querySelector<HTMLElement>('.pagefind-ui__results');
+      if (resultsContainer) {
+        if (!resultsContainer.id) resultsContainer.id = this.resultsContainerId;
+        resultsContainer.setAttribute('role', 'listbox');
+      }
+
+      const newResults = Array.from(
+        this.dialog.querySelectorAll<HTMLAnchorElement>('.pagefind-ui__result-link')
+      );
+
+      newResults.forEach((link, i) => {
+        if (!link.id) link.id = `aspire-search-result-${i}`;
+        link.setAttribute('role', 'option');
+      });
+
+      const sameLength = newResults.length === this.results.length;
+      const sameNodes = sameLength && newResults.every((r, i) => r === this.results[i]);
+      if (sameNodes) return;
+
+      // Result set changed (Pagefind re-rendered). Reset to first.
+      for (const stale of this.results) {
+        stale.removeAttribute('data-search-active');
+        stale.setAttribute('aria-selected', 'false');
+      }
+      this.results = newResults;
+      if (this.results.length > 0) {
+        this.setActive(0, /* scroll */ false);
+      } else {
+        this.activeIndex = -1;
+        this.input?.removeAttribute('aria-activedescendant');
+      }
+    }
+
+    private setActive(index: number, scroll = true): void {
+      if (this.activeIndex >= 0 && this.results[this.activeIndex]) {
+        const prev = this.results[this.activeIndex];
+        prev.removeAttribute('data-search-active');
+        prev.setAttribute('aria-selected', 'false');
+      }
+      this.activeIndex = index;
+      if (index >= 0 && this.results[index]) {
+        const el = this.results[index];
+        el.setAttribute('data-search-active', 'true');
+        el.setAttribute('aria-selected', 'true');
+        this.input?.setAttribute('aria-activedescendant', el.id);
+        if (scroll) {
+          const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+          el.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
+        }
+      }
+    }
+
+    private handleKey(e: KeyboardEvent): void {
+      if (e.key === 'ArrowDown') {
+        if (this.results.length === 0) return;
+        e.preventDefault();
+        const next = this.activeIndex < 0 ? 0 : (this.activeIndex + 1) % this.results.length;
+        this.setActive(next);
+      } else if (e.key === 'ArrowUp') {
+        if (this.results.length === 0) return;
+        e.preventDefault();
+        const prev = this.activeIndex <= 0 ? this.results.length - 1 : this.activeIndex - 1;
+        this.setActive(prev);
+      } else if (e.key === 'Home' && this.results.length > 0) {
+        e.preventDefault();
+        this.setActive(0);
+      } else if (e.key === 'End' && this.results.length > 0) {
+        e.preventDefault();
+        this.setActive(this.results.length - 1);
+      } else if (e.key === 'Enter' && this.activeIndex >= 0 && this.results[this.activeIndex]) {
+        e.preventDefault();
+        this.results[this.activeIndex].click();
+      }
+    }
+
+    destroy(): void {
+      this.input?.removeEventListener('keydown', this.keydownHandler);
+    }
+  }
+
+  class ApiSearchLinker {
+    private dialog: HTMLDialogElement;
+    private input: HTMLInputElement | null = null;
+    private buttons: HTMLAnchorElement[] = [];
+    private wired = false;
+    private readonly inputHandler: () => void;
+    private readonly clickHandler: () => void;
+
+    constructor(dialog: HTMLDialogElement) {
+      this.dialog = dialog;
+      this.inputHandler = () => this.update();
+      this.clickHandler = () => this.update();
+    }
+
+    refresh(): void {
+      if (!this.wired) {
+        const input = this.dialog.querySelector<HTMLInputElement>('.pagefind-ui__search-input');
+        if (input) {
+          this.input = input;
+          input.addEventListener('input', this.inputHandler);
+          this.wired = true;
+        }
+      }
+
+      const buttons = Array.from(
+        this.dialog.querySelectorAll<HTMLAnchorElement>('a[data-api-search-link]')
+      );
+
+      const sameLength = buttons.length === this.buttons.length;
+      const sameNodes = sameLength && buttons.every((b, i) => b === this.buttons[i]);
+      if (sameNodes && this.buttons.length > 0) return;
+
+      for (const stale of this.buttons) {
+        stale.removeEventListener('mousedown', this.clickHandler);
+      }
+      this.buttons = buttons;
+      for (const btn of this.buttons) {
+        // Recompute href on mousedown so middle-click / right-click → "Open in new tab" use the latest query.
+        btn.addEventListener('mousedown', this.clickHandler);
+      }
+      this.update();
+    }
+
+    private update(): void {
+      const q = (this.input?.value ?? '').trim();
+      for (const btn of this.buttons) {
+        const baseHref = btn.dataset.apiBaseHref ?? btn.href.split('?')[0];
+        btn.href = q ? `${baseHref}?q=${encodeURIComponent(q)}` : baseHref;
+      }
+    }
+
+    destroy(): void {
+      this.input?.removeEventListener('input', this.inputHandler);
+      for (const btn of this.buttons) {
+        btn.removeEventListener('mousedown', this.clickHandler);
+      }
+    }
+  }
+
+  function initSearchEnhancements(): void {
+    cleanup?.();
+    cleanup = undefined;
+
+    const siteSearch = document.querySelector<HTMLElement>('site-search');
+    if (!siteSearch) return;
+
+    const dialog = siteSearch.querySelector<HTMLDialogElement>('dialog');
+    const dialogFrame = dialog?.querySelector<HTMLElement>('.dialog-frame');
+    if (!dialog || !dialogFrame) return;
+
+    const nav = new SearchKeyboardNav(dialog);
+    const linker = new ApiSearchLinker(dialog);
+
+    const setup = () => {
+      injectTemplate(dialogFrame, 'api-search-notice-tpl', '.api-search-notice');
+      injectTemplate(dialogFrame, 'search-keyboard-footer-tpl', '.search-keyboard-footer');
+      nav.refresh();
+      linker.refresh();
+    };
+
+    setup();
+
+    const observer = new MutationObserver(setup);
+    observer.observe(siteSearch, { childList: true, subtree: true });
+
+    cleanup = () => {
+      observer.disconnect();
+      nav.destroy();
+      linker.destroy();
+    };
+  }
+
+  initSearchEnhancements();
+  document.addEventListener('astro:after-swap', initSearchEnhancements);
 </script>
 
 <style is:global>
@@ -123,6 +346,112 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, '');
   }
   .api-search-btn img {
     flex-shrink: 0;
+  }
+
+  /* ── Active result highlight (keyboard navigation) ─────────────── */
+  #starlight__search .pagefind-ui__result-link[data-search-active='true'] {
+    /* Cue the link itself; ::after pseudo-element from Starlight covers
+     * the whole row, so a strong outline around the title row reads as
+     * the active selection without affecting click semantics. */
+    color: var(--sl-color-text-accent);
+  }
+
+  #starlight__search
+    .pagefind-ui__result-title:has(.pagefind-ui__result-link[data-search-active='true']),
+  #starlight__search
+    .pagefind-ui__result-nested:has(.pagefind-ui__result-link[data-search-active='true']) {
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: -2px;
+    background-color: var(--sl-color-accent-low);
+  }
+
+  /* ── Keyboard hints footer ─────────────────────────────────────── */
+  .search-keyboard-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem 1.25rem;
+    margin-block-start: auto;
+    margin-inline: -1rem;
+    margin-block-end: -1rem;
+    padding: 0.6rem 1rem;
+    border-top: 1px solid var(--sl-color-gray-5);
+    background: var(--sl-color-black);
+    color: var(--sl-color-gray-2);
+    font-size: 0.78rem;
+    position: sticky;
+    bottom: -1rem;
+    z-index: 1;
+  }
+
+  .search-kb-hint {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    white-space: nowrap;
+  }
+
+  .search-kb-key {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.5rem;
+    height: 1.4rem;
+    padding: 0 0.35rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-bottom-width: 2px;
+    border-radius: 0.25rem;
+    color: var(--sl-color-text);
+    font-family: var(--__sl-font);
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1;
+  }
+
+  .search-kb-label {
+    font-weight: 500;
+    color: var(--sl-color-gray-2);
+  }
+
+  @media (min-width: 50rem) {
+    .search-keyboard-footer {
+      margin-inline: -1.5rem;
+      margin-block-end: -1.5rem;
+      padding: 0.65rem 1.5rem;
+      bottom: -1.5rem;
+    }
+  }
+
+  @media (max-width: 30rem) {
+    .search-keyboard-footer {
+      gap: 0.4rem 0.85rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.72rem;
+    }
+
+    .search-kb-key {
+      min-width: 1.25rem;
+      height: 1.2rem;
+      font-size: 0.68rem;
+      padding: 0 0.3rem;
+    }
+
+    .search-kb-label {
+      /* Keep labels visible on phones but tighten spacing. */
+      letter-spacing: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    #starlight__search .pagefind-ui__result-link[data-search-active='true'],
+    #starlight__search
+      .pagefind-ui__result-title:has(.pagefind-ui__result-link[data-search-active='true']),
+    #starlight__search
+      .pagefind-ui__result-nested:has(.pagefind-ui__result-link[data-search-active='true']) {
+      transition: none;
+    }
   }
 
   @media (max-width: 600px) {

--- a/src/frontend/src/components/starlight/Search.astro
+++ b/src/frontend/src/components/starlight/Search.astro
@@ -66,8 +66,8 @@ const typescriptHref = `${base}/reference/api/typescript/`;
    * Layered enhancements for the Starlight/Pagefind search dialog:
    *   1. Injects the C#/TypeScript "API search notice" template.
    *   2. Injects the keyboard-shortcut footer (↑ ↓ ↵ Esc).
-   *   3. Wires keyboard navigation across Pagefind result links with
-   *      aria-activedescendant for screen-reader users.
+   *   3. Wires keyboard navigation across Pagefind result links so
+   *      arrow keys and Tab move *real* focus (and stay in sync).
    *   4. Forwards the typed query into the API notice buttons as `?q=`,
    *      so a user who searches and falls back to the API listings keeps
    *      their query.
@@ -75,7 +75,8 @@ const typescriptHref = `${base}/reference/api/typescript/`;
    * Pagefind UI is rendered lazily (and not at all in `astro dev`), so we
    * use a single MutationObserver on the <site-search> custom element to
    * pick up newly mounted pieces and keep the active result list in sync
-   * as the user types.
+   * as the user types. Mutations are coalesced via requestAnimationFrame
+   * to avoid flicker while Pagefind re-renders results on every keystroke.
    */
   let cleanup: (() => void) | undefined;
 
@@ -89,15 +90,27 @@ const typescriptHref = `${base}/reference/api/typescript/`;
   class SearchKeyboardNav {
     private dialog: HTMLDialogElement;
     private input: HTMLInputElement | null = null;
-    private results: HTMLAnchorElement[] = [];
+    // All keyboard-navigable targets: Pagefind result links + the
+    // Pagefind "Load more results" button + the C#/TS API buttons. Up/Down
+    // cycle through them in DOM order so arrow nav matches Tab order.
+    private targets: HTMLElement[] = [];
     private activeIndex = -1;
     private wired = false;
+    private suppressFocusinSync = false;
     private readonly keydownHandler: (e: KeyboardEvent) => void;
+    private readonly focusinHandler: (e: FocusEvent) => void;
+    private readonly dialogStateHandler: () => void;
     private readonly resultsContainerId = 'aspire-search-results';
+    private readonly targetSelector =
+      '.pagefind-ui__result-link, .pagefind-ui__button, a[data-api-search-link]';
 
     constructor(dialog: HTMLDialogElement) {
       this.dialog = dialog;
       this.keydownHandler = (e) => this.handleKey(e);
+      this.focusinHandler = (e) => this.handleFocusIn(e);
+      this.dialogStateHandler = () => {
+        this.input?.setAttribute('aria-expanded', this.dialog.open ? 'true' : 'false');
+      };
     }
 
     refresh(): void {
@@ -107,88 +120,182 @@ const typescriptHref = `${base}/reference/api/typescript/`;
         input.setAttribute('role', 'combobox');
         input.setAttribute('aria-autocomplete', 'list');
         input.setAttribute('aria-controls', this.resultsContainerId);
-        input.setAttribute('aria-expanded', 'true');
-        input.addEventListener('keydown', this.keydownHandler);
+        // Capture-phase keydown on the dialog catches arrows whether the
+        // user is in the input or already on a focused result/button.
+        this.dialog.addEventListener('keydown', this.keydownHandler, true);
+        this.dialog.addEventListener('focusin', this.focusinHandler);
+        this.dialog.addEventListener('close', this.dialogStateHandler);
         this.wired = true;
       }
 
+      // `aria-expanded` reflects whether the listbox is actually visible.
+      // The native <dialog> tracks this via its `open` property.
+      this.input?.setAttribute('aria-expanded', this.dialog.open ? 'true' : 'false');
+
       const resultsContainer = this.dialog.querySelector<HTMLElement>('.pagefind-ui__results');
       if (resultsContainer) {
-        if (!resultsContainer.id) resultsContainer.id = this.resultsContainerId;
+        // Force the id to the value we advertise via `aria-controls` so the
+        // reference is never broken by an upstream id assignment.
+        resultsContainer.id = this.resultsContainerId;
         resultsContainer.setAttribute('role', 'listbox');
       }
 
-      const newResults = Array.from(
-        this.dialog.querySelectorAll<HTMLAnchorElement>('.pagefind-ui__result-link')
+      const newTargets = Array.from(
+        this.dialog.querySelectorAll<HTMLElement>(this.targetSelector)
       );
 
-      newResults.forEach((link, i) => {
-        if (!link.id) link.id = `aspire-search-result-${i}`;
-        link.setAttribute('role', 'option');
+      newTargets.forEach((el, i) => {
+        if (!el.id) el.id = `aspire-search-target-${i}`;
+        // Only the result links live inside the listbox; the load-more
+        // button and API buttons sit outside it, so they stay plain
+        // focusable controls (no `role="option"`).
+        if (el.classList.contains('pagefind-ui__result-link')) {
+          el.setAttribute('role', 'option');
+        }
       });
 
-      const sameLength = newResults.length === this.results.length;
-      const sameNodes = sameLength && newResults.every((r, i) => r === this.results[i]);
+      const sameLength = newTargets.length === this.targets.length;
+      const sameNodes = sameLength && newTargets.every((el, i) => el === this.targets[i]);
       if (sameNodes) return;
 
-      // Result set changed (Pagefind re-rendered). Reset to first.
-      for (const stale of this.results) {
+      // Capture the previously-active *result link* (not button). Buttons
+      // are stable across renders so they don't need preservation, and we
+      // don't want to auto-park the highlight on them.
+      const previousLink =
+        this.activeIndex >= 0 &&
+        this.targets[this.activeIndex] instanceof HTMLAnchorElement &&
+        this.targets[this.activeIndex]?.classList.contains('pagefind-ui__result-link')
+          ? (this.targets[this.activeIndex] as HTMLAnchorElement)
+          : null;
+
+      for (const stale of this.targets) {
         stale.removeAttribute('data-search-active');
         stale.setAttribute('aria-selected', 'false');
       }
-      this.results = newResults;
-      if (this.results.length > 0) {
-        this.setActive(0, /* scroll */ false);
+      this.targets = newTargets;
+
+      if (this.targets.length === 0) {
+        this.activeIndex = -1;
+        this.input?.removeAttribute('aria-activedescendant');
+        return;
+      }
+
+      // Resolve the first result link in the new list. We only ever
+      // auto-highlight result links — never the "Load more results" or
+      // C#/TypeScript API buttons. (The buttons stay reachable via Tab
+      // and arrow nav once the user explicitly enters the list.)
+      const firstResultLinkIndex = this.targets.findIndex(
+        (el) =>
+          el instanceof HTMLAnchorElement && el.classList.contains('pagefind-ui__result-link')
+      );
+
+      let preserved = -1;
+      if (previousLink) {
+        preserved = this.targets.indexOf(previousLink);
+        if (preserved < 0) {
+          const prevHref = previousLink.href;
+          preserved = this.targets.findIndex(
+            (el) =>
+              el instanceof HTMLAnchorElement &&
+              el.classList.contains('pagefind-ui__result-link') &&
+              el.href === prevHref
+          );
+        }
+      }
+
+      if (preserved >= 0) {
+        this.setActive(preserved, /* moveFocus */ false, /* scroll */ false);
+      } else if (firstResultLinkIndex >= 0) {
+        // Auto-highlight the first result (DocSearch / GH command-palette
+        // pattern) but keep focus in the input so the user can keep typing.
+        this.setActive(firstResultLinkIndex, false, false);
       } else {
+        // No results yet (e.g. dialog just opened, only API buttons exist).
+        // Leave nav un-anchored so the first ArrowDown lands on the first
+        // *real* navigation target the user expects.
         this.activeIndex = -1;
         this.input?.removeAttribute('aria-activedescendant');
       }
     }
 
-    private setActive(index: number, scroll = true): void {
-      if (this.activeIndex >= 0 && this.results[this.activeIndex]) {
-        const prev = this.results[this.activeIndex];
+    private setActive(index: number, moveFocus = false, scroll = true): void {
+      if (this.activeIndex >= 0 && this.targets[this.activeIndex]) {
+        const prev = this.targets[this.activeIndex];
         prev.removeAttribute('data-search-active');
         prev.setAttribute('aria-selected', 'false');
       }
       this.activeIndex = index;
-      if (index >= 0 && this.results[index]) {
-        const el = this.results[index];
-        el.setAttribute('data-search-active', 'true');
-        el.setAttribute('aria-selected', 'true');
+      if (index < 0 || !this.targets[index]) {
+        this.input?.removeAttribute('aria-activedescendant');
+        return;
+      }
+      const el = this.targets[index];
+      el.setAttribute('data-search-active', 'true');
+      el.setAttribute('aria-selected', 'true');
+      // Only point aria-activedescendant at result links; the API/load-more
+      // buttons aren't part of the listbox.
+      if (el.getAttribute('role') === 'option') {
         this.input?.setAttribute('aria-activedescendant', el.id);
-        if (scroll) {
-          const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-          el.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
-        }
+      } else {
+        this.input?.removeAttribute('aria-activedescendant');
+      }
+      if (moveFocus && document.activeElement !== el) {
+        this.suppressFocusinSync = true;
+        el.focus({ preventScroll: true });
+        this.suppressFocusinSync = false;
+      }
+      if (scroll) {
+        const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        el.scrollIntoView({ block: 'nearest', behavior: reduceMotion ? 'auto' : 'smooth' });
       }
     }
 
     private handleKey(e: KeyboardEvent): void {
       if (e.key === 'ArrowDown') {
-        if (this.results.length === 0) return;
+        if (this.targets.length === 0) return;
         e.preventDefault();
-        const next = this.activeIndex < 0 ? 0 : (this.activeIndex + 1) % this.results.length;
-        this.setActive(next);
+        const next = this.activeIndex < 0 ? 0 : (this.activeIndex + 1) % this.targets.length;
+        this.setActive(next, /* moveFocus */ true);
       } else if (e.key === 'ArrowUp') {
-        if (this.results.length === 0) return;
+        if (this.targets.length === 0) return;
         e.preventDefault();
-        const prev = this.activeIndex <= 0 ? this.results.length - 1 : this.activeIndex - 1;
-        this.setActive(prev);
-      } else if (e.key === 'Home' && this.results.length > 0) {
+        const prev = this.activeIndex <= 0 ? this.targets.length - 1 : this.activeIndex - 1;
+        this.setActive(prev, true);
+      } else if (e.key === 'Home' && this.targets.length > 0) {
         e.preventDefault();
-        this.setActive(0);
-      } else if (e.key === 'End' && this.results.length > 0) {
+        this.setActive(0, true);
+      } else if (e.key === 'End' && this.targets.length > 0) {
         e.preventDefault();
-        this.setActive(this.results.length - 1);
-      } else if (e.key === 'Enter' && this.activeIndex >= 0 && this.results[this.activeIndex]) {
-        e.preventDefault();
-        this.results[this.activeIndex].click();
+        this.setActive(this.targets.length - 1, true);
+      } else if (e.key === 'Enter' && this.activeIndex >= 0 && this.targets[this.activeIndex]) {
+        // If focus is already on the target, the browser's native Enter
+        // handles activation. Only synthesise a click when the user is
+        // still in the input.
+        if (e.target === this.input) {
+          e.preventDefault();
+          this.targets[this.activeIndex].click();
+        }
+      }
+      // Tab is intentionally NOT intercepted: native browser focus order
+      // walks through results + buttons, and `handleFocusIn` keeps
+      // activeIndex in sync — so up/down can resume cleanly from wherever
+      // Tab landed.
+    }
+
+    private handleFocusIn(e: FocusEvent): void {
+      if (this.suppressFocusinSync) return;
+      const target = e.target;
+      if (!(target instanceof HTMLElement)) return;
+      const idx = this.targets.indexOf(target);
+      if (idx >= 0 && idx !== this.activeIndex) {
+        this.setActive(idx, /* moveFocus */ false, /* scroll */ false);
       }
     }
 
     destroy(): void {
-      this.input?.removeEventListener('keydown', this.keydownHandler);
+      this.dialog.removeEventListener('keydown', this.keydownHandler, true);
+      this.dialog.removeEventListener('focusin', this.focusinHandler);
+      this.dialog.removeEventListener('close', this.dialogStateHandler);
     }
   }
 
@@ -274,10 +381,22 @@ const typescriptHref = `${base}/reference/api/typescript/`;
 
     setup();
 
-    const observer = new MutationObserver(setup);
+    // Pagefind re-renders the result list on every keystroke and emits
+    // many mutations per render. Coalesce to one refresh per frame so
+    // the active highlight doesn't flicker between intermediate states.
+    let rafId: number | null = null;
+    const scheduleSetup = () => {
+      if (rafId !== null) return;
+      rafId = requestAnimationFrame(() => {
+        rafId = null;
+        setup();
+      });
+    };
+    const observer = new MutationObserver(scheduleSetup);
     observer.observe(siteSearch, { childList: true, subtree: true });
 
     cleanup = () => {
+      if (rafId !== null) cancelAnimationFrame(rafId);
       observer.disconnect();
       nav.destroy();
       linker.destroy();
@@ -348,21 +467,51 @@ const typescriptHref = `${base}/reference/api/typescript/`;
     flex-shrink: 0;
   }
 
-  /* ── Active result highlight (keyboard navigation) ─────────────── */
-  #starlight__search .pagefind-ui__result-link[data-search-active='true'] {
-    /* Cue the link itself; ::after pseudo-element from Starlight covers
-     * the whole row, so a strong outline around the title row reads as
-     * the active selection without affecting click semantics. */
-    color: var(--sl-color-text-accent);
-  }
-
+  /* ── Active target (keyboard nav + Tab focus, unified) ─────────────
+     Starlight already paints :focus-within with `outline: 1px solid
+     --sl-color-accent-high` + `background: --sl-color-accent-low` on
+     `.pagefind-ui__result-title` (top-level) and `.pagefind-ui__result-nested`.
+     We mirror that exact treatment for `[data-search-active]` so the
+     virtual highlight (set while focus is still in the input) and real
+     focus produce the same look — no double border, no competing rules.
+  */
   #starlight__search
-    .pagefind-ui__result-title:has(.pagefind-ui__result-link[data-search-active='true']),
+    .pagefind-ui__result-title:not(:where(.pagefind-ui__result-nested *)):has(
+      > .pagefind-ui__result-link[data-search-active='true']
+    ),
   #starlight__search
     .pagefind-ui__result-nested:has(.pagefind-ui__result-link[data-search-active='true']) {
-    outline: 2px solid var(--sl-color-text-accent);
-    outline-offset: -2px;
+    outline: 1px solid var(--sl-color-accent-high);
     background-color: var(--sl-color-accent-low);
+  }
+
+  /* The Pagefind "Load more results" button and the C#/TS API buttons are
+     also keyboard-navigable. `[data-search-active]` is set on the element
+     itself (not a parent), and we match `:focus-visible` so Tab and
+     arrow nav land on the same look. */
+  #starlight__search .pagefind-ui__button[data-search-active='true'],
+  #starlight__search .pagefind-ui__button:focus-visible {
+    border-color: var(--sl-color-accent-high);
+    background-color: var(--sl-color-accent-low);
+    color: var(--sl-color-white);
+    outline: none;
+  }
+
+  .api-search-btn[data-search-active='true'],
+  .api-search-btn:focus-visible {
+    border-color: var(--sl-color-accent-high);
+    background-color: var(--sl-color-accent-low);
+    outline: none;
+  }
+
+  /* The Pagefind result link covers its row via `::after`. `scroll-margin`
+     on the link gives `scrollIntoView({block: 'nearest'})` enough room
+     to keep the active row visible above the sticky keyboard footer. */
+  #starlight__search .pagefind-ui__result-link,
+  #starlight__search .pagefind-ui__button,
+  .api-search-btn {
+    scroll-margin-block-start: 1rem;
+    scroll-margin-block-end: 4rem;
   }
 
   /* ── Keyboard hints footer ─────────────────────────────────────── */
@@ -445,12 +594,8 @@ const typescriptHref = `${base}/reference/api/typescript/`;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    #starlight__search .pagefind-ui__result-link[data-search-active='true'],
-    #starlight__search
-      .pagefind-ui__result-title:has(.pagefind-ui__result-link[data-search-active='true']),
-    #starlight__search
-      .pagefind-ui__result-nested:has(.pagefind-ui__result-link[data-search-active='true']) {
-      transition: none;
+    #starlight__search .pagefind-ui__result-link {
+      scroll-behavior: auto;
     }
   }
 

--- a/src/frontend/tests/e2e/site-search.spec.ts
+++ b/src/frontend/tests/e2e/site-search.spec.ts
@@ -70,6 +70,10 @@ test.describe('site search dialog', () => {
 
     const dialog = page.locator('site-search dialog[open]');
     const results = dialog.locator('.pagefind-ui__result-link');
+    // Anchor the input to the dialog element itself (not `dialog[open]`)
+    // so the locator still resolves after Escape closes the dialog and
+    // we can assert the post-close `aria-expanded` value.
+    const input = page.locator('site-search dialog input.pagefind-ui__search-input');
     await expect(results.first()).toBeVisible({ timeout: 15000 });
     await expect.poll(() => results.count()).toBeGreaterThanOrEqual(3);
 
@@ -77,7 +81,6 @@ test.describe('site search dialog', () => {
     await expect(results.nth(0)).toHaveAttribute('data-search-active', 'true');
     await expect(results.nth(0)).toHaveAttribute('aria-selected', 'true');
 
-    const input = dialog.locator('input.pagefind-ui__search-input');
     await expect(input).toBeFocused();
     await expect(input).toHaveAttribute('role', 'combobox');
     await expect(input).toHaveAttribute('aria-controls', 'aspire-search-results');

--- a/src/frontend/tests/e2e/site-search.spec.ts
+++ b/src/frontend/tests/e2e/site-search.spec.ts
@@ -137,9 +137,13 @@ test.describe('site search dialog', () => {
 
     // Press End to jump to the last keyboard target — that should be the
     // TypeScript API button (last item in DOM order: results → load-more
-    // → C# button → TS button).
+    // → C# button → TS button). Home/End are deliberately ignored while
+    // the caret is in the input (they keep native text-editing behaviour
+    // there), so we ArrowDown into the results first to move focus out
+    // of the search field.
     const input = dialog.locator('input.pagefind-ui__search-input');
-    await input.press('End');
+    await input.press('ArrowDown');
+    await page.keyboard.press('End');
     await expect(tsBtn).toHaveAttribute('data-search-active', 'true');
     await expect(tsBtn).toBeFocused();
 
@@ -154,6 +158,43 @@ test.describe('site search dialog', () => {
     await page.keyboard.press('Home');
     await expect(results.first()).toHaveAttribute('data-search-active', 'true');
     await expect(csharpBtn).not.toHaveAttribute('data-search-active', 'true');
+  });
+
+  test('Home/End in the search input do not focus the API/load-more buttons', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind is not available in dev mode; this assertion runs against astro preview.');
+
+    await typeSearchQuery(page, 'aspire');
+
+    const dialog = page.locator('site-search dialog[open]');
+    const input = dialog.locator('input.pagefind-ui__search-input');
+    const results = dialog.locator('.pagefind-ui__result-link');
+    const csharpBtn = dialog.locator('a[data-api-search-link][data-api-lang="csharp"]');
+    const tsBtn = dialog.locator('a[data-api-search-link][data-api-lang="typescript"]');
+
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+
+    // Pressing Home/End while focus is in the input must NOT move the
+    // active marker to the C#/TypeScript API buttons (or any other
+    // out-of-listbox target). This is the regression that previously
+    // stole the caret away from the search field whenever the user
+    // tried to jump to the start/end of their query text.
+    await input.press('Home');
+    await expect(csharpBtn).not.toHaveAttribute('data-search-active', 'true');
+    await expect(tsBtn).not.toHaveAttribute('data-search-active', 'true');
+    await expect(csharpBtn).not.toBeFocused();
+    await expect(tsBtn).not.toBeFocused();
+
+    await input.press('End');
+    await expect(csharpBtn).not.toHaveAttribute('data-search-active', 'true');
+    await expect(tsBtn).not.toHaveAttribute('data-search-active', 'true');
+    await expect(csharpBtn).not.toBeFocused();
+    await expect(tsBtn).not.toBeFocused();
   });
 
   test('typed query is forwarded to the C# and TypeScript API buttons', async ({ page }) => {

--- a/src/frontend/tests/e2e/site-search.spec.ts
+++ b/src/frontend/tests/e2e/site-search.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test, type Page } from '@playwright/test';
+import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
+
+/**
+ * Opens the Pagefind/Starlight search dialog and waits for either the
+ * Pagefind input or the dev-mode warning to appear.
+ *
+ * Returns `true` if the real Pagefind UI is mounted (so result-driven
+ * assertions are meaningful) and `false` if the page is being served by
+ * `astro dev`, where Pagefind is not built. Callers should `test.skip()`
+ * when the helper returns `false`.
+ */
+async function openSearchDialog(page: Page): Promise<boolean> {
+  const openButton = page.locator('site-search button[data-open-modal]');
+  await expect(openButton).toBeVisible({ timeout: 15000 });
+  await openButton.click();
+
+  const dialog = page.locator('site-search dialog[open]');
+  await expect(dialog).toBeVisible();
+
+  // Pagefind UI is mounted asynchronously after dialog open. In `astro dev`,
+  // Pagefind is not built, so the dialog renders a dev-mode warning instead.
+  const input = dialog.locator('input.pagefind-ui__search-input');
+  const devWarning = dialog.locator('text=/Search is only available in production builds/i');
+
+  await expect(input.or(devWarning)).toBeVisible({ timeout: 15000 });
+
+  return await input.isVisible().catch(() => false);
+}
+
+async function typeSearchQuery(page: Page, query: string): Promise<void> {
+  const input = page.locator('site-search dialog input.pagefind-ui__search-input');
+  await input.fill(query);
+}
+
+test.describe('site search dialog', () => {
+  test('renders keyboard shortcut hints in the footer', async ({ page }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind is not available in dev mode; this assertion runs against astro preview.');
+
+    const footer = page.locator('[data-testid="search-keyboard-footer"]');
+    await expect(footer).toBeVisible();
+
+    // Real <kbd> elements so the shortcut text scales with the user's font size.
+    await expect(footer.locator('kbd', { hasText: '↑' })).toBeVisible();
+    await expect(footer.locator('kbd', { hasText: '↓' })).toBeVisible();
+    await expect(footer.locator('kbd', { hasText: '↵' })).toBeVisible();
+    await expect(footer.locator('kbd', { hasText: 'Esc' })).toBeVisible();
+
+    await expect(footer).toContainText('Navigate');
+    await expect(footer).toContainText('Open');
+    await expect(footer).toContainText('Close');
+  });
+
+  test('arrow keys cycle through results and Escape closes the dialog', async ({ page }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind is not available in dev mode; keyboard nav runs against astro preview.');
+
+    // Use a query that consistently returns multiple Pagefind hits across
+    // the docs index. "aspire" is referenced by virtually every doc page.
+    await typeSearchQuery(page, 'aspire');
+
+    const dialog = page.locator('site-search dialog[open]');
+    const results = dialog.locator('.pagefind-ui__result-link');
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+    await expect.poll(() => results.count()).toBeGreaterThanOrEqual(2);
+
+    // First result should auto-highlight as soon as Pagefind renders.
+    await expect(results.nth(0)).toHaveAttribute('data-search-active', 'true');
+    await expect(results.nth(0)).toHaveAttribute('aria-selected', 'true');
+
+    const input = dialog.locator('input.pagefind-ui__search-input');
+    await expect(input).toBeFocused();
+    await expect(input).toHaveAttribute('role', 'combobox');
+    await expect(input).toHaveAttribute('aria-controls', 'aspire-search-results');
+
+    // ArrowDown moves the active marker to the next result.
+    await input.press('ArrowDown');
+    await expect(results.nth(0)).not.toHaveAttribute('data-search-active', 'true');
+    await expect(results.nth(1)).toHaveAttribute('data-search-active', 'true');
+    await expect(results.nth(1)).toHaveAttribute('aria-selected', 'true');
+
+    // ArrowUp returns to the first result.
+    await input.press('ArrowUp');
+    await expect(results.nth(0)).toHaveAttribute('data-search-active', 'true');
+    await expect(results.nth(1)).not.toHaveAttribute('data-search-active', 'true');
+
+    // The input's aria-activedescendant tracks the active result.
+    const activeId = await results.nth(0).getAttribute('id');
+    expect(activeId).toBeTruthy();
+    await expect(input).toHaveAttribute('aria-activedescendant', activeId!);
+
+    // Escape closes the dialog.
+    await input.press('Escape');
+    await expect(dialog).toBeHidden();
+  });
+
+  test('typed query is forwarded to the C# and TypeScript API buttons', async ({ page }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind input is required to type into; runs against astro preview.');
+
+    const dialog = page.locator('site-search dialog[open]');
+    const csharpBtn = dialog.locator('a[data-api-search-link][data-api-lang="csharp"]');
+    const tsBtn = dialog.locator('a[data-api-search-link][data-api-lang="typescript"]');
+
+    await expect(csharpBtn).toBeVisible();
+    await expect(tsBtn).toBeVisible();
+
+    // Pre-typing: hrefs should be the bare landing pages.
+    await expect(csharpBtn).toHaveAttribute('href', /\/reference\/api\/csharp\/$/);
+    await expect(tsBtn).toHaveAttribute('href', /\/reference\/api\/typescript\/$/);
+
+    // Use a query the TS API search index actually contains so the hand-off
+    // can be verified end-to-end.
+    await typeSearchQuery(page, 'withBun');
+
+    await expect(csharpBtn).toHaveAttribute('href', /\/reference\/api\/csharp\/\?q=withBun$/);
+    await expect(tsBtn).toHaveAttribute('href', /\/reference\/api\/typescript\/\?q=withBun$/);
+
+    // Click the TypeScript button — it should land on the TS API landing
+    // page with the query pre-applied via InpageSearchSync.
+    await tsBtn.click();
+    await page.waitForURL(/\/reference\/api\/typescript\/\?q=withBun/);
+
+    await dismissCookieConsentIfVisible(page);
+
+    const tsInput = page.locator('#ts-api-search-input');
+    await expect(tsInput).toHaveValue('withBun');
+
+    const tsResults = page.locator('#ts-api-search-results .api-search-result');
+    await expect(tsResults.first()).toBeVisible({ timeout: 10000 });
+  });
+
+  test('clearing the search input restores the default API button hrefs', async ({ page }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind input is required to type into; runs against astro preview.');
+
+    const dialog = page.locator('site-search dialog[open]');
+    const csharpBtn = dialog.locator('a[data-api-search-link][data-api-lang="csharp"]');
+    const tsBtn = dialog.locator('a[data-api-search-link][data-api-lang="typescript"]');
+
+    await typeSearchQuery(page, 'withBun');
+    await expect(csharpBtn).toHaveAttribute('href', /\?q=withBun$/);
+
+    await typeSearchQuery(page, '');
+    await expect(csharpBtn).toHaveAttribute('href', /\/reference\/api\/csharp\/$/);
+    await expect(tsBtn).toHaveAttribute('href', /\/reference\/api\/typescript\/$/);
+  });
+});

--- a/src/frontend/tests/e2e/site-search.spec.ts
+++ b/src/frontend/tests/e2e/site-search.spec.ts
@@ -55,7 +55,9 @@ test.describe('site search dialog', () => {
     await expect(footer).toContainText('Close');
   });
 
-  test('arrow keys cycle through results and Escape closes the dialog', async ({ page }) => {
+  test('arrow keys cycle through results, Tab keeps state, and Escape closes the dialog', async ({
+    page,
+  }) => {
     await page.goto('/');
     await dismissCookieConsentIfVisible(page);
 
@@ -69,7 +71,7 @@ test.describe('site search dialog', () => {
     const dialog = page.locator('site-search dialog[open]');
     const results = dialog.locator('.pagefind-ui__result-link');
     await expect(results.first()).toBeVisible({ timeout: 15000 });
-    await expect.poll(() => results.count()).toBeGreaterThanOrEqual(2);
+    await expect.poll(() => results.count()).toBeGreaterThanOrEqual(3);
 
     // First result should auto-highlight as soon as Pagefind renders.
     await expect(results.nth(0)).toHaveAttribute('data-search-active', 'true');
@@ -79,26 +81,76 @@ test.describe('site search dialog', () => {
     await expect(input).toBeFocused();
     await expect(input).toHaveAttribute('role', 'combobox');
     await expect(input).toHaveAttribute('aria-controls', 'aspire-search-results');
+    await expect(input).toHaveAttribute('aria-expanded', 'true');
 
-    // ArrowDown moves the active marker to the next result.
+    // ArrowDown moves the active marker to the next result *and* moves
+    // real focus there, so Tab can resume from that location.
     await input.press('ArrowDown');
     await expect(results.nth(0)).not.toHaveAttribute('data-search-active', 'true');
     await expect(results.nth(1)).toHaveAttribute('data-search-active', 'true');
     await expect(results.nth(1)).toHaveAttribute('aria-selected', 'true');
+    await expect(results.nth(1)).toBeFocused();
 
-    // ArrowUp returns to the first result.
-    await input.press('ArrowUp');
-    await expect(results.nth(0)).toHaveAttribute('data-search-active', 'true');
+    // Native Tab from result[1] should advance focus to result[2] and
+    // the focusin handler should keep activeIndex in sync.
+    await page.keyboard.press('Tab');
+    await expect(results.nth(2)).toBeFocused();
+    await expect(results.nth(2)).toHaveAttribute('data-search-active', 'true');
     await expect(results.nth(1)).not.toHaveAttribute('data-search-active', 'true');
 
+    // Up/Down can resume from the post-Tab location.
+    await page.keyboard.press('ArrowUp');
+    await expect(results.nth(1)).toBeFocused();
+    await expect(results.nth(1)).toHaveAttribute('data-search-active', 'true');
+
     // The input's aria-activedescendant tracks the active result.
-    const activeId = await results.nth(0).getAttribute('id');
+    const activeId = await results.nth(1).getAttribute('id');
     expect(activeId).toBeTruthy();
     await expect(input).toHaveAttribute('aria-activedescendant', activeId!);
 
-    // Escape closes the dialog.
-    await input.press('Escape');
+    // Escape closes the dialog (native <dialog> behaviour) and
+    // aria-expanded flips back to "false".
+    await page.keyboard.press('Escape');
     await expect(dialog).toBeHidden();
+    await expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  test('arrow nav also cycles through the C#/TypeScript API buttons', async ({ page }) => {
+    await page.goto('/');
+    await dismissCookieConsentIfVisible(page);
+
+    const ready = await openSearchDialog(page);
+    test.skip(!ready, 'Pagefind is not available in dev mode; this assertion runs against astro preview.');
+
+    await typeSearchQuery(page, 'aspire');
+
+    const dialog = page.locator('site-search dialog[open]');
+    const results = dialog.locator('.pagefind-ui__result-link');
+    const csharpBtn = dialog.locator('a[data-api-search-link][data-api-lang="csharp"]');
+    const tsBtn = dialog.locator('a[data-api-search-link][data-api-lang="typescript"]');
+
+    await expect(results.first()).toBeVisible({ timeout: 15000 });
+    await expect(csharpBtn).toBeVisible();
+
+    // Press End to jump to the last keyboard target — that should be the
+    // TypeScript API button (last item in DOM order: results → load-more
+    // → C# button → TS button).
+    const input = dialog.locator('input.pagefind-ui__search-input');
+    await input.press('End');
+    await expect(tsBtn).toHaveAttribute('data-search-active', 'true');
+    await expect(tsBtn).toBeFocused();
+
+    // ArrowUp from TS button should land on the C# button.
+    await page.keyboard.press('ArrowUp');
+    await expect(csharpBtn).toHaveAttribute('data-search-active', 'true');
+    await expect(csharpBtn).toBeFocused();
+    await expect(tsBtn).not.toHaveAttribute('data-search-active', 'true');
+
+    // Press Home to jump back to the very first result; the API buttons
+    // release the active marker.
+    await page.keyboard.press('Home');
+    await expect(results.first()).toHaveAttribute('data-search-active', 'true');
+    await expect(csharpBtn).not.toHaveAttribute('data-search-active', 'true');
   });
 
   test('typed query is forwarded to the C# and TypeScript API buttons', async ({ page }) => {


### PR DESCRIPTION
Improves the Pagefind-backed site search dialog with keyboard navigation, a hint footer, and query-forwarding API buttons.

## Screenshots

| Empty (just opened) | After typing |
|---|---|
| ![Empty dialog - only the C#/TypeScript API buttons are present and nothing is auto-highlighted](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/dapine/pr-891-screenshots/.github/screenshots/pr-891/search-ux-empty.png) | ![After typing browser - the first result auto-highlights with a single accent outline; sub-articles below stay quiet](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/dapine/pr-891-screenshots/.github/screenshots/pr-891/search-ux-default.png) |

| Arrow-key navigation | Arrow nav reaches the API buttons |
|---|---|
| ![After ArrowDown ArrowDown - active highlight has moved to a sub-article with the same single-outline treatment, and scroll keeps it clear of the sticky keyboard footer](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/dapine/pr-891-screenshots/.github/screenshots/pr-891/search-ux-arrows.png) | ![Pressing End jumps to the TypeScript API button at the very end of the nav order - same accent treatment as the result rows](https://raw.githubusercontent.com/IEvangelist/aspire.dev-1/dapine/pr-891-screenshots/.github/screenshots/pr-891/search-ux-buttons.png) |

## What changed

src/frontend/src/components/starlight/Search.astro

- **Keyboard navigation**: ArrowDown / ArrowUp / Home / End / Enter walk through Pagefind results. Up/Down also extend through the **Load more results** button and the **C# / TypeScript API buttons** so arrow nav covers the same set as native Tab. Escape closes the dialog (native `<dialog>` behaviour).
- **Unified Tab + arrow nav**: keydown lives on the dialog at capture phase so arrows fire whether focus is on the input or on a focused result. Arrows move *real* focus (`preventScroll: true`); a `focusin` handler keeps the active index in sync after Tab so up/down resume cleanly from wherever Tab landed.
- **Auto-highlight is restricted to result links**: opening the dialog with no query leaves nothing highlighted; as soon as Pagefind renders, the first result auto-highlights (DocSearch / GitHub command-palette style). Buttons are reachable via arrows but never default-active, so the first ArrowDown after typing always lands on the next result.
- **Active marker matches Starlight's existing `:focus-within`** exactly (1px accent-high outline + accent-low background), so virtual highlight (input still focused) and real focus produce identical pixels - no double border, no competing rules.
- **Scroll follows nav**: `scroll-margin-block-end` clears the sticky keyboard footer so `scrollIntoView({block: 'nearest'})` keeps the active row in view as you arrow through long result lists.
- **Pagefind re-renders coalesced via `requestAnimationFrame`** so the active highlight no longer flickers as the user types.
- **A11y wiring**: input gets `role=combobox`, `aria-controls`, `aria-expanded` (now reflects `dialog.open` - flips to `false` on Esc / backdrop close), and `aria-activedescendant` (only points at result-link options, not buttons). Result links get `role=option` + `aria-selected`. Results container gets `role=listbox` and an id that is force-set on every refresh so `aria-controls` is never broken by an upstream id assignment.
- **Footer keyboard hints**: sticky footer at the bottom of the dialog with arrow keys for navigation, Enter to open, Esc to close. Responsive layout collapses gracefully on mobile; `prefers-reduced-motion` is honoured.
- **API button query forwarding**: the C# and TypeScript API anchors in `api-search-notice-tpl` propagate the typed query as `?q=<encoded>`. `inpage-search-sync.ts` already consumes that on the landing pages, so this is end-to-end with no consumer changes. Default `href` is restored when the input is cleared, so middle/right-click `open in new tab` and no-JS scenarios keep working.
- **Single `MutationObserver`** drives template injection (idempotent) and refreshes both the keyboard-nav target list and the API-button `href`s whenever Pagefind re-renders. Re-initialised on `astro:after-swap`.

## Tests

`src/frontend/tests/e2e/site-search.spec.ts`

- Footer hints render with all `<kbd>` shortcuts.
- **Arrow keys cycle through results, Tab keeps state, and Escape closes the dialog**: ArrowDown moves real focus to the next result, Tab advances both focus and the active marker, ArrowUp resumes from the post-Tab position, and Escape both hides the dialog and flips `aria-expanded` back to `false`.
- **Arrow nav also cycles through the C#/TypeScript API buttons**: `End` jumps to the TS button (last in nav order), ArrowUp lands on the C# button, `Home` returns to the first result and clears the marker on the buttons.
- Query forwarding: typing `withBun` rewrites both API anchor `href`s, and clicking the TS link lands on `/reference/api/typescript/?q=withBun` with `#ts-api-search-input` populated and `.api-search-result` visible.
- Clearing the input restores default `href`s.

The `openSearchDialog()` helper `test.skip()`s when Pagefind isn't mounted (i.e., in `astro dev`), since the index is only built for `astro preview` / production. CI runs against the built site, so it exercises the full path.

## Validation

- `pnpm lint` - clean (`--max-warnings 0`)
- `pnpm test:unit` - all suites pass
- `pnpm build:production` - completes (Pagefind index rebuilt over 12,939 HTML pages)
- Local `astro preview` smoke-tested through every feedback round: empty-state, type-to-search, arrow nav across results + buttons, Tab/arrow sync, Escape, scroll-follow, query forwarding.

## Notes

- Pagefind itself is unchanged; everything is layered on top via DOM + a small `MutationObserver`, so this is robust to upstream Starlight / Pagefind updates.
- `:has()` is used for the active-result highlight selector (supported in all evergreens since 2023, matches the rest of the site).
- Auto-highlighting the first result follows Algolia DocSearch and the GitHub command palette. If we'd rather require `ArrowDown` first, that's a one-line change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>