### PR TITLE
docs: fix inaccurate APIs and workflow in Customize Azure resources

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -388,22 +388,31 @@ servicebus.ConfigureInfrastructure(infra =>
 
 ### Add Azure resources to the infrastructure
 
-You can inject additional Azure constructs (for example, a private endpoint) into an integration's generated infrastructure:
+You can inject additional Azure constructs into an integration's generated infrastructure when no first-class Aspire API exists for them. Call `infra.Add(...)` inside `ConfigureInfrastructure` with any strongly-typed [Azure.Provisioning](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning) construct.
+
+<Aside type="tip" title="Private endpoints have a first-class API">
+For private endpoints, prefer the higher-level [`AddPrivateEndpoint`](/integrations/cloud/azure/azure-virtual-network/#add-private-endpoints) extension from the `Aspire.Hosting.Azure.Network` package. It creates the Private DNS Zone, VNet link, and DNS zone group for you, and configures the target resource to deny public network access automatically.
+</Aside>
+
+The following example shows the lower-level pattern using `infra.Add(...)` with a strongly-typed [`PrivateEndpoint`](https://learn.microsoft.com/dotnet/api/azure.provisioning.network.privateendpoint) construct from `Azure.Provisioning.Network`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
+using Azure.Provisioning.Network;
+
 storage.ConfigureInfrastructure(infra =>
 {
-    var privateEndpoint = new PrivateEndpoint("storagepe")
-    {
-        Location = "eastus",
-        Subnet = new SubnetReference
+    var privateEndpoint = new PrivateEndpoint("storagepe");
+    privateEndpoint.Subnet.Id = "/subscriptions/.../subnets/mysubnet";
+    privateEndpoint.PrivateLinkServiceConnections.Add(
+        new NetworkPrivateLinkServiceConnection
         {
-            Id = "/subscriptions/.../subnets/mysubnet"
-        }
-    };
+            Name = "storage-connection",
+            PrivateLinkServiceId = "/subscriptions/.../storageAccounts/mystorage",
+            GroupIds = ["blob"]
+        });
 
     infra.Add(privateEndpoint);
 });
@@ -520,9 +529,7 @@ Reference it from the AppHost:
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var storage = builder.AddAzureBicepResource(
-    name: "storage",
-    bicepFilePath: "./custom-storage.bicep")
+var storage = builder.AddBicepTemplate("storage", "./custom-storage.bicep")
     .WithParameter("storageAccountName", "mystorageaccount");
 
 builder.AddProject<Projects.WebApp>("webapp")
@@ -554,11 +561,13 @@ await builder.build().run();
 
 ### Inspect generated Bicep
 
-After customizing with `ConfigureInfrastructure`, inspect the Bicep that Aspire generates:
+To inspect the Bicep that Aspire generates from your customizations, publish the AppHost to a directory and review the emitted files:
 
-1. Run your AppHost locally.
-2. Open the `./infra` directory inside your AppHost project.
-3. Review the generated `.bicep` files to verify your customizations.
+```bash title="Terminal"
+aspire publish -o ./publish
+```
+
+Aspire writes a `main.bicep` for the deployment, plus a `<resource-name>.module.bicep` file per Azure resource, into the output directory you specify. Open each `.module.bicep` to verify that your `ConfigureInfrastructure` changes were applied.
 
 <Aside type="tip">
 Use the Azure Portal's **Export template** feature to view Bicep for manually configured resources, then adapt it for Aspire.
@@ -572,3 +581,4 @@ Use the Azure Portal's **Export template** feature to view Bicep for manually co
 - [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning)
 - [Deploy to Azure Container Apps](/deployment/azure/container-apps/)
 - [Deploy to Azure App Service](/deployment/azure/app-service/)
+- [Bicep samples in the dotnet/aspire repo](https://github.com/dotnet/aspire/tree/main/playground/bicep)


### PR DESCRIPTION
Fixes #246

## Problem

The [Customize Azure resources](https://aspire.dev/integrations/cloud/azure/customize-resources/) page contains three concrete inaccuracies, each verified against the [`dotnet/aspire`](https://github.com/dotnet/aspire) source and the live aspire.dev site:

1. **Non-existent API**: The custom Bicep example used `builder.AddAzureBicepResource(name: ..., bicepFilePath: ...)`, which doesn't exist on `IDistributedApplicationBuilder`. The real API is [`AddBicepTemplate(name, bicepFile)`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs).
2. **Invalid `PrivateEndpoint` snippet**: The "Add Azure resources to the infrastructure" example used `Subnet = new SubnetReference { Id = ... }` (no such type) and omitted `PrivateLinkServiceConnections`, which is mandatory. The correct pattern (per [`AzurePrivateEndpointExtensions.cs#L122-L138`](https://github.com/dotnet/aspire/blob/main/src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs#L122-L138)) is `pe.Subnet.Id = "..."; pe.PrivateLinkServiceConnections.Add(new NetworkPrivateLinkServiceConnection { ... })`. Also, Aspire ships a first-class [`AddPrivateEndpoint`](https://aspire.dev/integrations/cloud/azure/azure-virtual-network/#add-private-endpoints) extension that should be the recommended path for this scenario.
3. **Wrong inspection workflow**: "Open the `./infra` directory inside your AppHost project" is incorrect. Aspire emits Bicep only at publish time via `aspire publish -o <dir>`, producing a `main.bicep` plus one `<resource-name>.module.bicep` per Azure resource. No `./infra/` folder is created at run time.

## Changes

- **`PrivateEndpoint` example** (`### Add Azure resources to the infrastructure`):
  - Added `using Azure.Provisioning.Network;` to the snippet.
  - Fixed the `Subnet` assignment to use `privateEndpoint.Subnet.Id = "..."`.
  - Added the required `PrivateLinkServiceConnections.Add(new NetworkPrivateLinkServiceConnection { Name, PrivateLinkServiceId, GroupIds })` call.
  - Added an `<Aside type="tip">` pointing readers at the first-class `AddPrivateEndpoint` extension from `Aspire.Hosting.Azure.Network` as the recommended path.
- **Custom Bicep C# example** (`### Use custom Bicep files`):
  - Replaced `AddAzureBicepResource(name: ..., bicepFilePath: ...)` with the real API `AddBicepTemplate("storage", "./custom-storage.bicep")`.
- **Inspect generated Bicep** (`### Inspect generated Bicep`):
  - Replaced the "Open `./infra`" steps with the actual workflow: `aspire publish -o ./publish`, then inspect the emitted `main.bicep` and `<resource-name>.module.bicep` files.
- **See also**:
  - Added a link to the [Bicep samples in the dotnet/aspire repo](https://github.com/dotnet/aspire/tree/main/playground/bicep) (explicitly requested by the reporter).

## Evidence

**Before** (captured from https://aspire.dev/integrations/cloud/azure/customize-resources/):

> 1. Run your AppHost locally.
> 2. Open the `./infra` directory inside your AppHost project.
> 3. Review the generated `.bicep` files to verify your customizations.

> ```csharp
> var storage = builder.AddAzureBicepResource(
>     name: "storage",
>     bicepFilePath: "./custom-storage.bicep")
> ```

> ```csharp
> var privateEndpoint = new PrivateEndpoint("storagepe")
> {
>     Location = "eastus",
>     Subnet = new SubnetReference { Id = "..." }
> };
> ```

**After** (this PR; verified via local `pnpm preview` against the rendered HTML):

- Custom Bicep example renders `builder.AddBicepTemplate("storage", "./custom-storage.bicep")`.
- `PrivateEndpoint` snippet uses the correct `Subnet.Id` / `PrivateLinkServiceConnections.Add(...)` pattern and an Aside points to `AddPrivateEndpoint`.
- Inspect section renders a `Terminal` codeblock with `aspire publish -o ./publish`.
- "See also" includes the Bicep samples link.

## How I verified

1. **Cross-checked every claim against the product source** (`dotnet/aspire`):
   - `AddBicepTemplate`/`AddBicepTemplateString` signatures from `src/Aspire.Hosting.Azure/AzureBicepResourceExtensions.cs`.
   - `PrivateEndpoint` usage pattern from `src/Aspire.Hosting.Azure.Network/AzurePrivateEndpointExtensions.cs#L122-L138`.
   - Emitted Bicep filenames from `src/Aspire.Hosting.Azure/AzurePublishingContext.cs` and the real artifacts in `playground/bicep/BicepSample.AppHost/*.module.bicep`.
2. **Reproduced all three issues on the live site** via Playwright before editing.
3. **Validated the edit locally**:
   - `pnpm build` (full Astro + Starlight build, 12,226 pages) — passed; `starlight-links-validator`: **All internal links are valid**.
   - `pnpm test:unit` — **163/163 tests passed**, including `twoslash-blocks.vitest.test.ts`.
   - `pnpm preview` + grep over rendered HTML confirms all four changes (`AddBicepTemplate`, `AddPrivateEndpoint` aside, `aspire publish -o ./publish`, Bicep samples link) are present in the final output, with no remaining occurrences of `AddAzureBicepResource`.
4. **Anchor `#add-private-endpoints`** on `azure-virtual-network` was confirmed to resolve by the build's link validator.

## Out of scope (follow-up candidates)

The reporter also mentioned that the page is "lacking" coverage of customizing parameters/outputs and adding existing resources. That's a content addition rather than a correctness fix, so it's not included here — happy to file a follow-up issue if useful.
