### PR TITLE
Warn TS AppHost users to run `aspire update --self` first in 13.4 release notes

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -51,6 +51,26 @@ This release introduces:
   stable version.
 </Aside>
 
+<Aside type="caution" title="TypeScript AppHost users: run `aspire update --self` first">
+  If you have a **TypeScript AppHost on Aspire 13.3.x**, you must update the
+  Aspire CLI itself **before** running `aspire update` on your project. Running
+  `aspire update` first will fail mid-update with an error like:
+
+  ```text
+  ❌ An unexpected error occurred: No code generator found for language: TypeScript
+  ```
+
+  The 13.3.x CLI bundles an apphost server that cannot load the 13.4 TypeScript
+  code generator, so package restore succeeds but TypeScript SDK regeneration
+  crashes. The failure leaves `aspire.config.json` pointing at 13.4 packages
+  while the CLI is still 13.3.x, which also breaks `aspire run` and
+  `aspire restore` until you finish the upgrade with `aspire update --self`.
+
+  Follow the steps below in order — `aspire update --self` first, then
+  `aspire update`. See [microsoft/aspire#17077](https://github.com/microsoft/aspire/issues/17077)
+  for background.
+</Aside>
+
 For general purpose upgrade guidance, see [Upgrade Aspire](/whats-new/upgrade-aspire/).
 
 The easiest way to upgrade to Aspire 13.4 is using the [`aspire update` command](/reference/cli/commands/aspire-update/):
@@ -374,7 +394,7 @@ Aspire is built in the open, and this release wouldn't be what it is without you
 
 <Steps>
 
-1. **Update the CLI** — run `aspire update --self`.
+1. **Update the CLI** — run `aspire update --self`. This step is **required** for TypeScript AppHosts; running `aspire update` against a 13.3.x TypeScript project before updating the CLI fails with `No code generator found for language: TypeScript` and leaves the project in a partially-upgraded, unrunnable state (see [microsoft/aspire#17077](https://github.com/microsoft/aspire/issues/17077)).
 2. **Update your projects** — run `aspire update` from the root of your repository.
 3. **Run `aspire doctor`** to check your environment setup.
 4. **Audit scripts and CI** for `aspire exec` and non-interactive `aspire update` calls.

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -51,7 +51,7 @@ This release introduces:
   stable version.
 </Aside>
 
-<Aside type="caution" title="TypeScript AppHost users: run `aspire update --self` first">
+<Aside type="caution" title="TypeScript AppHost users: run aspire update --self first">
   If you have a **TypeScript AppHost on Aspire 13.3.x**, you must update the
   Aspire CLI itself **before** running `aspire update` on your project. Running
   `aspire update` first will fail mid-update with an error like:
@@ -60,7 +60,7 @@ This release introduces:
   ❌ An unexpected error occurred: No code generator found for language: TypeScript
   ```
 
-  The 13.3.x CLI bundles an apphost server that cannot load the 13.4 TypeScript
+  The 13.3.x CLI bundles an AppHost server that cannot load the 13.4 TypeScript
   code generator, so package restore succeeds but TypeScript SDK regeneration
   crashes. The failure leaves `aspire.config.json` pointing at 13.4 packages
   while the CLI is still 13.3.x, which also breaks `aspire run` and


### PR DESCRIPTION
## What

Adds a caution `Aside` to the **Upgrade to Aspire 13.4** section of the 13.4 "What's new" page, and strengthens the **Migration from Aspire 13.3 to 13.4** step list, calling out that TypeScript AppHost users on 13.3.x **must** run `aspire update --self` before `aspire update`.

## Why

For TypeScript AppHost projects on Aspire 13.3.x, running `aspire update` before `aspire update --self` fails mid-flight with:

```
❌ An unexpected error occurred: No code generator found for language: TypeScript
```

The 13.3.x CLI bundles an apphost server that cannot load the 13.4 `Aspire.Hosting.CodeGeneration.TypeScript` assembly (new types in `Aspire.TypeSystem` cause `ReflectionTypeLoadException` during code-generator discovery). Package restore succeeds, `aspire.config.json` is rewritten to point at 13.4, then TypeScript SDK regeneration crashes — leaving the project in a partially-upgraded, unrunnable state where `aspire run` and `aspire restore` also fail until `aspire update --self` is run.

Tracking issue: microsoft/aspire#17077. The CLI-side fix (microsoft/aspire#17100) is in `main` and will ship with 13.4, but was **not backported to release/13.3**, so 13.3.x stable users will hit this until they update the CLI.

## Repro (verified today against `13.3.5` stable + `13.4.0-preview.1.26275.2` daily)

1. Install stable CLI (`13.3.5`).
2. `aspire new aspire-ts-starter`.
3. Install daily CLI side-by-side.
4. `aspire update --channel daily` (stable CLI) → fails with the error above; `aspire.config.json` SDK version is bumped to `13.4.0-preview.1.26275.2` while CLI is still `13.3.5`; subsequent `aspire run` also fails.

Workaround in the new `Aside`: run `aspire update --self` first.

## Diff

- Adds a TypeScript-specific caution `Aside` immediately above the upgrade `<Steps>` block.
- Adds an inline note to migration step 1 making explicit that `--self` is **required** for TypeScript AppHosts on 13.3.x, with a link to microsoft/aspire#17077.