### PR TITLE
Remove custom Azure Front Door resource names

### DIFF
--- a/src/apphost/Aspire.Dev.AppHost/Extensions/DeploymentExtensions.cs
+++ b/src/apphost/Aspire.Dev.AppHost/Extensions/DeploymentExtensions.cs
@@ -1,6 +1,5 @@
 using Aspire.Hosting.Azure;
 using Azure.Provisioning.Cdn;
-using Azure.Provisioning.Expressions;
 
 internal static class DeploymentExtensions
 {
@@ -12,34 +11,13 @@ internal static class DeploymentExtensions
             .WithOrigin(appServiceWebsite)
             .ConfigureInfrastructure(infra =>
             {
-                // Preserve the Azure names previously used in the existing Bicep templates
-                // to avoid unnecessary resources being deployed.
-
                 var resources = infra.GetProvisionableResources();
-                var uniqueStr = BicepFunction.GetUniqueString(BicepFunction.GetResourceGroup().Id);
 
-                // Preserve the Premium SKU used by the previous Front Door deployment.
-                var profile = resources.OfType<CdnProfile>().Single();
-                profile.SkuName = CdnSkuName.PremiumAzureFrontDoor;
-                profile.Name = BicepFunction.Take(BicepFunction.Interpolate($"frontdoor-afd{uniqueStr}"), 50);
-
-                // Configure endpoint naming
-                var frontDoorEndpoint = resources.OfType<FrontDoorEndpoint>().Single();
-                frontDoorEndpoint.Name = BicepFunction.Take(BicepFunction.Interpolate($"frontdoor-afd-endp-{uniqueStr}"), 50);
-
-                // Configure origin group naming
-                var originGroup = resources.OfType<FrontDoorOriginGroup>().Single();
-                originGroup.Name = BicepFunction.Take(BicepFunction.Interpolate($"appservice-origin-group-{uniqueStr}"), 50);
-
-                // Configure origin naming
                 var origin = resources.OfType<FrontDoorOrigin>().Single();
-                origin.Name = BicepFunction.Take(BicepFunction.Interpolate($"appservice-origin-{uniqueStr}"), 50);
                 origin.Weight = 1000;
                 origin.EnforceCertificateNameCheck = true;
 
-                // Configure route naming and caching
                 var route = resources.OfType<FrontDoorRoute>().Single();
-                route.Name = BicepFunction.Take(BicepFunction.Interpolate($"default-route-{uniqueStr}"), 50);
                 route.CacheConfiguration = new FrontDoorRouteCacheConfiguration
                 {
                     CompressionSettings = new RouteCacheCompressionSettings


### PR DESCRIPTION
## Summary
- Remove Azure Front Door resource name overrides from the AppHost deployment customization.
- Rely on the Aspire Front Door integration defaults for generated Front Door resource configuration, including the profile SKU.
- Preserve the existing origin settings and route caching configuration.

NOTE: This will require us to remove the existing AFD and use the new one. This is acceptable to do now, once, in order to use more simple code for the future.

NOTE 2: The AFD SKU gets defaulted to Premium in our deployment code when it adds the compliant WAF policy.

## Validation
- `dotnet build src\apphost\Aspire.Dev.AppHost\Aspire.Dev.AppHost.csproj --no-restore`