### PR TITLE
build(deps): override brace-expansion to >=5.0.6 (GHSA-jxxr-4gwj-5jf2)

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -123,6 +123,7 @@
       "@anthropic-ai/claude-code@<2.0.31": ">=2.0.31",
       "ajv@<6.14.0": "6.14.0",
       "ajv@>=7.0.0-alpha.0 <8.18.0": "8.18.0",
+      "brace-expansion@<5.0.6": ">=5.0.6",
       "devalue@<5.6.4": ">=5.6.4",
       "dompurify@<3.4.0": ">=3.4.0",
       "fast-xml-builder@<1.1.7": ">=1.1.7",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@anthropic-ai/claude-code@<2.0.31': '>=2.0.31'
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: 8.18.0
+  brace-expansion@<5.0.6: '>=5.0.6'
   devalue@<5.6.4: '>=5.6.4'
   dompurify@<3.4.0: '>=3.4.0'
   fast-xml-builder@<1.1.7: '>=1.1.7'
@@ -1708,8 +1709,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -5254,7 +5255,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6843,7 +6844,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   mrmime@2.0.1: {}
 


### PR DESCRIPTION
## Summary

Adds a pnpm override forcing `brace-expansion` to `>=5.0.6` to address [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) / CVE-2026-45149 (`brace-expansion`: large numeric range defeats documented `max` DoS protection).

## Background

Dependabot raised an alert (#81) for `brace-expansion@5.0.5` in `src/frontend/pnpm-lock.yaml`. GitHub auto-dismissed it because the vulnerable package is only reached transitively via dev-scoped tooling:

- `eslint` → `minimatch@10.2.5` → `brace-expansion@5.0.5`
- `@typescript-eslint/visitor-keys` → `minimatch@10.2.5` → `brace-expansion@5.0.5`
- `@eslint/object-schema` → `minimatch@10.2.5` → `brace-expansion@5.0.5`

However, the existing `pnpm.overrides` block in `src/frontend/package.json` already proactively pins safe versions of similarly-scoped transitive packages (`minimatch`, `postcss`, `rollup`, `lodash`, etc.), so this change brings `brace-expansion` in line with that pattern and removes the only remaining (auto-dismissed) Dependabot finding on the repo.

## Changes

- `src/frontend/package.json`: add `"brace-expansion@<5.0.6": ">=5.0.6"` to `pnpm.overrides`
- `src/frontend/pnpm-lock.yaml`: regenerated to resolve `brace-expansion@5.0.6` (replaces `5.0.5`)

Diff is intentionally minimal (1 line of `package.json`, 4 lines of lockfile).

## Validation

- `pnpm install --frozen-lockfile` succeeds against the updated lockfile.
- No occurrences of `brace-expansion@5.0.5` remain in the lockfile.

## References

- Advisory: https://github.com/advisories/GHSA-jxxr-4gwj-5jf2
- Alert: https://github.com/microsoft/aspire.dev/security/dependabot/81
