### PR TITLE
Update Aspire AppHost SDK and packages to 13.3.0

### DIFF
--- a/src/apphost/Aspire.Dev.AppHost/Aspire.Dev.AppHost.csproj
+++ b/src/apphost/Aspire.Dev.AppHost/Aspire.Dev.AppHost.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Aspire.AppHost.Sdk/13.2.4">
+<Project Sdk="Aspire.AppHost.Sdk/13.3.0">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Azure.AppService" Version="13.2.4" />
-    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.2.4" />
+    <PackageReference Include="Aspire.Hosting.Azure.AppService" Version="13.3.0" />
+    <PackageReference Include="Aspire.Hosting.JavaScript" Version="13.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the `Aspire.Dev.AppHost` project from Aspire 13.2.4 to 13.3.0:

- `Aspire.AppHost.Sdk` 13.2.4 → 13.3.0
- `Aspire.Hosting.Azure.AppService` 13.2.4 → 13.3.0
- `Aspire.Hosting.JavaScript` 13.2.4 → 13.3.0

Build and restore verified locally.