### PR TITLE
Add API docs regen branch to update-integration-data workflow

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -1,14 +1,44 @@
 {
   "entries": {
+    "actions/checkout@v6.0.2": {
+      "repo": "actions/checkout",
+      "version": "v6.0.2",
+      "sha": "de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+    },
+    "actions/create-github-app-token@v3.1.1": {
+      "repo": "actions/create-github-app-token",
+      "version": "v3.1.1",
+      "sha": "1b10c78c7865c340bc4f6099eb2f838309f1e8c3"
+    },
+    "actions/download-artifact@v8.0.1": {
+      "repo": "actions/download-artifact",
+      "version": "v8.0.1",
+      "sha": "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c"
+    },
     "actions/github-script@v9.0.0": {
       "repo": "actions/github-script",
       "version": "v9.0.0",
       "sha": "3a2844b7e9c422d3c10d287c895573f7108da1b3"
     },
-    "github/gh-aw-actions/setup@v0.71.5": {
+    "actions/setup-dotnet@v5": {
+      "repo": "actions/setup-dotnet",
+      "version": "v5",
+      "sha": "c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7"
+    },
+    "actions/setup-node@v6.4.0": {
+      "repo": "actions/setup-node",
+      "version": "v6.4.0",
+      "sha": "48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e"
+    },
+    "actions/upload-artifact@v7.0.1": {
+      "repo": "actions/upload-artifact",
+      "version": "v7.0.1",
+      "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
+    },
+    "github/gh-aw-actions/setup@v0.72.0": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.71.5",
-      "sha": "b8068426813005612b960b5ab0b8bd2c27142323"
+      "version": "v0.72.0",
+      "sha": "ff0525b685481744f490a0d362753d8001e4b39d"
     },
     "github/gh-aw/actions/setup@v0.71.5": {
       "repo": "github/gh-aw/actions/setup",

--- a/.github/skills/update-integrations/SKILL.md
+++ b/.github/skills/update-integrations/SKILL.md
@@ -7,6 +7,8 @@ description: Update integration documentation links and API reference data by sy
 
 This skill synchronizes the integration package catalog with documentation URL mappings and generates per-package API reference schemas. It ensures every NuGet package listed in the integrations data file has a corresponding documentation link and an up-to-date API reference JSON file.
 
+> **Automation note:** The scheduled `update-integration-data` agentic workflow (`.github/workflows/update-integration-data.md`) now runs the C# and TypeScript API regeneration automatically whenever it detects a `"version":` change in `src/frontend/src/data/aspire-integrations.json`. Use this skill for **manual or one-off runs** — for example: adding a new integration, validating release-branch feed resolution, troubleshooting a regen failure flagged by the workflow's PR, or regenerating data outside the scheduled cadence.
+
 ## Overview
 
 The aspire.dev site maintains three key data locations:

--- a/.github/workflows/update-integration-data.lock.yml
+++ b/.github/workflows/update-integration-data.lock.yml
@@ -1,5 +1,5 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"96b823231c8a0d25eefc82eca6f6834a4ea6eab6cab4911ccc1f6b233a030ebf","compiler_version":"v0.71.5","strict":true,"agent_id":"copilot"}
-# gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"b8068426813005612b960b5ab0b8bd2c27142323","version":"v0.71.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40","digest":"sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504","pinned_image":"ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40","digest":"sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280","pinned_image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40","digest":"sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51","pinned_image":"ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1934472dfdaee4d93d497d678a940203472511afe4e1d28821d41b5e7ef408f1","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -14,7 +14,7 @@
 # \  /\  / (_) | | | | ( | | | | (_) \ V  V /\__ \
 #  \/  \/ \___/|_| |_|\_\|_| |_|\___/ \_/\_/ |___/
 #
-# This file was automatically generated by gh-aw (v0.71.5). DO NOT EDIT.
+# This file was automatically generated by gh-aw (v0.72.0). DO NOT EDIT.
 #
 # To update this file, edit the corresponding .md file and run:
 #   gh aw compile
@@ -22,7 +22,7 @@
 #
 # For more information: https://github.github.com/gh-aw/introduction/overview/
 #
-# Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes.
+# Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes. When integration package versions change, also regenerates the C# and TypeScript API reference JSON files (and the twoslash bundle) and includes them in the same PR.
 #
 # Secrets used:
 #   - ASPIRE_BOT_APP_ID
@@ -39,14 +39,15 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+#   - actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
 #   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-#   - github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+#   - github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
 #
 # Container images used:
-#   - ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504
-#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280
-#   - ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51
+#   - ghcr.io/github/gh-aw-firewall/agent:0.25.41
+#   - ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41
+#   - ghcr.io/github/gh-aw-firewall/squid:0.25.41
 #   - ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c
 #   - ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959
 #   - node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
@@ -89,7 +90,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        uses: github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -105,14 +106,14 @@ jobs:
           GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_INFO_VERSION: "1.0.40"
           GH_AW_INFO_AGENT_VERSION: "1.0.40"
-          GH_AW_INFO_CLI_VERSION: "v0.71.5"
+          GH_AW_INFO_CLI_VERSION: "v0.72.0"
           GH_AW_INFO_WORKFLOW_NAME: "Integration Data Updater"
           GH_AW_INFO_EXPERIMENTAL: "false"
           GH_AW_INFO_SUPPORTS_TOOLS_ALLOWLIST: "true"
           GH_AW_INFO_STAGED: "false"
           GH_AW_INFO_ALLOWED_DOMAINS: '["defaults","containers","node","dotnet","github"]'
           GH_AW_INFO_FIREWALL_ENABLED: "true"
-          GH_AW_INFO_AWF_VERSION: "v0.25.40"
+          GH_AW_INFO_AWF_VERSION: "v0.25.41"
           GH_AW_INFO_AWMG_VERSION: ""
           GH_AW_INFO_FIREWALL_TYPE: "squid"
           GH_AW_COMPILED_STRICT: "true"
@@ -164,7 +165,7 @@ jobs:
       - name: Check compile-agentic version
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
-          GH_AW_COMPILED_VERSION: "v0.71.5"
+          GH_AW_COMPILED_VERSION: "v0.72.0"
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -187,23 +188,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_3ed0a54b4d497bb3_EOF'
+          cat << 'GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF'
           <system>
-          GH_AW_PROMPT_3ed0a54b4d497bb3_EOF
+          GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3ed0a54b4d497bb3_EOF'
+          cat << 'GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF'
           <safe-output-tools>
           Tools: create_pull_request, close_pull_request(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_3ed0a54b4d497bb3_EOF
+          GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_3ed0a54b4d497bb3_EOF'
+          cat << 'GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_3ed0a54b4d497bb3_EOF
+          GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_3ed0a54b4d497bb3_EOF'
+          cat << 'GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -232,12 +233,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_3ed0a54b4d497bb3_EOF
+          GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_3ed0a54b4d497bb3_EOF'
+          cat << 'GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF'
           </system>
           {{#runtime-import .github/workflows/update-integration-data.md}}
-          GH_AW_PROMPT_3ed0a54b4d497bb3_EOF
+          GH_AW_PROMPT_e6323f3c8ae0ae2d_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -304,8 +305,11 @@ jobs:
           path: |
             /tmp/gh-aw/aw_info.json
             /tmp/gh-aw/aw-prompts/prompt.txt
+            /tmp/gh-aw/aw-prompts/prompt-template.txt
+            /tmp/gh-aw/aw-prompts/prompt-import-tree.json
             /tmp/gh-aw/github_rate_limits.jsonl
             /tmp/gh-aw/base
+            /tmp/gh-aw/.github/agents
           if-no-files-found: ignore
           retention-days: 1
 
@@ -339,7 +343,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        uses: github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -371,6 +375,14 @@ jobs:
         run: bash "${RUNNER_TEMP}/gh-aw/actions/configure_gh_for_ghe.sh"
         env:
           GH_TOKEN: ${{ github.token }}
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
+        with:
+          global-json-file: global.json
+      - name: Install Aspire CLI
+        run: |
+          dotnet tool install -g Aspire.Cli
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
       - name: Setup pnpm
         run: corepack enable && corepack install
         working-directory: src/frontend
@@ -410,7 +422,7 @@ jobs:
         env:
           GH_HOST: github.com
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.41
       - name: Determine automatic lockdown mode for GitHub MCP Server
         id: determine-automatic-lockdown
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
@@ -432,16 +444,21 @@ jobs:
           GH_AW_AGENT_FOLDERS: ".agents .claude .codex .crush .gemini .github .opencode .pi"
           GH_AW_AGENT_FILES: ".crush.json AGENTS.md CLAUDE.md GEMINI.md PI.md opencode.jsonc"
         run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_base_github_folders.sh"
+      - name: Restore inline sub-agents from activation artifact
+        env:
+          GH_AW_SUB_AGENT_DIR: ".github/agents"
+          GH_AW_SUB_AGENT_EXT: ".agent.md"
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/restore_inline_sub_agents.sh"
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.41 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41 ghcr.io/github/gh-aw-firewall/squid:0.25.41 ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959 node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f
       - name: Generate Safe Outputs Config
         run: |
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_6a8919d0ae278c84_EOF'
-          {"close_pull_request":{"max":5,"required_labels":[":octocat: auto-merge"],"required_title_prefix":"chore: Update integration data","target":"*"},"create_pull_request":{"allowed_files":["src/frontend/src/data/aspire-integrations.json","src/frontend/src/data/github-stats.json","src/frontend/src/data/samples.json","src/frontend/src/assets/samples/**"],"draft":false,"fallback_as_issue":false,"labels":[":octocat: auto-merge"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore: "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_6a8919d0ae278c84_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_426d66a2a89c715a_EOF'
+          {"close_pull_request":{"max":5,"required_labels":[":octocat: auto-merge"],"required_title_prefix":"chore: Update integration data","target":"*"},"create_pull_request":{"allowed_files":["src/frontend/src/data/aspire-integrations.json","src/frontend/src/data/github-stats.json","src/frontend/src/data/samples.json","src/frontend/src/assets/samples/**","src/frontend/src/data/pkgs/**","src/frontend/src/data/ts-modules/**","src/frontend/src/data/twoslash/aspire.d.ts"],"draft":false,"fallback_as_issue":false,"labels":[":octocat: auto-merge"],"max":1,"max_patch_files":100,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore: "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_426d66a2a89c715a_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -668,7 +685,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_0dfcea956f6061e7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_496fc484ae191bdb_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -709,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_0dfcea956f6061e7_EOF
+          GH_AW_MCP_CONFIG_496fc484ae191bdb_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -741,7 +758,7 @@ jobs:
           GH_AW_NODE_BIN=$(command -v node 2>/dev/null || true)
           export GH_AW_NODE_BIN
           (umask 177 && touch /tmp/gh-aw/agent-stdio.log)
-          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["*.docker.com","*.docker.io","*.githubusercontent.com","*.vsblob.vsassets.io","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.npms.io","api.nuget.org","api.snapcraft.io","archive.ubuntu.com","auth.docker.io","azure.archive.ubuntu.com","azuresearch-usnc.nuget.org","azuresearch-ussc.nuget.org","builds.dotnet.microsoft.com","bun.sh","cdn.jsdelivr.net","ci.dot.net","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dc.services.visualstudio.com","deb.nodesource.com","deno.land","dist.nuget.org","dl.k8s.io","docs.github.com","dot.net","dotnet.microsoft.com","dotnetcli.blob.core.windows.net","esm.sh","gcr.io","get.pnpm.io","ghcr.io","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","googleapis.deno.dev","googlechromelabs.github.io","host.docker.internal","json-schema.org","json.schemastore.org","jsr.io","keyserver.ubuntu.com","lfs.github.com","mcr.microsoft.com","nodejs.org","npm.pkg.github.com","npmjs.com","npmjs.org","nuget.org","nuget.pkg.github.com","nugetregistryv2prod.blob.core.windows.net","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","oneocsp.microsoft.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","pkgs.dev.azure.com","pkgs.k8s.io","ppa.launchpad.net","production.cloudflare.docker.com","quay.io","raw.githubusercontent.com","registry.bower.io","registry.hub.docker.com","registry.npmjs.com","registry.npmjs.org","registry.yarnpkg.com","repo.yarnpkg.com","s.symcb.com","s.symcd.com","security.ubuntu.com","skimdb.npmjs.com","storage.googleapis.com","telemetry.enterprise.githubcopilot.com","telemetry.vercel.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com","www.microsoft.com","www.npmjs.com","www.npmjs.org","yarnpkg.com"]},"apiProxy":{"enabled":true,"models":{"auto":["large"],"deep-research":["copilot/deep-research*","google/deep-research*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"]}},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.41/awf-config.schema.json","network":{"allowDomains":["*.docker.com","*.docker.io","*.githubusercontent.com","*.vsblob.vsassets.io","api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","api.npms.io","api.nuget.org","api.snapcraft.io","archive.ubuntu.com","auth.docker.io","azure.archive.ubuntu.com","azuresearch-usnc.nuget.org","azuresearch-ussc.nuget.org","builds.dotnet.microsoft.com","bun.sh","cdn.jsdelivr.net","ci.dot.net","codeload.github.com","crl.geotrust.com","crl.globalsign.com","crl.identrust.com","crl.sectigo.com","crl.thawte.com","crl.usertrust.com","crl.verisign.com","crl3.digicert.com","crl4.digicert.com","crls.ssl.com","dc.services.visualstudio.com","deb.nodesource.com","deno.land","dist.nuget.org","dl.k8s.io","docs.github.com","dot.net","dotnet.microsoft.com","dotnetcli.blob.core.windows.net","esm.sh","gcr.io","get.pnpm.io","ghcr.io","github-cloud.githubusercontent.com","github-cloud.s3.amazonaws.com","github.blog","github.com","github.githubassets.com","googleapis.deno.dev","googlechromelabs.github.io","host.docker.internal","json-schema.org","json.schemastore.org","jsr.io","keyserver.ubuntu.com","lfs.github.com","mcr.microsoft.com","nodejs.org","npm.pkg.github.com","npmjs.com","npmjs.org","nuget.org","nuget.pkg.github.com","nugetregistryv2prod.blob.core.windows.net","objects.githubusercontent.com","ocsp.digicert.com","ocsp.geotrust.com","ocsp.globalsign.com","ocsp.identrust.com","ocsp.sectigo.com","ocsp.ssl.com","ocsp.thawte.com","ocsp.usertrust.com","ocsp.verisign.com","oneocsp.microsoft.com","packagecloud.io","packages.cloud.google.com","packages.microsoft.com","pkgs.dev.azure.com","pkgs.k8s.io","ppa.launchpad.net","production.cloudflare.docker.com","quay.io","raw.githubusercontent.com","registry.bower.io","registry.hub.docker.com","registry.npmjs.com","registry.npmjs.org","registry.yarnpkg.com","repo.yarnpkg.com","s.symcb.com","s.symcd.com","security.ubuntu.com","skimdb.npmjs.com","storage.googleapis.com","telemetry.enterprise.githubcopilot.com","telemetry.vercel.com","ts-crl.ws.symantec.com","ts-ocsp.ws.symantec.com","www.googleapis.com","www.microsoft.com","www.npmjs.com","www.npmjs.org","yarnpkg.com"]},"apiProxy":{"enabled":true,"models":{"auto":["large"],"deep-research":["copilot/deep-research*","google/deep-research*"],"gemini-flash":["copilot/gemini-*flash*","google/gemini-*flash*"],"gemini-pro":["copilot/gemini-*pro*","google/gemini-*pro*"],"gpt-4.1":["copilot/gpt-4.1*","openai/gpt-4.1*"],"gpt-5":["copilot/gpt-5*","openai/gpt-5*"],"gpt-5-codex":["copilot/gpt-5*codex*","openai/gpt-5*codex*"],"gpt-5-mini":["copilot/gpt-5*mini*","openai/gpt-5*mini*"],"gpt-5-nano":["copilot/gpt-5*nano*","openai/gpt-5*nano*"],"gpt-5-pro":["copilot/gpt-5*pro*","openai/gpt-5*pro*"],"haiku":["copilot/*haiku*","anthropic/*haiku*"],"large":["sonnet","gpt-5-pro","gpt-5","gemini-pro"],"mini":["haiku","gpt-5-mini","gpt-5-nano","gemini-flash"],"opus":["copilot/*opus*","anthropic/*opus*"],"reasoning":["copilot/o1*","copilot/o3*","copilot/o4*","openai/o1*","openai/o3*","openai/o4*"],"small":["mini"],"sonnet":["copilot/*sonnet*","anthropic/*sonnet*"]}},"container":{"imageTag":"0.25.41"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --exclude-env GITHUB_MCP_SERVER_TOKEN --exclude-env MCP_GATEWAY_API_KEY --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
             -- /bin/bash -c 'export PATH="${RUNNER_TEMP}/gh-aw/mcp-cli/bin:$PATH" && export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --allow-all-paths --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
@@ -754,7 +771,7 @@ jobs:
           GH_AW_PHASE: agent
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
           GH_AW_SAFE_OUTPUTS: ${{ steps.set-runtime-paths.outputs.GH_AW_SAFE_OUTPUTS }}
-          GH_AW_VERSION: v0.71.5
+          GH_AW_VERSION: v0.72.0
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
           GITHUB_COPILOT_INTEGRATION_ID: agentic-workflows
@@ -869,7 +886,7 @@ jobs:
         run: |
           # Fix permissions on firewall logs/audit dirs so they can be uploaded as artifacts
           # AWF runs with sudo, creating files owned by root
-          sudo chmod -R a+r /tmp/gh-aw/sandbox/firewall 2>/dev/null || true
+          sudo chmod -R a+rX /tmp/gh-aw/sandbox/firewall 2>/dev/null || true
           # Only run awf logs summary if awf command exists (it may not be installed if workflow failed before install step)
           if command -v awf &> /dev/null; then
             awf logs summary | tee -a "$GITHUB_STEP_SUMMARY"
@@ -952,7 +969,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        uses: github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1114,7 +1131,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        uses: github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1148,7 +1165,7 @@ jobs:
           rm -rf /tmp/gh-aw/sandbox/firewall/logs
           rm -rf /tmp/gh-aw/sandbox/firewall/audit
       - name: Download container images
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.40@sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.40@sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280 ghcr.io/github/gh-aw-firewall/squid:0.25.40@sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/download_docker_images.sh" ghcr.io/github/gh-aw-firewall/agent:0.25.41 ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41 ghcr.io/github/gh-aw-firewall/squid:0.25.41
       - name: Check if detection needed
         id: detection_guard
         if: always()
@@ -1188,7 +1205,7 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           WORKFLOW_NAME: "Integration Data Updater"
-          WORKFLOW_DESCRIPTION: "Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes."
+          WORKFLOW_DESCRIPTION: "Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes. When integration package versions change, also regenerates the C# and TypeScript API reference JSON files (and the twoslash bundle) and includes them in the same PR."
           HAS_PATCH: ${{ needs.agent.outputs.has_patch }}
         with:
           script: |
@@ -1211,7 +1228,7 @@ jobs:
         env:
           GH_HOST: github.com
       - name: Install AWF binary
-        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.40
+        run: bash "${RUNNER_TEMP}/gh-aw/actions/install_awf_binary.sh" v0.25.41
       - name: Execute GitHub Copilot CLI
         if: always() && steps.detection_guard.outputs.run_detection == 'true'
         continue-on-error: true
@@ -1224,7 +1241,7 @@ jobs:
           GH_AW_NODE_BIN=$(command -v node 2>/dev/null || true)
           export GH_AW_NODE_BIN
           (umask 177 && touch /tmp/gh-aw/threat-detection/detection.log)
-          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.40/awf-config.schema.json","network":{"allowDomains":["api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","github.com","host.docker.internal","telemetry.enterprise.githubcopilot.com"]},"apiProxy":{"enabled":true},"container":{"imageTag":"0.25.40,squid=sha256:b084f4a2c771f584ee68084ced52fa6b3245197a1889645d817462d307d3ac51,agent=sha256:14ff567e8d9d4c2fbc5e55c973488381c71d7e0fdbe72d30ee7b8a738fd86504,api-proxy=sha256:2883ca3e5ae9f330cafdd9345bfd4ae17fc8da36c96d4c9a1f76e922b4c45280,cli-proxy=sha256:3e7152911d4b4b7b97beef9d3d7d924ff7902227e86001ef3838fb728d5d514c"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
+          printf '%s\n' '{"$schema":"https://github.com/github/gh-aw-firewall/releases/download/v0.25.41/awf-config.schema.json","network":{"allowDomains":["api.business.githubcopilot.com","api.enterprise.githubcopilot.com","api.github.com","api.githubcopilot.com","api.individual.githubcopilot.com","github.com","host.docker.internal","telemetry.enterprise.githubcopilot.com"]},"apiProxy":{"enabled":true},"container":{"imageTag":"0.25.41"}}' > "${RUNNER_TEMP}/gh-aw/awf-config.json" && cp "${RUNNER_TEMP}/gh-aw/awf-config.json" /tmp/gh-aw/awf-config.json
           # shellcheck disable=SC1003
           sudo -E awf --config "${RUNNER_TEMP}/gh-aw/awf-config.json" --container-workdir "${GITHUB_WORKSPACE}" --mount "${RUNNER_TEMP}/gh-aw:${RUNNER_TEMP}/gh-aw:ro" --mount "${RUNNER_TEMP}/gh-aw:/host${RUNNER_TEMP}/gh-aw:ro" --env-all --exclude-env COPILOT_GITHUB_TOKEN --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --audit-dir /tmp/gh-aw/sandbox/firewall/audit --enable-host-access --allow-host-ports 80,443,8080 --skip-pull \
             -- /bin/bash -c 'export PATH="$(find /opt/hostedtoolcache /home/runner/work/_tool -maxdepth 4 -type d -name bin 2>/dev/null | tr '\''\n'\'' '\'':'\'')$PATH"; [ -n "$GOROOT" ] && export PATH="$GOROOT/bin:$PATH" || true && GH_AW_NODE_EXEC="${GH_AW_NODE_BIN:-}"; if [ -z "$GH_AW_NODE_EXEC" ] || [ ! -x "$GH_AW_NODE_EXEC" ]; then GH_AW_NODE_EXEC="$(command -v node 2>/dev/null || echo node)"; fi; "$GH_AW_NODE_EXEC" ${RUNNER_TEMP}/gh-aw/actions/copilot_harness.cjs /usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --disable-builtin-mcps --no-ask-user --allow-all-tools --add-dir "${GITHUB_WORKSPACE}" --prompt-file /tmp/gh-aw/aw-prompts/prompt.txt' 2>&1 | tee -a /tmp/gh-aw/threat-detection/detection.log
@@ -1235,7 +1252,7 @@ jobs:
           COPILOT_MODEL: ${{ vars.GH_AW_MODEL_DETECTION_COPILOT || 'claude-sonnet-4.6' }}
           GH_AW_PHASE: detection
           GH_AW_PROMPT: /tmp/gh-aw/aw-prompts/prompt.txt
-          GH_AW_VERSION: v0.71.5
+          GH_AW_VERSION: v0.72.0
           GITHUB_API_URL: ${{ github.api_url }}
           GITHUB_AW: true
           GITHUB_COPILOT_INTEGRATION_ID: agentic-workflows
@@ -1321,7 +1338,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@b8068426813005612b960b5ab0b8bd2c27142323 # v0.71.5
+        uses: github/gh-aw-actions/setup@ff0525b685481744f490a0d362753d8001e4b39d # v0.72.0
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1361,11 +1378,34 @@ jobs:
           github-api-url: ${{ github.api_url }}
           permission-contents: write
           permission-pull-requests: write
+      - name: Extract base branch from agent output
+        id: extract-base-branch
+        if: steps.download-agent-output.outcome == 'success'
+        shell: bash
+        run: |
+          if [ -f "/tmp/gh-aw/agent_output.json" ]; then
+            GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
+            BASE_BRANCH=$("$GH_AW_NODE" -e "
+              try {
+                const data = JSON.parse(require('fs').readFileSync('/tmp/gh-aw/agent_output.json', 'utf8'));
+                const item = (data.items || []).find(i =>
+                  (i.type === 'create_pull_request' || i.type === 'push_to_pull_request_branch') &&
+                  i.base_branch
+                );
+                if (item) process.stdout.write(item.base_branch);
+              } catch(e) {}
+            " 2>/dev/null || true)
+            # Validate: only allow safe git branch name characters
+            if [[ "$BASE_BRANCH" =~ ^[a-zA-Z0-9/_.-]+$ ]] && [ ${#BASE_BRANCH} -le 255 ]; then
+              printf 'base-branch=%s\n' "$BASE_BRANCH" >> "$GITHUB_OUTPUT"
+              echo "Extracted base branch from safe output: $BASE_BRANCH"
+            fi
+          fi
       - name: Checkout repository
         if: (!cancelled()) && needs.agent.result != 'skipped' && contains(needs.agent.outputs.output_types, 'create_pull_request')
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
+          ref: ${{ steps.extract-base-branch.outputs.base-branch || github.base_ref || github.event.pull_request.base.ref || github.ref_name || github.event.repository.default_branch }}
           token: ${{ steps.safe-outputs-app-token.outputs.token }}
           persist-credentials: false
           fetch-depth: 1
@@ -1400,7 +1440,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.docker.com,*.docker.io,*.githubusercontent.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,auth.docker.io,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,bun.sh,cdn.jsdelivr.net,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,dist.nuget.org,dl.k8s.io,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,esm.sh,gcr.io,get.pnpm.io,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,mcr.microsoft.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,pkgs.k8s.io,ppa.launchpad.net,production.cloudflare.docker.com,quay.io,raw.githubusercontent.com,registry.bower.io,registry.hub.docker.com,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":5,\"required_labels\":[\":octocat: auto-merge\"],\"required_title_prefix\":\"chore: Update integration data\",\"target\":\"*\"},\"create_pull_request\":{\"allowed_files\":[\"src/frontend/src/data/aspire-integrations.json\",\"src/frontend/src/data/github-stats.json\",\"src/frontend/src/data/samples.json\",\"src/frontend/src/assets/samples/**\"],\"draft\":false,\"fallback_as_issue\":false,\"labels\":[\":octocat: auto-merge\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore: \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":5,\"required_labels\":[\":octocat: auto-merge\"],\"required_title_prefix\":\"chore: Update integration data\",\"target\":\"*\"},\"create_pull_request\":{\"allowed_files\":[\"src/frontend/src/data/aspire-integrations.json\",\"src/frontend/src/data/github-stats.json\",\"src/frontend/src/data/samples.json\",\"src/frontend/src/assets/samples/**\",\"src/frontend/src/data/pkgs/**\",\"src/frontend/src/data/ts-modules/**\",\"src/frontend/src/data/twoslash/aspire.d.ts\"],\"draft\":false,\"fallback_as_issue\":false,\"labels\":[\":octocat: auto-merge\"],\"max\":1,\"max_patch_files\":100,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore: \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/update-integration-data.md
+++ b/.github/workflows/update-integration-data.md
@@ -1,5 +1,5 @@
 ---
-description: Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes.
+description: Daily update of integration data, sample metadata, and GitHub statistics by running pnpm update:all and creating a PR with the changes. When integration package versions change, also regenerates the C# and TypeScript API reference JSON files (and the twoslash bundle) and includes them in the same PR.
 on:
   schedule: daily on weekdays
 permissions:
@@ -9,6 +9,14 @@ runtimes:
   node:
     version: "24"
 steps:
+  - name: Setup .NET SDK
+    uses: actions/setup-dotnet@v5
+    with:
+      global-json-file: global.json
+  - name: Install Aspire CLI
+    run: |
+      dotnet tool install -g Aspire.Cli
+      echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
   - name: Setup pnpm
     run: corepack enable && corepack install
     working-directory: src/frontend
@@ -36,6 +44,9 @@ safe-outputs:
       - "src/frontend/src/data/github-stats.json"
       - "src/frontend/src/data/samples.json"
       - "src/frontend/src/assets/samples/**"
+      - "src/frontend/src/data/pkgs/**"
+      - "src/frontend/src/data/ts-modules/**"
+      - "src/frontend/src/data/twoslash/aspire.d.ts"
   close-pull-request:
     required-labels: [":octocat: auto-merge"]
     required-title-prefix: "chore: Update integration data"
@@ -53,9 +64,57 @@ You are an automation agent that updates integration data and GitHub statistics 
 1. Run the update script from the repository root: `pnpm update:all`
 2. Check if any files were modified using `git diff --stat`
 3. Review the generated integration data for official Aspire package icon warnings
-4. Check for existing open PRs created by this workflow
-5. If there are changes, create a pull request with the updated data files
-6. If there are no changes, call the `noop` safe output explaining that integration data is already up to date
+4. **Detect integration package version changes** in `src/frontend/src/data/aspire-integrations.json` (see "Version-change detection" below)
+5. **If version changes were detected, run the API reference regeneration branch** (see "API reference regeneration" below)
+6. Check for existing open PRs created by this workflow
+7. If there are changes, create a single pull request with the updated data files (and, when triggered, the regenerated API reference files)
+8. If there are no changes, call the `noop` safe output explaining that integration data is already up to date
+
+## Version-change detection
+
+After `pnpm update:all` completes, determine whether any package version field in `src/frontend/src/data/aspire-integrations.json` changed. The C# and TypeScript API reference data are keyed by package + version, so we only regenerate them when a version actually moves — metadata-only changes (icons, descriptions, download counts) must **not** trigger the regen branch.
+
+Run this from the repository root:
+
+```bash
+git diff --unified=0 -- src/frontend/src/data/aspire-integrations.json \
+  | grep -E '^[+-][[:space:]]*"version":' \
+  | sort -u
+```
+
+Treat it as a version change when **any** matching `+/-` `"version":` line exists (a value moved up, was added for a new package, or was removed for a deprecated package). Capture the affected package titles for the PR body — read each diff hunk and extract the `"title"` field of the surrounding entry so the PR body can list the packages that triggered the regen.
+
+If `git diff` shows no `"version":` lines, skip the regeneration branch and record "no version changes — API regen skipped" in the PR body.
+
+## API reference regeneration
+
+This branch only runs when version-change detection found at least one changed `"version":` line. When triggered:
+
+1. **Regenerate C# API reference JSON** for every package in `aspire-integrations.json`:
+
+   ```bash
+   pwsh src/tools/PackageJsonGenerator/generate-package-json.ps1
+   ```
+
+   The script writes `src/frontend/src/data/pkgs/{Package}.{Version}.json` files. Capture the script's success/failure summary for the PR body — successes, failures, and skipped packages (meta-packages without `lib/` content typically appear as skipped).
+
+2. **Regenerate TypeScript API reference JSON and the twoslash bundle**:
+
+   ```bash
+   pnpm --filter ./src/frontend run update:ts-api
+   ```
+
+   This script reads the C# package JSON from step 1, selects the `Aspire.Hosting` and `Aspire.Hosting.*` packages, and runs `aspire sdk dump` for each. It writes `src/frontend/src/data/ts-modules/{Package}.{Version}.json` files and then automatically chains `scripts/generate-twoslash-types.ts` to rebuild `src/frontend/src/data/twoslash/aspire.d.ts`. Capture any per-package failures for the PR body.
+
+3. **Verify the regen diff is well-scoped.** After both scripts complete, run `git status` and confirm changes are limited to:
+
+   - `src/frontend/src/data/pkgs/**`
+   - `src/frontend/src/data/ts-modules/**`
+   - `src/frontend/src/data/twoslash/aspire.d.ts`
+
+   plus the metadata files already produced by `pnpm update:all`. If the diff includes anything outside these paths, stop and report a `missing_tool` or `missing_data` safe output explaining the unexpected file.
+
+4. **File-count summary for the PR body.** Use `git diff --name-status` to count added (`A`), modified (`M`), and removed (`D`) files under `src/frontend/src/data/pkgs/`, `src/frontend/src/data/ts-modules/`, and whether `src/frontend/src/data/twoslash/aspire.d.ts` changed.
 
 ## Existing PR Handling
 
@@ -104,6 +163,10 @@ The update script should resolve official Aspire package icons to package-specif
   - `github-stats.json` — repository star counts, descriptions, and license info
   - `samples.json` — Aspire sample metadata
 - `pnpm update:all` can also refresh sample thumbnail assets under `src/frontend/src/assets/samples/`
+- When the API reference regeneration branch runs, additional files change under:
+  - `src/frontend/src/data/pkgs/` — per-package C# API JSON
+  - `src/frontend/src/data/ts-modules/` — per-package TypeScript API JSON
+  - `src/frontend/src/data/twoslash/aspire.d.ts` — consolidated twoslash type bundle
 - Use today's date in the PR title formatted as `M/D/YY` (e.g., `2/24/26`)
 - When creating a PR, first create a local branch, add only the allowed generated files, and commit the changes locally. Then call `create-pull-request` with `branch` set to the exact output of `git branch --show-current`.
 - Never include workflow files, package manifests, lockfiles, source files, or documentation edits in the generated data PR.
@@ -112,7 +175,7 @@ The update script should resolve official Aspire package icons to package-specif
 
 **Title**: `Update integration data and GitHub stats (DATE)`
 
-**Body** (use this template):
+**Body** (use this template; include the **API reference regeneration** section only when that branch actually ran):
 
 ```markdown
 ## Automated Integration Data Update - DATE
@@ -128,15 +191,43 @@ This PR contains automated updates to:
 - `src/frontend/src/data/samples.json` — Sample metadata, when changed
 - `src/frontend/src/assets/samples/` — Sample thumbnails, when changed
 
+### API reference regeneration
+
+<!-- Only include this section when version-change detection triggered the regen branch. -->
+<!-- Otherwise replace the entire section body with: -->
+<!-- _No integration package versions changed in this run — API reference regeneration was skipped._ -->
+
+Versions changed for the following packages, so the C# and TypeScript API reference data and the twoslash bundle were regenerated:
+
+- `<Aspire.Hosting.Foo>` `<old>` → `<new>`
+- `<Aspire.Hosting.Bar>` `<old>` → `<new>`
+- _(list truncated to first 10; full list visible in the diff)_
+
+| Area | Added | Modified | Removed |
+|---|---|---|---|
+| `src/frontend/src/data/pkgs/**` | _N_ | _N_ | _N_ |
+| `src/frontend/src/data/ts-modules/**` | _N_ | _N_ | _N_ |
+| `src/frontend/src/data/twoslash/aspire.d.ts` | — | _yes/no_ | — |
+
+Generator summary:
+
+- C# (`generate-package-json.ps1`): _S_ succeeded, _F_ failed, _K_ skipped
+- TS (`pnpm update:ts-api`): _S_ succeeded, _F_ failed
+- Failures (if any): `<Package@Version>` — _reason_
+
 ### Review Checklist
+
 - [ ] Verify integration data looks reasonable
 - [ ] Check for any suspicious changes or anomalies
 - [ ] Ensure package counts and versions are updated appropriately
 - [ ] Confirm official Aspire package icons still use package-specific NuGet icon URLs
+- [ ] (If regen ran) The set of new/removed `pkgs/` and `ts-modules/` files matches the version changes — no orphaned files for packages that didn't change
+- [ ] (If regen ran) `src/frontend/src/data/twoslash/aspire.d.ts` was committed (the diff must include this file or hover tooltips fall back to `any`)
+- [ ] (If regen ran) Generator failure list is empty or limited to known meta-packages
 ```
 
 ## Safe Outputs
 
-- If files were modified and no existing PR: use `create-pull-request` with the title and body above
+- If files were modified and no existing PR: use `create-pull-request` with the title and body above. The PR body must include the **API reference regeneration** section, populated when the regen branch ran or marked as skipped otherwise.
 - If files were modified and existing workflow-created PRs were found: use `create-pull-request` for the replacement and `close-pull-request` for the superseded PRs
 - If no files were modified: use `noop` with a clear explanation

--- a/.github/workflows/update-integration-data.md
+++ b/.github/workflows/update-integration-data.md
@@ -88,25 +88,27 @@ If `git diff` shows no `"version":` lines, skip the regeneration branch and reco
 
 ## API reference regeneration
 
-This branch only runs when version-change detection found at least one changed `"version":` line. When triggered:
+This branch only runs when version-change detection found at least one changed `"version":` line. The three phases below **must run in order** — each phase depends on the output of the previous one. Phases 2 and 3 happen to be wired together inside the same `pnpm` script (`scripts/update-ts-api.ts` chains the twoslash generator after the TS API generator), but they are described separately so the dependency chain is explicit and so per-phase failures can be reported in the PR body.
 
-1. **Regenerate C# API reference JSON** for every package in `aspire-integrations.json`:
+1. **Regenerate C# API reference JSON.** Produces the per-package JSON that the TS API phase depends on for package discovery.
 
    ```bash
    pwsh src/tools/PackageJsonGenerator/generate-package-json.ps1
    ```
 
-   The script writes `src/frontend/src/data/pkgs/{Package}.{Version}.json` files. Capture the script's success/failure summary for the PR body — successes, failures, and skipped packages (meta-packages without `lib/` content typically appear as skipped).
+   The script writes `src/frontend/src/data/pkgs/{Package}.{Version}.json` files for every package in `aspire-integrations.json`. Capture the script's success/failure summary for the PR body — successes, failures, and skipped packages (meta-packages without `lib/` content typically appear as skipped).
 
-2. **Regenerate TypeScript API reference JSON and the twoslash bundle**:
+2. **Regenerate TypeScript API reference JSON.** Depends on the C# package JSON from phase 1.
 
    ```bash
    pnpm --filter ./src/frontend run update:ts-api
    ```
 
-   This script reads the C# package JSON from step 1, selects the `Aspire.Hosting` and `Aspire.Hosting.*` packages, and runs `aspire sdk dump` for each. It writes `src/frontend/src/data/ts-modules/{Package}.{Version}.json` files and then automatically chains `scripts/generate-twoslash-types.ts` to rebuild `src/frontend/src/data/twoslash/aspire.d.ts`. Capture any per-package failures for the PR body.
+   `scripts/update-ts-api.ts` reads the freshly written `pkgs/*.json`, selects the `Aspire.Hosting` and `Aspire.Hosting.*` packages, runs `aspire sdk dump` for each via `src/tools/AtsJsonGenerator/generate-ts-api-json.ps1`, and writes `src/frontend/src/data/ts-modules/{Package}.{Version}.json` files. Capture any per-package failures for the PR body. Once the TS API JSON is written, the same script automatically continues into phase 3 — do not invoke it a second time.
 
-3. **Verify the regen diff is well-scoped.** After both scripts complete, run `git status` and confirm changes are limited to:
+3. **Regenerate the twoslash `.d.ts` bundle.** Depends on the TS API JSON from phase 2. This phase is **chained automatically** by `pnpm update:ts-api`; it runs `scripts/generate-twoslash-types.ts` against the freshly written `ts-modules/*.json` and rewrites `src/frontend/src/data/twoslash/aspire.d.ts`. If `pnpm update:ts-api` fails partway through the chain, distinguish in the PR body between a phase-2 failure (TS API generation) and a phase-3 failure (twoslash bundle) using the script's `❌ Generation failed:` vs `❌ Twoslash type generation failed:` log markers.
+
+4. **Verify the regen diff is well-scoped.** After all three phases complete, run `git status` and confirm changes are limited to:
 
    - `src/frontend/src/data/pkgs/**`
    - `src/frontend/src/data/ts-modules/**`
@@ -114,7 +116,7 @@ This branch only runs when version-change detection found at least one changed `
 
    plus the metadata files already produced by `pnpm update:all`. If the diff includes anything outside these paths, stop and report a `missing_tool` or `missing_data` safe output explaining the unexpected file.
 
-4. **File-count summary for the PR body.** Use `git diff --name-status` to count added (`A`), modified (`M`), and removed (`D`) files under `src/frontend/src/data/pkgs/`, `src/frontend/src/data/ts-modules/`, and whether `src/frontend/src/data/twoslash/aspire.d.ts` changed.
+5. **File-count summary for the PR body.** Use `git diff --name-status` to count added (`A`), modified (`M`), and removed (`D`) files under `src/frontend/src/data/pkgs/`, `src/frontend/src/data/ts-modules/`, and whether `src/frontend/src/data/twoslash/aspire.d.ts` changed.
 
 ## Existing PR Handling
 
@@ -211,8 +213,9 @@ Versions changed for the following packages, so the C# and TypeScript API refere
 
 Generator summary:
 
-- C# (`generate-package-json.ps1`): _S_ succeeded, _F_ failed, _K_ skipped
-- TS (`pnpm update:ts-api`): _S_ succeeded, _F_ failed
+- C# API JSON (`generate-package-json.ps1` → `pkgs/`): _S_ succeeded, _F_ failed, _K_ skipped
+- TS API JSON (`update-ts-api.ts` → `ts-modules/`): _S_ succeeded, _F_ failed
+- Twoslash bundle (`generate-twoslash-types.ts` → `twoslash/aspire.d.ts`): _succeeded / failed_
 - Failures (if any): `<Package@Version>` — _reason_
 
 ### Review Checklist


### PR DESCRIPTION
## Summary

Extends the existing `update-integration-data` agentic workflow so that, when integration package versions in `aspire-integrations.json` actually change, it also regenerates the API reference data and includes the result in the same PR.

Today the workflow only runs `pnpm update:all`, which refreshes `aspire-integrations.json`, `github-stats.json`, `samples.json`, and sample thumbnails. The C# (`pkgs/`), TypeScript (`ts-modules/`), and twoslash (`aspire.d.ts`) data sets have to be regenerated by hand whenever package versions move (see `.github/skills/update-integrations/SKILL.md`). This change moves that regen into the scheduled workflow without slowing down metadata-only days.

## Approach

- **Single combined PR.** The workflow continues to produce one PR. A new section in the PR body documents whether the API regen branch ran and which packages drove it.
- **Trigger.** Any `+ "version":` / `- "version":` line in the `aspire-integrations.json` diff. Metadata-only updates (icons, descriptions, download counts) skip the regen path entirely.
- **Full regen, not selective.** When triggered, the agent runs `pwsh src/tools/PackageJsonGenerator/generate-package-json.ps1` (no `-Packages` filter) and `pnpm --filter ./src/frontend run update:ts-api`. The TS script already chains the twoslash bundle refresh via `generate-twoslash-types.ts`.

## Changes

- `.github/workflows/update-integration-data.md`
  - Add `actions/setup-dotnet@v5` (`global-json-file: global.json`) and an `Install Aspire CLI` step (`dotnet tool install -g Aspire.Cli`) before the existing pnpm setup. The AWF agent container inherits `PATH` from the host, so tools installed via `setup-dotnet` are reachable.
  - Extend `safe-outputs.create-pull-request.allowed-files` with `src/frontend/src/data/pkgs/**`, `src/frontend/src/data/ts-modules/**`, and `src/frontend/src/data/twoslash/aspire.d.ts`.
  - Add **Version-change detection** and **API reference regeneration** sections to the prompt, plus regen-specific fields in the PR body template and review checklist.
- `.github/workflows/update-integration-data.lock.yml` and `.github/aw/actions-lock.json`: regenerated via `gh aw compile update-integration-data`.
- `.github/skills/update-integrations/SKILL.md`: brief automation handoff note clarifying the skill is now for manual / one-off runs.

## Validation

- `gh aw compile update-integration-data` succeeds; `gh aw compile --validate` reports no errors.
- Synthesized a `"version"` diff against the real `aspire-integrations.json` and confirmed the detection grep picks up every changed line:

  ```bash
  git diff --unified=0 -- src/frontend/src/data/aspire-integrations.json \
    | grep -E '^[+-][[:space:]]*"version":'
  ```

- No existing tests cover this automation. The first scheduled run after merge will exercise the end-to-end path.

## Notes / follow-ups

- This recompile also incidentally bumped `github/gh-aw-actions/setup` v0.71.5 → v0.72.0 and AWF firewall containers 0.25.40 → 0.25.41 (the local `gh aw` extension is on v0.72.0). Functional but flagging in case you want it split out.
- `Aspire.Cli` is installed as a stable global tool. If only a prerelease is available on a given day, the install would need `--prerelease`; happy to add that or pin a specific version if you'd rather.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
