### PR TITLE
Restructure docs sidebar: always-visible topics, full-width filter, anchored toggle

### DIFF
--- a/src/frontend/src/components/HeroSection.astro
+++ b/src/frontend/src/components/HeroSection.astro
@@ -121,8 +121,8 @@ const floatingIcons = buildFloatingIconLayout(title, iconNames, { rightRange: 55
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 4rem;
-    height: 4rem;
+    width: 3rem;
+    height: 3rem;
     border-radius: 0.75rem;
     background: color-mix(in srgb, var(--aspire-color-primary) 18%, var(--sl-color-bg));
     border: 2px solid color-mix(in srgb, var(--aspire-color-primary) 35%, transparent);
@@ -131,8 +131,8 @@ const floatingIcons = buildFloatingIconLayout(title, iconNames, { rightRange: 55
   }
 
   .hero-logo :global(img) {
-    width: 2.25rem;
-    height: 2.25rem;
+    width: 2rem;
+    height: 2rem;
   }
 
   .hero-content {
@@ -291,8 +291,8 @@ const floatingIcons = buildFloatingIconLayout(title, iconNames, { rightRange: 55
       margin-bottom: 1.5rem;
     }
     .hero-logo {
-      width: 3rem;
-      height: 3rem;
+      width: 2.75rem;
+      height: 2.75rem;
       margin-bottom: 1rem;
     }
     .hero-logo :global(img) {

--- a/src/frontend/src/components/TopicHero.astro
+++ b/src/frontend/src/components/TopicHero.astro
@@ -54,7 +54,7 @@ const subtitleSegments = subtitle
     {
       icon && (
         <div class="topic-hero-icon">
-          <Icon name={icon} size="2.5rem" />
+          <Icon name={icon} />
         </div>
       )
     }
@@ -146,13 +146,20 @@ const subtitleSegments = subtitle
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 4rem;
-    height: 4rem;
+    width: 3rem;
+    height: 3rem;
+    padding: 0.5rem;
+    box-sizing: border-box;
     border-radius: 0.75rem;
     background: color-mix(in srgb, var(--topic-accent) 18%, var(--sl-color-bg));
     border: 2px solid color-mix(in srgb, var(--topic-accent) 35%, transparent);
     color: var(--topic-accent);
     margin-bottom: 1.25rem;
+  }
+
+  .topic-hero-icon :global(svg) {
+    width: 100%;
+    height: 100%;
   }
 
   .topic-hero-title {
@@ -335,13 +342,9 @@ const subtitleSegments = subtitle
       margin-bottom: 1.5rem;
     }
     .topic-hero-icon {
-      width: 3rem;
-      height: 3rem;
+      width: 2.75rem;
+      height: 2.75rem;
       margin-bottom: 1rem;
-    }
-    .topic-hero-icon :global(svg) {
-      width: 1.75rem;
-      height: 1.75rem;
     }
     .topic-hero-title {
       font-size: clamp(1.35rem, 2.6vw, 1.75rem);
@@ -373,10 +376,6 @@ const subtitleSegments = subtitle
       height: 2.5rem;
       margin-bottom: 0.75rem;
       border-radius: 0.5rem;
-    }
-    .topic-hero-icon :global(svg) {
-      width: 1.5rem;
-      height: 1.5rem;
     }
     .topic-hero-title {
       font-size: clamp(1.2rem, 4.5vw, 1.5rem);

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -360,7 +360,7 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     <LinkButton
       href={'https://github.com/microsoft/aspire.dev'}
       variant="minimal"
-      title="aspire.dev"
+      title="GitHub: microsoft/aspire.dev"
     >
       <Icon name="github" />
       <span>aspire.dev</span>

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -115,7 +115,7 @@ const currentTopic = effectiveTopics.find((topic) => topic.isCurrent) ?? effecti
 const hasTopicSidebar = Boolean(
   !isApiRefPage && routeData?.hasSidebar && topicState?.isPageWithTopic && currentTopic
 );
-const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 0);
+const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
 ---
 
 <div
@@ -128,177 +128,92 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
     isApiRefPage ? (
       <>
         <div class="api-sidebar-sticky not-content">
-          <div
-            class:list={[
-              'sidebar-sticky-toolbar',
-              'api-sidebar-toolbar',
-              { 'sidebar-sticky-toolbar-topic-stack': hasSharedTopicDropdown },
-            ]}
-          >
-            <div class="sidebar-filter">
-              <div class="sidebar-filter-wrap">
+          {hasTopicsList && (
+            <ul
+              class="starlight-sidebar-topics topics-sidebar-list"
+              data-tour-target="topics-dropdown"
+              data-tour-step="topics-dropdown"
+            >
+              {effectiveTopics.map((topic) => (
+                <li>
+                  <a
+                    href={topic.link}
+                    class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
+                  >
+                    {topic.icon && (
+                      <div class="starlight-sidebar-topics-icon">
+                        <Icon name={topic.icon as any} />
+                      </div>
+                    )}
+                    <div>
+                      {topic.label}
+                      {topic.badge && (
+                        <Badge
+                          class="starlight-sidebar-topics-badge"
+                          text={topic.badge.text}
+                          variant={topic.badge.variant}
+                        />
+                      )}
+                    </div>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+          <div class="sidebar-filter sidebar-filter-row">
+            <div class="sidebar-filter-wrap">
+              <svg
+                class="sidebar-filter-icon"
+                aria-hidden="true"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+              </svg>
+              <label class="sr-only" for="sidebar-filter-input">
+                Filter sidebar
+              </label>
+              <input
+                type="text"
+                id="sidebar-filter-input"
+                class="sidebar-filter-input"
+                placeholder="Filter sidebar…"
+                autocomplete="off"
+                aria-label="Filter sidebar entries"
+              />
+              <button
+                type="button"
+                id="sidebar-filter-clear"
+                class="sidebar-filter-clear"
+                aria-label="Clear filter"
+                hidden
+              >
                 <svg
-                  class="sidebar-filter-icon"
                   aria-hidden="true"
                   width="14"
                   height="14"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  stroke-width="2"
+                  stroke-width="2.5"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                 >
-                  <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
-                </svg>
-                <label class="sr-only" for="sidebar-filter-input">
-                  Filter sidebar
-                </label>
-                <input
-                  type="text"
-                  id="sidebar-filter-input"
-                  class="sidebar-filter-input"
-                  placeholder="Filter sidebar…"
-                  autocomplete="off"
-                  aria-label="Filter sidebar entries"
-                />
-                <button
-                  type="button"
-                  id="sidebar-filter-clear"
-                  class="sidebar-filter-clear"
-                  aria-label="Clear filter"
-                  hidden
-                >
-                  <svg
-                    aria-hidden="true"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                </button>
-              </div>
-              <div id="sidebar-filter-status" class="sr-only" aria-live="polite" />
-            </div>
-            <button
-              type="button"
-              class="sidebar-collapse-btn"
-              id="sidebar-collapse-btn"
-              data-tour-target="sidebar-toggle"
-              aria-label="Collapse sidebar"
-              title="Collapse sidebar"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                aria-hidden="true"
-              >
-                <>
-                  <rect width="18" height="18" x="3" y="3" rx="2" />
-                  <path d="M9 3v18m7-6l-3-3l3-3" />
-                </>
-              </svg>
-            </button>
-          </div>
-          {hasSharedTopicDropdown && (
-            <div
-              class="sidebar-dropdown-shell topic-selector-dropdown"
-              data-sidebar-dropdown
-              data-tour-target="topics-dropdown"
-              data-tour-step="topics-dropdown"
-            >
-              <button
-                type="button"
-                class="sidebar-dropdown-trigger sidebar-dropdown-trigger-topic"
-                id="topic-sidebar-trigger"
-                aria-haspopup="menu"
-                aria-expanded="false"
-                data-dropdown-trigger
-              >
-                {currentTopic?.icon && (
-                  <span class="starlight-sidebar-topics-icon topic-selector-icon">
-                    <Icon name={currentTopic.icon as any} />
-                  </span>
-                )}
-                <span class="sidebar-dropdown-trigger-copy topic-selector-copy">
-                  <span class="sidebar-dropdown-trigger-label topic-selector-label">
-                    {currentTopic?.label}
-                  </span>
-                  {currentTopic?.badge && (
-                    <span class="sidebar-dropdown-trigger-meta topic-selector-meta">
-                      <Badge
-                        class="starlight-sidebar-topics-badge"
-                        text={currentTopic.badge.text}
-                        variant={currentTopic.badge.variant}
-                      />
-                    </span>
-                  )}
-                </span>
-                <svg
-                  class="sidebar-dropdown-caret"
-                  viewBox="0 0 20 20"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-width="1.8"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  aria-hidden="true"
-                >
-                  <path d="M5 7.5L10 12.5L15 7.5" />
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>
               </button>
-              <div
-                class="sidebar-dropdown-panel sidebar-dropdown-panel-topics"
-                hidden
-                data-dropdown-panel
-              >
-                <ul
-                  class="starlight-sidebar-topics starlight-sidebar-topics-menu"
-                  role="menu"
-                  aria-labelledby="topic-sidebar-trigger"
-                >
-                  {effectiveTopics.map((topic) => (
-                    <li role="none">
-                      <a
-                        href={topic.link}
-                        class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
-                        role="menuitem"
-                      >
-                        {topic.icon && (
-                          <div class="starlight-sidebar-topics-icon">
-                            <Icon name={topic.icon as any} />
-                          </div>
-                        )}
-                        <div>
-                          {topic.label}
-                          {topic.badge && (
-                            <Badge
-                              class="starlight-sidebar-topics-badge"
-                              text={topic.badge.text}
-                              variant={topic.badge.variant}
-                            />
-                          )}
-                        </div>
-                      </a>
-                    </li>
-                  ))}
-                </ul>
-              </div>
             </div>
-          )}
+            <div id="sidebar-filter-status" class="sr-only" aria-live="polite" />
+          </div>
           <div
-            class="sidebar-filter-empty sidebar-filter-empty-below-dropdown"
+            class="sidebar-filter-empty"
             id="sidebar-filter-empty"
             aria-labelledby="sidebar-filter-empty-copy"
             hidden
@@ -323,170 +238,90 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
     ) : hasTopicSidebar ? (
       <>
         <div class="topic-sidebar-sticky not-content">
-          <div class="topic-sidebar-toolbar">
-            <div class="sidebar-filter">
-              <div class="sidebar-filter-wrap">
+          <ul
+            class="starlight-sidebar-topics topics-sidebar-list"
+            data-tour-target="topics-dropdown"
+            data-tour-step="topics-dropdown"
+          >
+            {effectiveTopics.map((topic) => (
+              <li>
+                <a
+                  href={topic.link}
+                  class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
+                >
+                  {topic.icon && (
+                    <div class="starlight-sidebar-topics-icon">
+                      <Icon name={topic.icon as any} />
+                    </div>
+                  )}
+                  <div>
+                    {topic.label}
+                    {topic.badge && (
+                      <Badge
+                        class="starlight-sidebar-topics-badge"
+                        text={topic.badge.text}
+                        variant={topic.badge.variant}
+                      />
+                    )}
+                  </div>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <div class="sidebar-filter sidebar-filter-row">
+            <div class="sidebar-filter-wrap">
+              <svg
+                class="sidebar-filter-icon"
+                aria-hidden="true"
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+              </svg>
+              <label class="sr-only" for="sidebar-filter-input">
+                Filter sidebar
+              </label>
+              <input
+                type="text"
+                id="sidebar-filter-input"
+                class="sidebar-filter-input"
+                placeholder="Filter sidebar…"
+                autocomplete="off"
+                aria-label="Filter sidebar entries"
+              />
+              <button
+                type="button"
+                id="sidebar-filter-clear"
+                class="sidebar-filter-clear"
+                aria-label="Clear filter"
+                hidden
+              >
                 <svg
-                  class="sidebar-filter-icon"
                   aria-hidden="true"
                   width="14"
                   height="14"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
-                  stroke-width="2"
+                  stroke-width="2.5"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                 >
-                  <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
                 </svg>
-                <label class="sr-only" for="sidebar-filter-input">
-                  Filter sidebar
-                </label>
-                <input
-                  type="text"
-                  id="sidebar-filter-input"
-                  class="sidebar-filter-input"
-                  placeholder="Filter sidebar…"
-                  autocomplete="off"
-                  aria-label="Filter sidebar entries"
-                />
-                <button
-                  type="button"
-                  id="sidebar-filter-clear"
-                  class="sidebar-filter-clear"
-                  aria-label="Clear filter"
-                  hidden
-                >
-                  <svg
-                    aria-hidden="true"
-                    width="14"
-                    height="14"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-width="2.5"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  >
-                    <line x1="18" y1="6" x2="6" y2="18" />
-                    <line x1="6" y1="6" x2="18" y2="18" />
-                  </svg>
-                </button>
-              </div>
-              <div id="sidebar-filter-status" class="sr-only" aria-live="polite" />
+              </button>
             </div>
-            <button
-              type="button"
-              class="sidebar-collapse-btn"
-              id="topic-sidebar-collapse-btn"
-              data-tour-target="sidebar-toggle"
-              data-tour-step="sidebar-toggle"
-              aria-label="Collapse sidebar"
-              title="Collapse sidebar"
-            >
-              <svg
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                aria-hidden="true"
-              >
-                <>
-                  <rect width="18" height="18" x="3" y="3" rx="2" />
-                  <path d="M9 3v18m7-6l-3-3l3-3" />
-                </>
-              </svg>
-            </button>
+            <div id="sidebar-filter-status" class="sr-only" aria-live="polite" />
           </div>
           <div
-            class="sidebar-dropdown-shell topic-selector-dropdown"
-            data-sidebar-dropdown
-            data-tour-target="topics-dropdown"
-            data-tour-step="topics-dropdown"
-          >
-            <button
-              type="button"
-              class="sidebar-dropdown-trigger sidebar-dropdown-trigger-topic"
-              id="topic-sidebar-trigger"
-              aria-haspopup="menu"
-              aria-expanded="false"
-              data-dropdown-trigger
-            >
-              {currentTopic?.icon && (
-                <span class="starlight-sidebar-topics-icon topic-selector-icon">
-                  <Icon name={currentTopic.icon as any} />
-                </span>
-              )}
-              <span class="sidebar-dropdown-trigger-copy topic-selector-copy">
-                <span class="sidebar-dropdown-trigger-label topic-selector-label">
-                  {currentTopic?.label}
-                </span>
-                {currentTopic?.badge && (
-                  <span class="sidebar-dropdown-trigger-meta topic-selector-meta">
-                    <Badge
-                      class="starlight-sidebar-topics-badge"
-                      text={currentTopic.badge.text}
-                      variant={currentTopic.badge.variant}
-                    />
-                  </span>
-                )}
-              </span>
-              <svg
-                class="sidebar-dropdown-caret"
-                viewBox="0 0 20 20"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="1.8"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-              >
-                <path d="M5 7.5L10 12.5L15 7.5" />
-              </svg>
-            </button>
-            <div
-              class="sidebar-dropdown-panel sidebar-dropdown-panel-topics"
-              hidden
-              data-dropdown-panel
-            >
-              <ul
-                class="starlight-sidebar-topics starlight-sidebar-topics-menu"
-                role="menu"
-                aria-labelledby="topic-sidebar-trigger"
-              >
-                {effectiveTopics.map((topic) => (
-                  <li role="none">
-                    <a
-                      href={topic.link}
-                      class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
-                      role="menuitem"
-                    >
-                      {topic.icon && (
-                        <div class="starlight-sidebar-topics-icon">
-                          <Icon name={topic.icon as any} />
-                        </div>
-                      )}
-                      <div>
-                        {topic.label}
-                        {topic.badge && (
-                          <Badge
-                            class="starlight-sidebar-topics-badge"
-                            text={topic.badge.text}
-                            variant={topic.badge.variant}
-                          />
-                        )}
-                      </div>
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-          <div
-            class="sidebar-filter-empty sidebar-filter-empty-below-dropdown"
+            class="sidebar-filter-empty"
             id="sidebar-filter-empty"
             aria-labelledby="sidebar-filter-empty-copy"
             hidden
@@ -524,58 +359,109 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
 </div>
 {
   isApiRefPage && (
-    <button
-      type="button"
-      class="sidebar-expand-btn"
-      id="sidebar-expand-btn"
-      data-tour-target="sidebar-toggle"
-      aria-label="Expand sidebar"
-      title="Expand sidebar"
-      hidden
-    >
-      <svg
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        aria-hidden="true"
+    <>
+      <button
+        type="button"
+        class="sidebar-collapse-btn"
+        id="sidebar-collapse-btn"
+        data-tour-target="sidebar-toggle"
+        aria-label="Collapse sidebar"
+        title="Collapse sidebar"
       >
-        <>
-          <rect width="18" height="18" x="3" y="3" rx="2" />
-          <path d="M9 3v18m5-12l3 3l-3 3" />
-        </>
-      </svg>
-    </button>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <>
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="M9 3v18m7-6l-3-3l3-3" />
+          </>
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="sidebar-expand-btn"
+        id="sidebar-expand-btn"
+        data-tour-target="sidebar-toggle"
+        aria-label="Expand sidebar"
+        title="Expand sidebar"
+        hidden
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <>
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="M9 3v18m5-12l3 3l-3 3" />
+          </>
+        </svg>
+      </button>
+    </>
   )
 }
 {
   hasTopicSidebar && (
-    <button
-      type="button"
-      class="sidebar-expand-btn"
-      id="topic-sidebar-expand-btn"
-      data-tour-target="sidebar-toggle"
-      aria-label="Expand sidebar"
-      title="Expand sidebar"
-      hidden
-    >
-      <svg
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        aria-hidden="true"
+    <>
+      <button
+        type="button"
+        class="sidebar-collapse-btn"
+        id="topic-sidebar-collapse-btn"
+        data-tour-target="sidebar-toggle"
+        data-tour-step="sidebar-toggle"
+        aria-label="Collapse sidebar"
+        title="Collapse sidebar"
       >
-        <>
-          <rect width="18" height="18" x="3" y="3" rx="2" />
-          <path d="M9 3v18m5-12l3 3l-3 3" />
-        </>
-      </svg>
-    </button>
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <>
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="M9 3v18m7-6l-3-3l3-3" />
+          </>
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="sidebar-expand-btn"
+        id="topic-sidebar-expand-btn"
+        data-tour-target="sidebar-toggle"
+        aria-label="Expand sidebar"
+        title="Expand sidebar"
+        hidden
+      >
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <>
+            <rect width="18" height="18" x="3" y="3" rx="2" />
+            <path d="M9 3v18m5-12l3 3l-3 3" />
+          </>
+        </svg>
+      </button>
+    </>
   )
 }
 
@@ -657,46 +543,83 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
     --sidebar-control-height: 2.5rem;
   }
 
-  /* Sidebar sticky wrappers */
-  .api-sidebar-sticky {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    background: var(--sl-color-bg-sidebar);
-    margin-inline: calc(-1 * var(--sl-sidebar-pad-x));
-    padding-inline: var(--sl-sidebar-pad-x);
-  }
-
-  .sidebar-sticky-toolbar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    flex-wrap: nowrap;
-    padding: 0.75rem 0;
-    border-bottom: 1px solid var(--sl-color-hairline-light);
-  }
-
-  .sidebar-sticky-toolbar-topic-stack {
-    padding-bottom: 0.35rem;
-    border-bottom: 0;
-  }
-
+  /* Sidebar header wrappers — topics list + filter scroll along with the
+     rest of the sidebar content (no sticky positioning). */
+  .api-sidebar-sticky,
   .topic-sidebar-sticky {
-    position: sticky;
-    top: 0;
-    z-index: 2;
-    background: var(--sl-color-bg-sidebar);
-    margin-inline: calc(-1 * var(--sl-sidebar-pad-x));
-    padding-inline: var(--sl-sidebar-pad-x);
+    padding-top: 0.75rem;
   }
 
-  .topic-sidebar-toolbar {
+  /* Always-visible topics list sitting at the top of the sidebar. */
+  .topics-sidebar-list {
+    list-style: none;
+    margin: 0 0 0.75rem 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .topics-sidebar-list :global(li) {
+    margin: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .topics-sidebar-list :global(a) {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    padding: 0.75rem 0 0.35rem;
+    padding: 0.35rem 0.8rem;
+    font-size: var(--sl-text-sm, 0.875rem);
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--sl-color-white);
+    text-decoration: none;
+    border: 1px solid transparent;
+    border-radius: 0.375rem;
+  }
+
+  .topics-sidebar-list :global(a:hover),
+  .topics-sidebar-list :global(a:focus-visible) {
+    color: var(--sl-color-accent-high);
+    background-color: var(--sl-color-gray-6);
+  }
+
+  .topics-sidebar-list :global(a.starlight-sidebar-topics-current) {
+    color: var(--sl-color-accent-high);
+    background: var(--sidebar-dropdown-selected-bg);
+    border-color: var(--sidebar-dropdown-selected-border);
+  }
+
+  :global([data-theme='light']) .topics-sidebar-list :global(a.starlight-sidebar-topics-current) {
+    color: var(--sl-color-accent);
+  }
+
+  .topics-sidebar-list :global(.starlight-sidebar-topics-icon) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.2rem;
+    border: 1px solid var(--sl-color-gray-4);
+    border-radius: 0.25rem;
+    flex-shrink: 0;
+  }
+
+  .topics-sidebar-list :global(a:hover) :global(.starlight-sidebar-topics-icon),
+  .topics-sidebar-list :global(a:focus-visible) :global(.starlight-sidebar-topics-icon),
+  .topics-sidebar-list :global(a.starlight-sidebar-topics-current) :global(.starlight-sidebar-topics-icon) {
+    background-color: var(--sl-color-text-accent);
+    border-color: var(--sl-color-text-accent);
+    color: var(--sl-color-text-invert);
+  }
+
+  .topics-sidebar-list :global(.starlight-sidebar-topics-badge) {
+    margin-inline-start: 0.25em;
+  }
+
+  /* Filter row sits full-width directly below the topics list. */
+  .sidebar-filter-row {
+    margin-bottom: 0.75rem;
   }
 
   .sidebar-dropdown-shell {
@@ -1084,10 +1007,6 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
     color: var(--sl-color-text);
   }
 
-  .sidebar-filter-empty-below-dropdown {
-    margin-top: 0;
-  }
-
   .sidebar-filter-empty[hidden] {
     display: none;
   }
@@ -1178,60 +1097,71 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
 
   /* ── Sidebar collapse / expand ────────────────────────────────── */
 
-  .sidebar-collapse-btn {
-    margin-left: auto;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    padding: 0.5rem;
-    background: none;
-    border: none;
-    border-radius: 0.375rem;
-    color: var(--sl-color-text-accent);
-    cursor: pointer;
-    flex-shrink: 0;
-    transition:
-      color 0.15s,
-      background-color 0.15s;
-  }
-  .sidebar-collapse-btn:hover {
-    color: var(--sl-color-text);
-    background-color: var(--sl-color-gray-6);
-  }
-  .sidebar-collapse-btn svg {
-    width: 100%;
-    height: 100%;
-  }
-
+  /* Anchor the collapse/expand toggle to the sidebar's right edge so it
+     reads as a tab projecting from the sidebar. The button stays visible
+     (position: fixed) while the sidebar's own contents (topics, filter,
+     entries) scroll independently. When the sidebar is collapsed
+     (--sl-sidebar-width: 0), the button slides flush to the viewport
+     edge. When an announcement banner is visible the JS controller
+     writes --aspire-banner-height on <html>, pushing the button below
+     the banner. */
+  .sidebar-collapse-btn,
   .sidebar-expand-btn {
+    position: fixed;
+    top: calc(
+      var(--sl-nav-height, 3.5rem) + var(--aspire-banner-height, 0px) + 0.75rem
+    );
+    left: var(--sl-sidebar-width);
     display: flex;
     align-items: center;
     justify-content: center;
     width: 2.5rem;
     height: 2.5rem;
-    margin: 0.75rem auto 0;
-    padding: 0.5rem;
-    background: none;
-    border: none;
-    border-radius: 0.375rem;
+    padding: 0.55rem;
+    background: var(--sl-color-bg-sidebar);
+    border: 1px solid var(--sl-color-hairline-light);
+    /* Project from the sidebar's right edge — flat on the left, rounded
+       on the right. When collapsed the button sits at left:0 and the
+       flat left edge butts cleanly against the viewport border. */
+    border-left-color: transparent;
+    border-radius: 0 0.375rem 0.375rem 0;
     color: var(--sl-color-text-accent);
     cursor: pointer;
+    z-index: 20;
+    box-shadow: 2px 1px 3px color-mix(in srgb, var(--sl-color-black) 14%, transparent);
     transition:
       color 0.15s,
-      background-color 0.15s;
+      background-color 0.15s,
+      box-shadow 0.15s,
+      left 0.25s ease,
+      top 0.25s ease;
   }
-  .sidebar-expand-btn[hidden] {
-    display: none;
-  }
+  .sidebar-collapse-btn:hover,
   .sidebar-expand-btn:hover {
     color: var(--sl-color-text);
     background-color: var(--sl-color-gray-6);
+    box-shadow: 2px 2px 6px color-mix(in srgb, var(--sl-color-black) 22%, transparent);
   }
+  .sidebar-collapse-btn:focus-visible,
+  .sidebar-expand-btn:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 2px;
+  }
+  .sidebar-collapse-btn svg,
   .sidebar-expand-btn svg {
     width: 100%;
     height: 100%;
+  }
+  .sidebar-collapse-btn[hidden],
+  .sidebar-expand-btn[hidden] {
+    display: none;
+  }
+
+  /* When the sidebar is collapsed, hide the collapse button (the expand
+     button takes its place). The data-* attributes live on <html>. */
+  :global(html[data-sidebar-collapsed]) #sidebar-collapse-btn,
+  :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-collapse-btn {
+    display: none !important;
   }
 
   /* Hide collapse/expand on mobile-style sidebar (< 72rem for API pages) */
@@ -1243,10 +1173,6 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
   }
 
   @media (max-width: 50rem) {
-    .topic-sidebar-toolbar {
-      gap: 0.5rem;
-    }
-
     .sidebar-dropdown-trigger,
     .sidebar-dropdown-option {
       padding-inline: 0.7rem;
@@ -1800,13 +1726,57 @@ const hasSharedTopicDropdown = Boolean(currentTopic && effectiveTopics.length > 
     document.addEventListener('DOMContentLoaded', initTopicSidebarUi);
     document.addEventListener('astro:after-swap', initTopicSidebarUi);
     document.addEventListener('astro:page-load', focusSidebarFilter);
+    document.addEventListener('DOMContentLoaded', initBannerHeightTracking);
+    document.addEventListener('astro:after-swap', initBannerHeightTracking);
   }
   // Also init immediately in case DOMContentLoaded already fired
   if (document.readyState !== 'loading') initSidebarFilter();
   if (document.readyState !== 'loading') initSidebarCollapse();
   if (document.readyState !== 'loading') initTopicSidebarUi();
+  if (document.readyState !== 'loading') initBannerHeightTracking();
   // Defer focus slightly to run after Astro/Starlight's own DOM setup
   requestAnimationFrame(() => focusSidebarFilter());
+
+  /* ── Banner height tracking ───────────────────────────────────── */
+
+  /**
+   * Measure the announcement banner's height (if present and open) and
+   * write it to `--aspire-banner-height` on the root element so floating
+   * UI (the sidebar collapse/expand toggle) can offset itself below it.
+   * Updates on dismiss/state changes and on window resize.
+   */
+  function initBannerHeightTracking() {
+    const root = document.documentElement;
+    const update = () => {
+      const banner = document.querySelector('.sl-banner') as HTMLElement | null;
+      const open = banner && banner.dataset.bannerState !== 'closing' && !banner.hidden;
+      const height = open ? Math.round(banner.getBoundingClientRect().height) : 0;
+      if (height > 0) {
+        root.style.setProperty('--aspire-banner-height', `${height}px`);
+      } else {
+        root.style.removeProperty('--aspire-banner-height');
+      }
+    };
+
+    update();
+
+    const banner = document.querySelector('.sl-banner') as HTMLElement | null;
+    if (banner) {
+      // Track state changes (open → closing) emitted by Banner.astro's controller
+      const mo = new MutationObserver(update);
+      mo.observe(banner, { attributes: true, attributeFilter: ['data-banner-state', 'hidden'] });
+      // Track size changes too (e.g. responsive line-wrap)
+      if (typeof ResizeObserver !== 'undefined') {
+        const ro = new ResizeObserver(update);
+        ro.observe(banner);
+      }
+    }
+
+    if (!(window as any).__bannerHeightResizeBound) {
+      (window as any).__bannerHeightResizeBound = true;
+      window.addEventListener('resize', update);
+    }
+  }
 
   /* ── Sticky sidebar offsets & auto-scroll ─────────────────────── */
 

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -353,9 +353,9 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   }
   <div class="divider"></div>
   <div class="sidebar-bottom">
-    <LinkButton href={'https://github.com/microsoft/aspire.dev'} variant="minimal">
+    <LinkButton href={'https://github.com/microsoft/aspire.dev'} variant="minimal" title="aspire.dev">
       <Icon name="github" />
-      aspire.dev
+      <span>aspire.dev</span>
     </LinkButton>
   </div>
 </div>
@@ -1059,7 +1059,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   .sidebar-expand-btn {
     position: fixed;
     top: calc(
-      var(--sl-nav-height, 3.5rem) + var(--aspire-banner-height, 0px) + 0.75rem
+      var(--sl-nav-height, 3.5rem) + var(--aspire-banner-height, 0px) +
+        var(--sl-mobile-toc-height, 0px) + 0.75rem
     );
     left: var(--sl-sidebar-width);
     display: flex;
@@ -1553,6 +1554,15 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   const SIDEBAR_READY_ATTR = 'data-api-sidebar-ready';
   const TOPIC_SIDEBAR_READY_ATTR = 'data-topic-sidebar-ready';
 
+  /* Briefly tagging <html> with `data-sidebar-expanding` /
+     `data-topic-sidebar-expanding` while the rail → expanded transition
+     plays lets the filter and sidebar entries run a subtle blur-in
+     animation as they re-enter the layout. The flag clears just after
+     the underlying width transition (250ms) finishes. */
+  const SIDEBAR_EXPAND_ANIMATION_MS = 320;
+  let sidebarExpandTimer = 0;
+  let topicSidebarExpandTimer = 0;
+
   function setSidebarReady(ready: boolean): void {
     if (ready) {
       document.documentElement.setAttribute(SIDEBAR_READY_ATTR, '');
@@ -1632,9 +1642,16 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
 
   function setTopicSidebarCollapsed(collapsed: boolean, _expandBtn: HTMLElement): void {
     if (collapsed) {
+      window.clearTimeout(topicSidebarExpandTimer);
+      document.documentElement.removeAttribute('data-topic-sidebar-expanding');
       document.documentElement.setAttribute('data-topic-sidebar-collapsed', '');
     } else {
+      document.documentElement.setAttribute('data-topic-sidebar-expanding', '');
       document.documentElement.removeAttribute('data-topic-sidebar-collapsed');
+      window.clearTimeout(topicSidebarExpandTimer);
+      topicSidebarExpandTimer = window.setTimeout(() => {
+        document.documentElement.removeAttribute('data-topic-sidebar-expanding');
+      }, SIDEBAR_EXPAND_ANIMATION_MS);
     }
   }
 
@@ -1649,9 +1666,16 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     _collapseBtn: HTMLElement
   ) {
     if (collapsed) {
+      window.clearTimeout(sidebarExpandTimer);
+      document.documentElement.removeAttribute('data-sidebar-expanding');
       document.documentElement.setAttribute('data-sidebar-collapsed', '');
     } else {
+      document.documentElement.setAttribute('data-sidebar-expanding', '');
       document.documentElement.removeAttribute('data-sidebar-collapsed');
+      window.clearTimeout(sidebarExpandTimer);
+      sidebarExpandTimer = window.setTimeout(() => {
+        document.documentElement.removeAttribute('data-sidebar-expanding');
+      }, SIDEBAR_EXPAND_ANIMATION_MS);
     }
   }
 

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -138,6 +138,7 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
                 <li>
                   <a
                     href={topic.link}
+                    title={topic.label}
                     class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
                   >
                     {topic.icon && (
@@ -247,6 +248,7 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
               <li>
                 <a
                   href={topic.link}
+                  title={topic.label}
                   class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
                 >
                   {topic.icon && (

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -139,6 +139,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
                   <a
                     href={topic.link}
                     title={topic.label}
+                    aria-label={topic.label}
+                    aria-current={topic.isCurrent ? 'page' : undefined}
                     class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
                   >
                     {topic.icon && (
@@ -249,6 +251,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
                 <a
                   href={topic.link}
                   title={topic.label}
+                  aria-label={topic.label}
+                  aria-current={topic.isCurrent ? 'page' : undefined}
                   class:list={{ 'starlight-sidebar-topics-current': topic.isCurrent }}
                 >
                   {topic.icon && (
@@ -353,7 +357,11 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   }
   <div class="divider"></div>
   <div class="sidebar-bottom">
-    <LinkButton href={'https://github.com/microsoft/aspire.dev'} variant="minimal" title="aspire.dev">
+    <LinkButton
+      href={'https://github.com/microsoft/aspire.dev'}
+      variant="minimal"
+      title="aspire.dev"
+    >
       <Icon name="github" />
       <span>aspire.dev</span>
     </LinkButton>
@@ -369,6 +377,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-target="sidebar-toggle"
         aria-label="Collapse sidebar"
         title="Collapse sidebar"
+        aria-expanded="true"
+        aria-controls="starlight__sidebar"
       >
         <svg
           viewBox="0 0 24 24"
@@ -392,6 +402,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-target="sidebar-toggle"
         aria-label="Expand sidebar"
         title="Expand sidebar"
+        aria-expanded="false"
+        aria-controls="starlight__sidebar"
       >
         <svg
           viewBox="0 0 24 24"
@@ -422,6 +434,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-step="sidebar-toggle"
         aria-label="Collapse sidebar"
         title="Collapse sidebar"
+        aria-expanded="true"
+        aria-controls="starlight__sidebar"
       >
         <svg
           viewBox="0 0 24 24"
@@ -445,6 +459,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-target="sidebar-toggle"
         aria-label="Expand sidebar"
         title="Expand sidebar"
+        aria-expanded="false"
+        aria-controls="starlight__sidebar"
       >
         <svg
           viewBox="0 0 24 24"
@@ -1079,34 +1095,68 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     cursor: pointer;
     z-index: 20;
     box-shadow: 2px 1px 3px color-mix(in srgb, var(--sl-color-black) 14%, transparent);
-    /* Match the sidebar's width transition so the button slides with it. */
+    /* Match the sidebar's width transition so the button slides with it.
+       `visibility` flips instantly when becoming active so the button is
+       focusable mid-fade, and is delayed by the opacity duration when
+       deactivating so the fade-out can play. */
     transition:
       color 0.15s,
       background-color 0.15s,
       box-shadow 0.15s,
       opacity 0.25s ease,
       left 0.25s ease,
-      top 0.25s ease;
+      top 0.25s ease,
+      visibility 0s linear 0s;
   }
 
   /* Expand button starts hidden in the expanded state; collapse button
      starts hidden in the collapsed state. Both reside in the DOM and
-     transition opacity together with the sidebar width. */
+     transition opacity together with the sidebar width. `visibility:
+     hidden` is paired with the opacity fade so the inactive button is
+     truly inert — neither receivable to assistive tech nor reported as
+     visible to test runners like Playwright. */
   .sidebar-expand-btn {
     opacity: 0;
     pointer-events: none;
+    visibility: hidden;
+    transition:
+      color 0.15s,
+      background-color 0.15s,
+      box-shadow 0.15s,
+      opacity 0.25s ease,
+      left 0.25s ease,
+      top 0.25s ease,
+      visibility 0s linear 0.25s;
   }
 
   :global(html[data-sidebar-collapsed]) #sidebar-collapse-btn,
   :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-collapse-btn {
     opacity: 0;
     pointer-events: none;
+    visibility: hidden;
+    transition:
+      color 0.15s,
+      background-color 0.15s,
+      box-shadow 0.15s,
+      opacity 0.25s ease,
+      left 0.25s ease,
+      top 0.25s ease,
+      visibility 0s linear 0.25s;
   }
 
   :global(html[data-sidebar-collapsed]) #sidebar-expand-btn,
   :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-expand-btn {
     opacity: 1;
     pointer-events: auto;
+    visibility: visible;
+    transition:
+      color 0.15s,
+      background-color 0.15s,
+      box-shadow 0.15s,
+      opacity 0.25s ease,
+      left 0.25s ease,
+      top 0.25s ease,
+      visibility 0s linear 0s;
   }
 
   .sidebar-collapse-btn:hover,
@@ -1432,9 +1482,13 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         return;
       }
 
-      this.emptyCopyEl.textContent = query
+      const message = query
         ? `No sidebar article titles match "${query}".`
         : 'No matching sidebar article titles.';
+      this.emptyCopyEl.textContent = message;
+      // Also surface the message through the polite live region so screen
+      // readers hear *why* the list is empty, not just "0 matches".
+      this.updateStatus(message);
     }
   }
 
@@ -1563,6 +1617,22 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   let sidebarExpandTimer = 0;
   let topicSidebarExpandTimer = 0;
 
+  // Module-scoped observers so we can disconnect previous instances on
+  // re-init (astro:after-swap) instead of leaking one per navigation.
+  let bannerMutationObserver: MutationObserver | null = null;
+  let bannerResizeObserver: ResizeObserver | null = null;
+
+  function safeSetItem(key: string, value: string): void {
+    // localStorage can throw in private browsing / quota-exceeded /
+    // sandboxed iframes. Failing silently is the right call here — the
+    // in-memory DOM state still works, we just won't persist.
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      /* noop */
+    }
+  }
+
   function setSidebarReady(ready: boolean): void {
     if (ready) {
       document.documentElement.setAttribute(SIDEBAR_READY_ATTR, '');
@@ -1579,8 +1649,22 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     }
   }
 
+  function syncAriaExpanded(
+    collapseBtn: HTMLElement,
+    expandBtn: HTMLElement,
+    isCollapsed: boolean
+  ): void {
+    const value = isCollapsed ? 'false' : 'true';
+    collapseBtn.setAttribute('aria-expanded', value);
+    expandBtn.setAttribute('aria-expanded', value);
+  }
+
   function initSidebarCollapse() {
     setSidebarReady(false);
+    // Clear any pending expand-animation flag carried over from the
+    // previous page so it can't fire on the next page mid-navigation.
+    window.clearTimeout(sidebarExpandTimer);
+    document.documentElement.removeAttribute('data-sidebar-expanding');
 
     const container = document.querySelector('.topics-sidebar[data-api-ref]');
     if (!container) {
@@ -1593,21 +1677,37 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     const expandBtn = document.getElementById('sidebar-expand-btn');
     if (!collapseBtn || !expandBtn) return;
 
-    collapseBtn.addEventListener('click', () => {
-      setSidebarCollapsed(true, expandBtn, collapseBtn);
-      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
-    });
+    // Sync aria-expanded with the data-sidebar-collapsed attribute that
+    // Head.astro set from localStorage before this script ran.
+    syncAriaExpanded(
+      collapseBtn,
+      expandBtn,
+      document.documentElement.hasAttribute('data-sidebar-collapsed')
+    );
 
-    expandBtn.addEventListener('click', () => {
-      setSidebarCollapsed(false, expandBtn, collapseBtn);
-      localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '0');
-    });
+    if (collapseBtn.dataset.bound !== 'true') {
+      collapseBtn.dataset.bound = 'true';
+      collapseBtn.addEventListener('click', () => {
+        setSidebarCollapsed(true, expandBtn, collapseBtn);
+        safeSetItem(SIDEBAR_COLLAPSED_KEY, '1');
+      });
+    }
+
+    if (expandBtn.dataset.bound !== 'true') {
+      expandBtn.dataset.bound = 'true';
+      expandBtn.addEventListener('click', () => {
+        setSidebarCollapsed(false, expandBtn, collapseBtn);
+        safeSetItem(SIDEBAR_COLLAPSED_KEY, '0');
+      });
+    }
 
     setSidebarReady(true);
   }
 
   function initTopicSidebarCollapse() {
     setTopicSidebarReady(false);
+    window.clearTimeout(topicSidebarExpandTimer);
+    document.documentElement.removeAttribute('data-topic-sidebar-expanding');
 
     const container = document.querySelector('.topics-sidebar[data-topic-nav]');
     if (!container) {
@@ -1621,37 +1721,71 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
       return;
     }
 
+    syncAriaExpanded(
+      collapseBtn,
+      expandBtn,
+      document.documentElement.hasAttribute('data-topic-sidebar-collapsed')
+    );
+
     if (collapseBtn.dataset.bound !== 'true') {
       collapseBtn.dataset.bound = 'true';
       collapseBtn.addEventListener('click', () => {
-        setTopicSidebarCollapsed(true, expandBtn);
-        localStorage.setItem(TOPIC_SIDEBAR_COLLAPSED_KEY, '1');
+        setTopicSidebarCollapsed(true, expandBtn, collapseBtn);
+        safeSetItem(TOPIC_SIDEBAR_COLLAPSED_KEY, '1');
       });
     }
 
     if (expandBtn.dataset.bound !== 'true') {
       expandBtn.dataset.bound = 'true';
       expandBtn.addEventListener('click', () => {
-        setTopicSidebarCollapsed(false, expandBtn);
-        localStorage.setItem(TOPIC_SIDEBAR_COLLAPSED_KEY, '0');
+        setTopicSidebarCollapsed(false, expandBtn, collapseBtn);
+        safeSetItem(TOPIC_SIDEBAR_COLLAPSED_KEY, '0');
       });
     }
 
     setTopicSidebarReady(true);
   }
 
-  function setTopicSidebarCollapsed(collapsed: boolean, _expandBtn: HTMLElement): void {
+  function setTopicSidebarCollapsed(
+    collapsed: boolean,
+    expandBtn: HTMLElement,
+    collapseBtn: HTMLElement
+  ): void {
+    const root = document.documentElement;
+    const wasCollapsed = root.hasAttribute('data-topic-sidebar-collapsed');
+
     if (collapsed) {
       window.clearTimeout(topicSidebarExpandTimer);
-      document.documentElement.removeAttribute('data-topic-sidebar-expanding');
-      document.documentElement.setAttribute('data-topic-sidebar-collapsed', '');
+      root.removeAttribute('data-topic-sidebar-expanding');
+      root.setAttribute('data-topic-sidebar-collapsed', '');
+      collapseBtn.setAttribute('aria-expanded', 'false');
+      expandBtn.setAttribute('aria-expanded', 'false');
+      // Focus the now-visible button so keyboard users stay anchored.
+      try {
+        expandBtn.focus({ preventScroll: true });
+      } catch {
+        expandBtn.focus();
+      }
     } else {
-      document.documentElement.setAttribute('data-topic-sidebar-expanding', '');
-      document.documentElement.removeAttribute('data-topic-sidebar-collapsed');
-      window.clearTimeout(topicSidebarExpandTimer);
-      topicSidebarExpandTimer = window.setTimeout(() => {
-        document.documentElement.removeAttribute('data-topic-sidebar-expanding');
-      }, SIDEBAR_EXPAND_ANIMATION_MS);
+      // Only run the blur-in animation when actually transitioning from
+      // a collapsed state — not on initial load when we're already expanded.
+      if (wasCollapsed) {
+        root.setAttribute('data-topic-sidebar-expanding', '');
+        window.clearTimeout(topicSidebarExpandTimer);
+        topicSidebarExpandTimer = window.setTimeout(() => {
+          root.removeAttribute('data-topic-sidebar-expanding');
+        }, SIDEBAR_EXPAND_ANIMATION_MS);
+      }
+      root.removeAttribute('data-topic-sidebar-collapsed');
+      collapseBtn.setAttribute('aria-expanded', 'true');
+      expandBtn.setAttribute('aria-expanded', 'true');
+      if (wasCollapsed) {
+        try {
+          collapseBtn.focus({ preventScroll: true });
+        } catch {
+          collapseBtn.focus();
+        }
+      }
     }
   }
 
@@ -1662,20 +1796,41 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
 
   function setSidebarCollapsed(
     collapsed: boolean,
-    _expandBtn: HTMLElement,
-    _collapseBtn: HTMLElement
+    expandBtn: HTMLElement,
+    collapseBtn: HTMLElement
   ) {
+    const root = document.documentElement;
+    const wasCollapsed = root.hasAttribute('data-sidebar-collapsed');
+
     if (collapsed) {
       window.clearTimeout(sidebarExpandTimer);
-      document.documentElement.removeAttribute('data-sidebar-expanding');
-      document.documentElement.setAttribute('data-sidebar-collapsed', '');
+      root.removeAttribute('data-sidebar-expanding');
+      root.setAttribute('data-sidebar-collapsed', '');
+      collapseBtn.setAttribute('aria-expanded', 'false');
+      expandBtn.setAttribute('aria-expanded', 'false');
+      try {
+        expandBtn.focus({ preventScroll: true });
+      } catch {
+        expandBtn.focus();
+      }
     } else {
-      document.documentElement.setAttribute('data-sidebar-expanding', '');
-      document.documentElement.removeAttribute('data-sidebar-collapsed');
-      window.clearTimeout(sidebarExpandTimer);
-      sidebarExpandTimer = window.setTimeout(() => {
-        document.documentElement.removeAttribute('data-sidebar-expanding');
-      }, SIDEBAR_EXPAND_ANIMATION_MS);
+      if (wasCollapsed) {
+        root.setAttribute('data-sidebar-expanding', '');
+        window.clearTimeout(sidebarExpandTimer);
+        sidebarExpandTimer = window.setTimeout(() => {
+          root.removeAttribute('data-sidebar-expanding');
+        }, SIDEBAR_EXPAND_ANIMATION_MS);
+      }
+      root.removeAttribute('data-sidebar-collapsed');
+      collapseBtn.setAttribute('aria-expanded', 'true');
+      expandBtn.setAttribute('aria-expanded', 'true');
+      if (wasCollapsed) {
+        try {
+          collapseBtn.focus({ preventScroll: true });
+        } catch {
+          collapseBtn.focus();
+        }
+      }
     }
   }
 
@@ -1728,7 +1883,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     }
   }
 
-
   /* ── Banner height tracking ───────────────────────────────────── */
 
   /**
@@ -1754,14 +1908,27 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
 
     const banner = document.querySelector('.sl-banner') as HTMLElement | null;
     if (banner) {
+      // Disconnect any prior observers before re-attaching so we don't
+      // accumulate one set per client-side navigation.
+      bannerMutationObserver?.disconnect();
+      bannerResizeObserver?.disconnect();
+
       // Track state changes (open → closing) emitted by Banner.astro's controller
-      const mo = new MutationObserver(update);
-      mo.observe(banner, { attributes: true, attributeFilter: ['data-banner-state', 'hidden'] });
+      bannerMutationObserver = new MutationObserver(update);
+      bannerMutationObserver.observe(banner, {
+        attributes: true,
+        attributeFilter: ['data-banner-state', 'hidden'],
+      });
       // Track size changes too (e.g. responsive line-wrap)
       if (typeof ResizeObserver !== 'undefined') {
-        const ro = new ResizeObserver(update);
-        ro.observe(banner);
+        bannerResizeObserver = new ResizeObserver(update);
+        bannerResizeObserver.observe(banner);
       }
+    } else {
+      bannerMutationObserver?.disconnect();
+      bannerResizeObserver?.disconnect();
+      bannerMutationObserver = null;
+      bannerResizeObserver = null;
     }
 
     if (!(window as any).__bannerHeightResizeBound) {

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -390,7 +390,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-target="sidebar-toggle"
         aria-label="Expand sidebar"
         title="Expand sidebar"
-        hidden
       >
         <svg
           viewBox="0 0 24 24"
@@ -444,7 +443,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
         data-tour-target="sidebar-toggle"
         aria-label="Expand sidebar"
         title="Expand sidebar"
-        hidden
       >
         <svg
           viewBox="0 0 24 24"
@@ -1045,6 +1043,16 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
      edge. When an announcement banner is visible the JS controller
      writes --aspire-banner-height on <html>, pushing the button below
      the banner. */
+  /* Floating sidebar collapse/expand toggle. Both the collapse and the
+     expand button live at `left: var(--sl-sidebar-width)`, anchored to
+     the sidebar's right edge. When --sl-sidebar-width animates to 0,
+     the button slides flush to the viewport edge alongside the sidebar.
+
+     Both buttons share the same position. Visibility is driven by an
+     opacity crossfade keyed off `[data-sidebar-collapsed]` /
+     `[data-topic-sidebar-collapsed]` on <html>, with `pointer-events`
+     ensuring only the active button receives clicks. This keeps the
+     swap synchronised with the sidebar's width transition. */
   .sidebar-collapse-btn,
   .sidebar-expand-btn {
     position: fixed;
@@ -1055,31 +1063,52 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 2.5rem;
-    height: 2.5rem;
-    padding: 0.55rem;
-    background: var(--sl-color-bg-sidebar);
-    border: 1px solid var(--sl-color-hairline-light);
+    width: 3rem;
+    height: 3rem;
+    padding: 0.7rem;
+    background: var(--sl-color-bg);
+    border: none;
     /* Project from the sidebar's right edge — flat on the left, rounded
        on the right. When collapsed the button sits at left:0 and the
        flat left edge butts cleanly against the viewport border. */
-    border-left-color: transparent;
     border-radius: 0 0.375rem 0.375rem 0;
     color: var(--sl-color-text-accent);
     cursor: pointer;
     z-index: 20;
     box-shadow: 2px 1px 3px color-mix(in srgb, var(--sl-color-black) 14%, transparent);
+    /* Match the sidebar's width transition so the button slides with it. */
     transition:
       color 0.15s,
       background-color 0.15s,
       box-shadow 0.15s,
+      opacity 0.25s ease,
       left 0.25s ease,
       top 0.25s ease;
   }
+
+  /* Expand button starts hidden in the expanded state; collapse button
+     starts hidden in the collapsed state. Both reside in the DOM and
+     transition opacity together with the sidebar width. */
+  .sidebar-expand-btn {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  :global(html[data-sidebar-collapsed]) #sidebar-collapse-btn,
+  :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-collapse-btn {
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  :global(html[data-sidebar-collapsed]) #sidebar-expand-btn,
+  :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-expand-btn {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
   .sidebar-collapse-btn:hover,
   .sidebar-expand-btn:hover {
     color: var(--sl-color-text);
-    background-color: var(--sl-color-gray-6);
     box-shadow: 2px 2px 6px color-mix(in srgb, var(--sl-color-black) 22%, transparent);
   }
   .sidebar-collapse-btn:focus-visible,
@@ -1091,17 +1120,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   .sidebar-expand-btn svg {
     width: 100%;
     height: 100%;
-  }
-  .sidebar-collapse-btn[hidden],
-  .sidebar-expand-btn[hidden] {
-    display: none;
-  }
-
-  /* When the sidebar is collapsed, hide the collapse button (the expand
-     button takes its place). The data-* attributes live on <html>. */
-  :global(html[data-sidebar-collapsed]) #sidebar-collapse-btn,
-  :global(html[data-topic-sidebar-collapsed]) #topic-sidebar-collapse-btn {
-    display: none !important;
   }
 
   /* Hide collapse/expand on mobile-style sidebar (< 72rem for API pages) */
@@ -1563,11 +1581,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     const expandBtn = document.getElementById('sidebar-expand-btn');
     if (!collapseBtn || !expandBtn) return;
 
-    // Sync expand button visibility with the collapsed state
-    // (the data-sidebar-collapsed attribute is set early in Head.astro)
-    const isCollapsed = document.documentElement.hasAttribute('data-sidebar-collapsed');
-    expandBtn.hidden = !isCollapsed;
-
     collapseBtn.addEventListener('click', () => {
       setSidebarCollapsed(true, expandBtn, collapseBtn);
       localStorage.setItem(SIDEBAR_COLLAPSED_KEY, '1');
@@ -1596,9 +1609,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
       return;
     }
 
-    const isCollapsed = document.documentElement.hasAttribute('data-topic-sidebar-collapsed');
-    expandBtn.hidden = !isCollapsed;
-
     if (collapseBtn.dataset.bound !== 'true') {
       collapseBtn.dataset.bound = 'true';
       collapseBtn.addEventListener('click', () => {
@@ -1618,13 +1628,11 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     setTopicSidebarReady(true);
   }
 
-  function setTopicSidebarCollapsed(collapsed: boolean, expandBtn: HTMLElement): void {
+  function setTopicSidebarCollapsed(collapsed: boolean, _expandBtn: HTMLElement): void {
     if (collapsed) {
       document.documentElement.setAttribute('data-topic-sidebar-collapsed', '');
-      expandBtn.hidden = false;
     } else {
       document.documentElement.removeAttribute('data-topic-sidebar-collapsed');
-      expandBtn.hidden = true;
     }
   }
 
@@ -1635,24 +1643,14 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
 
   function setSidebarCollapsed(
     collapsed: boolean,
-    expandBtn: HTMLElement,
-    collapseBtn: HTMLElement
+    _expandBtn: HTMLElement,
+    _collapseBtn: HTMLElement
   ) {
     if (collapsed) {
       document.documentElement.setAttribute('data-sidebar-collapsed', '');
-      expandBtn.hidden = false;
     } else {
       document.documentElement.removeAttribute('data-sidebar-collapsed');
-      expandBtn.hidden = true;
     }
-  }
-
-  /** Auto-focus the sidebar filter input on API reference pages.
-   *  Skips if the page-level search input exists (it gets focus instead). */
-  function focusSidebarFilter() {
-    if (document.getElementById('api-search-input')) return;
-    const filterInput = document.getElementById('sidebar-filter-input') as HTMLInputElement | null;
-    filterInput?.focus();
   }
 
   // Guard against registering duplicate listeners on client-side navigation
@@ -1665,7 +1663,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     document.addEventListener('astro:after-swap', initSidebarCollapse);
     document.addEventListener('DOMContentLoaded', initTopicSidebarUi);
     document.addEventListener('astro:after-swap', initTopicSidebarUi);
-    document.addEventListener('astro:page-load', focusSidebarFilter);
     document.addEventListener('DOMContentLoaded', initBannerHeightTracking);
     document.addEventListener('astro:after-swap', initBannerHeightTracking);
     document.addEventListener('DOMContentLoaded', teleportSidebarToggles);
@@ -1677,8 +1674,6 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
   if (document.readyState !== 'loading') initTopicSidebarUi();
   if (document.readyState !== 'loading') initBannerHeightTracking();
   if (document.readyState !== 'loading') teleportSidebarToggles();
-  // Defer focus slightly to run after Astro/Starlight's own DOM setup
-  requestAnimationFrame(() => focusSidebarFilter());
 
   /* ── Sidebar toggle teleport ──────────────────────────────────── */
 

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -550,71 +550,11 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     padding-top: 0.75rem;
   }
 
-  /* Always-visible topics list sitting at the top of the sidebar. */
+  /* The visual styling for `.starlight-sidebar-topics` lives globally in
+     `site.css` (mirroring the original plugin look). The scoped class here
+     only adds a small bottom margin so the filter row beneath sits flush. */
   .topics-sidebar-list {
-    list-style: none;
-    margin: 0 0 0.75rem 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-  }
-
-  .topics-sidebar-list :global(li) {
-    margin: 0;
-    overflow-wrap: anywhere;
-  }
-
-  .topics-sidebar-list :global(a) {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.35rem 0.8rem;
-    font-size: var(--sl-text-sm, 0.875rem);
-    font-weight: 600;
-    line-height: 1.3;
-    color: var(--sl-color-white);
-    text-decoration: none;
-    border: 1px solid transparent;
-    border-radius: 0.375rem;
-  }
-
-  .topics-sidebar-list :global(a:hover),
-  .topics-sidebar-list :global(a:focus-visible) {
-    color: var(--sl-color-accent-high);
-    background-color: var(--sl-color-gray-6);
-  }
-
-  .topics-sidebar-list :global(a.starlight-sidebar-topics-current) {
-    color: var(--sl-color-accent-high);
-    background: var(--sidebar-dropdown-selected-bg);
-    border-color: var(--sidebar-dropdown-selected-border);
-  }
-
-  :global([data-theme='light']) .topics-sidebar-list :global(a.starlight-sidebar-topics-current) {
-    color: var(--sl-color-accent);
-  }
-
-  .topics-sidebar-list :global(.starlight-sidebar-topics-icon) {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.2rem;
-    border: 1px solid var(--sl-color-gray-4);
-    border-radius: 0.25rem;
-    flex-shrink: 0;
-  }
-
-  .topics-sidebar-list :global(a:hover) :global(.starlight-sidebar-topics-icon),
-  .topics-sidebar-list :global(a:focus-visible) :global(.starlight-sidebar-topics-icon),
-  .topics-sidebar-list :global(a.starlight-sidebar-topics-current) :global(.starlight-sidebar-topics-icon) {
-    background-color: var(--sl-color-text-accent);
-    border-color: var(--sl-color-text-accent);
-    color: var(--sl-color-text-invert);
-  }
-
-  .topics-sidebar-list :global(.starlight-sidebar-topics-badge) {
-    margin-inline-start: 0.25em;
+    margin-bottom: 0.75rem;
   }
 
   /* Filter row sits full-width directly below the topics list. */
@@ -1728,14 +1668,45 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     document.addEventListener('astro:page-load', focusSidebarFilter);
     document.addEventListener('DOMContentLoaded', initBannerHeightTracking);
     document.addEventListener('astro:after-swap', initBannerHeightTracking);
+    document.addEventListener('DOMContentLoaded', teleportSidebarToggles);
+    document.addEventListener('astro:after-swap', teleportSidebarToggles);
   }
   // Also init immediately in case DOMContentLoaded already fired
   if (document.readyState !== 'loading') initSidebarFilter();
   if (document.readyState !== 'loading') initSidebarCollapse();
   if (document.readyState !== 'loading') initTopicSidebarUi();
   if (document.readyState !== 'loading') initBannerHeightTracking();
+  if (document.readyState !== 'loading') teleportSidebarToggles();
   // Defer focus slightly to run after Astro/Starlight's own DOM setup
   requestAnimationFrame(() => focusSidebarFilter());
+
+  /* ── Sidebar toggle teleport ──────────────────────────────────── */
+
+  /**
+   * Move the floating sidebar collapse/expand toggle buttons to
+   * `<body>` so they escape the sidebar's stacking context. The
+   * sidebar pane lives in its own flex column; its descendants —
+   * even those with `position: fixed` — are still painted within
+   * the sidebar's flex item, which the main content area paints
+   * over. Reparenting to `<body>` puts the toggle in the root
+   * stacking context where its `z-index` actually wins, so mouse
+   * clicks reach the button instead of the page content beneath.
+   */
+  function teleportSidebarToggles() {
+    const ids = [
+      'sidebar-collapse-btn',
+      'sidebar-expand-btn',
+      'topic-sidebar-collapse-btn',
+      'topic-sidebar-expand-btn',
+    ];
+    for (const id of ids) {
+      const btn = document.getElementById(id);
+      if (btn && btn.parentElement !== document.body) {
+        document.body.appendChild(btn);
+      }
+    }
+  }
+
 
   /* ── Banner height tracking ───────────────────────────────────── */
 

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -42,11 +42,11 @@
   --color-dotnet-purple: #2c256b;
 
   --color-purple: var(--aspire-color-primary);
-  --color-magenta: hsl(316, 65%, 78%);  /* catppuccin-aligned pastel magenta */
+  --color-magenta: hsl(316, 65%, 78%); /* catppuccin-aligned pastel magenta */
   --color-flamingo: #f65163;
   --color-blue: #0078d7;
-  --color-cyan: hsl(183, 55%, 75%);     /* catppuccin-aligned pastel teal */
-  --color-yellow: hsl(50, 55%, 75%);    /* catppuccin-aligned pastel gold */
+  --color-cyan: hsl(183, 55%, 75%); /* catppuccin-aligned pastel teal */
+  --color-yellow: hsl(50, 55%, 75%); /* catppuccin-aligned pastel gold */
 
   /* Inline code surface (dark theme).
      bg uses currentColor (= the chip's text accent) mixed with #000 so the
@@ -99,15 +99,15 @@
     background-color: var(--aspire-color-secondary);
   }
 
-  .starlight-aside .starlight-aside--note>.starlight-aside__title {
+  .starlight-aside .starlight-aside--note > .starlight-aside__title {
     color: var(--sl-color-blue);
   }
 
-  aside.starlight-aside.starlight-aside--caution>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--caution > .starlight-aside__title {
     color: var(--sl-color-orange);
   }
 
-  aside.starlight-aside.starlight-aside--danger>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--danger > .starlight-aside__title {
     color: var(--sl-color-red);
   }
 
@@ -138,7 +138,7 @@
   --sl-color-text: var(--aspire-color-black) !important;
 
   /* WCAG AA contrast-safe text colors (catppuccin latte --sl-color-gray-2 #6c6f85 fails 4.5:1) */
-  --aspire-color-muted: #66697e;        /* 4.91:1 on #f3f4f7, 4.78:1 on #eff1f5 */
+  --aspire-color-muted: #66697e; /* 4.91:1 on #f3f4f7, 4.78:1 on #eff1f5 */
   --aspire-color-muted-strong: #515465; /* 4.85:1 on #ccd0da (kbd backgrounds) */
 
   /* Override green and orange-high for WCAG AA compliance (catppuccin defaults fail 4.5:1 threshold) */
@@ -148,9 +148,9 @@
   --sl-color-green-high: hsl(var(--sl-hue-green), 70%, 28%) !important;
   --sl-color-orange-high: hsl(var(--sl-hue-orange), 99%, 38%) !important;
 
-  --color-magenta: hsl(316, 85%, 38%);  /* catppuccin-aligned deep magenta */
-  --color-cyan: hsl(183, 85%, 28%);     /* catppuccin-aligned deep teal */
-  --color-yellow: hsl(50, 90%, 32%);    /* catppuccin-aligned deep gold */
+  --color-magenta: hsl(316, 85%, 38%); /* catppuccin-aligned deep magenta */
+  --color-cyan: hsl(183, 85%, 28%); /* catppuccin-aligned deep teal */
+  --color-yellow: hsl(50, 90%, 32%); /* catppuccin-aligned deep gold */
 
   /* Inline code surface (light theme).
      Same currentColor + neutral pattern as dark mode, but mixed with #fff
@@ -202,19 +202,19 @@
     color: var(--aspire-color-purple);
   }
 
-  aside.starlight-aside.starlight-aside--note>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--note > .starlight-aside__title {
     color: var(--sl-color-blue);
   }
 
-  aside.starlight-aside.starlight-aside--tip>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--tip > .starlight-aside__title {
     color: var(--sl-color-purple);
   }
 
-  aside.starlight-aside.starlight-aside--caution>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--caution > .starlight-aside__title {
     color: #ab3f00;
   }
 
-  aside.starlight-aside.starlight-aside--danger>.starlight-aside__title {
+  aside.starlight-aside.starlight-aside--danger > .starlight-aside__title {
     color: var(--sl-color-red);
   }
 
@@ -290,7 +290,9 @@
    :is(:root[data-theme='light']) anchors specificity high enough to
    beat both the dark (:root …) and light (:root[data-theme='light'] …)
    variants of the aside-link rule. */
-:is(:root[data-theme='light'], :root) .starlight-aside__content a:not([role='tab']):has(> code:only-child) {
+:is(:root[data-theme='light'], :root)
+  .starlight-aside__content
+  a:not([role='tab']):has(> code:only-child) {
   background: none;
   padding: 0;
   border-radius: 0;
@@ -326,9 +328,9 @@
   font-style: normal;
 }
 
-pre[data-language='bash']>code,
-pre[data-language='powershell']>code,
-pre[data-language='console']>code {
+pre[data-language='bash'] > code,
+pre[data-language='powershell'] > code,
+pre[data-language='console'] > code {
   line-height: initial;
 }
 
@@ -342,7 +344,10 @@ pre.mermaid[data-processed='true'] {
 
 /* Keep inline code together when it fits, but allow long tokens to wrap if needed. */
 /* Exclude td/th so code inside table cells keeps its default nowrap behavior. */
-:root:not(:has(.topics-sidebar[data-api-ref])) .sl-markdown-content :not(pre):not(td):not(th) > code:not(:where(.not-content *)) {
+:root:not(:has(.topics-sidebar[data-api-ref]))
+  .sl-markdown-content
+  :not(pre):not(td):not(th)
+  > code:not(:where(.not-content *)) {
   max-width: 100%;
   vertical-align: baseline;
   white-space: normal;
@@ -372,7 +377,7 @@ aside {
   margin-bottom: 1rem;
 }
 
-.sl-steps:has(> li:first-child > div.sl-heading-wrapper) {  
+.sl-steps:has(> li:first-child > div.sl-heading-wrapper) {
   padding-top: 1rem;
 }
 
@@ -410,20 +415,20 @@ starlight-file-tree .comment::before {
   transform-origin: center;
 }
 
-starlight-file-tree .directory>details>summary::marker,
-starlight-file-tree .directory>details>summary::-webkit-details-marker {
+starlight-file-tree .directory > details > summary::marker,
+starlight-file-tree .directory > details > summary::-webkit-details-marker {
   display: none !important;
 }
 
-starlight-file-tree .directory>details>summary {
+starlight-file-tree .directory > details > summary {
   list-style: none;
 }
 
-starlight-file-tree .directory>details>summary::-webkit-details-marker {
+starlight-file-tree .directory > details > summary::-webkit-details-marker {
   display: none !important;
 }
 
-starlight-file-tree .directory>details>summary::before {
+starlight-file-tree .directory > details > summary::before {
   content: '';
   display: inline-block;
   width: 1.25em;
@@ -432,11 +437,13 @@ starlight-file-tree .directory>details>summary::before {
   vertical-align: middle;
   background-color: currentColor;
   transition: transform 0.25s ease;
-  -webkit-mask: no-repeat center / contain url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='currentColor' d='M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z'/></svg>");
-  mask: no-repeat center / contain url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='currentColor' d='M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z'/></svg>");
+  -webkit-mask: no-repeat center / contain
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='currentColor' d='M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z'/></svg>");
+  mask: no-repeat center / contain
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24'><path fill='currentColor' d='M8.59 16.58L13.17 12L8.59 7.41L10 6l6 6l-6 6z'/></svg>");
 }
 
-starlight-file-tree .directory>details[open]>summary::before {
+starlight-file-tree .directory > details[open] > summary::before {
   transform: rotate(90deg);
 }
 
@@ -453,7 +460,7 @@ starlight-file-tree .directory>details[open]>summary::before {
 }
 
 #starlight__sidebar [aria-current='page'] {
-  border-radius: .5rem;
+  border-radius: 0.5rem;
 }
 
 footer .meta,
@@ -657,10 +664,12 @@ textarea:focus-visible {
 }
 
 :root:has(meta[name='page'][content='404']) #_top:hover {
-  background: linear-gradient(90deg,
-      var(--aspire-color) 0%,
-      var(--aspire-color-black) 50%,
-      var(--aspire-color) 100%);
+  background: linear-gradient(
+    90deg,
+    var(--aspire-color) 0%,
+    var(--aspire-color-black) 50%,
+    var(--aspire-color) 100%
+  );
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
@@ -670,10 +679,12 @@ textarea:focus-visible {
 }
 
 :root[data-theme='dark']:has(meta[name='page'][content='404']) #_top:hover {
-  background: linear-gradient(90deg,
-      var(--aspire-color) 0%,
-      var(--aspire-color-white) 50%,
-      var(--aspire-color) 100%);
+  background: linear-gradient(
+    90deg,
+    var(--aspire-color) 0%,
+    var(--aspire-color-white) 50%,
+    var(--aspire-color) 100%
+  );
   background-size: 200% 100%;
   background-clip: text;
   -webkit-background-clip: text;
@@ -713,7 +724,6 @@ textarea:focus-visible {
 
 /* Keyframes: quick squish (blink), then a gentle bounce with random flips */
 @keyframes blink-bounce {
-
   0%,
   15%,
   85%,
@@ -751,7 +761,7 @@ textarea:focus-visible {
   transform: translateY(-10%);
 }
 
-.hero>img {
+.hero > img {
   max-width: 100%;
   max-height: 15rem;
   height: auto;
@@ -798,7 +808,10 @@ textarea:focus-visible {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 0.375rem;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .starlight-sidebar-topics a:hover,
@@ -829,7 +842,10 @@ textarea:focus-visible {
   border-radius: 0.25rem;
   background: transparent;
   color: inherit;
-  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    border-color 0.15s,
+    color 0.15s;
 }
 
 .starlight-sidebar-topics a.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
@@ -893,17 +909,17 @@ site-search svg {
     padding-bottom: 1rem !important;
   }
 
-  .sl-markdown-content>.sl-heading-wrapper {
+  .sl-markdown-content > .sl-heading-wrapper {
     margin-top: 2rem;
     scroll-margin-top: 6rem;
   }
 
-  .sl-markdown-content>.sl-heading-wrapper:first-child {
+  .sl-markdown-content > .sl-heading-wrapper:first-child {
     margin-top: 0;
   }
 
-  .sl-markdown-content>.languages-supported+p,
-  .sl-markdown-content>.sl-heading-wrapper+p {
+  .sl-markdown-content > .languages-supported + p,
+  .sl-markdown-content > .sl-heading-wrapper + p {
     max-width: 80%;
   }
 
@@ -952,8 +968,8 @@ site-search svg {
       padding: 0.75rem 1.5rem;
     }
 
-    .sl-markdown-content>.languages-supported+p,
-    .sl-markdown-content>.sl-heading-wrapper+p {
+    .sl-markdown-content > .languages-supported + p,
+    .sl-markdown-content > .sl-heading-wrapper + p {
       max-width: 100%;
     }
 
@@ -985,7 +1001,7 @@ site-search svg {
 .d-inline {
   display: inline;
   vertical-align: middle;
-  padding: .1rem;
+  padding: 0.1rem;
 }
 
 #scroll-to-top-button {
@@ -1018,8 +1034,10 @@ li a.external-link::after {
   pointer-events: none;
   transition: transform 120ms ease;
 
-  -webkit-mask: no-repeat center / contain url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z'/><path d='M5 5h7v2H7v10h10v-5h2v7H5z'/></svg>");
-  mask: no-repeat center / contain url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z'/><path d='M5 5h7v2H7v10h10v-5h2v7H5z'/></svg>");
+  -webkit-mask: no-repeat center / contain
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z'/><path d='M5 5h7v2H7v10h10v-5h2v7H5z'/></svg>");
+  mask: no-repeat center / contain
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M14 3h7v7h-2V6.41l-9.29 9.3-1.42-1.42 9.3-9.29H14V3z'/><path d='M5 5h7v2H7v10h10v-5h2v7H5z'/></svg>");
 }
 
 :root {
@@ -1032,11 +1050,11 @@ li a.external-link::after {
 
 /* Widen sidebar for API reference pages (long package names) */
 :root:has(.topics-sidebar[data-api-ref]) {
-  --sl-sidebar-width: 40rem;  
+  --sl-sidebar-width: 40rem;
 }
 
 /* Narrower sidebar for TypeScript API reference pages */
-:root:has(.topics-sidebar[data-api-lang="ts"]) {
+:root:has(.topics-sidebar[data-api-lang='ts']) {
   --sl-sidebar-width: 30rem;
 }
 
@@ -1119,13 +1137,23 @@ li a.external-link::after {
   /* In rail mode, hide everything inside the sidebar except the topics
      card, the divider (so the footer floats to the bottom), and the
      bottom footer (GitHub icon). */
-  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
-  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
+  :root[data-sidebar-collapsed]
+    .topics-sidebar[data-api-ref]
+    > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
+  :root[data-topic-sidebar-collapsed]
+    .topics-sidebar[data-topic-nav]
+    > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
     display: none !important;
   }
 
-  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] .api-sidebar-sticky > *:not(.starlight-sidebar-topics),
-  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] .topic-sidebar-sticky > *:not(.starlight-sidebar-topics) {
+  :root[data-sidebar-collapsed]
+    .topics-sidebar[data-api-ref]
+    .api-sidebar-sticky
+    > *:not(.starlight-sidebar-topics),
+  :root[data-topic-sidebar-collapsed]
+    .topics-sidebar[data-topic-nav]
+    .topic-sidebar-sticky
+    > *:not(.starlight-sidebar-topics) {
     display: none !important;
   }
 
@@ -1133,7 +1161,9 @@ li a.external-link::after {
      else (card border/bg, icon-box, active treatment, row dimensions)
      is inherited from the expanded styles so the rail matches. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a {
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav])
+    .starlight-sidebar-topics
+    a {
     justify-content: center;
     gap: 0;
   }
@@ -1141,16 +1171,30 @@ li a.external-link::after {
   /* Hide the text labels inside the topics card and the footer link in
      rail mode. For the footer, we wrap the "aspire.dev" text in a
      <span> so we can target it cleanly here. */
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon),
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon),
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .sidebar-bottom .sl-link-button > span,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .sidebar-bottom .sl-link-button > span {
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref])
+    .starlight-sidebar-topics
+    a
+    > div:not(.starlight-sidebar-topics-icon),
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav])
+    .starlight-sidebar-topics
+    a
+    > div:not(.starlight-sidebar-topics-icon),
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref])
+    .sidebar-bottom
+    .sl-link-button
+    > span,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav])
+    .sidebar-bottom
+    .sl-link-button
+    > span {
     display: none;
   }
 
   /* Centre the GitHub footer link's icon in rail mode. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .sidebar-bottom .sl-link-button,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .sidebar-bottom .sl-link-button {
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav])
+    .sidebar-bottom
+    .sl-link-button {
     justify-content: center;
     gap: 0;
   }
@@ -1159,7 +1203,9 @@ li a.external-link::after {
      leaves enough room on its own (and the toggle still floats off the
      rail's right edge thanks to left: var(--sl-sidebar-width)). */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .content-panel > .sl-container,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .content-panel > .sl-container {
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav])
+    .content-panel
+    > .sl-container {
     padding-inline-start: 5rem;
   }
 
@@ -1167,11 +1213,23 @@ li a.external-link::after {
      expands. JS sets `data-sidebar-expanding` / `data-topic-sidebar-expanding`
      on <html> for ~320ms (just past the 250ms width transition), so this
      animation only plays on collapsed → expanded — not on initial load. */
-  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref]) .topics-sidebar[data-api-ref] .sidebar-filter,
-  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref]) .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
-  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav]) .topics-sidebar[data-topic-nav] .sidebar-filter,
-  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav]) .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
+  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref])
+    .topics-sidebar[data-api-ref]
+    .sidebar-filter,
+  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref])
+    .topics-sidebar[data-api-ref]
+    > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
+  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav])
+    .topics-sidebar[data-topic-nav]
+    .sidebar-filter,
+  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav])
+    .topics-sidebar[data-topic-nav]
+    > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
     animation: aspire-sidebar-blur-in 0.28s ease-out both;
+    /* Hint the compositor so the filter+opacity animation runs on the
+       GPU. Scoped to the brief window the flag is set so we don't keep
+       a layer pinned in memory long-term. */
+    will-change: filter, opacity;
   }
 }
 
@@ -1291,7 +1349,7 @@ it configures at which point the mobile toc should be replaced with the normal t
     display: flex;
   }
 
-  :root[data-has-toc] .content-panel>.sl-container {
+  :root[data-has-toc] .content-panel > .sl-container {
     margin-inline: 0;
   }
 }
@@ -1315,13 +1373,19 @@ it configures at which point the mobile toc should be replaced with the normal t
     display: block;
   }
 
-  :root[data-has-toc] .right-sidebar-panel>.sl-container {
-    max-width: calc(((100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 * var(--sl-sidebar-pad-x)) * .2
-          /* MAGIC NUMBER 🥲 */
-        ));
+  :root[data-has-toc] .right-sidebar-panel > .sl-container {
+    max-width: calc(
+      (
+        (
+            100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 *
+              var(--sl-sidebar-pad-x)
+          ) *
+          0.2 /* MAGIC NUMBER 🥲 */
+      )
+    );
   }
 
-  :root[data-has-toc] .content-panel>.sl-container {
+  :root[data-has-toc] .content-panel > .sl-container {
     margin-inline: var(--sl-content-margin-inline, auto);
   }
 }
@@ -1401,7 +1465,10 @@ header .try-aspire-btn,
   font-size: var(--sl-text-sm);
   text-decoration: none;
   border-radius: 0.5rem;
-  transition: background-color 0.2s ease, transform 0.15s ease, box-shadow 0.2s ease;
+  transition:
+    background-color 0.2s ease,
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
   white-space: nowrap;
   margin-inline-start: 0.5rem;
 }
@@ -1449,7 +1516,7 @@ header starlight-social-icons {
 }
 
 sl-sidebar-state-persist > span.sl-badge.small {
-  padding-right: .2rem;
+  padding-right: 0.2rem;
 }
 
 .pagination-links a {

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -757,21 +757,29 @@ textarea:focus-visible {
   height: auto;
 }
 
+/* Topic list styling — mirrors the original starlight-sidebar-topics
+   plugin: no border or background on the link, colour-only active/hover
+   state, boxed icons that fill with accent on active/hover. The same
+   markup appears in two places: rendered inline by us as the always-
+   visible topics list at the top of the sidebar, and (historically) by
+   the plugin itself. Keeping these as global rules so the styling
+   applies consistently regardless of where the markup originates. */
 .starlight-sidebar-topics {
   list-style: none;
   margin: 0 0 1rem 0;
-  padding: 0.25rem;
-  border: 1px solid var(--sl-color-hairline-light);
-  border-radius: 0.75rem;
-  background: var(--sl-color-bg);
+  padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 0.1rem;
 }
 
 .starlight-sidebar-topics li {
   margin: 0;
   padding: 0;
+  overflow-wrap: anywhere;
+}
+
+.starlight-sidebar-topics li + li {
+  margin-top: 0.25rem;
 }
 
 .starlight-sidebar-topics::after {
@@ -783,23 +791,31 @@ textarea:focus-visible {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border-radius: 0.5rem;
-  text-decoration: none;
-  color: var(--sl-color-text);
+  /* Left padding aligns the topic icon box with the filter icon
+     below it (both sit at --sidebar-control-pad-x = 0.8rem from the
+     container's content edge). */
+  padding: 0.3em var(--sidebar-control-pad-x, 0.8rem);
+  font-size: var(--sl-text-base);
   font-weight: 600;
-  transition: all 0.15s;
+  line-height: 1.5;
+  color: var(--sl-color-white);
+  text-decoration: none;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  transition: color 0.15s;
 }
 
 .starlight-sidebar-topics a:hover,
 .starlight-sidebar-topics a:focus-visible {
-  background: color-mix(in srgb, var(--aspire-color-secondary) 15%, transparent);
-  color: var(--sl-color-white);
+  background: transparent;
+  color: var(--sl-color-accent-high);
 }
 
 .starlight-sidebar-topics-current,
 .starlight-sidebar-topics a.starlight-sidebar-topics-current {
-  background: var(--sl-color-bg-nav);
-  border: 1px solid var(--aspire-color-secondary);
+  background: transparent;
+  border: none;
   color: var(--sl-color-accent-high);
 }
 
@@ -807,19 +823,21 @@ textarea:focus-visible {
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-right: 0.25rem;
-  border: none !important;
+  padding: 0.25rem;
+  margin-right: 0;
+  border: 1px solid var(--sl-color-gray-4);
+  border-radius: 0.25rem;
+  background: transparent;
+  flex-shrink: 0;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .starlight-sidebar-topics a:hover .starlight-sidebar-topics-icon,
-.starlight-sidebar-topics a:focus-visible .starlight-sidebar-topics-icon {
-  color: var(--sl-color-white);
-  background: initial;
-}
-
+.starlight-sidebar-topics a:focus-visible .starlight-sidebar-topics-icon,
 .starlight-sidebar-topics a.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
-  color: var(--sl-color-accent-high);
-  background: initial;
+  background-color: var(--sl-color-text-accent);
+  border-color: var(--sl-color-text-accent);
+  color: var(--sl-color-text-invert);
 }
 
 site-search svg {
@@ -855,24 +873,13 @@ site-search svg {
 }
 
 :root[data-theme='light'] {
-  .starlight-sidebar-topics {
-    background: var(--sl-color-bg-nav);
-    border: 1px solid var(--sl-color-gray-6);
-  }
-
   .starlight-sidebar-topics a {
     color: var(--sl-color-white);
   }
 
   .starlight-sidebar-topics a:hover,
-  .starlight-sidebar-topics a:focus-visible {
-  background: color-mix(in srgb, var(--aspire-color-primary) 15%, transparent);
-  }
-
-  .starlight-sidebar-topics-current,
+  .starlight-sidebar-topics a:focus-visible,
   .starlight-sidebar-topics a.starlight-sidebar-topics-current {
-    background: var(--sl-color-black);
-    border: 1px solid var(--aspire-color-primary);
     color: var(--sl-color-accent);
   }
 

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1077,20 +1077,19 @@ li a.external-link::after {
 }
 
 :root:has(.topics-sidebar[data-api-ref])[data-sidebar-collapsed] {
-  --sl-sidebar-width: 0rem;
+  --sl-sidebar-width: 3.5rem;
 }
 
 :root:has(.topics-sidebar[data-topic-nav])[data-topic-sidebar-collapsed] {
-  --sl-sidebar-width: 0rem;
+  --sl-sidebar-width: 3.5rem;
 }
 
 :root[data-has-toc] {
   --aspire-toc-panel-width: clamp(13.5rem, 16vw, 16rem);
 }
 
-/* Hide the entire sidebar content; the expand button is a sibling and stays visible.
-   Scoped to ≥ 72rem so the mobile overlay sidebar still works when
-   the user previously collapsed the desktop sidebar. */
+/* Collapsed sidebar = narrow "icon rail" showing just the topic icons.
+   The expand button still floats off the rail's right edge (left: var(--sl-sidebar-width)). */
 @media (min-width: 72rem) {
   :root[data-has-toc] .right-sidebar-panel {
     flex: 0 0 var(--aspire-toc-panel-width);
@@ -1102,30 +1101,56 @@ li a.external-link::after {
     max-width: var(--aspire-toc-panel-width);
   }
 
-  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] {
-    display: none !important;
-  }
-
-  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] {
-    display: none !important;
-  }
-
-  /* When fully collapsed, the sidebar pane has width 0 but must stay in
-     the DOM (display: block) so the floating expand button — which is a
-     descendant — continues to render. Drop the pane's right border and
-     padding so no residual chrome is visible. */
+  /* Strip the sidebar pane's chrome in rail mode but keep it visible. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar {
-    border-inline-end: none !important;
     background: transparent !important;
-    overflow: visible !important;
   }
 
+  /* In rail mode, hide everything inside the sidebar except the topics card. */
+  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky),
+  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky) {
+    display: none !important;
+  }
+
+  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] .api-sidebar-sticky > *:not(.starlight-sidebar-topics),
+  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] .topic-sidebar-sticky > *:not(.starlight-sidebar-topics) {
+    display: none !important;
+  }
+
+  /* Shrink the sidebar content's horizontal padding so the topics card
+     fits comfortably in the narrow rail. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar .sidebar-content,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar .sidebar-content {
-    padding: 0 !important;
+    padding-inline: 0.25rem !important;
   }
 
+  /* Topics card in rail mode: tighter padding, centred icons, no labels. */
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics {
+    padding: 0.25rem;
+  }
+
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a {
+    justify-content: center;
+    gap: 0;
+    padding: 0.3em 0;
+  }
+
+  /* Hide the label sibling (the <div> that isn't the icon box). */
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon),
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon) {
+    display: none;
+  }
+
+  /* Drop the floating toggle's overlap-shoulder when collapsed — the rail
+     leaves enough room on its own (and the toggle still floats off the
+     rail's right edge thanks to left: var(--sl-sidebar-width)). */
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .content-panel > .sl-container,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .content-panel > .sl-container {
+    padding-inline-start: 3.5rem;
+  }
 }
 
 /* API reference: keep mobile sidebar until 72rem (40rem sidebar is too wide for 50rem breakpoint) */

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1077,11 +1077,11 @@ li a.external-link::after {
 }
 
 :root:has(.topics-sidebar[data-api-ref])[data-sidebar-collapsed] {
-  --sl-sidebar-width: 3.5rem;
+  --sl-sidebar-width: 5rem;
 }
 
 :root:has(.topics-sidebar[data-topic-nav])[data-topic-sidebar-collapsed] {
-  --sl-sidebar-width: 3.5rem;
+  --sl-sidebar-width: 5rem;
 }
 
 :root[data-has-toc] {
@@ -1101,15 +1101,26 @@ li a.external-link::after {
     max-width: var(--aspire-toc-panel-width);
   }
 
-  /* Strip the sidebar pane's chrome in rail mode but keep it visible. */
+  /* In rail mode, give the sidebar a distinct bg so it reads as a panel
+     against the main content area (the page bg is white in light mode,
+     near-equal to the sidebar's normal white, so we lean on bg-nav).
+     Keep a right-edge border so the rail has a defined boundary. Also
+     drop the scrollbar gutter that the expanded sidebar reserves —
+     rail icons never overflow, and the gutter creates an asymmetric
+     right inset that pushes the card to the left. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar {
-    background: transparent !important;
+    background: var(--sl-color-bg-nav);
+    border-inline-end: 1px solid var(--sl-color-gray-5);
+    scrollbar-gutter: auto;
+    overflow-y: hidden;
   }
 
-  /* In rail mode, hide everything inside the sidebar except the topics card. */
-  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky),
-  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky) {
+  /* In rail mode, hide everything inside the sidebar except the topics
+     card, the divider (so the footer floats to the bottom), and the
+     bottom footer (GitHub icon). */
+  :root[data-sidebar-collapsed] .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
+  :root[data-topic-sidebar-collapsed] .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
     display: none !important;
   }
 
@@ -1118,30 +1129,30 @@ li a.external-link::after {
     display: none !important;
   }
 
-  /* Shrink the sidebar content's horizontal padding so the topics card
-     fits comfortably in the narrow rail. */
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar .sidebar-content,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar .sidebar-content {
-    padding-inline: 0.25rem !important;
-  }
-
-  /* Topics card in rail mode: tighter padding, centred icons, no labels. */
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics,
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics {
-    padding: 0.25rem;
-  }
-
+  /* In rail mode, centre the icon and hide the text label. Everything
+     else (card border/bg, icon-box, active treatment, row dimensions)
+     is inherited from the expanded styles so the rail matches. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a {
     justify-content: center;
     gap: 0;
-    padding: 0.3em 0;
   }
 
-  /* Hide the label sibling (the <div> that isn't the icon box). */
+  /* Hide the text labels inside the topics card and the footer link in
+     rail mode. For the footer, we wrap the "aspire.dev" text in a
+     <span> so we can target it cleanly here. */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon),
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon) {
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .starlight-sidebar-topics a > div:not(.starlight-sidebar-topics-icon),
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .sidebar-bottom .sl-link-button > span,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .sidebar-bottom .sl-link-button > span {
     display: none;
+  }
+
+  /* Centre the GitHub footer link's icon in rail mode. */
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .sidebar-bottom .sl-link-button,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .sidebar-bottom .sl-link-button {
+    justify-content: center;
+    gap: 0;
   }
 
   /* Drop the floating toggle's overlap-shoulder when collapsed — the rail
@@ -1149,7 +1160,38 @@ li a.external-link::after {
      rail's right edge thanks to left: var(--sl-sidebar-width)). */
   :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) .content-panel > .sl-container,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) .content-panel > .sl-container {
-    padding-inline-start: 3.5rem;
+    padding-inline-start: 5rem;
+  }
+
+  /* Subtle blur-in for the filter row and sidebar entries as the rail
+     expands. JS sets `data-sidebar-expanding` / `data-topic-sidebar-expanding`
+     on <html> for ~320ms (just past the 250ms width transition), so this
+     animation only plays on collapsed → expanded — not on initial load. */
+  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref]) .topics-sidebar[data-api-ref] .sidebar-filter,
+  :root[data-sidebar-expanding]:has(.topics-sidebar[data-api-ref]) .topics-sidebar[data-api-ref] > *:not(.api-sidebar-sticky):not(.divider):not(.sidebar-bottom),
+  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav]) .topics-sidebar[data-topic-nav] .sidebar-filter,
+  :root[data-topic-sidebar-expanding]:has(.topics-sidebar[data-topic-nav]) .topics-sidebar[data-topic-nav] > *:not(.topic-sidebar-sticky):not(.divider):not(.sidebar-bottom) {
+    animation: aspire-sidebar-blur-in 0.28s ease-out both;
+  }
+}
+
+@keyframes aspire-sidebar-blur-in {
+  from {
+    filter: blur(3px);
+    opacity: 0;
+  }
+  to {
+    filter: blur(0);
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :root[data-sidebar-expanding] .topics-sidebar[data-api-ref] .sidebar-filter,
+  :root[data-sidebar-expanding] .topics-sidebar[data-api-ref] > *,
+  :root[data-topic-sidebar-expanding] .topics-sidebar[data-topic-nav] .sidebar-filter,
+  :root[data-topic-sidebar-expanding] .topics-sidebar[data-topic-nav] > * {
+    animation: none !important;
   }
 }
 
@@ -1289,10 +1331,18 @@ it configures at which point the mobile toc should be replaced with the normal t
     navigation: auto;
   }
 
-  /* Give the sidebar its own view-transition group and disable its animation
-     so it doesn't participate in the cross-fade between topic pages. Without
-     this, sidebar items briefly flash an unstyled border during the swap. */
-  nav.sidebar {
+  /* Give the sidebar pane its own view-transition group and disable its
+     animation so it doesn't participate in the cross-fade between topic
+     pages. Without this, sidebar items briefly flash an unstyled border
+     during the swap.
+
+     Important: target `#starlight__sidebar` (the sidebar pane) rather
+     than `nav.sidebar` (the wrapper that ALSO contains the mobile menu
+     toggle). `view-transition-name` creates a stacking context — putting
+     it on the nav traps the mobile menu button inside a z-auto context
+     and the fixed top header (z-index: 10) paints over it, leaving
+     mobile users with no way to open the sidebar. */
+  #starlight__sidebar {
     view-transition-name: aspire-sidebar;
   }
 

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1072,11 +1072,11 @@ li a.external-link::after {
 }
 
 :root:has(.topics-sidebar[data-api-ref])[data-sidebar-collapsed] {
-  --sl-sidebar-width: 3.75rem;
+  --sl-sidebar-width: 0rem;
 }
 
 :root:has(.topics-sidebar[data-topic-nav])[data-topic-sidebar-collapsed] {
-  --sl-sidebar-width: 3.75rem;
+  --sl-sidebar-width: 0rem;
 }
 
 :root[data-has-toc] {
@@ -1105,22 +1105,20 @@ li a.external-link::after {
     display: none !important;
   }
 
-  /* Remove internal padding so the expand button can center in the full strip */
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar .sidebar-content {
-    padding-inline: 0;
-  }
-
-  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar .sidebar-content {
-    padding-inline: 0;
-  }
-
-  /* The sidebar border when collapsed */
-  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar {
-    border-inline-end: 1px solid var(--sl-color-hairline-light);
-  }
-
+  /* When fully collapsed, the sidebar pane has width 0 but must stay in
+     the DOM (display: block) so the floating expand button — which is a
+     descendant — continues to render. Drop the pane's right border and
+     padding so no residual chrome is visible. */
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar,
   :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar {
-    border-inline-end: 1px solid var(--sl-color-hairline-light);
+    border-inline-end: none !important;
+    background: transparent !important;
+    overflow: visible !important;
+  }
+
+  :root[data-sidebar-collapsed]:has(.topics-sidebar[data-api-ref]) #starlight__sidebar .sidebar-content,
+  :root[data-topic-sidebar-collapsed]:has(.topics-sidebar[data-topic-nav]) #starlight__sidebar .sidebar-content {
+    padding: 0 !important;
   }
 
 }
@@ -1246,6 +1244,19 @@ it configures at which point the mobile toc should be replaced with the normal t
 @media (prefers-reduced-motion: no-preference) {
   @view-transition {
     navigation: auto;
+  }
+
+  /* Give the sidebar its own view-transition group and disable its animation
+     so it doesn't participate in the cross-fade between topic pages. Without
+     this, sidebar items briefly flash an unstyled border during the swap. */
+  nav.sidebar {
+    view-transition-name: aspire-sidebar;
+  }
+
+  ::view-transition-old(aspire-sidebar),
+  ::view-transition-new(aspire-sidebar) {
+    animation: none !important;
+    mix-blend-mode: normal;
   }
 }
 

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -758,28 +758,26 @@ textarea:focus-visible {
 }
 
 /* Topic list styling — mirrors the original starlight-sidebar-topics
-   plugin: no border or background on the link, colour-only active/hover
-   state, boxed icons that fill with accent on active/hover. The same
-   markup appears in two places: rendered inline by us as the always-
-   visible topics list at the top of the sidebar, and (historically) by
-   the plugin itself. Keeping these as global rules so the styling
-   applies consistently regardless of where the markup originates. */
+   plugin: each link has no background or border, colour-only active/
+   hover state, boxed icons that fill with accent on active/hover.
+   The list itself sits inside a soft card container that visually
+   anchors the topic group within the sidebar. */
 .starlight-sidebar-topics {
   list-style: none;
   margin: 0 0 1rem 0;
-  padding: 0;
+  padding: 0.25rem;
+  border: 1px solid var(--sl-color-gray-5);
+  border-radius: 0.5rem;
+  background: var(--sl-color-bg);
   display: flex;
   flex-direction: column;
+  gap: 0.125rem;
 }
 
 .starlight-sidebar-topics li {
   margin: 0;
   padding: 0;
   overflow-wrap: anywhere;
-}
-
-.starlight-sidebar-topics li + li {
-  margin-top: 0.25rem;
 }
 
 .starlight-sidebar-topics::after {
@@ -791,32 +789,34 @@ textarea:focus-visible {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  /* Left padding aligns the topic icon box with the filter icon
-     below it (both sit at --sidebar-control-pad-x = 0.8rem from the
-     container's content edge). */
-  padding: 0.3em var(--sidebar-control-pad-x, 0.8rem);
+  padding: 0.3em;
   font-size: var(--sl-text-base);
   font-weight: 600;
   line-height: 1.5;
   color: var(--sl-color-white);
   text-decoration: none;
   background: transparent;
-  border: none;
-  border-radius: 0;
-  transition: color 0.15s;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 }
 
 .starlight-sidebar-topics a:hover,
 .starlight-sidebar-topics a:focus-visible {
-  background: transparent;
+  background: color-mix(in srgb, var(--sl-color-accent) 12%, transparent);
   color: var(--sl-color-accent-high);
 }
 
 .starlight-sidebar-topics-current,
 .starlight-sidebar-topics a.starlight-sidebar-topics-current {
-  background: transparent;
-  border: none;
+  background: color-mix(in srgb, var(--sl-color-accent) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--sl-color-accent) 45%, transparent);
   color: var(--sl-color-accent-high);
+}
+
+.starlight-sidebar-topics a.starlight-sidebar-topics-current:hover,
+.starlight-sidebar-topics a.starlight-sidebar-topics-current:focus-visible {
+  background: color-mix(in srgb, var(--sl-color-accent) 22%, transparent);
 }
 
 .starlight-sidebar-topics-icon {
@@ -825,15 +825,13 @@ textarea:focus-visible {
   justify-content: center;
   padding: 0.25rem;
   margin-right: 0;
-  border: 1px solid var(--sl-color-gray-4);
+  border: 1px solid transparent;
   border-radius: 0.25rem;
   background: transparent;
-  flex-shrink: 0;
+  color: inherit;
   transition: background-color 0.15s, border-color 0.15s, color 0.15s;
 }
 
-.starlight-sidebar-topics a:hover .starlight-sidebar-topics-icon,
-.starlight-sidebar-topics a:focus-visible .starlight-sidebar-topics-icon,
 .starlight-sidebar-topics a.starlight-sidebar-topics-current .starlight-sidebar-topics-icon {
   background-color: var(--sl-color-text-accent);
   border-color: var(--sl-color-text-accent);
@@ -880,7 +878,7 @@ site-search svg {
   .starlight-sidebar-topics a:hover,
   .starlight-sidebar-topics a:focus-visible,
   .starlight-sidebar-topics a.starlight-sidebar-topics-current {
-    color: var(--sl-color-accent);
+    color: var(--sl-color-accent-high);
   }
 
   /* Link hover effects */
@@ -1175,6 +1173,19 @@ li a.external-link::after {
   /* Keep MobileMenuFooter visible in mobile sidebar */
   :root:has(.topics-sidebar[data-api-ref]) .topics-sidebar > .md\:sl-hidden {
     display: block;
+  }
+}
+
+/* Reserve a "shoulder" of space on the main content area for the floating
+   sidebar toggle so it doesn't overlap the page H1. The toggle is 3rem wide
+   and anchored to the sidebar's right edge (or to the left viewport edge when
+   collapsed); reserving ~3.5rem of inline-start padding keeps the H1 and all
+   subsequent content cleanly to the right of it. Only applies on pages that
+   actually render the topics-sidebar (and only at the breakpoint where the
+   toggle is visible). */
+@media (min-width: 72rem) {
+  :root:has(.topics-sidebar) .content-panel > .sl-container {
+    padding-inline-start: 3.5rem;
   }
 }
 

--- a/src/frontend/tests/e2e/helpers.ts
+++ b/src/frontend/tests/e2e/helpers.ts
@@ -48,6 +48,11 @@ export async function waitForApiSidebarReady(page: Page): Promise<void> {
     .toBe(true);
   await expect(page.locator('#sidebar-collapse-btn')).toBeAttached();
   await expect(page.locator('#sidebar-expand-btn')).toBeAttached();
+  // Topics list (always-visible after the layout restructure) must
+  // render with at least one link before downstream tests interact.
+  await expect(
+    page.locator('.topics-sidebar[data-api-ref] .starlight-sidebar-topics').first()
+  ).toBeVisible();
   await expect
     .poll(async () => {
       const isCollapsed = await page.evaluate(() =>
@@ -71,6 +76,11 @@ export async function waitForTopicSidebarReady(page: Page): Promise<void> {
   await expect(page.locator('#topic-sidebar-collapse-btn')).toBeAttached();
   await expect(page.locator('#topic-sidebar-expand-btn')).toBeAttached();
   await expect(page.locator('#sidebar-filter-input')).toBeAttached();
+  // Topics list (always-visible after the layout restructure) must
+  // render with at least one link before downstream tests interact.
+  await expect(
+    page.locator('.topics-sidebar[data-topic-nav] .starlight-sidebar-topics').first()
+  ).toBeVisible();
   await expect
     .poll(async () => {
       const isCollapsed = await page.evaluate(() =>

--- a/src/frontend/tests/e2e/helpers.ts
+++ b/src/frontend/tests/e2e/helpers.ts
@@ -70,7 +70,6 @@ export async function waitForTopicSidebarReady(page: Page): Promise<void> {
     .toBe(true);
   await expect(page.locator('#topic-sidebar-collapse-btn')).toBeAttached();
   await expect(page.locator('#topic-sidebar-expand-btn')).toBeAttached();
-  await expect(page.locator('#topic-sidebar-trigger')).toBeAttached();
   await expect(page.locator('#sidebar-filter-input')).toBeAttached();
   await expect
     .poll(async () => {

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -341,7 +341,7 @@ test('API sidebar collapse state persists across reloads', async ({ page }) => {
   await expect.poll(() => readSidebarCollapsedPreference(page)).toBe('0');
 });
 
-test('API sidebar filter empty state and topic dropdown controls respond correctly', async ({
+test('API sidebar filter empty state and topics list controls respond correctly', async ({
   page,
 }) => {
   test.slow();
@@ -361,16 +361,14 @@ test('API sidebar filter empty state and topic dropdown controls respond correct
   const emptyState = page.locator('#sidebar-filter-empty');
   const emptyCopy = page.locator('#sidebar-filter-empty-copy');
   const emptyAction = page.locator('#sidebar-filter-empty-action');
-  const topicTrigger = page.locator('#topic-sidebar-trigger');
-  const topicPanel = page.locator('.topic-selector-dropdown [data-dropdown-panel]');
+  const topicsList = page.locator('.topics-sidebar .starlight-sidebar-topics').first();
 
-  await topicTrigger.click();
-  await expect(topicTrigger).toHaveAttribute('aria-expanded', 'true');
-  await expect(topicPanel).toBeVisible();
-
-  await page.keyboard.press('Escape');
-  await expect(topicTrigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(topicPanel).toBeHidden();
+  // Topics are now always visible as a list at the top of the sidebar
+  // (the previous dropdown trigger/panel were removed in the layout
+  // restructure). The list itself should be present and contain at least
+  // one topic link.
+  await expect(topicsList).toBeVisible();
+  await expect(topicsList.locator('a')).not.toHaveCount(0);
 
   await filterInput.fill('zzzz-sidebar-no-match');
 
@@ -403,16 +401,14 @@ test('topic sidebar custom controls persist collapse state and filter reset on r
   const emptyState = page.locator('#sidebar-filter-empty');
   const collapseButton = page.locator('#topic-sidebar-collapse-btn');
   const expandButton = page.locator('#topic-sidebar-expand-btn');
-  const topicTrigger = page.locator('#topic-sidebar-trigger');
-  const topicPanel = page.locator('.topic-selector-dropdown [data-dropdown-panel]');
+  const topicsList = page.locator('.topics-sidebar .starlight-sidebar-topics').first();
 
-  await topicTrigger.click();
-  await expect(topicTrigger).toHaveAttribute('aria-expanded', 'true');
-  await expect(topicPanel).toBeVisible();
-
-  await page.locator('main').click();
-  await expect(topicTrigger).toHaveAttribute('aria-expanded', 'false');
-  await expect(topicPanel).toBeHidden();
+  // Topics are now always visible as a list at the top of the sidebar
+  // (the previous dropdown trigger/panel were removed in the layout
+  // restructure). The list itself should be present and contain at least
+  // one topic link.
+  await expect(topicsList).toBeVisible();
+  await expect(topicsList.locator('a')).not.toHaveCount(0);
 
   await filterInput.fill('zzzz-topic-no-match');
   await expect(clearButton).toBeVisible();

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -168,7 +168,9 @@ test('homepage header actions stay reachable at zoomed and reflow widths', async
                 }
               }
 
-              return element.getAttribute('aria-label')?.trim() || element.textContent?.trim() || '';
+              return (
+                element.getAttribute('aria-label')?.trim() || element.textContent?.trim() || ''
+              );
             })
         )
       )
@@ -191,9 +193,11 @@ test('homepage header actions stay reachable at zoomed and reflow widths', async
       banner.getByRole('button', { name: /open cookie preferences dialog/i }).first()
     ).toBeVisible();
 
-    const installButton = banner.getByRole('button', {
-      name: /open install aspire cli dialog/i,
-    }).first();
+    const installButton = banner
+      .getByRole('button', {
+        name: /open install aspire cli dialog/i,
+      })
+      .first();
     await expect(installButton).toBeVisible();
     await installButton.click();
 
@@ -215,7 +219,10 @@ test('cookie consent reject-all keeps analytics disabled', async ({ page }) => {
   await page.goto('/get-started/prerequisites/');
   await openCookiePreferences(page);
 
-  await page.getByRole('button', { name: /reject all/i }).last().click();
+  await page
+    .getByRole('button', { name: /reject all/i })
+    .last()
+    .click();
   await waitForConsentRecorded(page);
   await waitForAnalyticsConsent(page, false);
   await waitForConsentCategories(page, ['necessary']);
@@ -361,14 +368,17 @@ test('API sidebar filter empty state and topics list controls respond correctly'
   const emptyState = page.locator('#sidebar-filter-empty');
   const emptyCopy = page.locator('#sidebar-filter-empty-copy');
   const emptyAction = page.locator('#sidebar-filter-empty-action');
-  const topicsList = page.locator('.topics-sidebar .starlight-sidebar-topics').first();
+  const topicsList = page
+    .locator('.topics-sidebar[data-api-ref] .starlight-sidebar-topics')
+    .first();
 
   // Topics are now always visible as a list at the top of the sidebar
   // (the previous dropdown trigger/panel were removed in the layout
-  // restructure). The list itself should be present and contain at least
-  // one topic link.
-  await expect(topicsList).toBeVisible();
+  // restructure). At least one topic link should be present, the current
+  // topic must be marked with `aria-current="page"`, and the filter still
+  // owns the no-match empty state.
   await expect(topicsList.locator('a')).not.toHaveCount(0);
+  await expect(topicsList.locator('a[aria-current="page"]')).toHaveCount(1);
 
   await filterInput.fill('zzzz-sidebar-no-match');
 
@@ -401,14 +411,17 @@ test('topic sidebar custom controls persist collapse state and filter reset on r
   const emptyState = page.locator('#sidebar-filter-empty');
   const collapseButton = page.locator('#topic-sidebar-collapse-btn');
   const expandButton = page.locator('#topic-sidebar-expand-btn');
-  const topicsList = page.locator('.topics-sidebar .starlight-sidebar-topics').first();
+  const topicsList = page
+    .locator('.topics-sidebar[data-topic-nav] .starlight-sidebar-topics')
+    .first();
 
   // Topics are now always visible as a list at the top of the sidebar
   // (the previous dropdown trigger/panel were removed in the layout
-  // restructure). The list itself should be present and contain at least
-  // one topic link.
-  await expect(topicsList).toBeVisible();
+  // restructure). At least one topic link, exactly one current-topic
+  // indicator, and the filter empty state are the same invariants the
+  // old dropdown test checked — just without the dropdown wrapper.
   await expect(topicsList.locator('a')).not.toHaveCount(0);
+  await expect(topicsList.locator('a[aria-current="page"]')).toHaveCount(1);
 
   await filterInput.fill('zzzz-topic-no-match');
   await expect(clearButton).toBeVisible();


### PR DESCRIPTION
Restructure the docs sidebar so topics are always discoverable and the filter/toggle layout works better at every breakpoint.

## Summary

Layout changes (rendered on every page that has the topics sidebar — both API-reference pages and topic-nav pages):

1. **Topics list is always visible.** The dropdown is gone; every topic renders as a discoverable, boxed card with a border that matches the filter input. The active topic gets an accent-tinted background + border and a filled accent icon box. Non-selected topic icons drop their border/background so they only decorate the active item.
2. **Filter input sits below the topics list, full-width.** No more side-by-side toolbar; the filter takes the whole sidebar width and lives in its own row.
3. **Collapse/expand toggle floats outside the sidebar.** The toggle is anchored to the sidebar's right edge (and snaps to `left: 0` when collapsed), teleported to `<body>` to escape stacking-context issues, and slides in sync with the sidebar's `width` transition via an opacity crossfade keyed off `[data-sidebar-collapsed]` / `[data-topic-sidebar-collapsed]` on `<html>`.
4. **Content panel reserves 3.5rem inline-start padding** when the topics sidebar is present (`≥ 72rem`) so the floating toggle never overlaps the page `<h1>`.

## Polish

- Topic-list card: `gray-5` border (matches filter input), `0.5rem` radius, `0.25rem` padding, distinct `--sl-color-bg` so it visually elevates from the sidebar.
- Active topic: `18%` accent background, `45%` accent border, filled accent icon box, `--sl-color-accent-high` text in light theme (fixes a WCAG 1.4.3 AA color-contrast issue — text-on-tint contrast jumps from 4.01:1 to ~11:1).
- Topic `<a>` padding equalised on all sides for a balanced visual rhythm.
- Floating toggle: 3rem ×ばつ 3rem, no border, no hover background change (just a subtle shadow lift and icon color shift on hover). Background matches the topics card.
- Hero icon: shrunk from 4rem to 3rem with 0.5rem padding (committed previously in this branch).
- Removed the auto-focus on the sidebar filter input — it was stealing focus from the page body on every navigation.

## Verified

- Light theme + dark theme, both breakpoints (`≥ 72rem` and `< 72rem`).
- Animation: sidebar width and toggle position transition together over 250ms — no more ""teleporting"" of the toggle on collapse/expand.
- Keyboard + click on all four toggle ids (`sidebar-collapse-btn`, `sidebar-expand-btn`, `topic-sidebar-collapse-btn`, `topic-sidebar-expand-btn`).
- WCAG 1.4.3 contrast: active topic text-on-bg ≈ 11:1 (light), well above AA's 4.5 requirement.
- H1 no longer overlapped by the toggle in expanded or collapsed state.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
