### PR TITLE
Update support.mdx for v13.3.2 release

### DIFF
--- a/src/frontend/src/content/docs/support.mdx
+++ b/src/frontend/src/content/docs/support.mdx
@@ -9,7 +9,7 @@ editUrl: false
 
 import { Badge } from '@astrojs/starlight/components';
 
-<Badge text="📆 Last updated: May 7, 2026" variant="tip" size="large" />
+<Badge text="📆 Last updated: May 14, 2026" variant="tip" size="large" />
 
 ## Microsoft support for Aspire
 
@@ -27,7 +27,7 @@ The following table lists Aspire versions that are actively supported:
 
 | Version     | Original release date | Latest patch version | Patch release date | End of support                               |
 | ----------- | --------------------- | -------------------- | ------------------ | -------------------------------------------- |
-| Aspire 13.3 | May 7, 2026           | 13.3.0               | May 7, 2026        | When next major or minor version is released. |
+| Aspire 13.3 | May 7, 2026           | 13.3.2               | May 14, 2026       | When next major or minor version is released. |
 
 ### Out of support versions
 


### PR DESCRIPTION
Updates the support page for the Aspire v13.3.2 patch release (May 14, 2026):

- Updated the **Last updated** badge from May 7, 2026 to May 14, 2026
- Updated Aspire 13.3 row: latest patch version 13.3.0 → 13.3.2, patch release date May 7, 2026 → May 14, 2026