### PR TITLE
docs: document legacy apphost.ts compatibility for TypeScript AppHosts

### DIFF
--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -155,6 +155,102 @@ const api = await builder
 await builder.build().run();
 ```
 
+## Legacy `apphost.ts` projects (pre-13.4)
+
+TypeScript AppHosts scaffolded by Aspire CLI versions earlier than 13.4 use a slightly different layout: the entry point is `apphost.ts` (not `apphost.mts`), and the generated TypeScript SDK lives in `./.modules/` (not `./.aspire/modules/`):
+
+<FileTree>
+
+- my-apphost/
+  - .modules/  Generated TypeScript SDK (do not edit)
+    - aspire.ts
+    - base.ts
+    - transport.ts
+  - apphost.ts  Your AppHost entry point
+  - aspire.config.json  Aspire configuration
+  - package.json
+  - tsconfig.apphost.json
+
+</FileTree>
+
+The pre-13.4 entry point imports the SDK with the `.js` extension:
+
+```typescript title="apphost.ts (pre-13.4)"
+import { createBuilder } from './.modules/aspire.js';
+```
+
+### Compatibility in 13.4
+
+The 13.4 Aspire CLI keeps these projects working without any changes:
+
+- When the CLI sees an `apphost.ts` file with no `apphost.mts` alongside it — either because `aspire.config.json` sets `appHost.path` to `apphost.ts`, or because a disk scan finds `apphost.ts` and no `apphost.mts` — it switches to the legacy output layout for that project.
+- Generated SDK files are written to `./.modules/` instead of `./.aspire/modules/`.
+- Generated files are rewritten from `.mts`/`.mjs` to `.ts`/`.js`, including the inter-module import specifiers inside the SDK, so the existing `./.modules/aspire.js` import in your `apphost.ts` continues to resolve.
+
+`aspire add`, `aspire restore`, `aspire run`, and `aspire start` all continue to work against an existing `apphost.ts` project with no edits required.
+
+<Aside type="tip">
+You don't need to migrate to keep your existing TypeScript AppHost running on Aspire 13.4. The compatibility path is automatic. Migrate only if you want the new default layout — for example, to match the file tree shown in newer documentation and samples.
+</Aside>
+
+### Migrating to the new `apphost.mts` layout
+
+If you'd like to move an existing project to the new default layout, the migration is mechanical. The steps below assume an AppHost root with `apphost.ts`, `./.modules/`, and the legacy `appHost.path` value:
+
+<Steps>
+
+1. **Rename the entry point file.**
+
+   ```bash
+   git mv apphost.ts apphost.mts
+   ```
+
+2. **Update the SDK import** in `apphost.mts` to use the new folder and the `.mjs` extension:
+
+   ```typescript title="apphost.mts" del={1} ins={2}
+   import { createBuilder } from './.modules/aspire.js';
+   import { createBuilder } from './.aspire/modules/aspire.mjs';
+   ```
+
+3. **Update `appHost.path`** in `aspire.config.json`:
+
+   ```json title="aspire.config.json" del={3} ins={4}
+   {
+     "appHost": {
+       "path": "apphost.ts",
+       "path": "apphost.mts",
+       "language": "typescript/nodejs"
+     }
+   }
+   ```
+
+4. **Update `tsconfig.apphost.json`** so its `include` (and any related glob) entries point at the new file and folder. Replace references to `apphost.ts` with `apphost.mts`, and references to `.modules/` with `.aspire/modules/`. For example:
+
+   ```json title="tsconfig.apphost.json" del={4,5} ins={6,7}
+   {
+     "compilerOptions": { /* ... */ },
+     "include": [
+       "apphost.ts",
+       ".modules/**/*.ts"
+       "apphost.mts",
+       ".aspire/modules/**/*.mts"
+     ]
+   }
+   ```
+
+5. **Delete the old generated SDK folder and regenerate.** The CLI now writes the SDK under `./.aspire/modules/`, so the old folder is no longer used:
+
+   ```bash
+   rm -rf .modules
+   aspire restore
+   ```
+
+   If your `.gitignore` ignores `.modules/`, replace that entry with `.aspire/` (or `.aspire/modules/`) to match the new location.
+
+</Steps>
+
+After migrating, `aspire run` behaves exactly the same as before — the CLI now uses the modern output path because `apphost.mts` is present.
+
 ## Package managers
 
 The Aspire CLI supports the following package managers at the **AppHost root** — the directory that contains your `apphost.mts` and `aspire.config.json`. The CLI selects between them by inspecting package manager signals, including the `packageManager` field in `package.json`, lock files, and package manager configuration in the AppHost root.

--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -231,7 +231,7 @@ If you'd like to move an existing project to the new default layout, the migrati
      "compilerOptions": { /* ... */ },
      "include": [
        "apphost.ts",
-       ".modules/**/*.ts"
+       ".modules/**/*.ts",
        "apphost.mts",
        ".aspire/modules/**/*.mts"
      ]

--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -157,7 +157,7 @@ await builder.build().run();
 
 ## Legacy `apphost.ts` projects (pre-13.4)
 
-TypeScript AppHosts scaffolded by Aspire CLI versions earlier than 13.4 use a slightly different layout: the entry point is `apphost.ts` (not `apphost.mts`), and the generated TypeScript SDK lives in `./.modules/` (not `./.aspire/modules/`):
+TypeScript AppHosts scaffolded by Aspire CLI versions earlier than 13.4 use a slightly different layout: the entry point was `apphost.ts` (not `apphost.mts`), and the generated TypeScript SDK lives in `./.modules/` (not `./.aspire/modules/`):
 
 <FileTree>
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -123,6 +123,8 @@ Aspire 13.4 strengthens the TypeScript experience by validating TypeScript AppHo
 
 The documentation now treats TypeScript AppHosts as a first-class peer to C# AppHosts: AppHost-focused guides and integration pages include TypeScript examples alongside C# where the API is available. The release also adds a new set of TypeScript samples so you can start from working `apphost.mts` projects instead of translating from C#.
 
+Existing TypeScript AppHosts scaffolded by earlier CLI versions (using `apphost.ts` and `./.modules/aspire.js`) continue to work on 13.4 without changes — the CLI transparently routes generated SDK files to the legacy `./.modules/` folder and rewrites them to `.ts`/`.js` so existing imports resolve. See [Legacy `apphost.ts` projects (pre-13.4)](/app-host/typescript-apphost/#legacy-apphostts-projects-pre-134) for details and an opt-in migration to the new `apphost.mts` layout.
+
 <LearnMore>
   For setup details, see [TypeScript AppHosts](/app-host/typescript-apphost/).
   To explore working examples, browse the [Aspire samples](/reference/samples/).


### PR DESCRIPTION
## Gap

The TypeScript AppHost docs on `release/13.4` only describe the new `apphost.mts` / `./.aspire/modules/` layout. TypeScript AppHosts scaffolded by pre-13.4 CLI versions use `apphost.ts` importing from `./.modules/aspire.js`, and the 13.4 CLI silently keeps these working — but nothing in the docs confirms that, and there's no migration guidance for users who want to opt in to the new layout.

## Changes

**`src/frontend/src/content/docs/app-host/typescript-apphost.mdx`** — add a new `## Legacy \`apphost.ts\` projects (pre-13.4)` section (placed after `## apphost.mts` so the page still leads with the modern layout) covering:

- The pre-13.4 file tree (`apphost.ts` + `./.modules/` with `.ts` SDK files).
- The CLI's automatic detection rule: `apphost.ts` present and `apphost.mts` absent, either via an explicit `appHost.path` of `apphost.ts` in `aspire.config.json` or via a disk scan when no explicit file is set.
- The two compatibility behaviors:
  - Generated SDK files are written to `./.modules/` instead of `./.aspire/modules/`.
  - Generated `.mts`/`.mjs` files are rewritten to `.ts`/`.js` (file extensions and inter-module import specifiers) so existing `./.modules/aspire.js` imports resolve.
- A reassurance that `aspire add`, `aspire restore`, `aspire run`, and `aspire start` keep working with no user changes.
- An opt-in `### Migrating to the new \`apphost.mts\` layout` subsection with concrete steps: rename the entry point, update the SDK import, update `appHost.path`, update `tsconfig.apphost.json` includes, delete `./.modules/` and re-restore (plus a `.gitignore` note).

**`src/frontend/src/content/docs/whats-new/aspire-13-4.mdx`** — one-sentence cross-reference in the TypeScript GA section pointing existing-project users at the new docs anchor.

## Out of scope

- Translated docs (`ja/`, `zh-cn/`, etc.) — handled by the translation workflow.
- Stale `apphost.ts` references on other pages (e.g. `integrations/compute/kubernetes.mdx`).
- The existing modern-layout content in `typescript-apphost.mdx` is unchanged.

## Validation

- `pnpm build:skip-search` completes successfully (12,274 pages, all internal links valid).
- Prose re-checked against the implementation contract in `microsoft/aspire` `src/Aspire.Cli/Projects/GuestAppHostProject.cs` (`ShouldEmitLegacyTypeScriptGeneratedFiles`, `ConvertGeneratedFilesForLegacyTypeScriptAppHost`, `LegacyGeneratedFolderName = \".modules\"`) and the E2E coverage added in microsoft/aspire#17504.

## Targeting

This PR targets `release/13.4` (not `main`) since it documents 13.4-specific compatibility behavior.