### PR TITLE
Use explicit Aspire CLI path for gh-aw integration updates

### DIFF
--- a/.github/workflows/update-integration-data.lock.yml
+++ b/.github/workflows/update-integration-data.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"23a575405969ee1cf1586b4c2f4b1a90b15c4cce8c46cd6dceae39acb1e0da4d","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"cb1019867b67c03d1dbceef60a73256fd6bd210f20ab35e6147532dce801223d","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_CI_TRIGGER_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-dotnet","sha":"c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7","version":"v5.2.0 (source v5)"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -191,23 +191,23 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_a5cc6100ba829ddd_EOF'
+          cat << 'GH_AW_PROMPT_d5484a836b89e8e5_EOF'
           <system>
-          GH_AW_PROMPT_a5cc6100ba829ddd_EOF
+          GH_AW_PROMPT_d5484a836b89e8e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a5cc6100ba829ddd_EOF'
+          cat << 'GH_AW_PROMPT_d5484a836b89e8e5_EOF'
           <safe-output-tools>
           Tools: create_pull_request, close_pull_request(max:5), missing_tool, missing_data, noop
-          GH_AW_PROMPT_a5cc6100ba829ddd_EOF
+          GH_AW_PROMPT_d5484a836b89e8e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_create_pull_request.md"
-          cat << 'GH_AW_PROMPT_a5cc6100ba829ddd_EOF'
+          cat << 'GH_AW_PROMPT_d5484a836b89e8e5_EOF'
           </safe-output-tools>
-          GH_AW_PROMPT_a5cc6100ba829ddd_EOF
+          GH_AW_PROMPT_d5484a836b89e8e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_a5cc6100ba829ddd_EOF'
+          cat << 'GH_AW_PROMPT_d5484a836b89e8e5_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -236,12 +236,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_a5cc6100ba829ddd_EOF
+          GH_AW_PROMPT_d5484a836b89e8e5_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_a5cc6100ba829ddd_EOF'
+          cat << 'GH_AW_PROMPT_d5484a836b89e8e5_EOF'
           </system>
           {{#runtime-import .github/workflows/update-integration-data.md}}
-          GH_AW_PROMPT_a5cc6100ba829ddd_EOF
+          GH_AW_PROMPT_d5484a836b89e8e5_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -388,7 +388,7 @@ jobs:
         with:
           global-json-file: global.json
       - name: Install Aspire CLI
-        run: "set -euo pipefail\naspire_bin=\"${RUNNER_TEMP}/gh-aw/aspire/bin\"\ncurl -sSL https://aspire.dev/install.sh | bash -s -- --install-path \"$aspire_bin\" --skip-path\necho \"$aspire_bin\" >> \"$GITHUB_PATH\"\nexport PATH=\"$aspire_bin:$PATH\"\naspire --version --banner\n"
+        run: "set -euo pipefail\naspire_bin=\"${RUNNER_TEMP}/gh-aw/aspire/bin\"\ncurl -sSL https://aspire.dev/install.sh | bash -s -- --install-path \"$aspire_bin\" --skip-path\necho \"ASPIRE_CLI_PATH=$aspire_bin/aspire\" >> \"$GITHUB_ENV\"\necho \"$aspire_bin\" >> \"$GITHUB_PATH\"\nexport PATH=\"$aspire_bin:$PATH\"\n\"$aspire_bin/aspire\" --version --banner\n"
       - name: Setup pnpm
         run: corepack enable && corepack install
         working-directory: src/frontend
@@ -462,9 +462,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_eef694fe092fb050_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_8d8ed88222d8128f_EOF'
           {"close_pull_request":{"max":5,"required_labels":[":octocat: auto-merge"],"required_title_prefix":"chore: Update integration data","target":"*"},"create_pull_request":{"allowed_files":["src/frontend/src/data/aspire-integrations.json","src/frontend/src/data/github-stats.json","src/frontend/src/data/samples.json","src/frontend/src/assets/samples/**","src/frontend/src/data/pkgs/**","src/frontend/src/data/ts-modules/**","src/frontend/src/data/twoslash/aspire.d.ts"],"draft":false,"fallback_as_issue":false,"labels":[":octocat: auto-merge"],"max":1,"max_patch_files":500,"max_patch_size":10240,"protect_top_level_dot_folders":true,"protected_files":["package.json","bun.lockb","bunfig.toml","deno.json","deno.jsonc","deno.lock","global.json","NuGet.Config","Directory.Packages.props","mix.exs","mix.lock","go.mod","go.sum","stack.yaml","stack.yaml.lock","pom.xml","build.gradle","build.gradle.kts","settings.gradle","settings.gradle.kts","gradle.properties","package-lock.json","yarn.lock","pnpm-lock.yaml","npm-shrinkwrap.json","requirements.txt","Pipfile","Pipfile.lock","pyproject.toml","setup.py","setup.cfg","Gemfile","Gemfile.lock","uv.lock","CODEOWNERS","DESIGN.md","README.md","CONTRIBUTING.md","CHANGELOG.md","SECURITY.md","CODE_OF_CONDUCT.md","AGENTS.md","CLAUDE.md","GEMINI.md"],"title_prefix":"chore: "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_eef694fe092fb050_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_8d8ed88222d8128f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -696,7 +696,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_a272af866b6e3ba7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_e6ad00286fa065a6_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -737,7 +737,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a272af866b6e3ba7_EOF
+          GH_AW_MCP_CONFIG_e6ad00286fa065a6_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/update-integration-data.md
+++ b/.github/workflows/update-integration-data.md
@@ -18,9 +18,10 @@ steps:
       set -euo pipefail
       aspire_bin="${RUNNER_TEMP}/gh-aw/aspire/bin"
       curl -sSL https://aspire.dev/install.sh | bash -s -- --install-path "$aspire_bin" --skip-path
+      echo "ASPIRE_CLI_PATH=$aspire_bin/aspire" >> "$GITHUB_ENV"
       echo "$aspire_bin" >> "$GITHUB_PATH"
       export PATH="$aspire_bin:$PATH"
-      aspire --version --banner
+      "$aspire_bin/aspire" --version --banner
   - name: Setup pnpm
     run: corepack enable && corepack install
     working-directory: src/frontend
@@ -114,17 +115,15 @@ This branch only runs when version-change detection found at least one changed `
 
 2. **Regenerate TypeScript API reference JSON.** Depends on the C# package JSON from phase 1.
 
-   ```bash
-   pnpm --filter ./src/frontend run update:ts-api
-   ```
-
-   Before running this phase, verify the Aspire CLI is available in the agent environment:
+   Before running this phase, verify the Aspire CLI is available in the agent environment using the explicit path exported by the setup step:
 
    ```bash
-   aspire --version --banner
+   aspire_cli="${ASPIRE_CLI_PATH:-${RUNNER_TEMP}/gh-aw/aspire/bin/aspire}"
+   "$aspire_cli" --version --banner
+   ASPIRE_CLI_PATH="$aspire_cli" pnpm --filter ./src/frontend run update:ts-api
    ```
 
-   `scripts/update-ts-api.ts` reads the freshly written `pkgs/*.json`, selects the `Aspire.Hosting` and `Aspire.Hosting.*` packages, runs `aspire sdk dump` for each via `src/tools/AtsJsonGenerator/generate-ts-api-json.ps1`, and writes `src/frontend/src/data/ts-modules/{Package}.{Version}.json` files. Capture any per-package failures for the PR body. Once the TS API JSON is written, the same script automatically continues into phase 3 — do not invoke it a second time.
+   `scripts/update-ts-api.ts` reads the freshly written `pkgs/*.json`, selects the `Aspire.Hosting` and `Aspire.Hosting.*` packages, runs `aspire sdk dump` for each via `src/tools/AtsJsonGenerator/generate-ts-api-json.ps1`, and writes `src/frontend/src/data/ts-modules/{Package}.{Version}.json` files. The script honors `ASPIRE_CLI_PATH`, so do not probe for or invoke bare `aspire` in gh-aw runs; the AWF sandbox does not inherit the host runner `PATH`. Capture any per-package failures for the PR body. Once the TS API JSON is written, the same script automatically continues into phase 3 — do not invoke it a second time.
 
 3. **Regenerate the twoslash `.d.ts` bundle.** Depends on the TS API JSON from phase 2. This phase is **chained automatically** by `pnpm update:ts-api`; it runs `scripts/generate-twoslash-types.ts` against the freshly written `ts-modules/*.json` and rewrites `src/frontend/src/data/twoslash/aspire.d.ts`. If `pnpm update:ts-api` fails partway through the chain, distinguish in the PR body between a phase-2 failure (TS API generation) and a phase-3 failure (twoslash bundle) using the script's `❌ Generation failed:` vs `❌ Twoslash type generation failed:` log markers.
 

--- a/src/frontend/scripts/update-ts-api.ts
+++ b/src/frontend/scripts/update-ts-api.ts
@@ -3,6 +3,7 @@
  *
  * Runs the AtsJsonGenerator tool against the aspire sdk dump output.
  * Requires: dotnet SDK and aspire CLI.
+ * Set ASPIRE_CLI_PATH to use an installed Aspire CLI that is not on PATH.
  *
  * By default, reads the generated C# package JSON files and generates
  * data for the matching Aspire.Hosting.* package/version set.
@@ -47,11 +48,12 @@ function checkPrerequisite(cmd: string, args: string[], name: string): boolean {
 
 function main(): void {
   const aspireRepoPath = process.argv[2] ?? process.env.ASPIRE_REPO_PATH;
+  const aspireCliPath = process.env.ASPIRE_CLI_PATH?.trim() || 'aspire';
 
   if (!checkPrerequisite('dotnet', ['--version'], 'dotnet SDK')) {
     process.exit(1);
   }
-  if (!checkPrerequisite('aspire', ['--version'], 'Aspire CLI')) {
+  if (!checkPrerequisite(aspireCliPath, ['--version'], 'Aspire CLI')) {
     process.exit(1);
   }
 

--- a/src/tools/AtsJsonGenerator/generate-ts-api-json.ps1
+++ b/src/tools/AtsJsonGenerator/generate-ts-api-json.ps1
@@ -35,6 +35,10 @@
     `aspire` CLI. Useful for testing local CLI changes. When set, the script
     invokes `dotnet run --no-launch-profile --project <path> --` instead of `aspire`.
 
+.ENVIRONMENT_VARIABLE ASPIRE_CLI_PATH
+    Path to the installed Aspire CLI executable. Used when -AspireCliProject is
+    not set; defaults to resolving `aspire` from PATH.
+
 .EXAMPLE
     # From a local Aspire repo clone (uses global CLI)
     ./generate-ts-api-json.ps1 -AspireRepoPath D:\GitHub\aspire
@@ -72,6 +76,7 @@ $AspireRepoCandidates = @(
 $ScriptDir = $PSScriptRoot
 $RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
 $ToolProject = Join-Path $ScriptDir "AtsJsonGenerator.csproj"
+$AspireCliPath = if ([string]::IsNullOrWhiteSpace($env:ASPIRE_CLI_PATH)) { "aspire" } else { $env:ASPIRE_CLI_PATH }
 
 if (-not $OutputDir) {
     $OutputDir = Join-Path $RepoRoot "src\frontend\src\data\ts-modules"
@@ -398,8 +403,8 @@ function Invoke-AspireCli {
         $proc = Start-Process -FilePath "dotnet" -ArgumentList $allArgs -WorkingDirectory $WorkingDirectory `
             -Wait -NoNewWindow -PassThru -RedirectStandardError $StderrFile
     } else {
-        # Use the globally installed aspire CLI
-        $proc = Start-Process -FilePath "aspire" -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory `
+        # Use the installed aspire CLI
+        $proc = Start-Process -FilePath $AspireCliPath -ArgumentList $Arguments -WorkingDirectory $WorkingDirectory `
             -Wait -NoNewWindow -PassThru -RedirectStandardError $StderrFile
     }
 
@@ -530,6 +535,8 @@ if (-not $AspireRepoPath) {
 Write-Host "Found $($Packages.Count) packages to process"
 if ($AspireCliProject) {
     Write-Host "Using local CLI: $AspireCliProject" -ForegroundColor DarkGray
+} else {
+    Write-Host "Using Aspire CLI: $AspireCliPath" -ForegroundColor DarkGray
 }
 
 # ── Build the tool ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- export the installed Aspire CLI executable as `ASPIRE_CLI_PATH` for gh-aw runs
- teach the TypeScript API generator and PowerShell ATS dump script to honor `ASPIRE_CLI_PATH`
- update the workflow instructions to validate and run `update:ts-api` with the explicit mounted CLI path instead of relying on the AWF sandbox PATH

## Validation
- `gh aw compile update-integration-data`
- `pnpm --dir .\src\frontend exec eslint scripts\update-ts-api.ts --max-warnings 0`
- PowerShell parse check for `src/tools/AtsJsonGenerator/generate-ts-api-json.ps1`