### PR TITLE
docs: fix inaccurate APIs and instructions on Customize Azure resources

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -388,7 +388,17 @@ servicebus.ConfigureInfrastructure(infra =>
 
 ### Add Azure resources to the infrastructure
 
-You can inject additional Azure constructs (for example, a private endpoint) into an integration's generated infrastructure:
+You can inject additional Azure constructs (for example, a private endpoint) into an integration's generated infrastructure when you need direct control over the underlying `Azure.Provisioning` types.
+
+<Aside type="tip" title="Prefer the high-level API when possible">
+  For private endpoints specifically, use the higher-level
+  [`AddPrivateEndpoint`](/integrations/cloud/azure/azure-virtual-network/#add-private-endpoints)
+  extension on an `AzureSubnetResource` from the `Aspire.Hosting.Azure.Network`
+  integration. It wires up the subnet, private link service connection, and
+  related DNS configuration for you. Reach for the
+  `ConfigureInfrastructure` approach below only when you need full control over
+  the underlying `Azure.Provisioning.Network.PrivateEndpoint` construct.
+</Aside>
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -396,18 +406,28 @@ You can inject additional Azure constructs (for example, a private endpoint) int
 ```csharp title="C# — AppHost.cs"
 storage.ConfigureInfrastructure(infra =>
 {
-    var privateEndpoint = new PrivateEndpoint("storagepe")
-    {
-        Location = "eastus",
-        Subnet = new SubnetReference
+    var account = infra.GetProvisionableResources()
+                       .OfType<StorageAccount>()
+                       .Single();
+
+    var subnetId = new ProvisioningParameter("subnetId", typeof(string));
+    infra.Add(subnetId);
+
+    var privateEndpoint = new PrivateEndpoint("storagepe");
+    privateEndpoint.Subnet.Id = subnetId;
+    privateEndpoint.PrivateLinkServiceConnections.Add(
+        new NetworkPrivateLinkServiceConnection
         {
-            Id = "/subscriptions/.../subnets/mysubnet"
-        }
-    };
+            Name = "storage-connection",
+            PrivateLinkServiceId = account.Id,
+            GroupIds = { "blob" }
+        });
 
     infra.Add(privateEndpoint);
 });
 ```
+
+`PrivateEndpoint` and `NetworkPrivateLinkServiceConnection` come from the `Azure.Provisioning.Network` namespace, and `ProvisioningParameter` comes from `Azure.Provisioning`. Adding a `ProvisioningParameter` lets you pass the subnet ID into the generated Bicep at deployment time.
 
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
@@ -520,9 +540,7 @@ Reference it from the AppHost:
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureBicepResource(
-    name: "storage",
-    bicepFilePath: "./custom-storage.bicep")
+var storage = builder.AddBicepTemplate("storage", "./custom-storage.bicep")
     .WithParameter("storageAccountName", "mystorageaccount");
 
 builder.AddProject<Projects.WebApp>("webapp")
@@ -530,6 +548,8 @@ builder.AddProject<Projects.WebApp>("webapp")
 
 builder.Build().Run();
 ```
+
+To author a Bicep template inline instead of referencing a file, use `AddBicepTemplateString` and pass the Bicep content as a string.
 
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
@@ -554,11 +574,23 @@ await builder.build().run();
 
 ### Inspect generated Bicep
 
-After customizing with `ConfigureInfrastructure`, inspect the Bicep that Aspire generates:
+After customizing with `ConfigureInfrastructure`, inspect the Bicep that Aspire generates by publishing the AppHost to an output directory:
 
-1. Run your AppHost locally.
-2. Open the `./infra` directory inside your AppHost project.
-3. Review the generated `.bicep` files to verify your customizations.
+1. From your AppHost project directory, run:
+
+   ```bash title="Generate Azure deployment artifacts"
+   aspire publish -o ./infra
+   ```
+
+2. Open the `./infra` directory (or the path you passed to `-o`).
+3. Review `main.bicep` along with each per-resource module at `<resource-name>/<resource-name>.bicep` to verify your customizations.
+
+<Aside type="note">
+  Running the AppHost locally (for example with `aspire run`) doesn't write Bicep
+  into your project directory — generated templates land in a temporary
+  directory used by the local provisioner. Use `aspire publish` whenever you
+  want a stable, on-disk copy of the Bicep that Aspire produces.
+</Aside>
 
 <Aside type="tip">
 Use the Azure Portal's **Export template** feature to view Bicep for manually configured resources, then adapt it for Aspire.


### PR DESCRIPTION
Fixes #246

## Summary

The **[Customize Azure resources](https://aspire.dev/integrations/cloud/azure/customize-resources/)** page contained three documented APIs / behaviors that don't match the current product. New users following the page can't compile the samples and can't find the files the page says will appear. This PR replaces those samples with ones that match the current `Aspire.Hosting.Azure`, `Aspire.Hosting.Azure.Network`, and `Azure.Provisioning` APIs.

## Changes

- **"Use custom Bicep files" (C# tab)** — Replaced the non-existent `builder.AddAzureBicepResource(name: "storage", bicepFilePath: "./custom-storage.bicep")` with the actual method, `builder.AddBicepTemplate("storage", "./custom-storage.bicep")`. Added a one-liner pointing readers at `AddBicepTemplateString` for inline templates.
- **"Add Azure resources to the infrastructure"** — Rewrote the `PrivateEndpoint` C# sample to use real types from `Azure.Provisioning.Network`: dropped the fake `SubnetReference` initializer, set `privateEndpoint.Subnet.Id` via an `Azure.Provisioning.ProvisioningParameter`, and added the missing `PrivateLinkServiceConnections.Add(new NetworkPrivateLinkServiceConnection { ... })` so the emitted Bicep is actually valid. Added a tip `<Aside>` pointing readers at the higher-level `AddPrivateEndpoint` extension in the [Azure Virtual Network integration](https://aspire.dev/integrations/cloud/azure/azure-virtual-network/#add-private-endpoints), which is the idiomatic API for most users. Added a short sentence explaining which namespaces the types come from.
- **"Inspect generated Bicep"** — Replaced the inaccurate "run AppHost locally → open `./infra`" instructions with the `aspire publish -o ./infra` workflow. Added a `<Aside type="note">` explaining that `aspire run` writes Bicep to a temp directory used by the local provisioner — it does not populate `./infra` in the AppHost project. Updated the directory-walkthrough to describe the actual emitted layout (`main.bicep` plus one module per resource).

## Evidence the issue still reproduces on the live site

Verified before editing by browsing https://aspire.dev/integrations/cloud/azure/customize-resources/ with playwright-cli on 2026-05-13:

- The C# sample for "Use custom Bicep files" still shows `builder.AddAzureBicepResource(name: "storage", bicepFilePath: "./custom-storage.bicep")` — that method does not exist in `Aspire.Hosting.Azure`. The only public surface is `AddBicepTemplate(name, bicepFile)` / `AddBicepTemplateString(name, bicepContent)` defined in [`AzureBicepResourceExtensions.cs`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs).
- The `PrivateEndpoint` sample assigns `Subnet = new SubnetReference { Id = "..." }` — `SubnetReference` is not a real type in `Azure.Provisioning.Network`. In Aspire's own code ([`AzurePrivateEndpointExtensions.cs`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs)) the `Subnet.Id` property is set directly. The sample is also missing the `PrivateLinkServiceConnections` collection, which means the Bicep it produces would be incomplete.
- The "Inspect generated Bicep" steps say "Run your AppHost locally" and "Open the `./infra` directory inside your AppHost project". Running `aspire run` does not populate a project-local `./infra` — `AzureProvisioningResource.GetBicepTemplateFile` writes to `Directory.CreateTempSubdirectory("aspire")`. Bicep only lands on disk in a stable location when you run `aspire publish -o <path>`.

## What doc-tester validated

- Code samples cross-checked against the matching product APIs in `microsoft/aspire`:
  - `AddBicepTemplate` / `AddBicepTemplateString` — `Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs`
  - `PrivateEndpoint.Subnet.Id` + `PrivateLinkServiceConnections.Add(new NetworkPrivateLinkServiceConnection { … })` — `Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs`
  - `aspire publish -o <path>` emission layout — `Aspire.Hosting.Azure/AzurePublishingContext.cs`
- Internal link to `AddPrivateEndpoint` follows the doc link conventions: site-relative (`/integrations/...`), trailing slash on the page, and `#add-private-endpoints` matches the rendered heading `id` on the target page.
- `pnpm exec astro sync` — passes.
- Local Astro dev server render: all three edited sections render without raw fence artifacts, the new anchor link resolves to the right heading, the old strings (`AddAzureBicepResource`, `SubnetReference`) are no longer present, and the new strings (`AddBicepTemplate(`, `NetworkPrivateLinkServiceConnection`, `new ProvisioningParameter`, `aspire publish -o ./infra`) are present.

## How I verified

1. `cd D:\GitHub\aspire.dev\src\frontend`
2. `pnpm exec astro sync` — succeeds.
3. `pnpm dev` and browse to `http://localhost:<port>/integrations/cloud/azure/customize-resources/`:
   - Confirm the rewritten "Add Azure resources to the infrastructure" code block reads cleanly.
   - Click the `AddPrivateEndpoint` link — it should jump to the **Add private endpoints** heading on the Azure Virtual Network page.
   - Confirm the C# tab of "Use custom Bicep files" shows `AddBicepTemplate(...)` (not `AddAzureBicepResource`).
   - Confirm "Inspect generated Bicep" now describes `aspire publish -o ./infra` and notes that `aspire run` uses a temp directory.

## Out of scope (deferring to a follow-up)

The reporter listed three additional wishlist items in the issue body that are orthogonal to the inaccuracies above and would meaningfully grow the page. I've kept this PR focused on the broken/inaccurate content so it stays easy to review. Tracking these as a follow-up:

- Passing `ParameterResource` (or other resource expressions) through to a custom Bicep template.
- Reading outputs from an `AddBicepTemplate` resource and using them elsewhere in the AppHost.
- Using the Bicep `existing` keyword in a custom template.
