### PR TITLE
docs: Fix Aspire.Hosting.Integration.Analyzers package reference in multi-language integration authoring guide

### DIFF
--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -39,15 +39,14 @@ When a TypeScript AppHost adds your integration, the Aspire CLI:
 
 Your C# code runs as-is — the TypeScript SDK is a thin client that calls into it. You don't need to rewrite anything in TypeScript.
 
-## Install the analyzer
+## Enable the analyzer
 
-The [`📦 Aspire.Hosting.Integration.Analyzers`](https://www.nuget.org/packages/Aspire.Hosting.Integration.Analyzers) package provides build-time validation that catches common export mistakes. Add it to your integration project:
+The integration analyzer provides build-time validation that catches common export mistakes. It ships **inside the [`📦 Aspire.Hosting`](https://www.nuget.org/packages/Aspire.Hosting) package** — you don't install a separate analyzer package. Because hosting integrations already reference `Aspire.Hosting`, all you need to do is opt in to the analyzer by setting the `EnableAspireIntegrationAnalyzers` MSBuild property in your integration project:
 
 ```xml title="XML — MyIntegration.csproj"
-<PackageReference Include="Aspire.Hosting.Integration.Analyzers" Version="13.3.0">
-    <PrivateAssets>all</PrivateAssets>
-    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-</PackageReference>
+<PropertyGroup>
+    <EnableAspireIntegrationAnalyzers>true</EnableAspireIntegrationAnalyzers>
+</PropertyGroup>
 ```
 
 The analyzer reports diagnostics that help you get your exports right before users encounter runtime errors. Common scenarios include detecting incompatible parameter types, missing export annotations on public methods, duplicate export or capability IDs, and synchronous callbacks that could deadlock in multi-language app hosts.
@@ -497,7 +496,7 @@ All types in the union must be ATS-compatible. The analyzer (ASPIREEXPORT005, AS
 
 ## Analyzer diagnostics
 
-The `Aspire.Hosting.Integration.Analyzers` package reports these diagnostics:
+The integration analyzer reports these diagnostics when `EnableAspireIntegrationAnalyzers` is set to `true`:
 
 | ID              | Severity | Description                                                                                 |
 | --------------- | -------- | ------------------------------------------------------------------------------------------- |

--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -39,6 +39,8 @@ When a TypeScript AppHost adds your integration, the Aspire CLI:
 
 Your C# code runs as-is — the TypeScript SDK is a thin client that calls into it. You don't need to rewrite anything in TypeScript.
 
+<a id="install-the-analyzer"></a>
+
 ## Enable the analyzer
 
 The integration analyzer provides build-time validation that catches common export mistakes. It ships **inside the [`📦 Aspire.Hosting`](https://www.nuget.org/packages/Aspire.Hosting) package** — you don't install a separate analyzer package. Because hosting integrations already reference `Aspire.Hosting`, all you need to do is opt in to the analyzer by setting the `EnableAspireIntegrationAnalyzers` MSBuild property in your integration project:


### PR DESCRIPTION
## Summary

The *Multi-language integrations* authoring guide currently tells readers to install a NuGet package that does not exist:

```xml
<PackageReference Include="Aspire.Hosting.Integration.Analyzers" Version="13.3.0">
    <PrivateAssets>all</PrivateAssets>
    <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
</PackageReference>
```

The corresponding project in `microsoft/aspire` ([`Aspire.Hosting.Integration.Analyzers.csproj`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Hosting.Integration.Analyzers/Aspire.Hosting.Integration.Analyzers.csproj)) sets `<IsPackable>false</IsPackable>` — the analyzer never ships as a standalone NuGet. Anyone following the guide hits NU1101.

## How the analyzer actually ships

It is embedded inside the `Aspire.Hosting` NuGet package via the `IncludeIntegrationAnalyzerInPackage` target in [`Aspire.Hosting.csproj`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Hosting/Aspire.Hosting.csproj) and activated by an MSBuild flag in [`buildTransitive/Aspire.Hosting.targets`](https://github.com/microsoft/aspire/blob/main/src/Aspire.Hosting/buildTransitive/Aspire.Hosting.targets):

```xml
<PropertyGroup>
  <EnableAspireIntegrationAnalyzers Condition="''$(EnableAspireIntegrationAnalyzers)'' == ''''">false</EnableAspireIntegrationAnalyzers>
</PropertyGroup>

<ItemGroup Condition="''$(EnableAspireIntegrationAnalyzers)'' == ''true''">
  <Analyzer Include="$(_AspireIntegrationAnalyzerAssembly)" Condition="Exists(''$(_AspireIntegrationAnalyzerAssembly)'')" />
</ItemGroup>
```

So integration authors just opt in:

```xml
<PropertyGroup>
    <EnableAspireIntegrationAnalyzers>true</EnableAspireIntegrationAnalyzers>
</PropertyGroup>
```

## Changes

- Rename the `## Install the analyzer` section to `## Enable the analyzer`, explain that the analyzer ships inside `Aspire.Hosting`, and replace the bogus `PackageReference` snippet with the `EnableAspireIntegrationAnalyzers` opt-in.
- Update the `## Analyzer diagnostics` lede so it no longer names the non-existent package.

Fixes #981.
