### PR TITLE
Docs: replace non-Azure AsExisting examples with AddConnectionString

### DIFF
--- a/.github/github-app.yml
+++ b/.github/github-app.yml
@@ -1,0 +1,4 @@
+instructions: Never call `pnpm build` locally, unless you get explicit user permission (even in Autopilot mode). We do not want to waste local resources, this action is taxing and is best performed on CI.
+automation:
+  auto_issue_session: true
+  remote_control: false

--- a/src/frontend/src/content/docs/get-started/glossary.mdx
+++ b/src/frontend/src/content/docs/get-started/glossary.mdx
@@ -302,7 +302,7 @@ Connect to resources that already exist (not managed by Aspire):
 var existingDb = builder.AddConnectionString("db");
 ```
 
-Aspire resolves this from `ConnectionStrings:db` (or environment variable `ConnectionStrings__db`) in the AppHost configuration.
+Aspire resolves this from `ConnectionStrings:db` (or environment variable `ConnectionStrings__db`) in the AppHost configuration and passes it through as a single connection string value.
 
 Use this for production databases or shared team resources.
 

--- a/src/frontend/src/content/docs/get-started/glossary.mdx
+++ b/src/frontend/src/content/docs/get-started/glossary.mdx
@@ -299,8 +299,7 @@ This lets you develop against Azure, AWS, or other cloud services without needin
 Connect to resources that already exist (not managed by Aspire):
 
 ```csharp title="AppHost.cs"
-var existingDb = builder.AddPostgres("db")
-    .AsExisting(name, resourceGroup);
+var existingDb = builder.AddConnectionString("db");
 ```
 
 Use this for production databases or shared team resources.

--- a/src/frontend/src/content/docs/get-started/glossary.mdx
+++ b/src/frontend/src/content/docs/get-started/glossary.mdx
@@ -302,6 +302,8 @@ Connect to resources that already exist (not managed by Aspire):
 var existingDb = builder.AddConnectionString("db");
 ```
 
+Aspire resolves this from `ConnectionStrings:db` (or environment variable `ConnectionStrings__db`) in the AppHost configuration.
+
 Use this for production databases or shared team resources.
 
 ---

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-connect.mdx
@@ -42,6 +42,29 @@ The Garnet resource exposes the following connection properties:
 Uri: garnet://:p%40ssw0rd1@localhost:6379
 ```
 
+## Environment variables and connection string formats
+
+The way Aspire exposes connection information depends on how the Garnet resource is modeled in your AppHost:
+
+### Using `WithReference` (typed Garnet resource)
+
+When your AppHost adds a typed Garnet resource with `builder.AddGarnet("cache")` and references it with `.WithReference(cache)`, Aspire injects **individual connection properties** as environment variables using the `[RESOURCE]_[PROPERTY]` format:
+
+- `CACHE_HOST` = hostname
+- `CACHE_PORT` = port number
+- `CACHE_PASSWORD` = password (if set)
+- `CACHE_URI` = full connection URI
+
+This is the **recommended approach** because Aspire manages the resource lifecycle, configuration, and provides typed client integrations.
+
+### Using `AddConnectionString` (external connection string)
+
+When your AppHost uses `builder.AddConnectionString("cache")` to reference an existing, pre-configured Garnet instance outside Aspire's control, only a **single connection string** environment variable is injected:
+
+- `ConnectionStrings__cache` = the full connection string provided to `AddConnectionString`
+
+With this approach, there are **no individual property variables** (`CACHE_HOST`, `CACHE_PORT`, etc.). Consuming apps must parse the connection string themselves or use client libraries that accept a connection string directly.
+
 ## Connect from your app
 
 Pick the language your consuming app is written in. Each example assumes your AppHost adds a Garnet resource named `cache` and references it from the consuming app.

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-connect.mdx
@@ -21,6 +21,8 @@ This page describes how consuming apps connect to a Garnet resource that's alrea
 
 When you reference a Garnet resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire Redis client integration (Garnet is RESP-compatible) for automatic dependency injection, health checks, and telemetry.
 
+These connection properties are available when the AppHost models a typed Garnet resource (for example, `AddGarnet("cache")`) and references it from a consuming app. If the AppHost uses `AddConnectionString("cache")` or `addConnectionString("cache")`, consuming apps receive a single `ConnectionStrings` value (`ConnectionStrings:cache` / `ConnectionStrings__cache`) instead of deconstructed resource variables such as `CACHE_URI`, `CACHE_HOST`, and `CACHE_PORT`.
+
 ## Connection properties
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `cache` becomes `CACHE_URI`.

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
@@ -330,15 +330,14 @@ await builder.build().run();
 
 ## Connect to an existing Garnet instance
 
-In C#, call `AsExisting` instead of `AddGarnet` to reference an externally managed Garnet instance:
+To reference an externally managed Garnet instance instead of running one as a container, use `AddConnectionString`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var cache = builder.AddGarnet("cache")
-    .AsExisting(connectionStringParameter: builder.AddParameter("cache-cs", secret: true));
+var cache = builder.AddConnectionString("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
     .WithReference(cache);
@@ -347,7 +346,19 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `asExisting(...)` API for Garnet. To connect to an existing Garnet instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const cache = await builder.addConnectionString("cache");
+
+await builder.addNodeApp("my-app", "./app", "index.js")
+    .withReference(cache);
+
+// After adding all resources, run the app...
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
@@ -362,9 +362,11 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Garnet resource-specific connection-property variables.
+
 ## Connection properties
 
-For the full reference of Garnet connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Garnet](../garnet-connect/).
+For the full reference of Garnet resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Garnet](../garnet-connect/).
 
 ## Hosting integration health checks
 

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
@@ -362,7 +362,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Garnet resource-specific connection-property variables.
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that value as a single connection string, not deconstructed Garnet resource-specific connection-property variables such as `CACHE_HOST`, `CACHE_PORT`, or `CACHE_URI`.
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-connect.mdx
@@ -42,6 +42,29 @@ The Redis resource exposes the following connection properties:
 Uri: redis://:p%40ssw0rd1@localhost:6379
 ```
 
+## Environment variables and connection string formats
+
+The way Aspire exposes connection information depends on how the Redis resource is modeled in your AppHost:
+
+### Using `WithReference` (typed Redis resource)
+
+When your AppHost adds a typed Redis resource with `builder.AddRedis("cache")` and references it with `.WithReference(cache)`, Aspire injects **individual connection properties** as environment variables using the `[RESOURCE]_[PROPERTY]` format:
+
+- `CACHE_HOST` = hostname
+- `CACHE_PORT` = port number
+- `CACHE_PASSWORD` = password (if set)
+- `CACHE_URI` = full connection URI
+
+This is the **recommended approach** because Aspire manages the resource lifecycle, configuration, and provides typed client integrations.
+
+### Using `AddConnectionString` (external connection string)
+
+When your AppHost uses `builder.AddConnectionString("cache")` to reference an existing, pre-configured Redis instance outside Aspire's control, only a **single connection string** environment variable is injected:
+
+- `ConnectionStrings__cache` = the full connection string provided to `AddConnectionString`
+
+With this approach, there are **no individual property variables** (`CACHE_HOST`, `CACHE_PORT`, etc.). Consuming apps must parse the connection string themselves or use client libraries that accept a connection string directly.
+
 ## Connect from your app
 
 Pick the language your consuming app is written in. Each example assumes your AppHost adds a Redis resource named `cache` and references it from the consuming app.

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-connect.mdx
@@ -21,6 +21,8 @@ This page describes how consuming apps connect to a Redis resource that's alread
 
 When you reference a Redis resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire Redis client integration for automatic dependency injection, health checks, and telemetry.
 
+These connection properties are available when the AppHost models a typed Redis resource (for example, `AddRedis("cache")`) and references it from a consuming app. If the AppHost uses `AddConnectionString("cache")` or `addConnectionString("cache")`, consuming apps receive a single `ConnectionStrings` value (`ConnectionStrings:cache` / `ConnectionStrings__cache`) instead of deconstructed resource variables such as `CACHE_URI`, `CACHE_HOST`, and `CACHE_PORT`.
+
 ## Connection properties
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `cache` becomes `CACHE_URI`.

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -503,15 +503,14 @@ await builder.build().run();
 
 ## Connect to an existing Redis instance
 
-In C#, call `AsExisting` instead of `AddRedis` to reference an externally managed Redis instance:
+To reference an externally managed Redis instance instead of running one as a container, use `AddConnectionString`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var cache = builder.AddRedis("cache")
-    .AsExisting(connectionStringParameter: builder.AddParameter("cache-cs", secret: true));
+var cache = builder.AddConnectionString("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
     .WithReference(cache);
@@ -520,7 +519,19 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `asExisting(...)` API for Redis. To connect to an existing Redis instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const cache = await builder.addConnectionString("cache");
+
+await builder.addNodeApp("my-app", "./app", "index.js")
+    .withReference(cache);
+
+// After adding all resources, run the app...
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -535,7 +535,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Redis resource-specific connection-property variables.
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that value as a single connection string, not deconstructed Redis resource-specific connection-property variables such as `CACHE_HOST`, `CACHE_PORT`, or `CACHE_URI`.
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -535,9 +535,11 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Redis resource-specific connection-property variables.
+
 ## Connection properties
 
-For the full reference of Redis connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Redis](../redis-connect/).
+For the full reference of Redis resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Redis](../redis-connect/).
 
 ## Hosting integration health checks
 

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-connect.mdx
@@ -21,6 +21,8 @@ This page describes how consuming apps connect to a Valkey resource that's alrea
 
 When you reference a Valkey resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire Redis client integration (Valkey is RESP-compatible) for automatic dependency injection, health checks, and telemetry.
 
+These connection properties are available when the AppHost models a typed Valkey resource (for example, `AddValkey("cache")`) and references it from a consuming app. If the AppHost uses `AddConnectionString("cache")` or `addConnectionString("cache")`, consuming apps receive a single `ConnectionStrings` value (`ConnectionStrings:cache` / `ConnectionStrings__cache`) instead of deconstructed resource variables such as `CACHE_URI`, `CACHE_HOST`, and `CACHE_PORT`.
+
 ## Connection properties
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `cache` becomes `CACHE_URI`.

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-connect.mdx
@@ -42,6 +42,29 @@ The Valkey resource exposes the following connection properties:
 Uri: valkey://:p%40ssw0rd1@localhost:6379
 ```
 
+## Environment variables and connection string formats
+
+The way Aspire exposes connection information depends on how the Valkey resource is modeled in your AppHost:
+
+### Using `WithReference` (typed Valkey resource)
+
+When your AppHost adds a typed Valkey resource with `builder.AddValkey("cache")` and references it with `.WithReference(cache)`, Aspire injects **individual connection properties** as environment variables using the `[RESOURCE]_[PROPERTY]` format:
+
+- `CACHE_HOST` = hostname
+- `CACHE_PORT` = port number
+- `CACHE_PASSWORD` = password (if set)
+- `CACHE_URI` = full connection URI
+
+This is the **recommended approach** because Aspire manages the resource lifecycle, configuration, and provides typed client integrations.
+
+### Using `AddConnectionString` (external connection string)
+
+When your AppHost uses `builder.AddConnectionString("cache")` to reference an existing, pre-configured Valkey instance outside Aspire's control, only a **single connection string** environment variable is injected:
+
+- `ConnectionStrings__cache` = the full connection string provided to `AddConnectionString`
+
+With this approach, there are **no individual property variables** (`CACHE_HOST`, `CACHE_PORT`, etc.). Consuming apps must parse the connection string themselves or use client libraries that accept a connection string directly.
+
 ## Connect from your app
 
 Pick the language your consuming app is written in. Each example assumes your AppHost adds a Valkey resource named `cache` and references it from the consuming app.

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
@@ -359,9 +359,11 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Valkey resource-specific connection-property variables.
+
 ## Connection properties
 
-For the full reference of Valkey connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Valkey](../valkey-connect/).
+For the full reference of Valkey resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Valkey](../valkey-connect/).
 
 ## Hosting integration health checks
 

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
@@ -327,15 +327,14 @@ await builder.build().run();
 
 ## Connect to an existing Valkey instance
 
-In C#, call `AsExisting` instead of `AddValkey` to reference an externally managed Valkey instance:
+To reference an externally managed Valkey instance instead of running one as a container, use `AddConnectionString`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var cache = builder.AddValkey("cache")
-    .AsExisting(connectionStringParameter: builder.AddParameter("cache-cs", secret: true));
+var cache = builder.AddConnectionString("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
     .WithReference(cache);
@@ -344,7 +343,19 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `asExisting(...)` API for Valkey. To connect to an existing Valkey instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const cache = await builder.addConnectionString("cache");
+
+await builder.addNodeApp("my-app", "./app", "index.js")
+    .withReference(cache);
+
+// After adding all resources, run the app...
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
@@ -359,7 +359,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that connection string, not Valkey resource-specific connection-property variables.
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` from `ConnectionStrings:cache` (or environment variable `ConnectionStrings__cache`) in the AppHost configuration. Consuming apps receive that value as a single connection string, not deconstructed Valkey resource-specific connection-property variables such as `CACHE_HOST`, `CACHE_PORT`, or `CACHE_URI`.
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-connect.mdx
@@ -39,6 +39,26 @@ The Elasticsearch resource exposes the following connection properties:
 Uri: http://elastic:p%40ssw0rd1@localhost:9200
 ```
 
+## Environment variables and connection string formats
+
+The way Aspire exposes connection information depends on how the Elasticsearch resource is modeled in your AppHost:
+
+### Using `WithReference` (typed Elasticsearch resource)
+
+When your AppHost adds a typed Elasticsearch resource with `builder.AddElasticsearch("elasticsearch")` and references it with `.WithReference(elasticsearch)`, Aspire injects **individual connection properties** as environment variables using the `[RESOURCE]_[PROPERTY]` format:
+
+- `ELASTICSEARCH_URI` = full connection URI
+
+This is the **recommended approach** because Aspire manages the resource lifecycle, configuration, and provides typed client integrations.
+
+### Using `AddConnectionString` (external connection string)
+
+When your AppHost uses `builder.AddConnectionString("elasticsearch")` to reference an existing, pre-configured Elasticsearch instance outside Aspire's control, only a **single connection string** environment variable is injected:
+
+- `ConnectionStrings__elasticsearch` = the full connection string provided to `AddConnectionString`
+
+With this approach, there are **no individual property variables** (`ELASTICSEARCH_URI`). Consuming apps must use the connection string directly or parse it themselves to extract the necessary connection details.
+
 ## Connect from your app
 
 Pick the language your consuming app is written in. Each example assumes your AppHost adds an Elasticsearch resource named `elasticsearch` and references it from the consuming app.

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-connect.mdx
@@ -21,6 +21,8 @@ This page describes how consuming apps connect to an Elasticsearch resource that
 
 When you reference an Elasticsearch resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire Elasticsearch client integration for automatic dependency injection, health checks, and telemetry.
 
+These connection properties are available when the AppHost models a typed Elasticsearch resource (for example, `AddElasticsearch("elasticsearch")`) and references it from a consuming app. If the AppHost uses `AddConnectionString("elasticsearch")` or `addConnectionString("elasticsearch")`, consuming apps receive a single `ConnectionStrings` value (`ConnectionStrings:elasticsearch` / `ConnectionStrings__elasticsearch`) instead of deconstructed resource variables such as `ELASTICSEARCH_URI`.
+
 ## Connection properties
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `elasticsearch` becomes `ELASTICSEARCH_URI`.

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
@@ -226,7 +226,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-With `AddConnectionString` and `addConnectionString`, Aspire resolves `elasticsearch` from `ConnectionStrings:elasticsearch` (or environment variable `ConnectionStrings__elasticsearch`) in the AppHost configuration. Consuming apps receive that connection string, not Elasticsearch resource-specific connection-property variables.
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `elasticsearch` from `ConnectionStrings:elasticsearch` (or environment variable `ConnectionStrings__elasticsearch`) in the AppHost configuration. Consuming apps receive that value as a single connection string, not deconstructed Elasticsearch resource-specific connection-property variables such as `ELASTICSEARCH_URI`.
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
@@ -194,15 +194,14 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 ## Connect to an existing Elasticsearch instance
 
-In C#, call `AsExisting` instead of `AddElasticsearch` to reference an externally managed Elasticsearch instance:
+To reference an externally managed Elasticsearch instance instead of running one as a container, use `AddConnectionString`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var elasticsearch = builder.AddElasticsearch("elasticsearch")
-    .AsExisting(connectionStringParameter: builder.AddParameter("elasticsearch-cs", secret: true));
+var elasticsearch = builder.AddConnectionString("elasticsearch");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(elasticsearch);
@@ -211,7 +210,19 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. To connect to an existing Elasticsearch instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const elasticsearch = await builder.addConnectionString("elasticsearch");
+
+await builder.addNodeApp("my-app", "./app", "index.js")
+    .withReference(elasticsearch);
+
+// After adding all resources, run the app...
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
@@ -226,9 +226,11 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `elasticsearch` from `ConnectionStrings:elasticsearch` (or environment variable `ConnectionStrings__elasticsearch`) in the AppHost configuration. Consuming apps receive that connection string, not Elasticsearch resource-specific connection-property variables.
+
 ## Connection properties
 
-For the full reference of Elasticsearch connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Elasticsearch](../elasticsearch-connect/).
+For the full reference of Elasticsearch resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Elasticsearch](../elasticsearch-connect/).
 
 ## Hosting integration health checks
 

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-connect.mdx
@@ -44,6 +44,31 @@ The RabbitMQ server resource exposes the following connection properties:
 Uri: amqp://guest:p%40ssw0rd1@localhost:5672
 ```
 
+## Environment variables and connection string formats
+
+The way Aspire exposes connection information depends on how the RabbitMQ resource is modeled in your AppHost:
+
+### Using `WithReference` (typed RabbitMQ resource)
+
+When your AppHost adds a typed RabbitMQ resource with `builder.AddRabbitMQ("messaging")` and references it with `.WithReference(messaging)`, Aspire injects **individual connection properties** as environment variables using the `[RESOURCE]_[PROPERTY]` format:
+
+- `MESSAGING_HOST` = hostname
+- `MESSAGING_PORT` = port number
+- `MESSAGING_USERNAME` = username
+- `MESSAGING_PASSWORD` = password
+- `MESSAGING_VIRTUALHOST` = virtual host path (if set)
+- `MESSAGING_URI` = full connection URI
+
+This is the **recommended approach** because Aspire manages the resource lifecycle, configuration, and provides typed client integrations.
+
+### Using `AddConnectionString` (external connection string)
+
+When your AppHost uses `builder.AddConnectionString("messaging")` to reference an existing, pre-configured RabbitMQ server outside Aspire's control, only a **single connection string** environment variable is injected:
+
+- `ConnectionStrings__messaging` = the full connection string provided to `AddConnectionString`
+
+With this approach, there are **no individual property variables** (`MESSAGING_HOST`, `MESSAGING_PORT`, etc.). Consuming apps must parse the connection string themselves or use client libraries that accept a connection string directly.
+
 ## Connect from your app
 
 Pick the language your consuming app is written in. Each example assumes your AppHost adds a RabbitMQ resource named `messaging` and references it from the consuming app.

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-connect.mdx
@@ -21,6 +21,8 @@ This page describes how consuming apps connect to a RabbitMQ resource that's alr
 
 When you reference a RabbitMQ resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire RabbitMQ client integration for automatic dependency injection, health checks, and telemetry.
 
+These connection properties are available when the AppHost models a typed RabbitMQ resource (for example, `AddRabbitMQ("messaging")`) and references it from a consuming app. If the AppHost uses `AddConnectionString("messaging")` or `addConnectionString("messaging")`, consuming apps receive a single `ConnectionStrings` value (`ConnectionStrings:messaging` / `ConnectionStrings__messaging`) instead of deconstructed resource variables such as `MESSAGING_URI`, `MESSAGING_HOST`, and `MESSAGING_PORT`.
+
 ## Connection properties
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `messaging` becomes `MESSAGING_URI`.

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
@@ -382,7 +382,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-With `AddConnectionString` and `addConnectionString`, Aspire resolves `messaging` from `ConnectionStrings:messaging` (or environment variable `ConnectionStrings__messaging`) in the AppHost configuration. Consuming apps receive that connection string, not RabbitMQ resource-specific connection-property variables.
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `messaging` from `ConnectionStrings:messaging` (or environment variable `ConnectionStrings__messaging`) in the AppHost configuration. Consuming apps receive that value as a single connection string, not deconstructed RabbitMQ resource-specific connection-property variables such as `MESSAGING_URI`, `MESSAGING_HOST`, or `MESSAGING_PORT`.
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
@@ -350,15 +350,14 @@ await builder.build().run();
 
 ## Connect to an existing RabbitMQ instance
 
-In C#, call `AsExisting` instead of `AddRabbitMQ` to reference an externally managed RabbitMQ instance:
+To reference an externally managed RabbitMQ instance instead of running one as a container, use `AddConnectionString`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var rabbitmq = builder.AddRabbitMQ("messaging")
-    .AsExisting(connectionStringParameter: builder.AddParameter("messaging-cs", secret: true));
+var rabbitmq = builder.AddConnectionString("messaging");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(rabbitmq);
@@ -367,7 +366,19 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `asExisting(...)` API for RabbitMQ. To connect to an existing RabbitMQ instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="TypeScript — apphost.ts"
+import { createBuilder } from './.modules/aspire.js';
+
+const builder = await createBuilder();
+
+const rabbitmq = await builder.addConnectionString("messaging");
+
+await builder.addNodeApp("my-app", "./app", "index.js")
+    .withReference(rabbitmq);
+
+// After adding all resources, run the app...
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
@@ -382,9 +382,11 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
+With `AddConnectionString` and `addConnectionString`, Aspire resolves `messaging` from `ConnectionStrings:messaging` (or environment variable `ConnectionStrings__messaging`) in the AppHost configuration. Consuming apps receive that connection string, not RabbitMQ resource-specific connection-property variables.
+
 ## Connection properties
 
-For the full reference of RabbitMQ connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to RabbitMQ](../rabbitmq-connect/).
+For the full reference of RabbitMQ resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to RabbitMQ](../rabbitmq-connect/).
 
 ## Hosting integration health checks
 


### PR DESCRIPTION
## Summary
This PR fixes the docs guidance behind #1074 by removing non-Azure `AsExisting(...)` examples that don't match available APIs.

The updated guidance now models existing external resources with `AddConnectionString(...)` / `addConnectionString(...)` instead.

## What changed
- Replaced non-Azure existing-instance snippets that used `AsExisting(connectionStringParameter: ...)`.
- Added C# and TypeScript examples using `AddConnectionString` / `addConnectionString`.
- Clarified that these values are resolved from AppHost configuration keys such as `ConnectionStrings:<name>` / `ConnectionStrings__<name>`.
- Clarified that this connection-string pattern does not inject typed resource-specific connection-property variables.

## Files updated
- `src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx`
- `src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx`
- `src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx`
- `src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx`
- `src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx`
- `src/frontend/src/content/docs/get-started/glossary.mdx`

Fixes #1074