### PR TITLE
Redirect /whats-new/ to the latest release notes

### DIFF
--- a/src/frontend/config/redirects.mjs
+++ b/src/frontend/config/redirects.mjs
@@ -28,6 +28,13 @@ function getLatestWhatsNewSlug() {
     }
   }
 
+  if (!bestSlug) {
+    throw new Error(
+      `No versioned "What's new" entries matched ${whatsNewVersionPattern} in ${whatsNewDir}. ` +
+        `The /whats-new/ redirect cannot be computed; check the file naming convention.`
+    );
+  }
+
   return bestSlug;
 }
 
@@ -42,14 +49,10 @@ export const redirects = {
   // `/whats-new/` has no index page; redirect it to the latest release notes
   // (computed from the filenames in src/content/docs/whats-new/). Uses 302
   // because the destination changes when a new version ships.
-  ...(latestWhatsNewSlug
-    ? {
-        '/whats-new/': {
-          status: 302,
-          destination: `/whats-new/${latestWhatsNewSlug}/`,
-        },
-      }
-    : {}),
+  '/whats-new/': {
+    status: 302,
+    destination: `/whats-new/${latestWhatsNewSlug}/`,
+  },
   '/configure-the-mcp-server/': '/get-started/aspire-mcp-server/',
   '/install-aspire-cli/': '/get-started/install-cli/',
   '/get-started/welcome/': '/docs/',

--- a/src/frontend/config/redirects.mjs
+++ b/src/frontend/config/redirects.mjs
@@ -1,9 +1,55 @@
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Matches versioned "What's new" release notes filenames such as
+// `aspire-13.mdx` (13.0), `aspire-13-3.mdx` (13.3), and `aspire-9-5.mdx` (9.5).
+// Excludes `upgrade-aspire.mdx` and other non-versioned pages.
+const whatsNewVersionPattern = /^aspire-(\d+)(?:-(\d+))?\.mdx$/;
+
+function getLatestWhatsNewSlug() {
+  const whatsNewDir = fileURLToPath(
+    new URL('../src/content/docs/whats-new/', import.meta.url)
+  );
+
+  let bestSlug = null;
+  let bestKey = -1;
+
+  for (const entry of readdirSync(whatsNewDir)) {
+    const match = whatsNewVersionPattern.exec(entry);
+    if (!match) continue;
+
+    const major = Number(match[1]);
+    const minor = Number(match[2] ?? 0);
+    const key = major * 1000 + minor;
+
+    if (key > bestKey) {
+      bestKey = key;
+      bestSlug = entry.replace(/\.mdx$/, '');
+    }
+  }
+
+  return bestSlug;
+}
+
+const latestWhatsNewSlug = getLatestWhatsNewSlug();
+
 export const redirects = {
   // https://docs.astro.build/en/guides/routing/#configured-redirects
   // For example:
   // '/original/path/': '/new/path'
   '/cli/': '/reference/cli/overview/',
   '/compatibility/': '/whats-new/upgrade-aspire/',
+  // `/whats-new/` has no index page; redirect it to the latest release notes
+  // (computed from the filenames in src/content/docs/whats-new/). Uses 302
+  // because the destination changes when a new version ships.
+  ...(latestWhatsNewSlug
+    ? {
+        '/whats-new/': {
+          status: 302,
+          destination: `/whats-new/${latestWhatsNewSlug}/`,
+        },
+      }
+    : {}),
   '/configure-the-mcp-server/': '/get-started/aspire-mcp-server/',
   '/install-aspire-cli/': '/get-started/install-cli/',
   '/get-started/welcome/': '/docs/',

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -33,7 +33,7 @@
     "test:unit:api-markdown": "vitest run --config vitest.config.ts tests/unit/api-markdown.vitest.test.ts",
     "test:unit:ts-api": "vitest run --config vitest.config.ts tests/unit/api-reference-routes.vitest.test.ts tests/unit/browser-storage.vitest.test.ts tests/unit/locale-routes.vitest.test.ts tests/unit/ts-api-routes.vitest.test.ts tests/unit/ts-api-search.vitest.test.ts",
     "test:unit:twoslash-types": "vitest run --config vitest.config.ts tests/unit/twoslash-types-generator.vitest.test.ts",
-    "test:unit:contracts": "vitest run --config vitest.config.ts tests/unit/analytics-script-contracts.vitest.test.ts",
+    "test:unit:contracts": "vitest run --config vitest.config.ts tests/unit/analytics-script-contracts.vitest.test.ts tests/unit/redirects.vitest.test.ts",
     "test:unit:components": "vitest run --config vitest.config.ts tests/unit/custom-components.vitest.test.ts tests/unit/site-tour.vitest.test.ts",
     "test:unit:docs": "vitest run --config vitest.config.ts tests/unit/filetree-format.vitest.test.ts",
     "test:unit:structured-data": "vitest run --config vitest.config.ts tests/unit/structured-data.vitest.test.ts tests/unit/update-integrations.vitest.test.ts",

--- a/src/frontend/tests/unit/redirects.vitest.test.ts
+++ b/src/frontend/tests/unit/redirects.vitest.test.ts
@@ -1,0 +1,72 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from 'vitest';
+
+import { redirects } from '../../config/redirects.mjs';
+
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testsDir, '..', '..');
+const whatsNewDir = path.join(frontendRoot, 'src', 'content', 'docs', 'whats-new');
+
+const versionPattern = /^aspire-(\d+)(?:-(\d+))?\.mdx$/;
+
+function findHighestVersionSlug(): string {
+  let bestSlug: string | null = null;
+  let bestKey = -1;
+
+  for (const entry of readdirSync(whatsNewDir)) {
+    const match = versionPattern.exec(entry);
+    if (!match) continue;
+
+    const major = Number(match[1]);
+    const minor = Number(match[2] ?? 0);
+    const key = major * 1000 + minor;
+
+    if (key > bestKey) {
+      bestKey = key;
+      bestSlug = entry.replace(/\.mdx$/, '');
+    }
+  }
+
+  if (!bestSlug) {
+    throw new Error(`No versioned whats-new entries found in ${whatsNewDir}`);
+  }
+
+  return bestSlug;
+}
+
+test('/whats-new/ has a configured redirect', () => {
+  expect(redirects).toHaveProperty('/whats-new/');
+});
+
+test('/whats-new/ redirect uses 302 (temporary) status', () => {
+  const entry = (redirects as Record<string, unknown>)['/whats-new/'];
+
+  expect(entry).toEqual(
+    expect.objectContaining({
+      status: 302,
+      destination: expect.stringMatching(/^\/whats-new\/aspire-[\d-]+\/$/),
+    })
+  );
+});
+
+test('/whats-new/ redirect destination points to the highest-versioned release notes file', () => {
+  const entry = (redirects as Record<string, unknown>)['/whats-new/'] as {
+    destination: string;
+  };
+  const expectedSlug = findHighestVersionSlug();
+
+  expect(entry.destination).toBe(`/whats-new/${expectedSlug}/`);
+});
+
+test('/whats-new/ redirect destination resolves to a real .mdx file on disk', () => {
+  const entry = (redirects as Record<string, unknown>)['/whats-new/'] as {
+    destination: string;
+  };
+
+  const slug = entry.destination.replace(/^\/whats-new\//, '').replace(/\/$/, '');
+  const filePath = path.join(whatsNewDir, `${slug}.mdx`);
+
+  expect(existsSync(filePath), `Expected ${filePath} to exist`).toBe(true);
+});


### PR DESCRIPTION
Visiting `https://aspire.dev/whats-new` currently 404s — there's no index page in `src/content/docs/whats-new/`, only per-version pages like `aspire-13-3.mdx`. This PR makes that URL land on the most recent release notes so the bare `/whats-new/` path is useful (e.g., for deep links from blog posts, social, or memory).

## Approach

Compute the latest version slug at build time by scanning `src/content/docs/whats-new/` for files matching `aspire-{major}(-{minor})?.mdx`, sorting by `major * 1000 + minor`, and picking the highest. Inject the result into the existing `redirects` map in `src/frontend/config/redirects.mjs` using Astro's object form:

```js
'/whats-new/': { status: 302, destination: '/whats-new/aspire-13-3/' }
```

Today this resolves to `/whats-new/aspire-13-3/`. When `aspire-13-4.mdx` (or `aspire-14.mdx`) ships, the redirect repoints automatically — no manual bump.

## Notes

- **302 (temporary)** is intentional: the destination changes when a new version drops, so we don't want clients/search engines to permanently cache the mapping. We could revisit if there's a reason to prefer 301/308.
- **Default locale only.** Non-default locales like `/ja/whats-new/` are out of scope; users navigate those via the sidebar.
- **`upgrade-aspire.mdx` is excluded** by the version regex (it has no version digits).
- **Filename-driven, not frontmatter-driven.** Keeps the helper independent of MDX parsing and resilient to inconsistent frontmatter across versions.

## Tests

Adds `src/frontend/tests/unit/redirects.vitest.test.ts` (wired into `test:unit:contracts`) with four assertions:

1. `/whats-new/` is in the redirect map.
2. The entry uses status `302` and a `/whats-new/aspire-…/` destination.
3. The destination matches the highest-versioned `aspire-N(-M).mdx` file on disk.
4. The destination resolves to a real `.mdx` file.

The third assertion is the safety net: if a future change accidentally drops the highest version (or a new version is added without rebuilding), the test fails loudly rather than the redirect silently pointing at a stale page.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>