### PR TITLE
Fix workflow health manager app permissions

### DIFF
--- a/.github/workflows/workflow-health-manager.lock.yml
+++ b/.github/workflows/workflow-health-manager.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"603fa53a4ee75a200bdc44cdef3a8c673885033d229e55bd001430d8afede2ed","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"16247440c65a3b8ba0c09ac14a3cda4756357e11b2e9a265ebb27b202cc0260c","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -191,20 +191,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_bbf51e5ceecff09a_EOF'
+          cat << 'GH_AW_PROMPT_2bc1f90f5160041b_EOF'
           <system>
-          GH_AW_PROMPT_bbf51e5ceecff09a_EOF
+          GH_AW_PROMPT_2bc1f90f5160041b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bbf51e5ceecff09a_EOF'
+          cat << 'GH_AW_PROMPT_2bc1f90f5160041b_EOF'
           <safe-output-tools>
           Tools: add_comment(max:15), create_issue(max:10), update_issue(max:5), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_bbf51e5ceecff09a_EOF
+          GH_AW_PROMPT_2bc1f90f5160041b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_bbf51e5ceecff09a_EOF'
+          cat << 'GH_AW_PROMPT_2bc1f90f5160041b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -236,12 +236,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_bbf51e5ceecff09a_EOF
+          GH_AW_PROMPT_2bc1f90f5160041b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_bbf51e5ceecff09a_EOF'
+          cat << 'GH_AW_PROMPT_2bc1f90f5160041b_EOF'
           </system>
           {{#runtime-import .github/workflows/workflow-health-manager.md}}
-          GH_AW_PROMPT_bbf51e5ceecff09a_EOF
+          GH_AW_PROMPT_2bc1f90f5160041b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -485,9 +485,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_9f8f37f9c164b04b_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_a26cdba0a1f6f537_EOF'
           {"add_comment":{"max":15},"create_issue":{"labels":["workflow-health"],"max":10},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":5}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_9f8f37f9c164b04b_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a26cdba0a1f6f537_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -772,7 +772,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_9994c4563071e971_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_8748641964d9f853_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -797,7 +797,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_9994c4563071e971_EOF
+          GH_AW_MCP_CONFIG_8748641964d9f853_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1064,7 +1064,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     concurrency:
@@ -1100,7 +1099,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Download agent output artifact
@@ -1440,7 +1438,6 @@ jobs:
     runs-on: ubuntu-slim
     permissions:
       contents: read
-      discussions: write
       issues: write
       pull-requests: write
     timeout-minutes: 15
@@ -1504,7 +1501,6 @@ jobs:
           repositories: ${{ github.event.repository.name }}
           github-api-url: ${{ github.api_url }}
           permission-contents: read
-          permission-discussions: write
           permission-issues: write
           permission-pull-requests: write
       - name: Configure GH_HOST for enterprise compatibility

--- a/.github/workflows/workflow-health-manager.md
+++ b/.github/workflows/workflow-health-manager.md
@@ -133,6 +133,7 @@ safe-outputs:
     labels: [workflow-health]
   add-comment:
     max: 15
+    discussions: false
   update-issue:
     max: 5
   noop:


### PR DESCRIPTION
## Summary
- Prevent the Workflow Health Manager safe-output comment tool from requesting Discussions write permission.
- Regenerate the gh-aw lock workflow with gh-aw v0.74.8 so `permission-discussions` is no longer emitted.

## Validation
- `gh aw compile workflow-health-manager --no-emit --validate --no-check-update`
- `gh aw compile --no-emit --validate --no-check-update`
- Confirmed generated `.lock.yml` files contain no `permission-discussions` or `discussions: write` entries.