### PR TITLE
[docs] Expand Connection property suffix breaking-change migration guide (13.2)

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13-2.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-2.mdx
@@ -1224,7 +1224,78 @@ The `BeforeResourceStartedEvent` now only fires when actually starting a resourc
 
 ### Connection property suffix
 
-A connection property suffix has been added which may require updates to code that accesses connection properties directly.
+Connection property keys exposed by built-in resources have been normalized so that keys that **name an entity** end in `Name`. This disambiguates a property key (the schema label) from the property value (the actual name being communicated) and gives consuming apps a consistent shape across every built-in integration.
+
+The renames follow three patterns:
+
+- **Database identifier**: `Database` → `DatabaseName`
+- **Model identifier**: `Model` → `ModelName`
+- **Consumer group identifier**: `ConsumerGroup` → `ConsumerGroupName`
+
+The affected built-in resources are:
+
+| Resource                                            | Old property    | New property         |
+| --------------------------------------------------- | --------------- | -------------------- |
+| Azure AI Foundry / Foundry deployment               | `Model`         | `ModelName`          |
+| Azure Cognitive Services / Azure OpenAI deployment  | `Model`         | `ModelName`          |
+| Azure Cosmos DB database                            | `Database`      | `DatabaseName`       |
+| Azure Event Hubs consumer group                     | `ConsumerGroup` | `ConsumerGroupName`  |
+| Azure Kusto read/write database                     | `Database`      | `DatabaseName`       |
+| Azure PostgreSQL database                           | `Database`      | `DatabaseName`       |
+| Azure SQL database                                  | `Database`      | `DatabaseName`       |
+| GitHub Models                                       | `Model`         | `ModelName`          |
+| Milvus database                                     | `Database`      | `DatabaseName`       |
+| MongoDB database                                    | `Database`      | `DatabaseName`       |
+| MySQL database                                      | `Database`      | `DatabaseName`       |
+| OpenAI model                                        | `Model`         | `ModelName`          |
+| Oracle database                                     | `Database`      | `DatabaseName`       |
+| PostgreSQL database                                 | `Database`      | `DatabaseName`       |
+| SQL Server database                                 | `Database`      | `DatabaseName`       |
+
+Your AppHost code is unaffected — the rename is on the **keys** that resources publish, not on the AppHost APIs you call. What changes is the value Aspire projects to consuming apps that `WithReference` one of these resources.
+
+```text title="Environment variables — Before (13.0)"
+DB1_DATABASE=orders
+CHAT_MODEL=gpt-4o-mini
+EVENTS_CONSUMERGROUP=$Default
+```
+
+```text title="Environment variables — After (13.2)"
+DB1_DATABASENAME=orders
+CHAT_MODELNAME=gpt-4o-mini
+EVENTS_CONSUMERGROUPNAME=$Default
+```
+
+For C# consumers that read the property directly, update the trailing token of the variable name:
+
+```csharp title="C# — Migration example"
+// Before
+var dbName = Environment.GetEnvironmentVariable("DB1_DATABASE");
+var model  = Environment.GetEnvironmentVariable("CHAT_MODEL");
+
+// After
+var dbName = Environment.GetEnvironmentVariable("DB1_DATABASENAME");
+var model  = Environment.GetEnvironmentVariable("CHAT_MODELNAME");
+```
+
+Polyglot SDKs that look up the property by name (for example `getConnectionProperty("chat", "Model")` in TypeScript or the Java/Python equivalents) need the same change.
+
+To migrate:
+
+1. Search consuming projects and deployment manifests for any of the old keys — `_DATABASE`, `_MODEL`, or `_CONSUMERGROUP` in environment-variable reads, and `"Database"`, `"Model"`, or `"ConsumerGroup"` arguments passed to polyglot connection-property helpers.
+2. Rename the trailing segment to the new name (`DatabaseName`, `ModelName`, or `ConsumerGroupName`). The resource name prefix doesn't change.
+3. Run your AppHost (`aspire run`) and confirm consumers receive the renamed property at startup. Other properties such as `Uri`, `Host`, `Port`, and `Key` aren't affected.
+
+For the complete connection-property reference of each integration — including how C#, TypeScript, Python, and Go consumers read the renamed properties — see the per-resource pages under [Integrations](/integrations/).
+
+<Aside type="note">
+  The same rename was also backported to a 13.1 patch release for the MongoDB, MySQL,
+  Milvus, Oracle, GitHub Models, and OpenAI resources. If you already updated those
+  property names during an Aspire 13.1.x upgrade, only the remaining resources in the
+  table above need attention when moving to 13.2. See the [Connection Properties
+  rename](/whats-new/aspire-13-1/#connection-properties-rename) note in the 13.1
+  release notes for context.
+</Aside>
 
 ### AIFoundry to Foundry transition
 


### PR DESCRIPTION
Fixes #413

## Summary

Aspire 13.2 (and the 13.1.x patch via [dotnet/aspire#13516](https://github.com/dotnet/aspire/pull/13516)) shipped a breaking change from [dotnet/aspire#13471](https://github.com/dotnet/aspire/pull/13471) that renamed connection property keys returned by `IResourceWithConnectionString.GetConnectionProperties()` for many built-in resources — adding a `Name` suffix when the property names an entity. The existing entry in `whats-new/aspire-13-2.mdx` was a single sentence with no examples, no rename table, and no migration steps, which is what #413 asked us to fix.

This PR expands the `### Connection property suffix` subsection of the 13.2 release notes into a full migration guide.

## Changes

Single-file change: `src/frontend/src/content/docs/whats-new/aspire-13-2.mdx`, replacing the one-line stub at the `### Connection property suffix` heading with:

- A two-paragraph explanation of **what** the rename normalizes (property keys that name an entity now end in `Name`) and **why** (disambiguates the key/schema label from the value/name and gives consuming apps a consistent shape across every built-in integration).
- A bulleted list of the **three rename patterns**: `Database` → `DatabaseName`, `Model` → `ModelName`, `ConsumerGroup` → `ConsumerGroupName`.
- A **complete table** of the 15 affected built-in resources (Azure AI Foundry, Azure Cognitive Services / Azure OpenAI deployment, Azure Cosmos DB, Azure Event Hubs, Azure Kusto, Azure PostgreSQL, Azure SQL, GitHub Models, Milvus, MongoDB, MySQL, OpenAI, Oracle, PostgreSQL, SQL Server).
- A note clarifying that the AppHost API surface is unchanged; only the property **keys** projected to consuming apps move.
- **Before/After** code blocks for the `[RESOURCE]_[PROPERTY]` environment variables and a C# `Environment.GetEnvironmentVariable` example.
- A note that polyglot SDK lookups by property name need the same string change.
- A 3-step **migration list**: search for the old token in env-var reads and SDK helpers, rename to the new token, then verify with `aspire run`.
- A link to the per-resource pages under `/integrations/` for full property reference.
- An `<Aside type="note">` cross-linking to the existing [Connection Properties rename](https://aspire.dev/whats-new/aspire-13-1/#connection-properties-rename) callout in the 13.1 release notes so readers who already migrated the 6 resources backported into 13.1.x know which of the remaining resources still need attention.

## Evidence the issue still reproduced

Before this PR, [aspire.dev/whats-new/aspire-13-2/#connection-property-suffix](https://aspire.dev/whats-new/aspire-13-2/#connection-property-suffix) renders only:

> A connection property suffix has been added which may require updates to code that accesses connection properties directly.

No examples, no rename list, no migration guidance — matching exactly what #413 calls out.

## How I verified

1. Ran the live site through Playwright at `https://aspire.dev/whats-new/aspire-13-2/#connection-property-suffix` to confirm the existing stub before changes.
2. Cross-checked the full rename list against the diff of [dotnet/aspire#13471](https://github.com/dotnet/aspire/pull/13471) (15 built-in resources). The 6 resources that were also backported to a 13.1 patch ([dotnet/aspire#13516](https://github.com/dotnet/aspire/pull/13516)) — MongoDB, MySQL, Milvus, Oracle, GitHub Models, OpenAI — match the existing table in `whats-new/aspire-13-1.mdx` and are deliberately not removed from this 13.2 list (a 13.0 → 13.2 upgrader still hits them).
3. Cross-checked the env-var naming convention (`[RESOURCE_UPPER]_[PROPERTY_UPPER]`) against integration `connect` pages (for example `integrations/databases/mongodb/mongodb-connect.mdx`).
4. Ran the docs site locally with `pnpm dev` and walked the rendered page via Playwright:
   - Confirmed the heading, intro, patterns list, resource table, env-var/code blocks, migration steps, and `<Aside>` all render.
   - Clicked the cross-link in the Aside — it navigates to `/whats-new/aspire-13-1/#connection-properties-rename` and scrolls to the existing partial table.
   - Confirmed the `/integrations/` link resolves to the Aspire Integrations landing page.
5. The TOC for this page has `tableOfContents.maxHeadingLevel: 2`, so the existing `### Connection property suffix` subheading is intentionally not surfaced in the "On this page" navigation; this matches the surrounding breaking-change entries.

## Notes for reviewers

- This is **docs-only**. No code or product change is required — the rename in the product shipped with Aspire 13.2.
- The 13.1 page's existing `### Connection Properties rename` table is **not** touched in this PR (out of scope for #413, which is explicitly the 13.2 docs).
- The `AuthenticationDatabase` key mentioned in the original PR description of `dotnet/aspire#13471` was **not** actually renamed in the merged diff (`MongoDBServerResource` still emits `"AuthenticationDatabase"`); it's deliberately excluded from the table.
