### PR TITLE
fix(docs): update import paths for createBuilder in TypeScript examples

### DIFF
--- a/src/frontend/src/components/AppHostBuilder.astro
+++ b/src/frontend/src/components/AppHostBuilder.astro
@@ -445,7 +445,7 @@ builder.Build().Run();`,
 
 // Define all possible code combinations — TypeScript
 const tsCodes: Record<string, string> = {
-  empty: `import { createBuilder } from './.modules/aspire.js';
+  empty: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -455,7 +455,7 @@ const builder = await createBuilder();
 
 await builder.build().run();`,
 
-  frontend: `import { createBuilder } from './.modules/aspire.js';
+  frontend: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -466,7 +466,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  frontendContainer: `import { createBuilder } from './.modules/aspire.js';
+  frontendContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -482,7 +482,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseFrontend: `import { createBuilder } from './.modules/aspire.js';
+  databaseFrontend: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -498,7 +498,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  databaseFrontendContainer: `import { createBuilder } from './.modules/aspire.js';
+  databaseFrontendContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -519,7 +519,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  apiFrontend: `import { createBuilder } from './.modules/aspire.js';
+  apiFrontend: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -536,7 +536,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  apiFrontendContainer: `import { createBuilder } from './.modules/aspire.js';
+  apiFrontendContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -558,7 +558,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseApiFrontend: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiFrontend: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -581,7 +581,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  databaseApiFrontendContainer: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiFrontendContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -609,7 +609,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  database: `import { createBuilder } from './.modules/aspire.js';
+  database: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -620,7 +620,7 @@ const postgres = await builder
 
 await builder.build().run();`,
 
-  databaseContainer: `import { createBuilder } from './.modules/aspire.js';
+  databaseContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -636,7 +636,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  api: `import { createBuilder } from './.modules/aspire.js';
+  api: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -647,7 +647,7 @@ const api = await builder
 
 await builder.build().run();`,
 
-  apiContainer: `import { createBuilder } from './.modules/aspire.js';
+  apiContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -663,7 +663,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseApi: `import { createBuilder } from './.modules/aspire.js';
+  databaseApi: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -680,7 +680,7 @@ const api = await builder
 
 await builder.build().run();`,
 
-  databaseApiContainer: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiContainer: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -702,7 +702,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  container: `import { createBuilder } from './.modules/aspire.js';
+  container: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -713,7 +713,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  frontendDeployment: `import { createBuilder } from './.modules/aspire.js';
+  frontendDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -726,7 +726,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  frontendContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  frontendContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -745,7 +745,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseFrontendDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseFrontendDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -765,7 +765,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  databaseFrontendContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseFrontendContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -791,7 +791,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  apiFrontendDeployment: `import { createBuilder } from './.modules/aspire.js';
+  apiFrontendDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -811,7 +811,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  apiFrontendContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  apiFrontendContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -837,7 +837,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseApiFrontendDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiFrontendDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -866,7 +866,7 @@ const frontend = await builder
 
 await builder.build().run();`,
 
-  databaseApiFrontendContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiFrontendContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -901,7 +901,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -914,7 +914,7 @@ const postgres = await builder
 
 await builder.build().run();`,
 
-  databaseContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -933,7 +933,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  apiDeployment: `import { createBuilder } from './.modules/aspire.js';
+  apiDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -945,7 +945,7 @@ const api = await builder
 
 await builder.build().run();`,
 
-  apiContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  apiContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -963,7 +963,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  databaseApiDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -984,7 +984,7 @@ const api = await builder
 
 await builder.build().run();`,
 
-  databaseApiContainerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  databaseApiContainerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -1011,7 +1011,7 @@ const customContainer = await builder
 
 await builder.build().run();`,
 
-  containerDeployment: `import { createBuilder } from './.modules/aspire.js';
+  containerDeployment: `import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -1215,7 +1215,7 @@ await builder.build().run();`,
             data-variant={key}
             style={key === 'frontend' ? '' : 'display: none;'}
           >
-            <Code code={code} lang="ts" title="apphost.ts" />
+            <Code code={code} lang="ts" title="apphost.mts" />
           </div>
         ))
       }

--- a/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
@@ -32,7 +32,7 @@ builder.AddProject<Projects.ApiService>("api")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -80,7 +80,7 @@ var value = builder.Configuration[key]; // value = "local-value"
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -129,7 +129,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -282,7 +282,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -421,7 +421,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -515,7 +515,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
@@ -33,7 +33,7 @@ builder.AddProject<Projects.ApiService>("api")
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -81,7 +81,7 @@ var value = builder.Configuration[key]; // value = "local-value"
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -130,7 +130,7 @@ builder.Build().Run();
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -283,7 +283,7 @@ builder.Build().Run();
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -422,7 +422,7 @@ builder.Build().Run();
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -516,7 +516,7 @@ builder.Build().Run();
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 

--- a/src/frontend/src/content/docs/ja/fundamentals/health-checks.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/health-checks.mdx
@@ -446,7 +446,7 @@ builder.AddProject<Projects.WebApp>("webapp")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -484,7 +484,7 @@ builder.AddProject<Projects.Frontend>("frontend")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -539,7 +539,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 `builder.services.addHealthChecks()` によるカスタム正常性チェックの登録は、TypeScript AppHost SDK ではまだ利用できません。代わりに HTTP ベースの正常性チェックには `withHttpHealthCheck` を使用してください。
 :::
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/fundamentals/health-checks.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/health-checks.mdx
@@ -447,7 +447,7 @@ builder.AddProject<Projects.WebApp>("webapp")
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -485,7 +485,7 @@ builder.AddProject<Projects.Frontend>("frontend")
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
@@ -540,7 +540,7 @@ builder.AddProject<Projects.MyApp>("myapp")
 :::
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 

--- a/src/frontend/src/content/docs/ja/fundamentals/persist-data-volumes.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/persist-data-volumes.mdx
@@ -60,7 +60,7 @@ builder.Build().Run();
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 

--- a/src/frontend/src/content/docs/ja/fundamentals/persist-data-volumes.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/persist-data-volumes.mdx
@@ -59,7 +59,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/fundamentals/service-discovery.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/service-discovery.mdx
@@ -44,7 +44,7 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
 <TabItem id="typescript" label="TypeScript">
 
 ```typescript title="TypeScript — apphost.ts" twoslash
-import { createBuilder } from './.modules/aspire.js';
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 

--- a/src/frontend/src/content/docs/ja/fundamentals/service-discovery.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/service-discovery.mdx
@@ -43,7 +43,7 @@ var frontend = builder.AddProject<Projects.MyFrontend>("frontend")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.ts" twoslash
+```typescript title="TypeScript — apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();


### PR DESCRIPTION
Updates stale TypeScript twoslash imports that referenced `./.modules/aspire.js` to the current path `./.aspire/modules/aspire.mjs`, matching the English source. Also renames the `AppHostBuilder` interactive TS code block title from `apphost.ts` to `apphost.mts`.

Fixes the failing `twoslash-blocks.vitest.test.ts` check on `release/13.4` ([CI run](https://github.com/microsoft/aspire.dev/actions/runs/26450586442/job/77870176443?pr=907)) where 11 blocks across the Japanese fundamentals docs failed `ts(2307) — Cannot find module './.modules/aspire.js'`.

Files touched:
- `src/frontend/src/components/AppHostBuilder.astro` (30 TS snippets + title)
- `src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx`
- `src/frontend/src/content/docs/ja/fundamentals/health-checks.mdx`
- `src/frontend/src/content/docs/ja/fundamentals/service-discovery.mdx`
- `src/frontend/src/content/docs/ja/fundamentals/persist-data-volumes.mdx`