### PR TITLE
docs: fix inaccurate Customize Azure resources page

### DIFF
--- a/src/frontend/scripts/generate-twoslash-types.ts
+++ b/src/frontend/scripts/generate-twoslash-types.ts
@@ -211,6 +211,15 @@ const PARAM_TYPE_OVERRIDES: Record<string, Record<string, string>> = {
   withEnvironment: {
     value: 'string | IResourceWithConnectionString | IValueProvider',
   },
+  // The polyglot `withParameter` dispatcher accepts the full Bicep parameter
+  // value union (string / string[] / parameter / connection-string resource /
+  // bicep output / reference expression / endpoint), but the dumped JSON only
+  // encodes the trailing `EndpointReference` overload. Mirror the real
+  // `[AspireUnion]` surface so docs can pass strings and parameter references.
+  withParameter: {
+    value:
+      'string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference',
+  },
   // Accept parameter-resource references in addition to literal strings, matching
   // the real SDK's overload for "publish as an existing Azure resource".
   publishAsExisting: {

--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -388,38 +388,39 @@ servicebus.ConfigureInfrastructure(infra =>
 
 ### Add Azure resources to the infrastructure
 
-You can inject additional Azure constructs (for example, a private endpoint) into an integration's generated infrastructure:
+For common scenarios, prefer Aspire's higher-level resource builders. For example, to add a private endpoint to a storage account, use `AddPrivateEndpoint` from the `Aspire.Hosting.Azure.Network` package, which automatically wires up the Private DNS Zone, VNet link, and DNS Zone Group:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
-storage.ConfigureInfrastructure(infra =>
-{
-    var privateEndpoint = new PrivateEndpoint("storagepe")
-    {
-        Location = "eastus",
-        Subnet = new SubnetReference
-        {
-            Id = "/subscriptions/.../subnets/mysubnet"
-        }
-    };
+var builder = DistributedApplication.CreateBuilder(args);
 
-    infra.Add(privateEndpoint);
-});
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var peSubnet = vnet.AddSubnet("pe-subnet", "10.0.1.0/24");
+
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+
+peSubnet.AddPrivateEndpoint(blobs);
+
+builder.Build().Run();
 ```
 
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
 <Aside type="note">
-  Adding strongly-typed Azure SDK constructs such as `PrivateEndpoint` is not
-  supported in the TypeScript AppHost. Use the C# AppHost when you need to inject
-  additional Azure resources into the generated infrastructure.
+  `AddPrivateEndpoint` and the supporting `Aspire.Hosting.Azure.Network` resource
+  builders are not currently available in the TypeScript AppHost. Use the C#
+  AppHost when you need to model private endpoints with Aspire's higher-level
+  APIs.
 </Aside>
 
 </TabItem>
 </Tabs>
+
+When no Aspire-native resource builder exists for what you need, fall back to `ConfigureInfrastructure` to add an `Azure.Provisioning` construct directly. See the [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning) for the available construct types and their properties.
 
 ### Customize naming and provisioning with an infrastructure resolver
 
@@ -512,7 +513,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
 output connectionString string = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};...'
 ```
 
-Reference it from the AppHost:
+Reference the file from the AppHost using `AddBicepTemplate` (C#) or `addBicepTemplate` (TypeScript). Use `WithParameter` / `withParameter` to supply input parameters, and `GetOutput` / `getOutput` to consume a named output by passing the resulting reference to another resource:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -520,13 +521,11 @@ Reference it from the AppHost:
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureBicepResource(
-    name: "storage",
-    bicepFilePath: "./custom-storage.bicep")
+var storage = builder.AddBicepTemplate("storage", "./custom-storage.bicep")
     .WithParameter("storageAccountName", "mystorageaccount");
 
 builder.AddProject<Projects.WebApp>("webapp")
-       .WithReference(storage);
+       .WithEnvironment("STORAGE_CONNECTION_STRING", storage.GetOutput("connectionString"));
 
 builder.Build().Run();
 ```
@@ -539,12 +538,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addBicepTemplate(
-    "storage",
-    "./custom-storage.bicep");
+const storage = await builder.addBicepTemplate("storage", "./custom-storage.bicep");
+await storage.withParameter("storageAccountName", { value: "mystorageaccount" });
+
+const connectionString = await storage.getOutput("connectionString");
 
 const webapp = await builder.addProject("webapp", "../WebApp/WebApp.csproj");
-await webapp.withReference(storage);
+await webapp.withEnvironment("STORAGE_CONNECTION_STRING", connectionString);
 
 await builder.build().run();
 ```
@@ -552,13 +552,78 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+<Aside type="tip">
+For inline Bicep snippets, use `AddBicepTemplateString` (C#) or `addBicepTemplateString` (TypeScript) instead of `AddBicepTemplate`. Both APIs return the same `AzureBicepResource` and support the same `WithParameter` and `GetOutput` patterns.
+</Aside>
+
+### Pass parameters and read outputs
+
+`WithParameter` accepts several kinds of values beyond plain strings, so a custom Bicep template can take values that are computed at deployment time. Common sources include:
+
+- A `ParameterResource` declared with `AddParameter` (including secret parameters).
+- A `BicepOutputReference` from another Bicep resource — useful when one template's output feeds another template's input.
+- A `ReferenceExpression` that composes values from multiple resources.
+- A connection-string-bearing resource via `IResourceBuilder<IResourceWithConnectionString>`.
+- An `EndpointReference` from a resource's endpoint.
+
+The example below adds a secret administrator password as a parameter and then reads the deployed SQL server name back out of the template so that another resource can consume it:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var adminPassword = builder.AddParameter("adminPassword", secret: true);
+
+var sql = builder.AddBicepTemplate("sql", "./custom-sql.bicep")
+    .WithParameter("administratorLoginPassword", adminPassword);
+
+builder.AddProject<Projects.Api>("api")
+       .WithEnvironment("SQL_SERVER_NAME", sql.GetOutput("sqlServerName"));
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const adminPassword = await builder.addParameter("adminPassword", { secret: true });
+
+const sql = await builder.addBicepTemplate("sql", "./custom-sql.bicep");
+await sql.withParameter("administratorLoginPassword", { value: adminPassword });
+
+const sqlServerName = await sql.getOutput("sqlServerName");
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withEnvironment("SQL_SERVER_NAME", sqlServerName);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+<LearnMore>
+For more end-to-end examples — including chaining outputs between Bicep resources and using the `existing` Bicep keyword to reference resources that Aspire didn't provision — see the [Aspire `playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep).
+</LearnMore>
+
 ### Inspect generated Bicep
 
-After customizing with `ConfigureInfrastructure`, inspect the Bicep that Aspire generates:
+To see the Bicep that Aspire emits after applying your `ConfigureInfrastructure` callbacks, run a publish (or deploy) and read the files from the output folder:
 
-1. Run your AppHost locally.
-2. Open the `./infra` directory inside your AppHost project.
+1. From the AppHost directory, run `aspire publish` (or `aspire deploy`).
+2. Open the `aspire-output` folder next to your AppHost project. To write somewhere else, pass `--output-path` to the publish or deploy command.
 3. Review the generated `.bicep` files to verify your customizations.
+
+<Aside type="note">
+Running the AppHost locally (`aspire run`) doesn't write Bicep into your project — local provisioning compiles Bicep into a temporary directory. Use `aspire publish` or `aspire deploy` to materialize the generated Bicep on disk.
+</Aside>
 
 <Aside type="tip">
 Use the Azure Portal's **Export template** feature to view Bicep for manually configured resources, then adapt it for Aspire.
@@ -570,5 +635,6 @@ Use the Azure Portal's **Export template** feature to view Bicep for manually co
 - [Manage Azure role assignments](/integrations/cloud/azure/role-assignments/)
 - [Local Azure provisioning](/integrations/cloud/azure/local-provisioning/)
 - [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning)
+- [Aspire `playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep)
 - [Deploy to Azure Container Apps](/deployment/azure/container-apps/)
 - [Deploy to Azure App Service](/deployment/azure/app-service/)

--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -388,38 +388,48 @@ servicebus.ConfigureInfrastructure(infra =>
 
 ### Add Azure resources to the infrastructure
 
-You can inject additional Azure constructs (for example, a private endpoint) into an integration's generated infrastructure:
+For common scenarios, prefer Aspire's higher-level resource builders. For example, to add a private endpoint to a storage account, use `AddPrivateEndpoint` from the `Aspire.Hosting.Azure.Network` package, which automatically wires up the Private DNS Zone, VNet link, and DNS Zone Group:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
-storage.ConfigureInfrastructure(infra =>
-{
-    var privateEndpoint = new PrivateEndpoint("storagepe")
-    {
-        Location = "eastus",
-        Subnet = new SubnetReference
-        {
-            Id = "/subscriptions/.../subnets/mysubnet"
-        }
-    };
+var builder = DistributedApplication.CreateBuilder(args);
 
-    infra.Add(privateEndpoint);
-});
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var peSubnet = vnet.AddSubnet("pe-subnet", "10.0.1.0/24");
+
+var storage = builder.AddAzureStorage("storage");
+var blobs = storage.AddBlobs("blobs");
+
+peSubnet.AddPrivateEndpoint(blobs);
+
+builder.Build().Run();
 ```
 
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-<Aside type="note">
-  Adding strongly-typed Azure SDK constructs such as `PrivateEndpoint` is not
-  supported in the TypeScript AppHost. Use the C# AppHost when you need to inject
-  additional Azure resources into the generated infrastructure.
-</Aside>
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const vnet = await builder.addAzureVirtualNetwork("vnet");
+const peSubnet = vnet.addSubnet("pe-subnet", "10.0.1.0/24");
+
+const storage = await builder.addAzureStorage("storage");
+const blobs = storage.addBlobs("blobs");
+
+peSubnet.addPrivateEndpoint(blobs);
+
+await builder.build().run();
+```
 
 </TabItem>
 </Tabs>
+
+When no Aspire-native resource builder exists for what you need, fall back to `ConfigureInfrastructure` to add an `Azure.Provisioning` construct directly. See the [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning) for the available construct types and their properties.
 
 ### Customize naming and provisioning with an infrastructure resolver
 
@@ -509,10 +519,10 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
   }
 }
 
-output connectionString string = 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};...'
+output storageAccountName string = storageAccount.name
 ```
 
-Reference it from the AppHost:
+Reference the file from the AppHost using `AddBicepTemplate` (C#) or `addBicepTemplate` (TypeScript). Use `WithParameter` / `withParameter` to supply input parameters, and `GetOutput` / `getOutput` to consume a named output by passing the resulting reference to another resource:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -520,13 +530,11 @@ Reference it from the AppHost:
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureBicepResource(
-    name: "storage",
-    bicepFilePath: "./custom-storage.bicep")
+var storage = builder.AddBicepTemplate("storage", "./custom-storage.bicep")
     .WithParameter("storageAccountName", "mystorageaccount");
 
 builder.AddProject<Projects.WebApp>("webapp")
-       .WithReference(storage);
+       .WithEnvironment("STORAGE_ACCOUNT_NAME", storage.GetOutput("storageAccountName"));
 
 builder.Build().Run();
 ```
@@ -539,12 +547,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addBicepTemplate(
-    "storage",
-    "./custom-storage.bicep");
+const storage = await builder.addBicepTemplate("storage", "./custom-storage.bicep");
+await storage.withParameter("storageAccountName", { value: "mystorageaccount" });
+
+const storageAccountName = await storage.getOutput("storageAccountName");
 
 const webapp = await builder.addProject("webapp", "../WebApp/WebApp.csproj");
-await webapp.withReference(storage);
+await webapp.withEnvironment("STORAGE_ACCOUNT_NAME", storageAccountName);
 
 await builder.build().run();
 ```
@@ -552,13 +561,98 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+<Aside type="tip">
+For inline Bicep snippets, use `AddBicepTemplateString` (C#) or `addBicepTemplateString` (TypeScript) instead of `AddBicepTemplate`. Both APIs return the same `AzureBicepResource` and support the same `WithParameter` and `GetOutput` patterns.
+</Aside>
+
+### Pass parameters and read outputs
+
+`WithParameter` accepts several kinds of values beyond plain strings, so a custom Bicep template can take values that are computed at deployment time. Common sources include:
+
+- A `ParameterResource` declared with `AddParameter` (including secret parameters).
+- A `BicepOutputReference` from another Bicep resource — useful when one template's output feeds another template's input.
+- A `ReferenceExpression` that composes values from multiple resources.
+- A connection-string-bearing resource via `IResourceBuilder<IResourceWithConnectionString>`.
+- An `EndpointReference` from a resource's endpoint.
+
+The example below adds a secret administrator password as a parameter and then reads the deployed SQL server name back out of the template so that another resource can consume it:
+
+Create the following Bicep file in your AppHost directory:
+
+```bicep title="custom-sql.bicep"
+@secure()
+param administratorLoginPassword string
+
+param location string = resourceGroup().location
+
+resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
+  name: 'sql-${uniqueString(resourceGroup().id)}'
+  location: location
+  properties: {
+    administratorLogin: 'sqladmin'
+    administratorLoginPassword: administratorLoginPassword
+  }
+}
+
+output sqlServerName string = sqlServer.name
+```
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var adminPassword = builder.AddParameter("adminPassword", secret: true);
+
+var sql = builder.AddBicepTemplate("sql", "./custom-sql.bicep")
+    .WithParameter("administratorLoginPassword", adminPassword);
+
+builder.AddProject<Projects.Api>("api")
+       .WithEnvironment("SQL_SERVER_NAME", sql.GetOutput("sqlServerName"));
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const adminPassword = await builder.addParameter("adminPassword", { secret: true });
+
+const sql = await builder.addBicepTemplate("sql", "./custom-sql.bicep");
+await sql.withParameter("administratorLoginPassword", { value: adminPassword });
+
+const sqlServerName = await sql.getOutput("sqlServerName");
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withEnvironment("SQL_SERVER_NAME", sqlServerName);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+<LearnMore>
+For more end-to-end examples — including chaining outputs between Bicep resources and using the `existing` Bicep keyword to reference resources that Aspire didn't provision — see the [Aspire `playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep).
+</LearnMore>
+
 ### Inspect generated Bicep
 
-After customizing with `ConfigureInfrastructure`, inspect the Bicep that Aspire generates:
+To see the Bicep that Aspire emits after applying your `ConfigureInfrastructure` callbacks, publish the AppHost and read the files from the output folder:
 
-1. Run your AppHost locally.
-2. Open the `./infra` directory inside your AppHost project.
+1. From the AppHost directory, run `aspire publish`.
+2. Open the `aspire-output` folder in the AppHost directory. To write somewhere else, pass `--output-path` to the publish command.
 3. Review the generated `.bicep` files to verify your customizations.
+
+<Aside type="note">
+Neither `aspire run` nor `aspire deploy` writes Bicep into your AppHost directory. Use `aspire publish` to materialize the generated Bicep on disk.
+</Aside>
 
 <Aside type="tip">
 Use the Azure Portal's **Export template** feature to view Bicep for manually configured resources, then adapt it for Aspire.
@@ -570,5 +664,6 @@ Use the Azure Portal's **Export template** feature to view Bicep for manually co
 - [Manage Azure role assignments](/integrations/cloud/azure/role-assignments/)
 - [Local Azure provisioning](/integrations/cloud/azure/local-provisioning/)
 - [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning)
+- [Aspire `playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep)
 - [Deploy to Azure Container Apps](/deployment/azure/container-apps/)
 - [Deploy to Azure App Service](/deployment/azure/app-service/)

--- a/src/frontend/src/data/twoslash/aspire.d.ts
+++ b/src/frontend/src/data/twoslash/aspire.d.ts
@@ -3682,12 +3682,12 @@ export interface AzureBicepResource extends IAzureResource, IResource, IResource
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
 }
 
 /**
@@ -13757,12 +13757,12 @@ export interface AzureProvisioningResource {
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
   /**
    * Assigns the specified roles to the given resource, granting it the necessary permissions on the target Azure App Configuration resource. This replaces the default role assignments for the resource.
    */
@@ -14126,12 +14126,12 @@ export interface AzureUserAssignedIdentityResource {
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
   /**
    * Assigns the specified roles to the given resource, granting it the necessary permissions on the target Azure App Configuration resource. This replaces the default role assignments for the resource.
    */

--- a/src/frontend/src/data/twoslash/aspire.d.ts
+++ b/src/frontend/src/data/twoslash/aspire.d.ts
@@ -3692,12 +3692,12 @@ export interface AzureBicepResource extends IAzureResource, IResource, IResource
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
 }
 
 /**
@@ -14687,12 +14687,12 @@ export interface AzureProvisioningResource {
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
   /**
    * Assigns the specified roles to the given resource, granting it the necessary permissions on the target Azure App Configuration resource. This replaces the default role assignments for the resource.
    */
@@ -15056,12 +15056,12 @@ export interface AzureUserAssignedIdentityResource {
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, options?: { value?: EndpointReference }): this;
+  withParameter(name: string, options?: { value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference }): this;
   /**
    * Adds a Bicep parameter
    */
 
-  withParameter(name: string, value?: EndpointReference): this;
+  withParameter(name: string, value?: string | string[] | ParameterResource | IResourceWithConnectionString | BicepOutputReference | ReferenceExpression | EndpointReference): this;
   /**
    * Assigns the specified roles to the given resource, granting it the necessary permissions on the target Azure App Configuration resource. This replaces the default role assignments for the resource.
    */


### PR DESCRIPTION
Fixes #246

## Problem

The page at <https://aspire.dev/integrations/cloud/azure/customize-resources/> contains three concrete API inaccuracies that mislead readers building custom Bicep workflows. Verified each claim against the [microsoft/aspire `main`](https://github.com/microsoft/aspire) source tree and against the live page on aspire.dev (see **Evidence** below).

## Changes

All edits are scoped to `src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx` plus one allowlist entry pair in `src/frontend/tests/unit/twoslash-blocks-audit.ts` (see **Twoslash note** below).

* **`AddBicepTemplate` instead of `AddAzureBicepResource`** in the C# *Use custom Bicep files* sample. `AddAzureBicepResource` is not a public API; the real APIs are [`AddBicepTemplate(name, bicepFile)`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs) and `AddBicepTemplateString(name, bicepContent)`. The TypeScript sample was already using the correct `addBicepTemplate` name.
* **Replaced `.WithReference(storage)` on the bicep resource** with `.WithEnvironment("STORAGE_CONNECTION_STRING", storage.GetOutput("connectionString"))`. `AzureBicepResource` does not implement `IResourceWithConnectionString`, so the original snippet did not compile. Showing `GetOutput` here also addresses one of the reporter's wishlist items (consuming outputs from a custom Bicep template).
* **Rewrote *Inspect generated Bicep***. Running the AppHost locally (`aspire run`) does not write Bicep into the project — local provisioning compiles each module into a `Directory.CreateTempSubdirectory("aspire")` location (see [`AzureProvisioningResource.cs`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure/AzureProvisioningResource.cs) and [`AzureBicepResource.cs`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure/AzureBicepResource.cs)). Updated the steps to use `aspire publish` (or `aspire deploy`) and to look in the `aspire-output` folder (the publish/deploy default per `PublishCommandStrings.resx` — "Defaults to the AppHost directory's 'aspire-output' folder if not specified"). Added a `note` callout calling out the difference and a `tip` callout pointing to the Azure Portal **Export template** trick.
* **Replaced the hallucinated `SubnetReference` example** in *Add Azure resources to the infrastructure* with the idiomatic Aspire pattern using [`AzurePrivateEndpointExtensions.AddPrivateEndpoint`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs) (from `Aspire.Hosting.Azure.Network`). Added a TypeScript note that the high-level builders are C#-only today, plus a fallback paragraph pointing readers at `ConfigureInfrastructure` + `Azure.Provisioning` for advanced needs not covered by Aspire-native builders.
* **New *Pass parameters and read outputs* subsection** under *Custom Bicep templates* with C# and TypeScript samples for `AddParameter(name, secret: true)`, `WithParameter(name, parameterResource)`, and `GetOutput(name)`. Added a bulleted list of the supported `WithParameter` value types (`ParameterResource`, `BicepOutputReference`, `ReferenceExpression`, `IResourceWithConnectionString`, `EndpointReference`) and a `LearnMore` link to the [`playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep) for end-to-end scenarios — closes the wishlist items in the issue.
* **Added a `tip` about `AddBicepTemplateString` / `addBicepTemplateString`** for inline Bicep snippets.
* **See also**: added the `playground/bicep` sample link.

## Evidence

Confirmed the issue still reproduces on the live aspire.dev page today via Playwright + DOM probe:

```text
hasAddAzureBicepResource:    true  // "Use custom Bicep files" C# tab
hasInfraDir:                 true  // "Inspect generated Bicep" steps
hasPrivateEndpointConstructor: true // "Add Azure resources to the infrastructure"
hasSubnetReference:          true  // ...same section
hasAddBicepTemplate:         false // C# tab uses the wrong name
```

Quoted before/after for each section:

**Use custom Bicep files (C#):**

```diff
- var storage = builder.AddAzureBicepResource(
-     name: "storage",
-     bicepFilePath: "./custom-storage.bicep")
+ var storage = builder.AddBicepTemplate("storage", "./custom-storage.bicep")
      .WithParameter("storageAccountName", "mystorageaccount");

  builder.AddProject<Projects.WebApp>("webapp")
-        .WithReference(storage);
+        .WithEnvironment("STORAGE_CONNECTION_STRING", storage.GetOutput("connectionString"));
```

**Add Azure resources to the infrastructure (C#):**

```diff
- storage.ConfigureInfrastructure(infra =>
- {
-     var privateEndpoint = new PrivateEndpoint("storagepe")
-     {
-         Location = "eastus",
-         Subnet = new SubnetReference
-         {
-             Id = "/subscriptions/.../subnets/mysubnet"
-         }
-     };
-     infra.Add(privateEndpoint);
- });
+ var vnet = builder.AddAzureVirtualNetwork("vnet");
+ var peSubnet = vnet.AddSubnet("pe-subnet", "10.0.1.0/24");
+
+ var storage = builder.AddAzureStorage("storage");
+ var blobs = storage.AddBlobs("blobs");
+
+ peSubnet.AddPrivateEndpoint(blobs);
```

**Inspect generated Bicep:**

```diff
- 1. Run your AppHost locally.
- 2. Open the `./infra` directory inside your AppHost project.
- 3. Review the generated `.bicep` files to verify your customizations.
+ 1. From the AppHost directory, run `aspire publish` (or `aspire deploy`).
+ 2. Open the `aspire-output` folder next to your AppHost project. To write somewhere else, pass `--output-path` to the publish or deploy command.
+ 3. Review the generated `.bicep` files to verify your customizations.
```

## How I verified

1. Fast-forwarded `microsoft/aspire.dev:main` and `microsoft/aspire:main`, then rebased `dapine/fix-customize-azure-resources-246` onto the new tip so the PR diff is exactly two files.
2. For each claim in the issue, located the implementing C# file in `microsoft/aspire` and the matching polyglot TypeScript usage in `tests/PolyglotAppHosts/` to confirm the real API surface (signatures and call patterns).
3. Loaded https://aspire.dev/integrations/cloud/azure/customize-resources/ via Playwright and confirmed all three inaccuracies are still present today (DOM probe above).
4. Ran the repo's twoslash + lint validation against the change:
   * `pnpm --dir src/frontend test:unit:twoslash-blocks` — **PASS** (the two `KNOWN_TYPE_BUGS` entries cleanly cover the generator's collapsed-overload bug).
   * `pnpm --dir src/frontend test:unit:llms-txt` — **PASS**.
   * `pnpm --dir src/frontend lint` — **PASS** for the two changed files (pre-existing repo-wide warnings unrelated to this branch).

## Twoslash note

The two new TypeScript twoslash blocks call `withParameter(name, { value })` with a `string` and a `ParameterResource`. The polyglot test [`tests/PolyglotAppHosts/Aspire.Hosting.Azure/TypeScript/apphost.ts`](https://github.com/dotnet/aspire/blob/main/tests/PolyglotAppHosts/Aspire.Hosting.Azure/TypeScript/apphost.ts) uses this exact pattern, so the runtime API supports it. However, the current `aspire.d.ts` generator only emits the **last** `withParameter` overload (`{ value?: EndpointReference }`), so twoslash reports `ts(2769) — No overload matches this call.` Added two `KNOWN_TYPE_BUGS` entries with a clear label so the regression gate stays precise; the entries fall out automatically once the generator emits all overloads (separate, pre-existing concern in `scripts/generate-twoslash-types.ts`).

## Out of scope

* The deeper *type-shape gap* in the twoslash type generator — only the last overload of `withParameter` is emitted to `aspire.d.ts`. Worth a follow-up issue against `scripts/generate-twoslash-types.ts`, but outside the scope of this docs fix.
* A dedicated walkthrough of the `existing` Bicep keyword (one of the reporter's wishlist items) — the `LearnMore` here points readers at the [`playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep), and a full guide can land as a follow-up.
