### PR TITLE
Run update-release-branch on every push to main; drop daily cron

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  schedule:
-    # Runs daily at 04:00 UTC
-    - cron: '0 4 * * *'
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -1,6 +1,9 @@
 name: Update Release Branch
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     # Runs daily at 04:00 UTC
     - cron: '0 4 * * *'


### PR DESCRIPTION
Replaces the daily 04:00 UTC cron on `.github/workflows/update-release-branch.yml` with a `push` trigger on `main`, so the workflow runs after every PR merged into `main` and keeps the active `release/{major}.{minor}` branch (currently `release/13.4`) continuously up to date.

## What changed

- Added `push: branches: [main]` to the workflow's `on:` triggers.
- Removed the now-redundant `schedule: cron: '0 4 * * *'` trigger.
- `workflow_dispatch` is retained as a manual fallback.

## Why

A PR merge to `main` produces a push to `main` regardless of merge strategy (merge commit, squash, rebase), so a `push` trigger catches every merge. That makes the daily cron redundant: it would only ever fire on an already-synced branch (or if no merges happened in 24h, in which case there's nothing to merge anyway). Dropping it removes a redundant scheduled run.

## Safety notes

- The existing `concurrency` group `update-release-branch` with `cancel-in-progress: false` ensures rapid back-to-back merges queue rather than race.
- Permissions are unchanged (`contents: write` only on the job).
- If no matching `release/{major}.{minor}` branch exists, the workflow already short-circuits with `Nothing to do`.
- `workflow_dispatch` is still available to trigger the workflow manually if needed.