### PR TITLE
Use OsAwareTabs for Bash/PowerShell pairs in AKS deployment guides

### DIFF
--- a/.github/skills/doc-writer/SKILL.md
+++ b/.github/skills/doc-writer/SKILL.md
@@ -96,6 +96,7 @@ Additional commonly used imports:
 ```tsx
 import { Kbd } from "starlight-kbd/components";
 import LearnMore from "@components/LearnMore.astro";
+import OsAwareTabs from "@components/OsAwareTabs.astro";
 import PivotSelector from "@components/PivotSelector.astro";
 import Pivot from "@components/Pivot.astro";
 import ThemeImage from "@components/ThemeImage.astro";
@@ -182,6 +183,43 @@ Press F5 to start debugging.
 ```
 
 If a heading should appear in the **On this page** table of contents, keep that heading outside the `Tabs` component. Headings placed inside `TabItem` content may be skipped by the generated TOC.
+
+#### OsAwareTabs (Bash and PowerShell)
+
+When the **only** tab options are **Bash** and **PowerShell**, **always** use the `OsAwareTabs` custom component instead of bare `<Tabs>` / `<TabItem>`. `OsAwareTabs` wraps Starlight's synced `Tabs` and adds OS-aware behavior:
+
+- Detects the reader's operating system and defaults the active tab to **PowerShell** on Windows and **Bash** everywhere else.
+- Uses the canonical `seti:shell` and `seti:powershell` icons so the labels render consistently across the site.
+- Persists the reader's choice across pages via the standard Starlight `syncKey`. Use `syncKey="terminal"` so all OS-aware terminal blocks stay in sync.
+- Exposes two named slots — `unix` and `windows` — that contain the Bash and PowerShell content respectively.
+
+````mdx
+import OsAwareTabs from "@components/OsAwareTabs.astro";
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash
+az group create --name my-group --location westus3
+```
+
+</div>
+<div slot="windows">
+
+```powershell
+az group create --name my-group --location westus3
+```
+
+</div>
+</OsAwareTabs>
+````
+
+A few rules to follow:
+
+- Do **not** wrap a Bash + PowerShell pairing in bare `<Tabs syncKey="shell-lang">` — convert it to `OsAwareTabs` instead. This is the canonical pattern used across the dashboard, install-cli, container-networking, and AKS deployment guides.
+- Always set `syncKey="terminal"` unless there is a specific reason to scope the persistence differently. The site-wide convention is a single shared key so a reader who picks PowerShell once continues to see PowerShell on every page that offers the choice.
+- Keep the leading and trailing blank lines around the inner code fences (as shown above). MDX requires the blank lines so the fenced code block is parsed correctly inside the slotted `<div>`.
+- `OsAwareTabs` is **only** for the Bash + PowerShell pairing. Continue to use bare `<Tabs>` / `<TabItem>` for non-OS choices such as C#/TypeScript AppHost samples (`syncKey='aspire-lang'`), CLI vs IDE, deployment targets, or package managers.
 
 #### Pivot/PivotSelector
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -9,6 +9,7 @@ sidebar:
 
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
 
 This walkthrough shows how to use `AddGateway` to expose .NET Aspire services on Azure Kubernetes Service (AKS) with **Application Gateway for Containers (AGC)** and automatic TLS certificate provisioning via **cert-manager HTTP-01** challenges.
 
@@ -33,8 +34,8 @@ The following steps create the Azure infrastructure needed for Gateway API with 
 
 Application Gateway for Containers requires several resource providers and preview features to be registered in your Azure subscription:
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Register required resource providers
@@ -61,8 +62,8 @@ az extension add --name alb
 az extension add --name aks-preview
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Register required resource providers
@@ -89,8 +90,8 @@ az extension add --name alb
 az extension add --name aks-preview
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 <Aside type="note">
   Feature registration can take several minutes. Use `az feature show` to check
@@ -101,8 +102,8 @@ az extension add --name aks-preview
 
 ### Create the resource group and cluster
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Variables — customize these for your environment
@@ -135,8 +136,8 @@ az aks get-credentials \
   --name $CLUSTER_NAME
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Variables — customize these for your environment
@@ -169,13 +170,13 @@ az aks get-credentials `
   --name $CLUSTER_NAME
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create and attach a container registry
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Create Azure Container Registry
@@ -191,8 +192,8 @@ az aks update \
   --attach-acr $ACR_NAME
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Create Azure Container Registry
@@ -208,15 +209,15 @@ az aks update `
   --attach-acr $ACR_NAME
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create the ApplicationLoadBalancer
 
 Create a dedicated subnet for AGC in the cluster's VNet, then deploy the `ApplicationLoadBalancer` custom resource:
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Get the managed cluster resource group and VNet
@@ -255,8 +256,8 @@ EOF
 kubectl get applicationloadbalancer alb-aspire --watch
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Get the managed cluster resource group and VNet
@@ -295,15 +296,15 @@ spec:
 kubectl get applicationloadbalancer alb-aspire --watch
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Install cert-manager
 
 Install cert-manager with Gateway API support enabled. Unlike DNS-01 validation, HTTP-01 does **not** require a managed identity, federated credentials, or workload identity configuration — cert-manager only needs to create a temporary `HTTPRoute` on the Gateway.
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Install cert-manager with Gateway API support
@@ -318,8 +319,8 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
 kubectl get pods -n cert-manager
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Install cert-manager with Gateway API support
@@ -334,15 +335,15 @@ helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager `
 kubectl get pods -n cert-manager
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create the HTTP-01 ClusterIssuer
 
 Create a `ClusterIssuer` that uses the `gatewayHTTPRoute` solver. This tells cert-manager to respond to ACME HTTP-01 challenges by creating a temporary `HTTPRoute` on the Gateway — the challenge is served from the **same frontend and IP** as your application.
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 kubectl apply -f - <<EOF
@@ -367,8 +368,8 @@ EOF
 kubectl get clusterissuer letsencrypt-http01
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 @"
@@ -393,8 +394,8 @@ spec:
 kubectl get clusterissuer letsencrypt-http01
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 <Aside type="note">
 The `parentRefs` in the `ClusterIssuer` specifies `kind: Gateway` without a specific name or namespace. This allows the solver to attach to whichever Gateway owns the `Certificate` resource. cert-manager discovers the correct Gateway automatically.
@@ -495,8 +496,8 @@ The `WithTls()` call with no arguments auto-generates the TLS secret name (`ingr
 
 Set environment variables to provide parameter values, then run `aspire deploy`:
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 export Parameters__registryEndpoint=myaspireacr.azurecr.io
@@ -509,8 +510,8 @@ export Parameters__externalFqdn=myapp.example.com
 aspire deploy
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 $env:Parameters__registryEndpoint = "myaspireacr.azurecr.io"
@@ -523,8 +524,8 @@ $env:Parameters__externalFqdn = "myapp.example.com"
 aspire deploy
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 <Aside type="note">
   Parameter values are provided via environment variables using the naming
@@ -551,8 +552,8 @@ After deployment, the Gateway is assigned a public FQDN by AGC. Create a DNS rec
 
    If using Azure DNS:
 
-   <Tabs syncKey="shell-lang">
-   <TabItem label="bash">
+   <OsAwareTabs syncKey="terminal">
+   <div slot="unix">
 
    ```bash
    AGC_FQDN=$(kubectl get gateway ingress \
@@ -565,8 +566,8 @@ After deployment, the Gateway is assigned a public FQDN by AGC. Create a DNS rec
      --cname $AGC_FQDN
    ```
 
-   </TabItem>
-   <TabItem label="PowerShell">
+   </div>
+   <div slot="windows">
 
    ```powershell
    $AGC_FQDN = $(kubectl get gateway ingress `
@@ -579,8 +580,8 @@ After deployment, the Gateway is assigned a public FQDN by AGC. Create a DNS rec
      --cname $AGC_FQDN
    ```
 
-   </TabItem>
-   </Tabs>
+   </div>
+   </OsAwareTabs>
 
 3. **Wait for cert-manager** to complete the HTTP-01 challenge. cert-manager starts the challenge immediately on deployment and retries with exponential backoff until DNS resolves. This typically takes 5–10 minutes once the DNS record is active.
 

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -9,6 +9,7 @@ sidebar:
 
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
 
 This walkthrough shows how to use `AddIngress` to expose .NET Aspire services on
 Azure Kubernetes Service (AKS) with **Application Gateway for Containers (AGC)**
@@ -30,8 +31,8 @@ The following steps create all the Azure infrastructure needed for this walkthro
 
 Application Gateway for Containers requires several resource providers and preview features to be registered in your Azure subscription:
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Register required resource providers
@@ -58,8 +59,8 @@ az extension add --name alb
 az extension add --name aks-preview
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Register required resource providers
@@ -86,8 +87,8 @@ az extension add --name alb
 az extension add --name aks-preview
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 <Aside type="note">
   Feature registration can take several minutes. Use `az feature show` to check
@@ -98,8 +99,8 @@ az extension add --name aks-preview
 
 ### Create the resource group and cluster
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Variables — customize these for your environment
@@ -133,8 +134,8 @@ az aks get-credentials \
   --name $CLUSTER_NAME
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Variables — customize these for your environment
@@ -168,13 +169,13 @@ az aks get-credentials `
   --name $CLUSTER_NAME
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create and attach a container registry
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Create Azure Container Registry
@@ -190,8 +191,8 @@ az aks update \
   --attach-acr $ACR_NAME
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Create Azure Container Registry
@@ -207,15 +208,15 @@ az aks update `
   --attach-acr $ACR_NAME
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create the ApplicationLoadBalancer
 
 Create a dedicated subnet for AGC in the cluster's VNet, then deploy the `ApplicationLoadBalancer` custom resource:
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Get the managed cluster resource group and VNet
@@ -254,8 +255,8 @@ EOF
 kubectl get applicationloadbalancer alb-aspire --watch
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Get the managed cluster resource group and VNet
@@ -294,13 +295,13 @@ spec:
 kubectl get applicationloadbalancer alb-aspire --watch
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ### Create an Azure DNS zone
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Create the DNS zone
@@ -315,8 +316,8 @@ az network dns zone show \
   --query nameServers -o tsv
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Create the DNS zone
@@ -331,8 +332,8 @@ az network dns zone show `
   --query nameServers -o tsv
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 <Aside type="note">
   You need to add NS records for `$DNS_ZONE` at your domain registrar pointing
@@ -342,8 +343,8 @@ az network dns zone show `
 
 ### Install cert-manager with Azure DNS support
 
-<Tabs syncKey="shell-lang">
-<TabItem label="bash">
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash
 # Install cert-manager with Gateway API support
@@ -445,8 +446,8 @@ EOF
 kubectl get clusterissuer letsencrypt-prod
 ```
 
-</TabItem>
-<TabItem label="PowerShell">
+</div>
+<div slot="windows">
 
 ```powershell
 # Install cert-manager with Gateway API support
@@ -548,8 +549,8 @@ spec:
 kubectl get clusterissuer letsencrypt-prod
 ```
 
-</TabItem>
-</Tabs>
+</div>
+</OsAwareTabs>
 
 ## Configure the AppHost
 


### PR DESCRIPTION
The `kubernetes-gateway-aks` and `kubernetes-ingress-aks` deployment guides currently render their Bash + PowerShell command pairs with bare `<Tabs syncKey="shell-lang">` blocks. The site already has a dedicated `OsAwareTabs.astro` custom component that:

- Detects the reader's OS and defaults to **PowerShell** on Windows / **Bash** elsewhere
- Uses the canonical `seti:shell` and `seti:powershell` icons
- Persists the selection across pages via `syncKey="terminal"`

This is what the rest of the docs (dashboard, install-cli, container-networking, etc.) already use. This PR converts the AKS pages to match.

## Changes

- **`src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx`** — Convert 8 Bash/PowerShell `<Tabs syncKey="shell-lang">` blocks (including one nested inside `<Steps>`) to `<OsAwareTabs syncKey="terminal">`. The C#/TypeScript AppHost language tabs are intentionally left as bare `<Tabs>`.
- **`src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx`** — Convert 6 Bash/PowerShell `<Tabs syncKey="shell-lang">` blocks to `<OsAwareTabs syncKey="terminal">`. The C#/TypeScript AppHost language tabs are likewise unchanged.
- **`.github/skills/doc-writer/SKILL.md`** — Add an `OsAwareTabs` section under "Component Usage" mandating the component whenever the only options are Bash and PowerShell, including a canonical example. Add the import to the additional-imports list.

The actual command contents are unchanged — only the wrapping component changes.

## Validation

Targeted frontend tests pass:

- `pnpm --dir ./src/frontend run test:unit:components` — 65/65 passed
- `pnpm --dir ./src/frontend run test:unit:contracts` — 7/7 passed
- `pnpm --dir ./src/frontend run test:unit:docs` — 2/2 passed
- `pnpm --dir ./src/frontend exec astro sync` — content collections compile cleanly
