### PR TITLE
Temporarily disable expressive-code-twoslash

### DIFF
--- a/src/frontend/ec.config.mjs
+++ b/src/frontend/ec.config.mjs
@@ -7,13 +7,20 @@ import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers';
 import ecTwoSlash from 'expressive-code-twoslash';
 import { pluginDisableCopy } from './src/expressive-code-plugins/disable-copy.mjs';
 
+// TEMP: expressive-code-twoslash is temporarily disabled. Flip
+// TWOSLASH_ENABLED back to `true` to restore type-aware hover tooltips
+// in docs TS samples — the rest of the configuration is preserved so
+// re-enabling is a one-line change.
+const TWOSLASH_ENABLED = false;
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ASPIRE_TYPES_PATH = resolve(__dirname, 'src/data/twoslash/aspire.d.ts');
-const aspireTypes = existsSync(ASPIRE_TYPES_PATH)
-  ? readFileSync(ASPIRE_TYPES_PATH, 'utf8')
-  : '';
+const aspireTypes =
+  TWOSLASH_ENABLED && existsSync(ASPIRE_TYPES_PATH)
+    ? readFileSync(ASPIRE_TYPES_PATH, 'utf8')
+    : '';
 
-if (!aspireTypes) {
+if (TWOSLASH_ENABLED && !aspireTypes) {
   // Non-fatal — twoslash blocks that import the SDK will just show `any`.
   // Run `pnpm twoslash-types` to refresh.
   console.warn('[ec] src/data/twoslash/aspire.d.ts missing — run `pnpm twoslash-types`');
@@ -25,41 +32,45 @@ export default {
     pluginCollapsibleSections(),
     pluginLineNumbers(),
     pluginDisableCopy(),
-    ecTwoSlash({
-      // Only run on TS blocks that opt in via the `twoslash` meta flag.
-      instanceConfigs: {
-        // Docs samples use both `ts` and `typescript` fence languages; accept both.
-        twoslash: { explicitTrigger: true, languages: ['ts', 'tsx', 'typescript'] },
-      },
-      includeJsDoc: true,
-      twoslashOptions: {
-        compilerOptions: {
-          // ts.ModuleResolutionKind.Bundler so `./.modules/aspire.js` falls
-          // through to the virtual `.modules/aspire.ts` file declared below.
-          moduleResolution: 100,
-          // ts.ModuleKind.ESNext (paired with bundler resolution).
-          module: 99,
-          // ts.ScriptTarget.ESNext.
-          target: 99,
-          strict: true,
-          noEmit: true,
-          // Omit `lib` so twoslash falls back to `lib.esnext.full.d.ts`
-          // (target: ESNext) — that bundle pulls in `Date`, `URL`, DOM,
-          // and other common globals via triple-slash references. Pinning
-          // an explicit `lib` array breaks those references in the VFS.
-        },
-        handbookOptions: {
-          // Keep type squigglies rendered inline but don't fail the build when
-          // a sample has unannotated compiler errors — the generated SDK is a
-          // best-effort shape and docs samples shouldn't need `// @errors` tags.
-          noErrorValidation: true,
-        },
-        // Virtual files merged into the Twoslash VFS. The Aspire SDK types
-        // are declared at `.modules/aspire.ts` so docs samples that import
-        // `'./.modules/aspire.js'` resolve against the real API surface.
-        extraFiles: aspireTypes ? { '.modules/aspire.ts': aspireTypes } : {},
-      },
-    }),
+    ...(TWOSLASH_ENABLED
+      ? [
+          ecTwoSlash({
+            // Only run on TS blocks that opt in via the `twoslash` meta flag.
+            instanceConfigs: {
+              // Docs samples use both `ts` and `typescript` fence languages; accept both.
+              twoslash: { explicitTrigger: true, languages: ['ts', 'tsx', 'typescript'] },
+            },
+            includeJsDoc: true,
+            twoslashOptions: {
+              compilerOptions: {
+                // ts.ModuleResolutionKind.Bundler so `./.modules/aspire.js` falls
+                // through to the virtual `.modules/aspire.ts` file declared below.
+                moduleResolution: 100,
+                // ts.ModuleKind.ESNext (paired with bundler resolution).
+                module: 99,
+                // ts.ScriptTarget.ESNext.
+                target: 99,
+                strict: true,
+                noEmit: true,
+                // Omit `lib` so twoslash falls back to `lib.esnext.full.d.ts`
+                // (target: ESNext) — that bundle pulls in `Date`, `URL`, DOM,
+                // and other common globals via triple-slash references. Pinning
+                // an explicit `lib` array breaks those references in the VFS.
+              },
+              handbookOptions: {
+                // Keep type squigglies rendered inline but don't fail the build when
+                // a sample has unannotated compiler errors — the generated SDK is a
+                // best-effort shape and docs samples shouldn't need `// @errors` tags.
+                noErrorValidation: true,
+              },
+              // Virtual files merged into the Twoslash VFS. The Aspire SDK types
+              // are declared at `.modules/aspire.ts` so docs samples that import
+              // `'./.modules/aspire.js'` resolve against the real API surface.
+              extraFiles: aspireTypes ? { '.modules/aspire.ts': aspireTypes } : {},
+            },
+          }),
+        ]
+      : []),
   ],
   defaultProps: {
     showLineNumbers: false,

--- a/src/frontend/tests/unit/twoslash-types-generator.vitest.test.ts
+++ b/src/frontend/tests/unit/twoslash-types-generator.vitest.test.ts
@@ -11,17 +11,20 @@ const outputFile = path.join(frontendRoot, 'src', 'data', 'twoslash', 'aspire.d.
 
 let output = '';
 
-beforeAll(() => {
-  // The output is source-controlled, so don't unlink it. Re-run the generator
-  // in place; subsequent assertions read the refreshed content.
-  // Invoke tsx directly via node to avoid cross-platform `pnpm`/`pnpm.cmd`
-  // resolution issues (and the DEP0190 warning from `shell: true`).
-  const tsxBin = path.join(frontendRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
-  execFileSync(process.execPath, [tsxBin, generatorScript], { cwd: frontendRoot, stdio: 'pipe' });
-  output = readFileSync(outputFile, 'utf8');
-}, 60_000);
+// TEMP: twoslash is temporarily disabled in ec.config.mjs. Re-enable this
+// suite (and flip TWOSLASH_ENABLED back to `true` in ec.config.mjs) when the
+// twoslash integration is restored.
+describe.skip('generate-twoslash-types', () => {
+  beforeAll(() => {
+    // The output is source-controlled, so don't unlink it. Re-run the generator
+    // in place; subsequent assertions read the refreshed content.
+    // Invoke tsx directly via node to avoid cross-platform `pnpm`/`pnpm.cmd`
+    // resolution issues (and the DEP0190 warning from `shell: true`).
+    const tsxBin = path.join(frontendRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+    execFileSync(process.execPath, [tsxBin, generatorScript], { cwd: frontendRoot, stdio: 'pipe' });
+    output = readFileSync(outputFile, 'utf8');
+  }, 60_000);
 
-describe('generate-twoslash-types', () => {
   test('writes aspire.d.ts to disk', () => {
     expect(existsSync(outputFile)).toBe(true);
     expect(statSync(outputFile).size).toBeGreaterThan(10_000);


### PR DESCRIPTION
Temporarily disables `expressive-code-twoslash` and skips its unit test suite while we investigate / address an issue with twoslash integration.

## Changes

- **`src/frontend/ec.config.mjs`** - Introduces a `TWOSLASH_ENABLED` flag (set to `false`). The full `ecTwoSlash(...)` plugin configuration is preserved behind a conditional spread so re-enabling is a one-line flip. The `aspire.d.ts` file read and missing-bundle warning are also gated on the flag so nothing complains about the artifact while the plugin is off.
- **`src/frontend/tests/unit/twoslash-types-generator.vitest.test.ts`** - Wrapped in `describe.skip(...)` with a matching `TEMP` marker. The `beforeAll` (which invokes `generate-twoslash-types.ts`) was moved inside the skipped describe so the generator is not invoked while the suite is skipped.

> [!NOTE]
> Only the `ecTwoSlash` plugin is gated. The other Expressive Code plugins (`pluginCollapsibleSections`, `pluginLineNumbers`, `pluginDisableCopy`) sit before the conditional spread and remain loaded.

## Behavior

- `twoslash` meta on TS code fences across the docs is silently ignored by Expressive Code when the plugin is unloaded - verified by running `astro build` locally; no MDX errors and no EC warnings.
- `pnpm test:unit:twoslash-types` exits 0 with `6 tests | 6 skipped`.
- ESLint passes on the touched files (`pnpm exec eslint ec.config.mjs tests/unit/twoslash-types-generator.vitest.test.ts --max-warnings 0`).

## Re-enabling

Flip `TWOSLASH_ENABLED` back to `true` in `ec.config.mjs` and replace `describe.skip` with `describe` in the vitest suite.
