### PR TITLE
docs(ts-apphost): document supported AppHost-root package managers and Node engine (microsoft/aspire#17031)

### DIFF
--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -201,7 +201,7 @@ The supported ranges are:
 - **Node.js 22.13+** (LTS) — supported.
 - **Node.js 24+** — supported; this is the range the scaffolded `engines.node` constraint allows out of the box.
 
-Older Node.js versions are not supported. npm, pnpm, Yarn 4, and Bun all enforce `engines.node` on install, so an unsupported runtime fails before the AppHost starts.
+Older Node.js versions are not supported. Package managers may enforce `engines.node` on install (for example, pnpm does by default, while npm only does when `engine-strict` is configured), so unsupported runtimes are best treated as blocked even when a given toolchain only warns.
 
 <Aside type="note">
 If you widen `engines.node` beyond the scaffolded constraint, you take on responsibility for compatibility. Aspire CLI behavior, TypeScript SDK generation, and the `tsc --noEmit` startup validation are tested against the ranges listed above.

--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -138,14 +138,17 @@ await builder.build().run();
 
 ## Package managers
 
-The Aspire CLI automatically detects which package manager your TypeScript AppHost uses by inspecting lock files and the `packageManager` field in `package.json`. The following package managers are supported:
+The Aspire CLI supports the following package managers at the **AppHost root** — the directory that contains your `apphost.ts` and `aspire.config.json`. The CLI selects between them by inspecting the `packageManager` field in `package.json` and any lock files in the AppHost root.
 
-| Package manager | Lock file detected | Notes |
+| Package manager | Lock file | Support |
 |---|---|---|
-| npm | `package-lock.json` | Default; no extra setup required |
-| pnpm | `pnpm-lock.yaml` | |
-| Yarn (v4+) | `yarn.lock` | Must be Yarn 4 or later (Berry) |
-| Bun | `bun.lock` / `bun.lockb` | |
+| npm | `package-lock.json` | **Supported (default)** — no extra setup required |
+| pnpm | `pnpm-lock.yaml` | **Supported** |
+| Yarn 4+ (Berry) | `yarn.lock` (with Yarn 4 metadata) | **Supported** |
+| Bun | `bun.lock` / `bun.lockb` | **Supported** |
+| Yarn Classic (v1) | `yarn.lock` with `# yarn lockfile v1` | **Not supported** |
+
+This policy governs the **AppHost root only**. Apps the AppHost orchestrates — for example, a Node.js service added with `addNodeApp`, a Bun guest app, or a workspace package — can use any package manager their own tooling requires; they are independent of the AppHost-root toolchain.
 
 <Aside type="caution">
 **Yarn Classic (v1) is not supported.** If the Aspire CLI detects a Yarn Classic lock file (`# yarn lockfile v1`) or a `packageManager` field such as `"yarn@1.x"` in `package.json`, it throws an error and stops. Upgrade to Yarn 4 or later, or switch to npm, pnpm, or Bun.
@@ -180,13 +183,37 @@ The scaffolded `package.json` includes convenience scripts and the required Node
 
 The `dev` script means you can also start your AppHost with `npm run dev` (or the equivalent for your toolchain, for example `bun run dev` or `pnpm run dev`).
 
+### Supported Node.js engine
+
+Aspire 13.4 TypeScript AppHosts target the Node.js engine range that `aspire init` writes into the scaffolded `package.json`:
+
+```json title="package.json — supported engines.node"
+{
+  "engines": {
+    "node": "^20.19.0 || ^22.13.0 || >=24"
+  }
+}
+```
+
+The supported ranges are:
+
+- **Node.js 20.19+** (LTS) — supported.
+- **Node.js 22.13+** (LTS) — supported.
+- **Node.js 24+** — supported; this is the range the scaffolded `engines.node` constraint allows out of the box.
+
+Older Node.js versions are not supported. npm, pnpm, Yarn 4, and Bun all enforce `engines.node` on install, so an unsupported runtime fails before the AppHost starts.
+
+<Aside type="note">
+If you widen `engines.node` beyond the scaffolded constraint, you take on responsibility for compatibility. Aspire CLI behavior, TypeScript SDK generation, and the `tsc --noEmit` startup validation are tested against the ranges listed above.
+</Aside>
+
 ## Package manager toolchain
 
 The Aspire CLI automatically detects which Node-compatible package manager your project uses and adjusts install and run commands accordingly. The following toolchains are supported: **npm** (default), **Bun**, **Yarn**, and **pnpm**.
 
 ### Toolchain detection
 
-The CLI resolves the toolchain by inspecting the AppHost directory and its parent directories (up to eight levels). It checks, in order:
+Detection follows the [supported AppHost-root package managers](#package-managers) policy. The CLI resolves the toolchain by inspecting the AppHost directory and its parent directories (up to eight levels). It checks, in order:
 
 <Steps>
 

--- a/src/frontend/src/content/docs/get-started/prerequisites.mdx
+++ b/src/frontend/src/content/docs/get-started/prerequisites.mdx
@@ -32,7 +32,7 @@ Ready to dive into Aspire? Before you begin, make sure your development environm
     </TabItem>
     <TabItem id='typescript' label='TypeScript'>
 
-    Aspire's TypeScript AppHost requires [Node.js](https://nodejs.org/) 20 or later (LTS recommended) and a compatible package manager. The following package managers are supported: **npm** (included with Node.js), **pnpm**, **Yarn**, and **Bun**. The Aspire CLI auto-detects the active toolchain from your `package.json` `packageManager` field or from lockfiles in your project directory or parent directories.
+    Aspire's TypeScript AppHost requires [Node.js](https://nodejs.org/) **20.19+, 22.13+, or 24+** — the engine range that `aspire init` writes into the scaffolded `package.json` (`"engines": { "node": "^20.19.0 || ^22.13.0 || >=24" }`). It also requires a [supported AppHost-root package manager](/app-host/typescript-apphost/#package-managers): **npm** (default, included with Node.js), **pnpm**, **Yarn 4+** (Berry), or **Bun**. **Yarn Classic (v1) is not supported.** The Aspire CLI auto-detects the active toolchain from your `package.json` `packageManager` field or from lockfiles in your project directory or parent directories.
 
     Follow the [Node.js installation instructions](https://nodejs.org/) for your operating system (Windows, macOS, or Linux) to complete the setup. If you use an alternative package manager, install it separately:
 


### PR DESCRIPTION
Addresses [microsoft/aspire#17031](https://github.com/microsoft/aspire/issues/17031) (milestone **13.4**, child of EPIC [#16961](https://github.com/microsoft/aspire/issues/16961), depends on policy decision [#17029](https://github.com/microsoft/aspire/issues/17029)) by making the supported AppHost-root package-manager set and the supported Node.js engine constraint explicit in the TypeScript AppHost documentation.

## Deliverables (from #17031)

- [x] **Document npm as default.** Now flagged as `**Supported (default)**` in the table on `app-host/typescript-apphost.mdx`, and called out as the default in `get-started/prerequisites.mdx`.
- [x] **Document pnpm support.** Now flagged as `**Supported**` in the table; listed in the prereqs sentence.
- [x] **Document Bun support.** Now flagged as `**Supported**` in the table; listed in the prereqs sentence.
- [x] **Document Yarn 4+ support.** Row updated to **Yarn 4+ (Berry)** with lock-file qualifier "with Yarn 4 metadata"; flagged as `**Supported**`.
- [x] **Document Yarn Classic unsupported.** Added as an explicit `**Not supported**` row in the table (the existing detailed `<Aside type="caution">` is preserved unchanged immediately below the table); explicitly mentioned in the prereqs sentence.
- [x] **Document supported Node engine constraint.** New `### Supported Node.js engine` subsection under `## package.json` documents the scaffolded `engines.node` constraint `^20.19.0 || ^22.13.0 || >=24`, with one bullet per supported line (20.19+, 22.13+, 24+) and a caveat about widening the range. The prereqs page is tightened from "Node.js 20 or later" to "**20.19+, 22.13+, or 24+**".

## Scope and shape

This is a surgical, content-only PR targeting `release/13.4`. Two files touched:

- `src/frontend/src/content/docs/app-host/typescript-apphost.mdx` (+33 / −5)
- `src/frontend/src/content/docs/get-started/prerequisites.mdx` (+1 / −1)

The framing change reflects the issue's emphasis on **AppHost-root** package managers — the directory containing `apphost.ts` and `aspire.config.json` — and a new sentence clarifies that the policy does not govern guest apps the AppHost orchestrates (e.g. via `addNodeApp`).

## What's intentionally preserved

To keep the diff small and reviewer-friendly, the following are unchanged:

- The detailed Yarn Classic `<Aside type="caution">` (detection wording + Corepack upgrade snippet).
- The full `## Package manager toolchain` section (detection order, per-toolchain commands table, `aspire doctor` paragraph). A one-sentence cross-link to the new support policy was added at the top of `### Toolchain detection`.
- The scaffolded `package.json` sample under `## package.json` (the new engines subsection references it, doesn't replace it).
- No sidebar (`config/sidebar/*.ts`), redirect, `i18n`, `support.mdx`, or `whats-new/aspire-13-4.mdx` changes.
- No CI / validation policy changes from the broader EPIC #16961.

## Validation

From `src/frontend`:

- `pnpm exec astro sync` — no errors (the pre-existing duplicate-id warnings on `deployment/kubernetes` are unrelated).
- `pnpm lint` (= `astro sync` + `eslint . --max-warnings 0`) — exit `0`.
- `pnpm test:unit` — **20 files, 220 tests pass**.

## Notes for reviewers

- Issue #17029 ("package-manager support policy" deliverable) is the upstream decision that #17031 documents. If #17029 lands a different decision before this PR merges, the table / prereqs sentence can be adjusted in a follow-up.
- This change is `release/13.4`-only; per the repo's existing merge-up cadence (`Merge release/13.4 into main`), the same content will reach `main` without a separate PR.

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;
