### PR TITLE
[13.2 Docs] Add migration guidance for Connection Property Suffix

### DIFF
--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
@@ -34,18 +34,18 @@ The GitHub Model resource exposes the following connection properties:
 | ------------- | ----------- |
 | `Endpoint`    | The GitHub Models inference endpoint URI, for example `https://models.github.ai/inference` |
 | `Key`         | The API key (GitHub PAT or `GITHUB_TOKEN`) for authentication |
-| `Model`       | The model identifier for inference requests, for instance `openai/gpt-4o-mini` |
+| `ModelName`   | The model identifier for inference requests, for instance `openai/gpt-4o-mini` |
 
 **Example connection string:**
 
 ```
-Endpoint=https://models.github.ai/inference;Key=github_pat_abc123...;Model=openai/gpt-4o-mini
+Endpoint=https://models.github.ai/inference;Key=github_pat_abc123...;ModelName=openai/gpt-4o-mini
 ```
 
 When an organization is configured, the endpoint includes the organization slug:
 
 ```
-Endpoint=https://models.github.ai/orgs/my-org/inference;Key=github_pat_abc123...;Model=openai/gpt-4o-mini
+Endpoint=https://models.github.ai/orgs/my-org/inference;Key=github_pat_abc123...;ModelName=openai/gpt-4o-mini
 ```
 
 ## Connect from your app
@@ -202,7 +202,7 @@ using Azure.AI.Inference;
 
 var endpoint = Environment.GetEnvironmentVariable("CHAT_ENDPOINT");
 var apiKey = Environment.GetEnvironmentVariable("CHAT_KEY");
-var modelName = Environment.GetEnvironmentVariable("CHAT_MODEL");
+var modelName = Environment.GetEnvironmentVariable("CHAT_MODELNAME");
 
 var client = new ChatCompletionsClient(
     new Uri(endpoint!),
@@ -243,7 +243,7 @@ func main() {
     // Read the Aspire-injected connection properties
     apiKey := os.Getenv("CHAT_KEY")
     endpoint := os.Getenv("CHAT_ENDPOINT")
-    modelName := os.Getenv("CHAT_MODEL")
+    modelName := os.Getenv("CHAT_MODELNAME")
 
     config := openai.DefaultConfig(apiKey)
     config.BaseURL = endpoint
@@ -287,7 +287,7 @@ client = OpenAI(
     base_url=os.environ["CHAT_ENDPOINT"],
 )
 
-model_name = os.environ["CHAT_MODEL"]
+model_name = os.environ["CHAT_MODELNAME"]
 
 response = client.chat.completions.create(
     model=model_name,
@@ -314,7 +314,7 @@ client = ChatCompletionsClient(
     credential=AzureKeyCredential(os.environ["CHAT_KEY"]),
 )
 
-model_name = os.environ["CHAT_MODEL"]
+model_name = os.environ["CHAT_MODELNAME"]
 
 response = client.complete(
     messages=[UserMessage(content="Hello!")],
@@ -341,7 +341,7 @@ const client = new OpenAI({
     baseURL: process.env.CHAT_ENDPOINT,
 });
 
-const modelName = process.env.CHAT_MODEL ?? 'openai/gpt-4o-mini';
+const modelName = process.env.CHAT_MODELNAME ?? 'openai/gpt-4o-mini';
 
 const response = await client.chat.completions.create({
     model: modelName,

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-connect.mdx
@@ -251,7 +251,7 @@ func main() {
     port := os.Getenv("MYSQLDB_PORT")
     user := os.Getenv("MYSQLDB_USERNAME")
     password := os.Getenv("MYSQLDB_PASSWORD")
-    dbName := os.Getenv("MYSQLDB_DATABASE")
+    dbName := os.Getenv("MYSQLDB_DATABASENAME")
 
     dsn := fmt.Sprintf("%s:%s@tcp(%s:%s)/%s", user, password, host, port, dbName)
 
@@ -292,7 +292,7 @@ conn = mysql.connector.connect(
     port=int(os.getenv("MYSQLDB_PORT", "3306")),
     user=os.getenv("MYSQLDB_USERNAME"),
     password=os.getenv("MYSQLDB_PASSWORD"),
-    database=os.getenv("MYSQLDB_DATABASE"),
+    database=os.getenv("MYSQLDB_DATABASENAME"),
 )
 
 cursor = conn.cursor()
@@ -321,7 +321,7 @@ const connection = await mysql.createConnection({
     port: Number(process.env.MYSQLDB_PORT),
     user: process.env.MYSQLDB_USERNAME,
     password: process.env.MYSQLDB_PASSWORD,
-    database: process.env.MYSQLDB_DATABASE,
+    database: process.env.MYSQLDB_DATABASENAME,
 });
 
 // Use connection to query the database...
@@ -349,7 +349,7 @@ const pool = mysql.createPool({
     port: Number(process.env.MYSQLDB_PORT),
     user: process.env.MYSQLDB_USERNAME,
     password: process.env.MYSQLDB_PASSWORD,
-    database: process.env.MYSQLDB_DATABASE,
+    database: process.env.MYSQLDB_DATABASENAME,
     waitForConnections: true,
     connectionLimit: 10,
 });

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-connect.mdx
@@ -53,7 +53,7 @@ The SQL Server database resource inherits all properties from its parent server 
 | ---------------------- | ----------- |
 | `Uri`                  | The connection URI with the database name, with the format `mssql://{Username}:{Password}@{Host}:{Port}/{DatabaseName}` |
 | `JdbcConnectionString` | JDBC connection string with the database name, with the format `jdbc:sqlserver://{Host}:{Port};trustServerCertificate=true;databaseName={DatabaseName}`. User and password credentials are provided as separate `Username` and `Password` properties. |
-| `Database`             | The name of the database |
+| `DatabaseName`         | The name of the database |
 
 **Example connection strings:**
 
@@ -287,7 +287,7 @@ sql_host = os.getenv("SQLDB_HOST")
 sql_port = os.getenv("SQLDB_PORT", "1433")
 sql_user = os.getenv("SQLDB_USERNAME")
 sql_password = os.getenv("SQLDB_PASSWORD")
-sql_database = os.getenv("SQLDB_DATABASE")
+sql_database = os.getenv("SQLDB_DATABASENAME")
 
 connection_string = (
     f"DRIVER={{ODBC Driver 18 for SQL Server}};"
@@ -337,7 +337,7 @@ const config: sql.config = {
     port: Number(process.env.SQLDB_PORT),
     user: process.env.SQLDB_USERNAME,
     password: process.env.SQLDB_PASSWORD,
-    database: process.env.SQLDB_DATABASE,
+    database: process.env.SQLDB_DATABASENAME,
     options: {
         trustServerCertificate: true,
     },

--- a/src/frontend/src/content/docs/whats-new/aspire-13-2.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-2.mdx
@@ -1224,7 +1224,76 @@ The `BeforeResourceStartedEvent` now only fires when actually starting a resourc
 
 ### Connection property suffix
 
-A connection property suffix has been added which may require updates to code that accesses connection properties directly.
+Several connection properties for "named entity" resources gained an explicit `Name` suffix so the property clearly refers to the entity's name rather than the entity itself. This affects both the connection-property API (`GetConnectionProperty`) and the environment variables Aspire injects via `WithReference(...)` and `ReferenceEnvironmentInjectionFlags.ConnectionProperties`.
+
+A subset of these renames first shipped in 13.1; 13.2 completes the rollout across the remaining built-in resources. The full list of renamed properties as of 13.2 is:
+
+| Old property name | New property name | Affected resources |
+| ----------------- | ----------------- | ------------------ |
+| `Database`        | `DatabaseName`    | `PostgresDatabase`, `AzurePostgresFlexibleServerDatabase`, `MySqlDatabase`, `SqlServerDatabase`, `AzureSqlDatabase`, `OracleDatabase`, `MongoDBDatabase`, `MilvusDatabase`, `AzureCosmosDBDatabase`, `AzureKustoReadWriteDatabase` |
+| `Model`           | `ModelName`       | `OpenAIModel`, `AzureOpenAIDeployment`, `FoundryDeployment`, `GitHubModel` |
+| `ConsumerGroup`   | `ConsumerGroupName` | `AzureEventHubConsumerGroup` |
+
+Aspire serializes property names directly into environment variable names with the `[RESOURCE]_[PROPERTY]` pattern, so any consuming app that reads the renamed properties from the environment must use the new uppercase names. For example, a SQL Server database resource named `sqldb`:
+
+```diff title="Bash — Environment variable"
+- SQLDB_DATABASE=catalog
++ SQLDB_DATABASENAME=catalog
+```
+
+Update consuming app code that reads the variable directly:
+
+<Tabs syncKey="aspire-consuming-lang">
+<TabItem label="C#">
+
+```diff lang="csharp" title="C# — Read injected connection property"
+- var database = Environment.GetEnvironmentVariable("SQLDB_DATABASE");
++ var database = Environment.GetEnvironmentVariable("SQLDB_DATABASENAME");
+```
+
+</TabItem>
+<TabItem label="Python">
+
+```diff lang="python" title="Python — Read injected connection property"
+- database = os.getenv("SQLDB_DATABASE")
++ database = os.getenv("SQLDB_DATABASENAME")
+```
+
+</TabItem>
+<TabItem label="TypeScript">
+
+```diff lang="typescript" title="TypeScript — Read injected connection property"
+- const database = process.env.SQLDB_DATABASE;
++ const database = process.env.SQLDB_DATABASENAME;
+```
+
+</TabItem>
+<TabItem label="Go">
+
+```diff lang="go" title="Go — Read injected connection property"
+- database := os.Getenv("SQLDB_DATABASE")
++ database := os.Getenv("SQLDB_DATABASENAME")
+```
+
+</TabItem>
+</Tabs>
+
+If your AppHost code reads connection properties through the `IResourceWithConnectionString` API, update those calls as well:
+
+```diff lang="csharp" title="C# — AppHost.cs"
+- var database = sqldb.Resource.GetConnectionProperty("Database");
++ var database = sqldb.Resource.GetConnectionProperty("DatabaseName");
+```
+
+To migrate, search your solution for the affected uppercase environment variable names (for example, `_DATABASE`, `_MODEL`, and `_CONSUMERGROUP`) along with `GetConnectionProperty("Database")`, `GetConnectionProperty("Model")`, and `GetConnectionProperty("ConsumerGroup")`, and apply the rename. Properties not listed in the table — for example, `Endpoint`, `Host`, `Port`, `Username`, `Password`, `Uri`, and `Key` — are unchanged.
+
+<Aside type="note">
+  Properties that don't refer to a named entity were not renamed. For example, the
+  `AuthenticationDatabase` property on `MongoDBServerResource` and the
+  `Organization` property on `GitHubModelResource` keep their existing names.
+</Aside>
+
+For the full per-resource property catalog, see the **Connection properties** section on each integration's *connect* page — for example, [Connect to Azure Cosmos DB](/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-connect/#connection-properties), [Connect to SQL Server](/integrations/databases/sql-server/sql-server-connect/#connection-properties), or [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/#connection-properties).
 
 ### AIFoundry to Foundry transition
 


### PR DESCRIPTION
Fixes #413

## Summary

The Aspire 13.2 release notes' **Connection property suffix** entry was a single-sentence placeholder that didn't tell readers which properties were renamed, which resources were affected, what the resulting environment variables look like, or how to update existing code. This PR replaces it with a full migration guide and fixes a handful of stale env-var examples in the affected integrations' *connect* pages.

## What changed

**`whats-new/aspire-13-2.mdx`** — expanded the `### Connection property suffix` section with:
- One-paragraph explanation of *what* the suffix is and *why* (named-entity properties gained an explicit `Name` suffix for consistency).
- Note that a subset shipped in 13.1 and 13.2 completes the rollout (so 13.0 → 13.2 readers get the full picture).
- A property-rename table:
  - `Database` → `DatabaseName` (Postgres, AzurePostgresFlexibleServer, MySql, SqlServer, AzureSql, Oracle, MongoDB, Milvus, AzureCosmosDB, AzureKusto)
  - `Model` → `ModelName` (OpenAI, AzureOpenAI, Foundry, GitHub Models)
  - `ConsumerGroup` → `ConsumerGroupName` (AzureEventHub)
- Before/after examples for the `[RESOURCE]_[PROPERTY]` env var pattern in **Bash, C#, Python, TypeScript, and Go**.
- A `GetConnectionProperty(...)` before/after for AppHost code.
- Migration guidance (which strings to grep for) and an explicit "what was *not* renamed" callout for `AuthenticationDatabase` and `Organization`.
- Cross-links to representative integration *connect* pages so readers can find the full per-resource property catalog.

**Stale env var fixes in integration docs** — these are tightly coupled to the rename and were still showing the pre-13.2 names:

- `integrations/databases/mysql/mysql-connect.mdx` — 4 sites: `MYSQLDB_DATABASE` → `MYSQLDB_DATABASENAME` (Go, Python, TypeScript, TS pool variant).
- `integrations/databases/sql-server/sql-server-connect.mdx` — 2 code sites + property table: `SQLDB_DATABASE` → `SQLDB_DATABASENAME`, table entry `Database` → `DatabaseName`.
- `integrations/ai/github-models/github-models-connect.mdx` — 5 code sites + property table + 2 example connection strings: `CHAT_MODEL` → `CHAT_MODELNAME`, `Model=…` → `ModelName=…`, table entry `Model` → `ModelName`.

## Verified against current source

I cross-checked every property name in the table against the resource source in `microsoft/aspire` `main`:

- `SqlServerDatabaseResource.cs:74` — emits `"DatabaseName"`
- `MySqlDatabaseResource.cs:73` — emits `"DatabaseName"`
- `MongoDBDatabaseResource.cs:52` — emits `"DatabaseName"`
- `PostgresDatabaseResource.cs:72`, `AzurePostgresFlexibleServerDatabaseResource.cs:93`, `OracleDatabaseResource.cs:62`, `MilvusDatabaseResource.cs:48`, `AzureCosmosDBDatabaseResource.cs:70`, `AzureSqlDatabaseResource.cs:109`, `AzureKustoReadWriteDatabaseResource.cs:79` — all emit `"DatabaseName"`
- `OpenAIModelResource.cs:47`, `AzureOpenAIDeploymentResource.cs:114`, `FoundryDeploymentResource.cs:109`, `GitHubModelResource.cs:91` — all emit `"ModelName"`
- `AzureEventHubConsumerGroupResource.cs:79` — emits `"ConsumerGroupName"`

Also verified — these were *not* renamed (despite earlier mentions in the original PR description):
- `MongoDBServerResource.cs:146` — still emits `"AuthenticationDatabase"`.
- `GitHubModelResource.cs:95` — still emits `"Organization"`.

That's why no change was made to `mongodb-connect.mdx`'s `MONGODB_AUTHENTICATIONDATABASE` example — it remains correct.

## Out of scope (intentionally not touched)

- `mongodb-host.mdx` `MONGO_DATABASE`, `mysql-host.mdx` `MYSQL_DATABASE`, `postgres-host.mdx` `POSTGRES_DATABASE`, `sql-server-host.mdx` `SQL_DATABASE`, `seed-database.mdx` `MYSQL_DATABASE` — these are user-defined `WithEnvironment(...)` examples or container image env vars, not Aspire-injected connection property names.
- `ravendb-connect.mdx`, `surrealdb-connect.mdx`, `ollama-connect.mdx` — these resources live in the CommunityToolkit and weren't part of `dotnet/aspire#13471`.
- The 13.1 release notes already cover a partial rename list and weren't restructured here. The new 13.2 section explicitly notes the 13.1 → 13.2 split so readers coming from 13.0 still get the full set in one place.

## Evidence: live site reproduces the issue

Before — current live page at https://aspire.dev/whats-new/aspire-13-2/#connection-property-suffix shows just the single placeholder sentence:

> A connection property suffix has been added which may require updates to code that accesses connection properties directly.

(Verified by fetching the rendered HTML of the live page; the entire `connection-property-suffix` section between `BeforeResourceStartedEvent behavior` and `AIFoundry to Foundry transition` is one sentence.)

After — see the diff in `whats-new/aspire-13-2.mdx`.

## How I verified

```bash
# From src/frontend
pnpm exec astro sync           # passes (only pre-existing kubernetes duplicate-id warnings)
pnpm test:unit:docs            # 2 passed
pnpm test:unit:components      # 65 passed
pnpm test:unit:structured-data # 14 passed
pnpm build:skip-search         # built 12,226 pages — "All internal links are valid."
```

ESLint (`pnpm lint`) was not run as a gate because the repo has pre-existing failures in `playwright-report/trace/assets/*.js` (minified Playwright report artifacts) unrelated to MDX content. None of the touched files surface lint errors.

Cross-link anchors verified by grep against each target page (`## Connection properties` headings exist on `azure-cosmos-db-connect.mdx:24`, `sql-server-connect.mdx:24`, and `github-models-connect.mdx:25`).

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
