### PR TITLE
Preserve fenced code-block newlines in llms-small.txt

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -29,7 +29,7 @@
     "astro": "pnpm git-env && astro",
     "test": "pnpm test:unit && pnpm test:e2e",
     "test:all": "pnpm lint && pnpm test",
-    "test:unit": "pnpm test:unit:contracts && pnpm test:unit:components && pnpm test:unit:docs && pnpm test:unit:api-markdown && pnpm test:unit:ts-api && pnpm test:unit:twoslash-types && pnpm test:unit:structured-data && pnpm test:unit:cli-config-schema",
+    "test:unit": "pnpm test:unit:contracts && pnpm test:unit:components && pnpm test:unit:docs && pnpm test:unit:api-markdown && pnpm test:unit:ts-api && pnpm test:unit:twoslash-types && pnpm test:unit:structured-data && pnpm test:unit:cli-config-schema && pnpm test:unit:llms-small-whitespace",
     "test:unit:api-markdown": "vitest run --config vitest.config.ts tests/unit/api-markdown.vitest.test.ts",
     "test:unit:ts-api": "vitest run --config vitest.config.ts tests/unit/api-reference-routes.vitest.test.ts tests/unit/browser-storage.vitest.test.ts tests/unit/locale-routes.vitest.test.ts tests/unit/ts-api-routes.vitest.test.ts tests/unit/ts-api-search.vitest.test.ts",
     "test:unit:twoslash-types": "vitest run --config vitest.config.ts tests/unit/twoslash-types-generator.vitest.test.ts",
@@ -38,6 +38,7 @@
     "test:unit:docs": "vitest run --config vitest.config.ts tests/unit/filetree-format.vitest.test.ts",
     "test:unit:structured-data": "vitest run --config vitest.config.ts tests/unit/structured-data.vitest.test.ts tests/unit/update-integrations.vitest.test.ts",
     "test:unit:cli-config-schema": "vitest run --config vitest.config.ts tests/unit/cli-config-schema.vitest.test.ts",
+    "test:unit:llms-small-whitespace": "vitest run --config vitest.config.ts tests/unit/llms-small-whitespace.vitest.test.ts",
     "test:e2e:api-markdown": "playwright test --config playwright.api-markdown.config.mjs",
     "test:e2e": "playwright test",
     "test:e2e:install": "playwright install chromium",
@@ -79,7 +80,7 @@
     "starlight-image-zoom": "^0.14.1",
     "starlight-kbd": "^0.4.0",
     "starlight-links-validator": "^0.24.0",
-    "starlight-llms-txt": "^0.8.1",
+    "starlight-llms-txt": "0.8.1",
     "starlight-page-actions": "^0.6.0",
     "starlight-scroll-to-top": "^1.0.1",
     "starlight-sidebar-topics": "^0.7.1",
@@ -124,6 +125,9 @@
       "simple-git@<3.32.3": ">=3.32.3",
       "svgo@=4.0.0": ">=4.0.1",
       "uuid@<14.0.0": ">=14.0.0"
+    },
+    "patchedDependencies": {
+      "starlight-llms-txt@0.8.1": "patches/starlight-llms-txt@0.8.1.patch"
     }
   }
 }

--- a/src/frontend/patches/starlight-llms-txt@0.8.1.patch
+++ b/src/frontend/patches/starlight-llms-txt@0.8.1.patch
@@ -1,5 +1,5 @@
 diff --git a/entryToSimpleMarkdown.ts b/entryToSimpleMarkdown.ts
-index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b234068ecd22003fdad2fbe47930c890892bea25 100644
+index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b2858348745f7116f9a9e598cd10a0a098f056c0 100644
 --- a/entryToSimpleMarkdown.ts
 +++ b/entryToSimpleMarkdown.ts
 @@ -20,6 +20,7 @@ const minifyDefaults = {
@@ -10,7 +10,7 @@ index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b234068ecd22003fdad2fbe47930c890
  	customSelectors: [],
  };
  /** Resolved minification options */
-@@ -192,7 +193,26 @@ export async function entryToSimpleMarkdown(
+@@ -192,7 +193,31 @@ export async function entryToSimpleMarkdown(
  	});
  	let markdown = String(file).trim();
  	if (shouldMinify && minify.whitespace) {
@@ -20,18 +20,23 @@ index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b234068ecd22003fdad2fbe47930c890
 +			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
 +			// samples stay multi-line. Fences are matched at the start of a line
 +			// and the closing fence must use the same marker length and
-+			// indentation as the opener (via back-references).
++			// indentation as the opener (via back-references). The body chunk is
++			// optional so empty fences (`` ```\n``` ``) still match.
 +			const fenceMatcher =
-+				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
++				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n(?:[\s\S]*?\n)?\1\2[ \t]*(?=\n|$)/g;
 +			const parts: string[] = [];
 +			let lastIndex = 0;
 +			for (const match of markdown.matchAll(fenceMatcher)) {
-+				parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
++				const index = match.index ?? 0;
++				parts.push(markdown.slice(lastIndex, index).replace(/\s+/g, ' '));
 +				parts.push('\n', match[0], '\n');
-+				lastIndex = match.index + match[0].length;
++				lastIndex = index + match[0].length;
 +			}
 +			parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
-+			markdown = parts.join('');
++			// `String(file).trim()` already stripped boundary whitespace from the
++			// input; trim again so the `\n` wrappers we added around fences at
++			// the start/end of the document don't reintroduce it.
++			markdown = parts.join('').trim();
 +		} else {
 +			markdown = markdown.replace(/\s+/g, ' ');
 +		}

--- a/src/frontend/patches/starlight-llms-txt@0.8.1.patch
+++ b/src/frontend/patches/starlight-llms-txt@0.8.1.patch
@@ -1,12 +1,12 @@
 diff --git a/entryToSimpleMarkdown.ts b/entryToSimpleMarkdown.ts
-index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b2858348745f7116f9a9e598cd10a0a098f056c0 100644
+index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..c9561aadb8ec4be885a828b7a5ebc2da0ec6fd6f 100644
 --- a/entryToSimpleMarkdown.ts
 +++ b/entryToSimpleMarkdown.ts
 @@ -20,6 +20,7 @@ const minifyDefaults = {
  	danger: false,
  	details: true,
  	whitespace: true,
-+	preserveCodeBlocks: true,
++	collapseCodeBlocks: false,
  	customSelectors: [],
  };
  /** Resolved minification options */
@@ -15,7 +15,9 @@ index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b2858348745f7116f9a9e598cd10a0a0
  	let markdown = String(file).trim();
  	if (shouldMinify && minify.whitespace) {
 -		markdown = markdown.replace(/\s+/g, ' ');
-+		if (minify.preserveCodeBlocks) {
++		if (minify.collapseCodeBlocks) {
++			markdown = markdown.replace(/\s+/g, ' ');
++		} else {
 +			// Collapse whitespace in prose, but keep the contents of fenced code
 +			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
 +			// samples stay multi-line. Fences are matched at the start of a line
@@ -37,37 +39,38 @@ index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b2858348745f7116f9a9e598cd10a0a0
 +			// input; trim again so the `\n` wrappers we added around fences at
 +			// the start/end of the document don't reintroduce it.
 +			markdown = parts.join('').trim();
-+		} else {
-+			markdown = markdown.replace(/\s+/g, ' ');
 +		}
  	}
  	return markdown;
  }
 diff --git a/types.ts b/types.ts
-index c7260e0ddd8b251d399d6d31b767924b8413ee81..f08910727ecb8a81248f51035ea1f4e6d2b4273d 100644
+index c7260e0ddd8b251d399d6d31b767924b8413ee81..ae048511968d45bbef14c2d5b780bdaffcba0df7 100644
 --- a/types.ts
 +++ b/types.ts
-@@ -130,6 +130,24 @@ export interface StarlightLllmsTextOptions {
+@@ -130,6 +130,27 @@ export interface StarlightLllmsTextOptions {
  		 */
  		whitespace?: boolean;
  
 +		/**
-+		 * When `whitespace` is enabled, preserve the original newlines (and
-+		 * indentation) inside fenced code blocks (``` and ~~~) so that
-+		 * multi-line code samples stay multi-line in `llms-small.txt`.
++		 * When `whitespace` is enabled, also collapse whitespace inside fenced
++		 * code blocks (``` and ~~~). By default, the bodies of fenced code
++		 * blocks keep their original newlines (and indentation) so multi-line
++		 * code samples stay multi-line in `llms-small.txt`.
 +		 *
-+		 * Whitespace in prose (paragraphs, lists, etc.) is still collapsed for
-+		 * token efficiency — only code-block bodies are exempt. Both
-+		 * variable-length fences (e.g. four or more backticks) and tilde fences
-+		 * are recognized. Has no effect when `whitespace` is `false`.
++		 * Whitespace in prose (paragraphs, lists, etc.) is always collapsed
++		 * when `whitespace` is enabled; this option only controls whether
++		 * code-block bodies are exempt. Both variable-length fences (e.g.
++		 * four or more backticks) and tilde fences are recognized.
 +		 *
-+		 * Set this to `false` to restore the previous behavior of collapsing
++		 * Set this to `true` to restore the previous behavior of collapsing
 +		 * every whitespace run, including newlines inside code fences, into a
 +		 * single space.
 +		 *
-+		 * @default true
++		 * Has no effect when `whitespace` is `false`.
++		 *
++		 * @default false
 +		 */
-+		preserveCodeBlocks?: boolean;
++		collapseCodeBlocks?: boolean;
 +
  		/**
  		 * Custom selectors to exclude when generating `llms-small.txt`.

--- a/src/frontend/patches/starlight-llms-txt@0.8.1.patch
+++ b/src/frontend/patches/starlight-llms-txt@0.8.1.patch
@@ -1,0 +1,69 @@
+diff --git a/entryToSimpleMarkdown.ts b/entryToSimpleMarkdown.ts
+index 5fdc6c54ae6edc5874db921dde4b89ed9e15dc3c..b234068ecd22003fdad2fbe47930c890892bea25 100644
+--- a/entryToSimpleMarkdown.ts
++++ b/entryToSimpleMarkdown.ts
+@@ -20,6 +20,7 @@ const minifyDefaults = {
+ 	danger: false,
+ 	details: true,
+ 	whitespace: true,
++	preserveCodeBlocks: true,
+ 	customSelectors: [],
+ };
+ /** Resolved minification options */
+@@ -192,7 +193,26 @@ export async function entryToSimpleMarkdown(
+ 	});
+ 	let markdown = String(file).trim();
+ 	if (shouldMinify && minify.whitespace) {
+-		markdown = markdown.replace(/\s+/g, ' ');
++		if (minify.preserveCodeBlocks) {
++			// Collapse whitespace in prose, but keep the contents of fenced code
++			// blocks (``` and ~~~, of any length ≥ 3) intact so multi-line code
++			// samples stay multi-line. Fences are matched at the start of a line
++			// and the closing fence must use the same marker length and
++			// indentation as the opener (via back-references).
++			const fenceMatcher =
++				/(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
++			const parts: string[] = [];
++			let lastIndex = 0;
++			for (const match of markdown.matchAll(fenceMatcher)) {
++				parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
++				parts.push('\n', match[0], '\n');
++				lastIndex = match.index + match[0].length;
++			}
++			parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
++			markdown = parts.join('');
++		} else {
++			markdown = markdown.replace(/\s+/g, ' ');
++		}
+ 	}
+ 	return markdown;
+ }
+diff --git a/types.ts b/types.ts
+index c7260e0ddd8b251d399d6d31b767924b8413ee81..f08910727ecb8a81248f51035ea1f4e6d2b4273d 100644
+--- a/types.ts
++++ b/types.ts
+@@ -130,6 +130,24 @@ export interface StarlightLllmsTextOptions {
+ 		 */
+ 		whitespace?: boolean;
+ 
++		/**
++		 * When `whitespace` is enabled, preserve the original newlines (and
++		 * indentation) inside fenced code blocks (``` and ~~~) so that
++		 * multi-line code samples stay multi-line in `llms-small.txt`.
++		 *
++		 * Whitespace in prose (paragraphs, lists, etc.) is still collapsed for
++		 * token efficiency — only code-block bodies are exempt. Both
++		 * variable-length fences (e.g. four or more backticks) and tilde fences
++		 * are recognized. Has no effect when `whitespace` is `false`.
++		 *
++		 * Set this to `false` to restore the previous behavior of collapsing
++		 * every whitespace run, including newlines inside code fences, into a
++		 * single space.
++		 *
++		 * @default true
++		 */
++		preserveCodeBlocks?: boolean;
++
+ 		/**
+ 		 * Custom selectors to exclude when generating `llms-small.txt`.
+ 		 *

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -23,6 +23,11 @@ overrides:
   svgo@=4.0.0: '>=4.0.1'
   uuid@<14.0.0: '>=14.0.0'
 
+patchedDependencies:
+  starlight-llms-txt@0.8.1:
+    hash: d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab
+    path: patches/starlight-llms-txt@0.8.1.patch
+
 importers:
 
   .:
@@ -109,8 +114,8 @@ importers:
         specifier: ^0.24.0
         version: 0.24.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-llms-txt:
-        specifier: ^0.8.1
-        version: 0.8.1(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
+        specifier: 0.8.1
+        version: 0.8.1(patch_hash=d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-page-actions:
         specifier: ^0.6.0
         version: 0.6.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))(vite@7.3.2(@types/node@24.12.2)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
@@ -222,23 +227,11 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
-  '@astrojs/internal-helpers@0.8.0':
-    resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
-
   '@astrojs/internal-helpers@0.9.0':
     resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
-  '@astrojs/markdown-remark@7.1.0':
-    resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
-
   '@astrojs/markdown-remark@7.1.1':
     resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
-
-  '@astrojs/mdx@5.0.3':
-    resolution: {integrity: sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==}
-    engines: {node: '>=22.12.0'}
-    peerDependencies:
-      astro: ^6.0.0
 
   '@astrojs/mdx@5.0.4':
     resolution: {integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==}
@@ -3777,39 +3770,9 @@ snapshots:
 
   '@astrojs/compiler@4.0.0': {}
 
-  '@astrojs/internal-helpers@0.8.0':
-    dependencies:
-      picomatch: 4.0.4
-
   '@astrojs/internal-helpers@0.9.0':
     dependencies:
       picomatch: 4.0.4
-
-  '@astrojs/markdown-remark@7.1.0':
-    dependencies:
-      '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/prism': 4.0.1
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      js-yaml: 4.1.1
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.1
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@astrojs/markdown-remark@7.1.1':
     dependencies:
@@ -3833,25 +3796,6 @@ snapshots:
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@astrojs/mdx@5.0.3(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))':
-    dependencies:
-      '@astrojs/markdown-remark': 7.1.0
-      '@mdx-js/mdx': 3.1.1
-      acorn: 8.16.0
-      astro: 6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)
-      es-module-lexer: 2.1.0
-      estree-util-visit: 2.0.0
-      hast-util-to-html: 9.0.5
-      piccolore: 0.1.3
-      rehype-raw: 7.0.0
-      remark-gfm: 4.0.1
-      remark-smartypants: 3.0.2
-      source-map: 0.7.6
-      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -7525,9 +7469,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-llms-txt@0.8.1(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
+  starlight-llms-txt@0.8.1(patch_hash=d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
-      '@astrojs/mdx': 5.0.3(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       '@astrojs/starlight': 0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       '@types/hast': 3.0.4
       '@types/micromatch': 4.0.10

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
 
 patchedDependencies:
   starlight-llms-txt@0.8.1:
-    hash: d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab
+    hash: adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2
     path: patches/starlight-llms-txt@0.8.1.patch
 
 importers:
@@ -115,7 +115,7 @@ importers:
         version: 0.24.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-llms-txt:
         specifier: 0.8.1
-        version: 0.8.1(patch_hash=d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.8.1(patch_hash=adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-page-actions:
         specifier: ^0.6.0
         version: 0.6.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))(vite@7.3.2(@types/node@24.12.2)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
@@ -7469,7 +7469,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-llms-txt@0.8.1(patch_hash=d95975b9e5ceef5195091dea08a9ace9f9a5f7cd291758e493abbd401f0e77ab)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
+  starlight-llms-txt@0.8.1(patch_hash=adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@astrojs/mdx': 5.0.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       '@astrojs/starlight': 0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -25,7 +25,7 @@ overrides:
 
 patchedDependencies:
   starlight-llms-txt@0.8.1:
-    hash: adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2
+    hash: c75a640e8646a713540e4a7dc1ca434eca7632ec490028201bdddf841e5f8871
     path: patches/starlight-llms-txt@0.8.1.patch
 
 importers:
@@ -115,7 +115,7 @@ importers:
         version: 0.24.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-llms-txt:
         specifier: 0.8.1
-        version: 0.8.1(patch_hash=adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
+        version: 0.8.1(patch_hash=c75a640e8646a713540e4a7dc1ca434eca7632ec490028201bdddf841e5f8871)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       starlight-page-actions:
         specifier: ^0.6.0
         version: 0.6.0(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))(vite@7.3.2(@types/node@24.12.2)(jiti@1.21.7)(tsx@4.21.0)(yaml@2.8.3))
@@ -7469,7 +7469,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  starlight-llms-txt@0.8.1(patch_hash=adb8a985973540208d45b961ff151600faf8db59330d78a71446ec2bf141dee2)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
+  starlight-llms-txt@0.8.1(patch_hash=c75a640e8646a713540e4a7dc1ca434eca7632ec490028201bdddf841e5f8871)(@astrojs/starlight@0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)))(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@astrojs/mdx': 5.0.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))
       '@astrojs/starlight': 0.38.4(astro@6.2.2(@types/node@24.12.2)(jiti@1.21.7)(rollup@4.60.3)(tsx@4.21.0)(yaml@2.8.3))

--- a/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
+++ b/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+// This file pins the behavior of the patched `starlight-llms-txt` plugin so a
+// future dependency bump or accidental patch loss is caught in CI rather than
+// regressing the generated `dist/llms-small.txt`.
+//
+// Background: `starlight-llms-txt@0.8.1` ships an `entryToSimpleMarkdown.ts`
+// whose `minify.whitespace` path runs `markdown.replace(/\s+/g, ' ')`, which
+// collapses every whitespace run — including newlines inside fenced code
+// blocks — into a single space. Downstream LLM consumers (e.g. the Aspire CLI
+// `aspire docs get` command) then render multi-line code samples as flowed
+// prose.
+//
+// The patch in `src/frontend/patches/starlight-llms-txt@0.8.1.patch` introduces
+// a `minify.preserveCodeBlocks` option (default `true`) that preserves the
+// bodies of ``` and ~~~ fenced blocks while still collapsing whitespace in
+// surrounding prose. The upstream PR mirrors this change.
+
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testsDir, '..', '..');
+const patchedPluginPath = path.join(
+  frontendRoot,
+  'node_modules',
+  'starlight-llms-txt',
+  'entryToSimpleMarkdown.ts',
+);
+
+describe('starlight-llms-txt patch sentinel', () => {
+  test('patched entryToSimpleMarkdown.ts contains preserveCodeBlocks branch', () => {
+    const source = readFileSync(patchedPluginPath, 'utf8');
+
+    expect(
+      source,
+      'patched plugin should declare the preserveCodeBlocks default',
+    ).toContain('preserveCodeBlocks: true');
+    expect(
+      source,
+      'patched plugin should guard the new branch with the option',
+    ).toContain('minify.preserveCodeBlocks');
+    expect(
+      source,
+      'patched plugin should match fenced code blocks at start of line',
+    ).toContain('`{3,}|~{3,}');
+  });
+});
+
+// The minify algorithm from the patch, inlined here so the fixtures run in
+// isolation from the plugin's full runtime (which depends on Astro/Starlight).
+// MUST stay byte-identical to the implementation in
+// `patches/starlight-llms-txt@0.8.1.patch`.
+function minifyPreservingCodeBlocks(markdown: string): string {
+  const fenceMatcher = /(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
+  const parts: string[] = [];
+  let lastIndex = 0;
+  for (const match of markdown.matchAll(fenceMatcher)) {
+    parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
+    parts.push('\n', match[0], '\n');
+    lastIndex = match.index + match[0].length;
+  }
+  parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
+  return parts.join('');
+}
+
+const fixtures: Array<{ name: string; input: string; expected: string }> = [
+  {
+    name: 'plain prose collapses to single space',
+    input: 'Hello\nworld\n\n   tabs\there.',
+    expected: 'Hello world tabs here.',
+  },
+  {
+    name: 'single fenced block preserves internal newlines',
+    input:
+      'Before paragraph.\n\n```bash\naspire certs trust\naspire certs clean\n```\n\nAfter paragraph.',
+    expected:
+      'Before paragraph. \n```bash\naspire certs trust\naspire certs clean\n```\n After paragraph.',
+  },
+  {
+    name: 'two adjacent fenced blocks',
+    input: '```a\nx\n```\n```b\ny\n```',
+    expected: '\n```a\nx\n```\n \n```b\ny\n```\n',
+  },
+  {
+    name: '4-backtick fence containing literal triple-backtick',
+    input: 'pre\n\n````md\nFenced ``` example\nMore body\n````\n\npost',
+    expected: 'pre \n````md\nFenced ``` example\nMore body\n````\n post',
+  },
+  {
+    name: 'tilde fence preserved',
+    input: 'pre\n\n~~~py\ndef foo():\n    return 1\n~~~\n\npost',
+    expected: 'pre \n~~~py\ndef foo():\n    return 1\n~~~\n post',
+  },
+  {
+    name: 'fence nested under list item keeps indentation',
+    input: '- item\n\n  ```cs\n  var x = 1;\n  ```\n\n- next',
+    expected: '- item \n  ```cs\n  var x = 1;\n  ```\n - next',
+  },
+  {
+    name: 'inline triple-backtick in prose is NOT a fence',
+    input: 'See ```inline``` text.',
+    expected: 'See ```inline``` text.',
+  },
+  {
+    name: 'fence at start of input',
+    input: '```js\nconst a = 1;\n```\n\ntrailing prose',
+    expected: '\n```js\nconst a = 1;\n```\n trailing prose',
+  },
+  {
+    name: 'fence at end of input',
+    input: 'leading prose\n\n```js\nconst a = 1;\n```',
+    expected: 'leading prose \n```js\nconst a = 1;\n```\n',
+  },
+  {
+    name: 'mismatched fence length does not match',
+    input: 'pre\n\n```bash\naspire run\n````\n\npost',
+    expected: 'pre ```bash aspire run ```` post',
+  },
+];
+
+describe('starlight-llms-txt minify preserves fenced code blocks', () => {
+  for (const fixture of fixtures) {
+    test(fixture.name, () => {
+      expect(minifyPreservingCodeBlocks(fixture.input)).toBe(fixture.expected);
+    });
+  }
+});

--- a/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
+++ b/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
@@ -14,10 +14,12 @@ import { describe, expect, test } from 'vitest';
 // `aspire docs get` command) then render multi-line code samples as flowed
 // prose.
 //
-// The patch in `src/frontend/patches/starlight-llms-txt@0.8.1.patch` introduces
-// a `minify.preserveCodeBlocks` option (default `true`) that preserves the
-// bodies of ``` and ~~~ fenced blocks while still collapsing whitespace in
-// surrounding prose. The upstream PR mirrors this change.
+// The patch in `src/frontend/patches/starlight-llms-txt@0.8.1.patch` adds a
+// `minify.collapseCodeBlocks` option (default `false`). When unset (the new
+// default), the plugin preserves the bodies of ``` and ~~~ fenced blocks
+// while still collapsing whitespace in surrounding prose. Setting it to
+// `true` restores the legacy flatten-everything behavior. The upstream PR
+// mirrors this change.
 //
 // The sentinel below pins the *exact* fence regex shipped in the patched
 // plugin to the regex used by the inlined helper. That makes the behavior
@@ -41,17 +43,17 @@ const INLINED_FENCE_MATCHER =
   /(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n(?:[\s\S]*?\n)?\1\2[ \t]*(?=\n|$)/g;
 
 describe('starlight-llms-txt patch sentinel', () => {
-  test('patched entryToSimpleMarkdown.ts contains preserveCodeBlocks branch', () => {
+  test('patched entryToSimpleMarkdown.ts contains collapseCodeBlocks branch', () => {
     const source = readFileSync(patchedPluginPath, 'utf8');
 
     expect(
       source,
-      'patched plugin should declare the preserveCodeBlocks default',
-    ).toContain('preserveCodeBlocks: true');
+      'patched plugin should declare the collapseCodeBlocks default',
+    ).toContain('collapseCodeBlocks: false');
     expect(
       source,
-      'patched plugin should guard the new branch with the option',
-    ).toContain('minify.preserveCodeBlocks');
+      'patched plugin should gate the legacy branch on the new option',
+    ).toContain('minify.collapseCodeBlocks');
     expect(
       source,
       'patched plugin should trim boundary whitespace introduced by the `\\n` wrappers',

--- a/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
+++ b/src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts
@@ -18,6 +18,12 @@ import { describe, expect, test } from 'vitest';
 // a `minify.preserveCodeBlocks` option (default `true`) that preserves the
 // bodies of ``` and ~~~ fenced blocks while still collapsing whitespace in
 // surrounding prose. The upstream PR mirrors this change.
+//
+// The sentinel below pins the *exact* fence regex shipped in the patched
+// plugin to the regex used by the inlined helper. That makes the behavior
+// fixtures (which run the inlined helper) a faithful test of what's actually
+// running at build time — drift between the inlined copy and the shipped
+// patched code fails CI on the sentinel.
 
 const testsDir = path.dirname(fileURLToPath(import.meta.url));
 const frontendRoot = path.resolve(testsDir, '..', '..');
@@ -27,6 +33,12 @@ const patchedPluginPath = path.join(
   'starlight-llms-txt',
   'entryToSimpleMarkdown.ts',
 );
+
+// Source of the fence regex used by the inlined helper, captured as a string
+// so it can be compared byte-for-byte to the regex literal embedded in the
+// patched plugin file. MUST equal `INLINED_FENCE_MATCHER.toString()`.
+const INLINED_FENCE_MATCHER =
+  /(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n(?:[\s\S]*?\n)?\1\2[ \t]*(?=\n|$)/g;
 
 describe('starlight-llms-txt patch sentinel', () => {
   test('patched entryToSimpleMarkdown.ts contains preserveCodeBlocks branch', () => {
@@ -42,26 +54,45 @@ describe('starlight-llms-txt patch sentinel', () => {
     ).toContain('minify.preserveCodeBlocks');
     expect(
       source,
-      'patched plugin should match fenced code blocks at start of line',
-    ).toContain('`{3,}|~{3,}');
+      'patched plugin should trim boundary whitespace introduced by the `\\n` wrappers',
+    ).toContain("parts.join('').trim()");
+    expect(
+      source,
+      'patched plugin should guard the optional `match.index`',
+    ).toContain('match.index ?? 0');
+  });
+
+  test('patched fence regex matches the regex used by the inlined helper', () => {
+    const source = readFileSync(patchedPluginPath, 'utf8');
+    const regexLiteral = source.match(/\/\(\?<=\^\|\\n\)[^\n]+\/g/);
+
+    expect(
+      regexLiteral,
+      'patched plugin should declare a fenceMatcher regex literal',
+    ).not.toBeNull();
+    // This pins the regex shipped in the plugin to the regex run by the
+    // fixtures below. If upstream amends the algorithm, the inlined copy and
+    // this assertion both need to be updated together.
+    expect(regexLiteral![0]).toBe(INLINED_FENCE_MATCHER.toString());
   });
 });
 
 // The minify algorithm from the patch, inlined here so the fixtures run in
 // isolation from the plugin's full runtime (which depends on Astro/Starlight).
 // MUST stay byte-identical to the implementation in
-// `patches/starlight-llms-txt@0.8.1.patch`.
+// `patches/starlight-llms-txt@0.8.1.patch`; the sentinel above enforces this.
 function minifyPreservingCodeBlocks(markdown: string): string {
-  const fenceMatcher = /(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
+  const fenceMatcher = new RegExp(INLINED_FENCE_MATCHER.source, INLINED_FENCE_MATCHER.flags);
   const parts: string[] = [];
   let lastIndex = 0;
   for (const match of markdown.matchAll(fenceMatcher)) {
-    parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
+    const index = match.index ?? 0;
+    parts.push(markdown.slice(lastIndex, index).replace(/\s+/g, ' '));
     parts.push('\n', match[0], '\n');
-    lastIndex = match.index + match[0].length;
+    lastIndex = index + match[0].length;
   }
   parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
-  return parts.join('');
+  return parts.join('').trim();
 }
 
 const fixtures: Array<{ name: string; input: string; expected: string }> = [
@@ -80,7 +111,7 @@ const fixtures: Array<{ name: string; input: string; expected: string }> = [
   {
     name: 'two adjacent fenced blocks',
     input: '```a\nx\n```\n```b\ny\n```',
-    expected: '\n```a\nx\n```\n \n```b\ny\n```\n',
+    expected: '```a\nx\n```\n \n```b\ny\n```',
   },
   {
     name: '4-backtick fence containing literal triple-backtick',
@@ -105,17 +136,27 @@ const fixtures: Array<{ name: string; input: string; expected: string }> = [
   {
     name: 'fence at start of input',
     input: '```js\nconst a = 1;\n```\n\ntrailing prose',
-    expected: '\n```js\nconst a = 1;\n```\n trailing prose',
+    expected: '```js\nconst a = 1;\n```\n trailing prose',
   },
   {
     name: 'fence at end of input',
     input: 'leading prose\n\n```js\nconst a = 1;\n```',
-    expected: 'leading prose \n```js\nconst a = 1;\n```\n',
+    expected: 'leading prose \n```js\nconst a = 1;\n```',
   },
   {
     name: 'mismatched fence length does not match',
     input: 'pre\n\n```bash\naspire run\n````\n\npost',
     expected: 'pre ```bash aspire run ```` post',
+  },
+  {
+    name: 'empty fenced block is preserved',
+    input: 'pre\n\n```\n```\n\npost',
+    expected: 'pre \n```\n```\n post',
+  },
+  {
+    name: 'fence-only input (start AND end of input)',
+    input: '```js\nconst a = 1;\n```',
+    expected: '```js\nconst a = 1;\n```',
   },
 ];
 


### PR DESCRIPTION
## Summary

`https://aspire.dev/llms-small.txt` is consumed by LLM tooling (notably the Aspire CLI's `aspire docs get` command) but every fenced code block in it is collapsed onto a single line. This makes code samples like

````text
```bash aspire certs trust ``` Remove and re-trust
````

render as flowed prose instead of multi-line code.

Root cause: the `starlight-llms-txt@0.8.1` plugin's `minify.whitespace` path runs `markdown.replace(/\s+/g, ' ')` after `remark-stringify`, which flattens every whitespace run — including newlines inside ``` ```/`~~~` ``` blocks — into a single space. `llms-full.txt` is unaffected because it uses `minify: false`.

## Change

Apply a `pnpm patch` against `starlight-llms-txt@0.8.1` that introduces a new `minify.preserveCodeBlocks` option (default `true`). When enabled, the plugin finds fenced code blocks anchored to the start of a line and preserves their bodies while continuing to collapse whitespace in surrounding prose.

Regex / algorithm:

```ts
const fenceMatcher =
  /(?<=^|\n)([ \t]*)(`{3,}|~{3,})[^\n]*\n[\s\S]*?\n\1\2[ \t]*(?=\n|$)/g;
const parts: string[] = [];
let lastIndex = 0;
for (const match of markdown.matchAll(fenceMatcher)) {
  parts.push(markdown.slice(lastIndex, match.index).replace(/\s+/g, ' '));
  parts.push('\n', match[0], '\n');
  lastIndex = match.index + match[0].length;
}
parts.push(markdown.slice(lastIndex).replace(/\s+/g, ' '));
markdown = parts.join('');
```

Properties:

- Variable-length fences (e.g. four or more backticks for bodies that contain ``` ``` ```) are supported.
- Tilde fences (` ~~~ `) are also matched.
- Closing fence must match the opener's marker length and indentation (via `\1\2` back-references), so fences nested under list items keep their structure.
- Inline triple-backticks in prose are not misclassified — the lookbehind requires the fence to begin at a line start.

`minify.preserveCodeBlocks: false` restores the legacy flatten-everything behavior. aspire.dev's `astro.config.mjs` does not need to set the option; it picks up the new default.

## Upstream

The same change is up at delucis/starlight-llms-txt#104. Once a release containing it ships, this `pnpm patch` can be dropped and `starlight-llms-txt` unpinned (small follow-up PR).

## Pin

`starlight-llms-txt` is pinned to exact `0.8.1` while the patch is active so a future range-bump can't silently drop the patch.

## Tests

`src/frontend/tests/unit/llms-small-whitespace.vitest.test.ts` covers:

1. Sentinel — reads the patched `entryToSimpleMarkdown.ts` from `node_modules/starlight-llms-txt/` and asserts the new code is present. Catches a missing/stale/reverted patch in CI.
2. 10 behavior fixtures — single fence, adjacent fences, 4-backtick + literal inline ``` ```, tilde fences, list-nested fences with indentation, inline triple-backtick in prose, fence at start/end of input, mismatched fence lengths, and plain-prose collapsing.

Wired into the `test:unit` chain as `test:unit:llms-small-whitespace`.

## Verified

- `pnpm test:unit` — all suites pass, including the new one (11 tests).
- `pnpm build:skip-search` — `dist/llms-small.txt` now renders the bug-report code blocks (`aspire certs`, the Azure Network Security Perimeter C# / TypeScript blocks on the 13.3 What's New page) multi-line.
- `dist/llms-full.txt` byte count matches the live build exactly (4,910,424 B). The non-minified path is unchanged.

## Out of scope

- Removing the patch after the upstream release ships (small follow-up PR).
- The Aspire CLI's `aspire docs get` mitigation (switching its default source to `llms-full.txt`) is owned separately in `microsoft/aspire`.