### PR TITLE
Fix Issue Arborist issue fetch

### DIFF
--- a/.github/workflows/issue-arborist.lock.yml
+++ b/.github/workflows/issue-arborist.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"91a230805277e5e3f5dfcc0657ec2edd4d96ab51dbf415e3d2c6158ed57829be","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"b8bf3757e5cc6df2ff6b9ccb734dc2bb834ecc58821e0e6687d159929c9f4cd4","compiler_version":"v0.74.8","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["ASPIRE_BOT_APP_ID","ASPIRE_BOT_PRIVATE_KEY","COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/create-github-app-token","sha":"bcd2ba49218906704ab6c1aa796996da409d3eb1","version":"v3.2.0"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"efa55847f72aadb03490d955263ff911bf758700","version":"v0.74.8"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/cli-proxy:0.25.49"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.49"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.9","digest":"sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388","pinned_image":"ghcr.io/github/gh-aw-mcpg:v0.3.9@sha256:64828b42a4482f58fab16509d7f8f495a6d97c972a98a68aff20543531ac0388"},{"image":"ghcr.io/github/github-mcp-server:v1.0.4"},{"image":"node:lts-alpine","digest":"sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f","pinned_image":"node:lts-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -190,20 +190,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF'
+          cat << 'GH_AW_PROMPT_6b5bce6a184ff34b_EOF'
           <system>
-          GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF
+          GH_AW_PROMPT_6b5bce6a184ff34b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF'
+          cat << 'GH_AW_PROMPT_6b5bce6a184ff34b_EOF'
           <safe-output-tools>
           Tools: create_issue(max:6), link_sub_issue(max:50), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF
+          GH_AW_PROMPT_6b5bce6a184ff34b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF'
+          cat << 'GH_AW_PROMPT_6b5bce6a184ff34b_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -235,12 +235,12 @@ jobs:
             - **Note**: If a branch you need is not in the list above and is not listed as an additional fetched ref, it has NOT been checked out. For private repositories you cannot fetch it without proper authentication. If the branch is required and not available, exit with an error and ask the user to add it to the `fetch:` option of the `checkout:` configuration (e.g., `fetch: ["refs/pulls/open/*"]` for all open PR refs, or `fetch: ["main", "feature/my-branch"]` for specific branches).
           </github-context>
           
-          GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF
+          GH_AW_PROMPT_6b5bce6a184ff34b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/cli_proxy_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF'
+          cat << 'GH_AW_PROMPT_6b5bce6a184ff34b_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-arborist.md}}
-          GH_AW_PROMPT_2e5a3a0d82bae1a5_EOF
+          GH_AW_PROMPT_6b5bce6a184ff34b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -417,11 +417,28 @@ jobs:
           set -euo pipefail
           mkdir -p /tmp/gh-aw/issues-data
           echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
-          gh issue list --repo "$GITHUB_REPOSITORY" \
-            --search "-parent-issue:*" \
-            --state open \
-            --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
-            --limit 100 \
+          curl --fail-with-body --silent --show-error \
+            --cacert /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --get "${GITHUB_API_URL}/search/issues" \
+            --data-urlencode "q=repo:${GITHUB_REPOSITORY} is:issue is:open -parent-issue:* sort:updated-desc" \
+            --data-urlencode "per_page=100" \
+            | jq '[.items[] | {
+                number,
+                title,
+                author: .user,
+                createdAt: .created_at,
+                state: (.state | ascii_upcase),
+                url: .html_url,
+                body,
+                labels,
+                updatedAt: .updated_at,
+                closedAt: .closed_at,
+                milestone,
+                assignees
+              }]' \
             > /tmp/gh-aw/issues-data/issues.json
           total=$(jq 'length' /tmp/gh-aw/issues-data/issues.json)
           echo "✓ Saved $total issues to /tmp/gh-aw/issues-data/issues.json"
@@ -511,9 +528,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_0ca3f71744f87432_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_f3d3d27fe6940b7b_EOF'
           {"create_issue":{"group":true,"labels":["issue-arborist"],"max":6,"title_prefix":"[Parent] "},"create_report_incomplete_issue":{},"link_sub_issue":{"max":50},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_0ca3f71744f87432_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_f3d3d27fe6940b7b_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -739,7 +756,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_e8538c9772f1a45d_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_f37112dcc0bc6b7a_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "safeoutputs": {
@@ -764,7 +781,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_e8538c9772f1a45d_EOF
+          GH_AW_MCP_CONFIG_f37112dcc0bc6b7a_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true

--- a/.github/workflows/issue-arborist.md
+++ b/.github/workflows/issue-arborist.md
@@ -42,11 +42,28 @@ steps:
       set -euo pipefail
       mkdir -p /tmp/gh-aw/issues-data
       echo "⬇ Downloading the last 100 open issues (excluding sub-issues)..."
-      gh issue list --repo "$GITHUB_REPOSITORY" \
-        --search "-parent-issue:*" \
-        --state open \
-        --json number,title,author,createdAt,state,url,body,labels,updatedAt,closedAt,milestone,assignees \
-        --limit 100 \
+      curl --fail-with-body --silent --show-error \
+        --cacert /tmp/gh-aw/proxy-logs/proxy-tls/ca.crt \
+        --header "Authorization: Bearer ${GH_TOKEN}" \
+        --header "Accept: application/vnd.github+json" \
+        --header "X-GitHub-Api-Version: 2022-11-28" \
+        --get "${GITHUB_API_URL}/search/issues" \
+        --data-urlencode "q=repo:${GITHUB_REPOSITORY} is:issue is:open -parent-issue:* sort:updated-desc" \
+        --data-urlencode "per_page=100" \
+        | jq '[.items[] | {
+            number,
+            title,
+            author: .user,
+            createdAt: .created_at,
+            state: (.state | ascii_upcase),
+            url: .html_url,
+            body,
+            labels,
+            updatedAt: .updated_at,
+            closedAt: .closed_at,
+            milestone,
+            assignees
+          }]' \
         > /tmp/gh-aw/issues-data/issues.json
       total=$(jq 'length' /tmp/gh-aw/issues-data/issues.json)
       echo "✓ Saved $total issues to /tmp/gh-aw/issues-data/issues.json"


### PR DESCRIPTION
## Summary
- replace the Issue Arborist pre-agent `gh issue list` call with a direct Search REST API request
- reshape the API response back into the issue JSON structure expected by the workflow prompt
- regenerate the `issue-arborist.lock.yml` file with `gh aw compile`

## Validation
- `gh aw compile issue-arborist --approve --no-check-update`
- `gh aw compile issue-arborist --no-emit --validate --approve --no-check-update`
- `git diff --check`
- smoke-tested the Search API query and jq projection against `microsoft/aspire.dev`