### PR TITLE
Refine upgrade Aspire page wording

### DIFF
--- a/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
+++ b/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
@@ -60,9 +60,7 @@ For more information, see [Aspire extension for VS Code](/get-started/aspire-vsc
 
 ## Remove the legacy workload (Aspire 8 only)
 
-Earlier Aspire 8 installations could include a legacy Aspire workload. If your machine has it installed, remove it after updating the CLI.
-
-This step is only needed when you're upgrading from Aspire 8 and the legacy workload is installed. For Aspire 9 or later, no action is required.
+If you're upgrading from Aspire 8 and your machine has the legacy Aspire workload installed, remove it after updating the CLI. For Aspire 9 or later, no action is required.
 
 Remove the **aspire workload** with the following command:
 

--- a/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
+++ b/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
@@ -31,9 +31,9 @@ If you're new to Aspire, there's no reason to upgrade anything. See [prerequisit
 
     This command automatically:
 
-    - Detects outdated Aspire packages and templates
-    - Updates package versions for the configured Aspire channel
-    - Handles versions declared inline or in supported centralized package version files
+    - Detects outdated Aspire integrations, templates, and SDK version
+    - Updates the SDK version and Aspire integration versions for the configured Aspire channel
+    - Handles versions declared inline, in `aspire.config.json`, or in supported centralized version files
 
 </Steps>
 

--- a/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
+++ b/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
@@ -1,13 +1,13 @@
 ---
 title: Upgrade Aspire
-description: Learn how to upgrade your Aspire projects to the latest version.
+description: Learn how to upgrade an Aspire app to the latest version.
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
 import { Kbd } from 'starlight-kbd/components';
 import LearnMore from '@components/LearnMore.astro';
 
-Upgrading Aspire involves updating the **Aspire CLI** itself, the **Aspire SDK**, and all related **packages** in your solution. The `aspire update` command handles most of this for you, but you may also need to review breaking changes and update tooling extensions.
+Upgrade Aspire by updating the **Aspire CLI** and the Aspire packages used by your app. The `aspire update` command handles most package updates for supported AppHost configurations, but you should also review breaking changes and update tooling extensions.
 
 <Aside type="note">
 If you're new to Aspire, there's no reason to upgrade anything. See [prerequisites](/get-started/prerequisites/) and [install Aspire CLI](/get-started/install-cli/) to get started.
@@ -23,17 +23,17 @@ If you're new to Aspire, there's no reason to upgrade anything. See [prerequisit
     aspire update --self
     ```
 
-2. **Update your Aspire solution** by running:
+2. **Update your Aspire app** by running:
 
-    ```bash title="Update your Aspire solution"
+    ```bash title="Update your Aspire app"
     aspire update
     ```
 
     This command automatically:
 
-    - Updates the [`Aspire.AppHost.Sdk` version](/get-started/aspire-sdk/)
-    - Updates all Aspire NuGet packages to the latest version
-    - Supports both regular projects and Central Package Management (CPM)
+    - Detects outdated Aspire packages and templates
+    - Updates package versions for the configured Aspire channel
+    - Handles versions declared inline or in supported centralized package version files
 
 </Steps>
 
@@ -60,15 +60,13 @@ For more information, see [Aspire extension for VS Code](/get-started/aspire-vsc
 
 ## Remove the legacy workload (Aspire 8 only)
 
-Still rocking the Aspire workload? No judgment here—we've all been there. 🕰️ Time to let it go and join us in the future!
+Earlier Aspire 8 installations could include a legacy Aspire workload. If your machine has it installed, remove it after updating the CLI.
 
-<Aside type="tip">
-This step is only needed if you're upgrading from Aspire 8. If you're already on Aspire 9 or later, you're good.
-</Aside>
+This step is only needed when you're upgrading from Aspire 8 and the legacy workload is installed. For Aspire 9 or later, no action is required.
 
-Please remove the **aspire workload** with the following command:
+Remove the **aspire workload** with the following command:
 
-```bash 
+```bash title="Remove the legacy Aspire workload"
 dotnet workload uninstall aspire
 ```
 


### PR DESCRIPTION
Updates the upgrade guide to avoid framing Aspire upgrades around .NET-specific concepts. The page now describes upgrading an Aspire app through CLI and package updates, and keeps the Aspire 8 workload cleanup as conditional guidance.

## Changes

- Replaces solution, SDK, NuGet, and CPM-oriented wording with app, package, and channel-oriented copy.
- Removes casual language from the Aspire 8 workload cleanup section.
- Clarifies that legacy workload removal only applies when upgrading from Aspire 8 and the workload is installed.

## Validation

- Not run: frontend dependencies are not installed in this worktree, so `pnpm --dir ./src/frontend exec prettier --check src/content/docs/whats-new/upgrade-aspire.mdx` could not find `prettier`.