### PR TITLE
chore: raise max-patch-size cap for Integration Data Updater

### DIFF
--- a/.github/workflows/update-integration-data.lock.yml
+++ b/.github/workflows/update-integration-data.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ad4fbbe63660e8cb06c67c08c6d0b246092794b905d083f2ff689b0f5cc44cd6","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"93ae43c9cb7b687ab98d7be4296bd140720a1e813e072d881c81b337d8eaef7b","compiler_version":"v0.72.0","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"1b10c78c7865c340bc4f6099eb2f838309f1e8c3","version":"v3.1.1"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"ff0525b685481744f490a0d362753d8001e4b39d","version":"v0.72.0"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.41"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.41"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.6","digest":"sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.6@sha256:2bb8eef86006a4c5963c55616a9c51c32f27bfdecb023b8aa6f91f6718d9171c"},{"image":"ghcr.io/github/github-mcp-server:v1.0.3","digest":"sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959","pinned_image":"ghcr.io/github/github-mcp-server:v1.0.3@sha256:2ac27ef03461ef2b877031b838a7d1fd7f12b12d4ace7796d8cad91446d55959"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -188,23 +188,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_5d17a812cdbe9c07_EOF'
+          cat << 'GH_AW_PROMPT_b0d23103f95e9b29_EOF'
           <system>
-          GH_AW_PROMPT_5d17a812cdbe9c07_EOF
+          GH_AW_PROMPT_b0d23103f95e9b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5d17a812cdbe9c07_EOF'
+          cat << 'GH_AW_PROMPT_b0d23103f95e9b29_EOF'
           <safe-output-tools>
           Tools: create_pull_request, close_pull_request(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_5d17a812cdbe9c07_EOF
+          GH_AW_PROMPT_b0d23103f95e9b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_5d17a812cdbe9c07_EOF'
+          cat << 'GH_AW_PROMPT_b0d23103f95e9b29_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_5d17a812cdbe9c07_EOF
+          GH_AW_PROMPT_b0d23103f95e9b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_5d17a812cdbe9c07_EOF'
+          cat << 'GH_AW_PROMPT_b0d23103f95e9b29_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if __GH_AW_GITHUB_ACTOR__ }}
@@ -233,12 +233,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_5d17a812cdbe9c07_EOF
+          GH_AW_PROMPT_b0d23103f95e9b29_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_5d17a812cdbe9c07_EOF'
+          cat << 'GH_AW_PROMPT_b0d23103f95e9b29_EOF'
           </system>
           {{#runtime-import .github/workflows/update-integration-data.md}}
-          GH_AW_PROMPT_5d17a812cdbe9c07_EOF
+          GH_AW_PROMPT_b0d23103f95e9b29_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -456,9 +456,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a97bc6476d8d5370_EOF'
-          {"close_pull_request":{"max":5,"required_labels":[":octocat: auto-merge"],"required_title_prefix":"chore: Update integration data","target":"*"},"create_pull_request":{"allowed_files":["src/frontend/src/data/aspire-integrations.json","src/frontend/src/data/github-stats.json","src/frontend/src/data/samples.json","src/frontend/src/assets/samples/**","src/frontend/src/data/pkgs/**","src/frontend/src/data/ts-modules/**","src/frontend/src/data/twoslash/aspire.d.ts"],"draft":false,"fallback_as_issue":false,"labels":[":octocat: auto-merge"],"max":1,"max_patch_files":500,"max_patch_size":1024,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore: "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_a97bc6476d8d5370_EOF
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_1ab7ea3f6c0a77c2_EOF'
+          {"close_pull_request":{"max":5,"required_labels":[":octocat: auto-merge"],"required_title_prefix":"chore: Update integration data","target":"*"},"create_pull_request":{"allowed_files":["src/frontend/src/data/aspire-integrations.json","src/frontend/src/data/github-stats.json","src/frontend/src/data/samples.json","src/frontend/src/assets/samples/**","src/frontend/src/data/pkgs/**","src/frontend/src/data/ts-modules/**","src/frontend/src/data/twoslash/aspire.d.ts"],"draft":false,"fallback_as_issue":false,"labels":[":octocat: auto-merge"],"max":1,"max_patch_files":500,"max_patch_size":10240,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore: "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
+          GH_AW_SAFE_OUTPUTS_CONFIG_1ab7ea3f6c0a77c2_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -685,7 +685,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_83a222ffc2f163d9_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_d63e99d59adec694_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -726,7 +726,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_83a222ffc2f163d9_EOF
+          GH_AW_MCP_CONFIG_d63e99d59adec694_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1440,7 +1440,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "*.docker.com,*.docker.io,*.githubusercontent.com,*.vsblob.vsassets.io,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.npms.io,api.nuget.org,api.snapcraft.io,archive.ubuntu.com,auth.docker.io,azure.archive.ubuntu.com,azuresearch-usnc.nuget.org,azuresearch-ussc.nuget.org,builds.dotnet.microsoft.com,bun.sh,cdn.jsdelivr.net,ci.dot.net,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,dc.services.visualstudio.com,deb.nodesource.com,deno.land,dist.nuget.org,dl.k8s.io,docs.github.com,dot.net,dotnet.microsoft.com,dotnetcli.blob.core.windows.net,esm.sh,gcr.io,get.pnpm.io,ghcr.io,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.blog,github.com,github.githubassets.com,googleapis.deno.dev,googlechromelabs.github.io,host.docker.internal,json-schema.org,json.schemastore.org,jsr.io,keyserver.ubuntu.com,lfs.github.com,mcr.microsoft.com,nodejs.org,npm.pkg.github.com,npmjs.com,npmjs.org,nuget.org,nuget.pkg.github.com,nugetregistryv2prod.blob.core.windows.net,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,oneocsp.microsoft.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,pkgs.dev.azure.com,pkgs.k8s.io,ppa.launchpad.net,production.cloudflare.docker.com,quay.io,raw.githubusercontent.com,registry.bower.io,registry.hub.docker.com,registry.npmjs.com,registry.npmjs.org,registry.yarnpkg.com,repo.yarnpkg.com,s.symcb.com,s.symcd.com,security.ubuntu.com,skimdb.npmjs.com,storage.googleapis.com,telemetry.enterprise.githubcopilot.com,telemetry.vercel.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.googleapis.com,www.microsoft.com,www.npmjs.com,www.npmjs.org,yarnpkg.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":5,\"required_labels\":[\":octocat: auto-merge\"],\"required_title_prefix\":\"chore: Update integration data\",\"target\":\"*\"},\"create_pull_request\":{\"allowed_files\":[\"src/frontend/src/data/aspire-integrations.json\",\"src/frontend/src/data/github-stats.json\",\"src/frontend/src/data/samples.json\",\"src/frontend/src/assets/samples/**\",\"src/frontend/src/data/pkgs/**\",\"src/frontend/src/data/ts-modules/**\",\"src/frontend/src/data/twoslash/aspire.d.ts\"],\"draft\":false,\"fallback_as_issue\":false,\"labels\":[\":octocat: auto-merge\"],\"max\":1,\"max_patch_files\":500,\"max_patch_size\":1024,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore: \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"close_pull_request\":{\"max\":5,\"required_labels\":[\":octocat: auto-merge\"],\"required_title_prefix\":\"chore: Update integration data\",\"target\":\"*\"},\"create_pull_request\":{\"allowed_files\":[\"src/frontend/src/data/aspire-integrations.json\",\"src/frontend/src/data/github-stats.json\",\"src/frontend/src/data/samples.json\",\"src/frontend/src/assets/samples/**\",\"src/frontend/src/data/pkgs/**\",\"src/frontend/src/data/ts-modules/**\",\"src/frontend/src/data/twoslash/aspire.d.ts\"],\"draft\":false,\"fallback_as_issue\":false,\"labels\":[\":octocat: auto-merge\"],\"max\":1,\"max_patch_files\":500,\"max_patch_size\":10240,\"protect_top_level_dot_folders\":true,\"protected_files\":[\"package.json\",\"bun.lockb\",\"bunfig.toml\",\"deno.json\",\"deno.jsonc\",\"deno.lock\",\"global.json\",\"NuGet.Config\",\"Directory.Packages.props\",\"mix.exs\",\"mix.lock\",\"go.mod\",\"go.sum\",\"stack.yaml\",\"stack.yaml.lock\",\"pom.xml\",\"build.gradle\",\"build.gradle.kts\",\"settings.gradle\",\"settings.gradle.kts\",\"gradle.properties\",\"package-lock.json\",\"yarn.lock\",\"pnpm-lock.yaml\",\"npm-shrinkwrap.json\",\"requirements.txt\",\"Pipfile\",\"Pipfile.lock\",\"pyproject.toml\",\"setup.py\",\"setup.cfg\",\"Gemfile\",\"Gemfile.lock\",\"uv.lock\",\"CODEOWNERS\",\"DESIGN.md\",\"README.md\",\"CONTRIBUTING.md\",\"CHANGELOG.md\",\"SECURITY.md\",\"CODE_OF_CONDUCT.md\",\"AGENTS.md\",\"CLAUDE.md\",\"GEMINI.md\"],\"title_prefix\":\"chore: \"},\"create_report_incomplete_issue\":{},\"missing_data\":{},\"missing_tool\":{},\"noop\":{\"max\":1,\"report-as-issue\":\"true\"},\"report_incomplete\":{}}"
           GH_AW_CI_TRIGGER_TOKEN: ${{ secrets.GH_AW_CI_TRIGGER_TOKEN }}
           GITHUB_TOKEN: ${{ steps.safe-outputs-app-token.outputs.token }}
         with:

--- a/.github/workflows/update-integration-data.md
+++ b/.github/workflows/update-integration-data.md
@@ -34,9 +34,10 @@ safe-outputs:
   # Raise the default 100-file patch cap: the API-reference regen branch can
   # write hundreds of files under pkgs/ and ts-modules/ on a single run.
   max-patch-files: 500
-  # Raise the patch-size cap to the schema maximum (10 MB). The regenerated
-  # C#/TS API JSON plus the twoslash bundle routinely produces a ~2 MB patch
-  # today, and this gives plenty of headroom for the integration set to grow.
+  # Raise the patch-size cap to the schema maximum (10,240 KB ≈ 10 MB). The
+  # regenerated C#/TS API JSON plus the twoslash bundle routinely produces a
+  # ~1,777 KB patch today (≈ 1.8 MB), and this gives plenty of headroom for
+  # the integration set to grow.
   max-patch-size: 10240
   github-app:
     client-id: ${{ secrets.ASPIRE_BOT_APP_ID }}

--- a/.github/workflows/update-integration-data.md
+++ b/.github/workflows/update-integration-data.md
@@ -34,6 +34,10 @@ safe-outputs:
   # Raise the default 100-file patch cap: the API-reference regen branch can
   # write hundreds of files under pkgs/ and ts-modules/ on a single run.
   max-patch-files: 500
+  # Raise the patch-size cap to the schema maximum (10 MB). The regenerated
+  # C#/TS API JSON plus the twoslash bundle routinely produces a ~2 MB patch
+  # today, and this gives plenty of headroom for the integration set to grow.
+  max-patch-size: 10240
   github-app:
     client-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
     private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

The [5/18 Integration Data Updater run](https://github.com/microsoft/aspire.dev/actions/runs/26045126730/job/76571279201) failed with:

```text
Patch size: 1777 KB (maximum allowed: 1024 KB)
✗ Message 1 (create_pull_request) failed: Patch size (1777 KB) exceeds maximum allowed size (1024 KB)
```

#993 raised `max-patch-files` and unblocked the file-count cap, but the byte-size cap is the next ceiling we hit — the regenerated C#/TS API JSON plus the twoslash bundle now produces a ~1.8 MB patch on a regen day, and the default `max-patch-size` is 1024 KB.

## Change

- `.github/workflows/update-integration-data.md` — set `safe-outputs.max-patch-size: 10240` (the gh-aw schema maximum, 10 MB). That's ~5.8× today's failing patch, so it should keep this from re-tripping as the integration set grows.
- `.github/workflows/update-integration-data.lock.yml` — regenerated via `gh aw compile` (gh-aw v0.72.0); the handler config now embeds `"max_patch_size":10240`.

Note: I initially tried 16384, but the gh-aw schema enforces `max-patch-size` ≤ 10240 KB, so 10240 is the cap.