### PR TITLE
Add Aspire Skills documentation

### DIFF
--- a/src/frontend/config/sidebar/docs.topics.ts
+++ b/src/frontend/config/sidebar/docs.topics.ts
@@ -433,6 +433,10 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
               slug: 'get-started/ai-coding-agents',
             },
             {
+              label: 'Aspire Skills',
+              slug: 'get-started/aspire-skills',
+            },
+            {
               label: 'Aspire MCP server',
               slug: 'get-started/aspire-mcp-server',
             },

--- a/src/frontend/scripts/update-github-stats.ts
+++ b/src/frontend/scripts/update-github-stats.ts
@@ -7,6 +7,7 @@ const REPOS = [
   'microsoft/aspire-samples',
   'CommunityToolkit/Aspire',
   'microsoft/aspire.dev',
+  'microsoft/aspire-skills',
   'microsoft/dcp',
 ] as const;
 const OUTPUT_PATH = './src/data/github-stats.json';

--- a/src/frontend/src/content/docs/community/contributors.mdx
+++ b/src/frontend/src/content/docs/community/contributors.mdx
@@ -70,6 +70,13 @@ Want to help [improve the aspire.dev site?](/community/contributor-guide/) We're
 <ContributorList githubRepo="microsoft/aspire.dev" ignore={ignore} />
 <GitHubRepoStats stats={stats} repoName="microsoft/aspire.dev" />
 
+## 🤖 Aspire Skills contributors
+
+Aspire Skills helps AI coding agents follow Aspire workflows consistently, from AppHost setup and orchestration to deployment and diagnostics. Contributions to the skills, plugin metadata, docs, and evals help agents stay aligned with current Aspire guidance and improve the experience for everyone using AI-assisted development with Aspire.
+
+<ContributorList githubRepo="microsoft/aspire-skills" ignore={ignore} />
+<GitHubRepoStats stats={stats} repoName="microsoft/aspire-skills" />
+
 ## ⚙️ DCP contributors
 
 The [Distributed Component Platform (DCP)](/architecture/overview/#developer-control-plane) is an open-source project that provides a framework for building distributed applications. It is designed to simplify the development of microservices and serverless applications by providing a set of tools and libraries that make it easy to create, deploy, and manage distributed components.

--- a/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
@@ -1,21 +1,20 @@
 ---
 title: Dashboard and AI coding agents
 seoTitle: Aspire dashboard and AI coding agents for distributed apps
-description: Learn how AI coding agents use the Aspire CLI and optional agent integrations to read dashboard telemetry, diagnose failures, and propose code changes.
+description: Learn how AI coding agents use the Aspire CLI to read dashboard telemetry, diagnose failures, and propose code changes.
 ---
 
-import { Aside, Steps } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 
-AI coding agents can use the [Aspire CLI](/reference/cli/overview/) to fetch logs and telemetry from the Aspire dashboard. Agents can also use the [Aspire MCP server](/get-started/aspire-mcp-server/) when their host supports MCP. This gives agents the same observability data that developers see in the dashboard UI — structured logs, distributed traces, resource status, and console output — so they can diagnose issues, verify fixes, and add new features with full context.
+AI coding agents can use the [Aspire CLI](/reference/cli/overview/) to fetch logs and telemetry from the Aspire dashboard. This gives agents the same observability data that developers see in the dashboard UI — structured logs, distributed traces, resource status, and console output — so they can diagnose issues, verify fixes, and add new features with full context.
 
 ## How agents use dashboard data
 
-When an Aspire app is running, the dashboard collects OpenTelemetry data from all resources. AI coding agents primarily access this data through the Aspire CLI:
+When an Aspire app is running, the dashboard collects OpenTelemetry data from all resources. AI coding agents access this data through the Aspire CLI:
 
 - **Aspire CLI** — Commands like [`aspire logs`](/reference/cli/commands/aspire-logs/), [`aspire otel logs`](/reference/cli/commands/aspire-otel-logs/), [`aspire otel traces`](/reference/cli/commands/aspire-otel-traces/), and [`aspire describe`](/reference/cli/commands/aspire-describe/) retrieve resource status, console logs, and telemetry directly from the terminal. All commands support `--format Json` for structured output that agents can parse.
-- **Optional Aspire MCP server** — The [MCP server](/get-started/aspire-mcp-server/) exposes tools such as `list_resources`, `list_structured_logs`, `list_traces`, and `list_console_logs` for agent hosts that support the Model Context Protocol.
 
-Both channels draw from the same underlying dashboard data. Whether an agent reads logs via the CLI or through configured MCP tools, it sees the same information as the dashboard UI.
+The CLI draws from the same underlying dashboard data. Whether an agent reads logs from the terminal or a developer views them in the dashboard UI, they see the same information.
 
 ### Typical agent workflow
 
@@ -66,18 +65,6 @@ aspire otel logs --dashboard-url "http://localhost:18888"
 aspire otel traces --dashboard-url "http://localhost:18888"
 aspire otel spans --dashboard-url "http://localhost:18888"
 ```
-
-### Use Aspire MCP with the standalone dashboard
-
-Start the MCP server in dashboard-only mode using `--dashboard-url`:
-
-```bash title="Aspire CLI"
-aspire agent mcp --dashboard-url "http://localhost:18888"
-```
-
-This exposes the dashboard's telemetry tools (structured logs, traces, and resource data) to any MCP-compatible AI assistant.
-
-Configuration is required in the agent to use the MCP server. For configuration details, see [Aspire MCP server configuration](/get-started/aspire-mcp-server/#configuration). The `--dashboard-url` must be passed as a command line argument when configuring the MCP server for standalone use.
 
 ### Sample skill for standalone dashboard
 
@@ -132,6 +119,5 @@ aspire otel spans --dashboard-url http://localhost:18888
 
 - [Use AI coding agents](/get-started/ai-coding-agents/) — full setup guide with `aspire agent init`
 - [Aspire Skills](/get-started/aspire-skills/) — plugin installation and included skills
-- [Aspire MCP server](/get-started/aspire-mcp-server/) — optional runtime data access for MCP-compatible tools
 - [Standalone Aspire dashboard](/dashboard/standalone/) — running the dashboard without an AppHost
 - [Aspire CLI reference](/reference/cli/overview/)

--- a/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
@@ -19,7 +19,7 @@ Both channels draw from the same underlying dashboard data. Whether an agent rea
 
 ### Typical agent workflow
 
-The following workflow is an example — [Aspire skill files](/get-started/ai-coding-agents/#aspire-skill-file) teach agents the best patterns to run and debug Aspire apps automatically. A typical agent-driven debugging session looks like this:
+The following workflow is an example — [Aspire skill files](/get-started/ai-coding-agents/#aspire-skill-file) and the [Aspire Skills plugin pack](/get-started/aspire-skills/) teach agents the best patterns to run and debug Aspire apps automatically. A typical agent-driven debugging session looks like this:
 
 <Steps>
 
@@ -33,7 +33,7 @@ The following workflow is an example — [Aspire skill files](/get-started/ai-co
 
 ## Get started
 
-The fastest way to set up AI coding agents with Aspire is the `aspire agent init` command. See [Use AI coding agents](/get-started/ai-coding-agents/) for the full setup guide, including skill files, MCP server configuration, and supported AI assistants.
+The fastest way to set up AI coding agents with Aspire is the `aspire agent init` command. See [Use AI coding agents](/get-started/ai-coding-agents/) for the full setup guide, including skill files, MCP server configuration, and supported AI assistants. For global plugin installation, included skills, and eval coverage, see [Aspire Skills](/get-started/aspire-skills/).
 
 ## Standalone mode
 
@@ -131,6 +131,7 @@ aspire otel spans --dashboard-url http://localhost:18888
 ## See also
 
 - [Use AI coding agents](/get-started/ai-coding-agents/) — full setup guide with `aspire agent init`
+- [Aspire Skills](/get-started/aspire-skills/) — plugin installation, included skills, and eval coverage
 - [Aspire MCP server](/get-started/aspire-mcp-server/) — MCP tools, security, and troubleshooting
 - [Standalone Aspire dashboard](/dashboard/standalone/) — running the dashboard without an AppHost
 - [Aspire CLI reference](/reference/cli/overview/)

--- a/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/dashboard/ai-coding-agents.mdx
@@ -1,21 +1,21 @@
 ---
 title: Dashboard and AI coding agents
 seoTitle: Aspire dashboard and AI coding agents for distributed apps
-description: Learn how AI coding agents use the Aspire CLI and MCP server to read logs and telemetry from the Aspire dashboard, diagnose failures, and propose code changes.
+description: Learn how AI coding agents use the Aspire CLI and optional agent integrations to read dashboard telemetry, diagnose failures, and propose code changes.
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
 
-AI coding agents can use the [Aspire CLI](/reference/cli/overview/) and [Aspire MCP server](/get-started/aspire-mcp-server/) to fetch logs and telemetry from the Aspire dashboard. This gives agents the same observability data that developers see in the dashboard UI — structured logs, distributed traces, resource status, and console output — so they can diagnose issues, verify fixes, and add new features with full context.
+AI coding agents can use the [Aspire CLI](/reference/cli/overview/) to fetch logs and telemetry from the Aspire dashboard. Agents can also use the [Aspire MCP server](/get-started/aspire-mcp-server/) when their host supports MCP. This gives agents the same observability data that developers see in the dashboard UI — structured logs, distributed traces, resource status, and console output — so they can diagnose issues, verify fixes, and add new features with full context.
 
 ## How agents use dashboard data
 
-When an Aspire app is running, the dashboard collects OpenTelemetry data from all resources. AI coding agents access this data through two channels:
+When an Aspire app is running, the dashboard collects OpenTelemetry data from all resources. AI coding agents primarily access this data through the Aspire CLI:
 
 - **Aspire CLI** — Commands like [`aspire logs`](/reference/cli/commands/aspire-logs/), [`aspire otel logs`](/reference/cli/commands/aspire-otel-logs/), [`aspire otel traces`](/reference/cli/commands/aspire-otel-traces/), and [`aspire describe`](/reference/cli/commands/aspire-describe/) retrieve resource status, console logs, and telemetry directly from the terminal. All commands support `--format Json` for structured output that agents can parse.
-- **Aspire MCP server** — The [MCP server](/get-started/aspire-mcp-server/) exposes tools such as `list_resources`, `list_structured_logs`, `list_traces`, and `list_console_logs` that agents call directly through the Model Context Protocol.
+- **Optional Aspire MCP server** — The [MCP server](/get-started/aspire-mcp-server/) exposes tools such as `list_resources`, `list_structured_logs`, `list_traces`, and `list_console_logs` for agent hosts that support the Model Context Protocol.
 
-Both channels draw from the same underlying dashboard data. Whether an agent reads logs via the CLI or through MCP tools, it sees the same information as the dashboard UI.
+Both channels draw from the same underlying dashboard data. Whether an agent reads logs via the CLI or through configured MCP tools, it sees the same information as the dashboard UI.
 
 ### Typical agent workflow
 
@@ -25,7 +25,7 @@ The following workflow is an example — [Aspire skill files](/get-started/ai-co
 
 1. The agent starts the Aspire app with `aspire start` and waits for resources to become healthy with `aspire wait`.
 1. The agent runs `aspire describe` to check resource status and identify any unhealthy services.
-1. The agent fetches structured logs with `aspire otel logs` or the `list_structured_logs` MCP tool, filtering by resource name to find errors.
+1. The agent fetches structured logs with `aspire otel logs`, filtering by resource name to find errors.
 1. The agent retrieves distributed traces with `aspire otel traces` to understand cross-service request flow and identify latency issues.
 1. Using the collected data, the agent makes code changes, restarts the affected resource, and verifies the fix by checking logs and traces again.
 
@@ -33,11 +33,11 @@ The following workflow is an example — [Aspire skill files](/get-started/ai-co
 
 ## Get started
 
-The fastest way to set up AI coding agents with Aspire is the `aspire agent init` command. See [Use AI coding agents](/get-started/ai-coding-agents/) for the full setup guide, including skill files, MCP server configuration, and supported AI assistants. For global plugin installation, included skills, and eval coverage, see [Aspire Skills](/get-started/aspire-skills/).
+The fastest way to set up AI coding agents with Aspire is the `aspire agent init` command. See [Use AI coding agents](/get-started/ai-coding-agents/) for the full setup guide, including skill files and supported AI assistants. For global plugin installation and included skills, see [Aspire Skills](/get-started/aspire-skills/).
 
 ## Standalone mode
 
-The Aspire CLI and MCP server work with the [standalone dashboard](/dashboard/standalone/) — you don't need an Aspire AppHost project. This is useful when monitoring any application that sends OpenTelemetry data to the dashboard.
+The Aspire CLI works with the [standalone dashboard](/dashboard/standalone/) — you don't need an Aspire AppHost project. This is useful when monitoring any application that sends OpenTelemetry data to the dashboard.
 
 ### Start the standalone dashboard
 
@@ -131,7 +131,7 @@ aspire otel spans --dashboard-url http://localhost:18888
 ## See also
 
 - [Use AI coding agents](/get-started/ai-coding-agents/) — full setup guide with `aspire agent init`
-- [Aspire Skills](/get-started/aspire-skills/) — plugin installation, included skills, and eval coverage
-- [Aspire MCP server](/get-started/aspire-mcp-server/) — MCP tools, security, and troubleshooting
+- [Aspire Skills](/get-started/aspire-skills/) — plugin installation and included skills
+- [Aspire MCP server](/get-started/aspire-mcp-server/) — optional runtime data access for MCP-compatible tools
 - [Standalone Aspire dashboard](/dashboard/standalone/) — running the dashboard without an AppHost
 - [Aspire CLI reference](/reference/cli/overview/)

--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -1,21 +1,27 @@
 ---
 title: Use AI coding agents
 seoTitle: Use AI coding agents with Aspire AppHost projects today
-description: Set up AI coding agents to work with Aspire — install skills, configure the Aspire MCP server, and enable browser automation for distributed-app development workflows.
+description: Set up AI coding agents to work with Aspire — install skills, configure agent tooling, and enable browser automation for distributed-app development workflows.
 ---
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
-import { Aside, Steps, Tabs, TabItem, FileTree } from '@astrojs/starlight/components';
+import {
+  Aside,
+  Steps,
+  Tabs,
+  TabItem,
+  FileTree,
+} from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
 import LoopingVideo from '@components/LoopingVideo.astro';
 import LearnMore from '@components/LearnMore.astro';
 
-Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr>-compatible tool — can immediately understand, build, debug, and monitor your distributed applications. For global agent-host plugins and the shared Aspire skill pack, see [Aspire Skills](/get-started/aspire-skills/).
+Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another agentic coding tool — can immediately understand, build, debug, and monitor your distributed applications. For global agent-host plugins and the shared Aspire skill pack, see [Aspire Skills](/get-started/aspire-skills/).
 
 ## Why Aspire for coding agents
 
-Aspire gives coding agents the same visibility into your running application that a developer has. The resource data, structured logs, and distributed traces you see in the [Aspire Dashboard](/dashboard/overview/) are exposed to agents through the [Aspire MCP server](/get-started/aspire-mcp-server/) and the [Aspire CLI](/get-started/install-cli/). Whether a person is debugging in the dashboard or an agent is diagnosing through MCP, they see the same picture.
+Aspire gives coding agents the same visibility into your running application that a developer has. The resource data, structured logs, and distributed traces you see in the [Aspire Dashboard](/dashboard/overview/) are available through the [Aspire CLI](/get-started/install-cli/) and, when configured, agent integrations such as the [Aspire MCP server](/get-started/aspire-mcp-server/). Whether a person is debugging in the dashboard or an agent is diagnosing from the terminal, they see the same picture.
 
 The Aspire CLI is built for agent-driven workflows — commands support non-interactive execution to avoid blocking on prompts, and many commands support `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
 
@@ -37,27 +43,27 @@ When you create a new Aspire project with `aspire new` or `aspire init`, you're 
 
 1. Select the **skill locations** where you want files installed. The **Standard** location is pre-selected by default:
 
-   | Location | Directory | Notes |
-   |---|---|---|
-   | **Standard** | `.agents/skills/` | Supported by VS Code, GitHub Copilot, and OpenCode |
-   | **Claude Code** | `.claude/skills/` | Claude Code specific |
-   | **GitHub Skills** | `.github/skills/` | VS Code / GitHub Copilot specific |
-   | **OpenCode** | `.opencode/skill/` | OpenCode specific |
+   | Location          | Directory          | Notes                                              |
+   | ----------------- | ------------------ | -------------------------------------------------- |
+   | **Standard**      | `.agents/skills/`  | Supported by VS Code, GitHub Copilot, and OpenCode |
+   | **Claude Code**   | `.claude/skills/`  | Claude Code specific                               |
+   | **GitHub Skills** | `.github/skills/`  | VS Code / GitHub Copilot specific                  |
+   | **OpenCode**      | `.opencode/skill/` | OpenCode specific                                  |
 
 1. Select the **skills and tools** to install into those locations. All options are pre-selected by default:
-
    - **Aspire skill** — teaches your AI agent how to use Aspire CLI commands
    - **Playwright CLI** — enables browser automation for testing web resources
    - **dotnet-inspect skill** — teaches your AI agent to query .NET API surfaces
 
 </Steps>
 
-<AsciinemaPlayer 
-  src="/casts/agent-init.cast" 
-  poster="npt:0:08" 
+<AsciinemaPlayer
+  src="/casts/agent-init.cast"
+  poster="npt:0:08"
   autoPlay={true}
   cols={256}
-  rows={10} />
+  rows={10}
+/>
 
 ## What gets configured
 
@@ -70,13 +76,13 @@ The skill file teaches your AI coding agent how to work with Aspire. It includes
 <FileTree>
 
 - .agents/skills/aspire/
-  - SKILL.md  Standard (VS Code, GitHub Copilot, OpenCode)
+  - SKILL.md Standard (VS Code, GitHub Copilot, OpenCode)
 - .github/skills/aspire/
-  - SKILL.md  GitHub Copilot (legacy location)
+  - SKILL.md GitHub Copilot (legacy location)
 - .claude/skills/aspire/
-  - SKILL.md  Claude Code
+  - SKILL.md Claude Code
 - .opencode/skill/aspire/
-  - SKILL.md  OpenCode
+  - SKILL.md OpenCode
 
 </FileTree>
 
@@ -85,7 +91,7 @@ The skill file guides your agent on how to:
 - Start and manage your Aspire application (`aspire start`, `aspire stop`, `aspire describe`)
 - Debug issues using structured logs and distributed traces
 - Add integrations with `aspire add` and search documentation with `aspire docs`
-- Use resource MCP tools for database queries and other resource-specific operations
+- Use resource-specific tools for database queries and other operations
 
 ### dotnet-inspect skill
 
@@ -110,9 +116,9 @@ The skill enables your agent to inspect NuGet package API surfaces, compare API 
 The `dotnet-inspect` skill should not be installed alongside the Aspire skill. The Aspire skill already includes support for `aspire docs api` subcommands, providing a powerful way to query Aspire APIs across both C# and TypeScript.
 :::
 
-### Aspire MCP server
+### Optional Aspire MCP server
 
-The MCP server gives your AI agent direct runtime access to your running Aspire application — resource status, logs, traces, and commands. See [Aspire MCP server](/get-started/aspire-mcp-server/) for configuration details, available tools, and the security model.
+If your AI assistant supports MCP, the Aspire MCP server gives it direct runtime access to your running Aspire application — resource status, logs, traces, and commands. See [Aspire MCP server](/get-started/aspire-mcp-server/) for configuration details, available tools, and the security model.
 
 ### Aspire Skills plugin pack
 
@@ -138,7 +144,9 @@ If your project has an `AGENTS.md` file from a previous version of Aspire, you c
 </Steps>
 
 <Aside type="tip">
-The skill file is more structured than `AGENTS.md` and includes a complete CLI command reference table, workflow patterns, and rules that the agent follows automatically. You can customize it for your project's specific needs.
+  The skill file is more structured than `AGENTS.md` and includes a complete CLI
+  command reference table, workflow patterns, and rules that the agent follows
+  automatically. You can customize it for your project's specific needs.
 </Aside>
 
 ## Your first prompts
@@ -158,36 +166,40 @@ Once configured, start your preferred AI coding environment. Try asking your age
       controls={true}
       sources={[
         {
-          src: "/mcp-vscode-list-resources.mp4",
-          type: "video/mp4",
-          title: "VS Code demonstrating Aspire MCP integration with GitHub Copilot"
-        }
+          src: '/mcp-vscode-list-resources.mp4',
+          type: 'video/mp4',
+          title:
+            'VS Code demonstrating Aspire MCP integration with GitHub Copilot',
+        },
       ]}
     />
   </TabItem>
   <TabItem label="Claude Code" id="demo-claude">
-    <AsciinemaPlayer 
+    <AsciinemaPlayer
       src="/casts/mcp-claudecode-cli.cast"
       poster="npt:0:27"
       autoPlay={true}
       cols={256}
-      rows={28} />
+      rows={28}
+    />
   </TabItem>
   <TabItem label="Copilot CLI" id="demo-copilot">
-    <AsciinemaPlayer 
+    <AsciinemaPlayer
       src="/casts/mcp-copilot-cli.cast"
       poster="npt:0:22"
       autoPlay={true}
       cols={256}
-      rows={28} />
+      rows={28}
+    />
   </TabItem>
   <TabItem label="OpenCode" id="demo-opencode">
-    <AsciinemaPlayer 
+    <AsciinemaPlayer
       src="/casts/mcp-opencode-cli.cast"
       poster="npt:0:14"
       autoPlay={true}
       cols={256}
-      rows={28} />
+      rows={28}
+    />
   </TabItem>
 </Tabs>
 
@@ -203,15 +215,17 @@ The `aspire agent init` command supports project-local setup for the following A
 The [Aspire Skills plugin pack](/get-started/aspire-skills/#install-as-an-agent-plugin-or-extension) also provides install paths for Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, and Ollama with Copilot CLI.
 
 <Aside type="note">
-The Aspire MCP server uses the STDIO transport protocol and may work with other agentic coding environments that support this MCP communication protocol.
+  The Aspire MCP server uses the STDIO transport protocol and may work with
+  other agentic coding environments that support this MCP communication
+  protocol.
 </Aside>
 
 ## See also
 
-- [Aspire MCP server](/get-started/aspire-mcp-server/) — tools, security, and troubleshooting for the MCP server
 - [Aspire Skills](/get-started/aspire-skills/) — plugin installation, included skills, and eval coverage
 - [aspire agent command](/reference/cli/commands/aspire-agent/)
 - [aspire agent init command](/reference/cli/commands/aspire-agent-init/)
 - [aspire agent mcp command](/reference/cli/commands/aspire-agent-mcp/)
+- [Aspire MCP server](/get-started/aspire-mcp-server/) — optional runtime data access for MCP-compatible tools
 - [Dashboard security considerations](/dashboard/security-considerations/)
 - [Dashboard and AI coding agents](/dashboard/ai-coding-agents/)

--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -11,7 +11,7 @@ import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
 import LoopingVideo from '@components/LoopingVideo.astro';
 import LearnMore from '@components/LearnMore.astro';
 
-Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr>-compatible tool — can immediately understand, build, debug, and monitor your distributed applications.
+Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr>-compatible tool — can immediately understand, build, debug, and monitor your distributed applications. For global agent-host plugins and the shared Aspire skill pack, see [Aspire Skills](/get-started/aspire-skills/).
 
 ## Why Aspire for coding agents
 
@@ -19,7 +19,7 @@ Aspire gives coding agents the same visibility into your running application tha
 
 The Aspire CLI is built for agent-driven workflows — commands support non-interactive execution to avoid blocking on prompts, and many commands support `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
 
-The Aspire skill file (installed by `aspire agent init`) teaches agents all of these patterns automatically.
+The Aspire skill file (installed by `aspire agent init`) teaches agents all of these patterns automatically. The separate [Aspire Skills](/get-started/aspire-skills/) plugin pack makes the same Aspire-aware routing and guardrails available to supported agent hosts globally.
 
 ## Get started
 
@@ -114,6 +114,15 @@ The `dotnet-inspect` skill should not be installed alongside the Aspire skill. T
 
 The MCP server gives your AI agent direct runtime access to your running Aspire application — resource status, logs, traces, and commands. See [Aspire MCP server](/get-started/aspire-mcp-server/) for configuration details, available tools, and the security model.
 
+### Aspire Skills plugin pack
+
+The [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) repository packages the Aspire skill, focused sub-skills, plugin metadata, and evals for agent hosts that support plugin or extension installation. Use it when you want Aspire guidance installed globally for tools such as Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, or Ollama with Copilot CLI.
+
+<LearnMore>
+  For installation commands, included skills, and evaluation coverage, see
+  [Aspire Skills](/get-started/aspire-skills/).
+</LearnMore>
+
 ## Migrate from AGENTS.md
 
 If your project has an `AGENTS.md` file from a previous version of Aspire, you can migrate to the new skill file format. The skill file provides better structure and is recognized natively by AI coding agents.
@@ -184,12 +193,14 @@ Once configured, start your preferred AI coding environment. Try asking your age
 
 ## Supported AI assistants
 
-The `aspire agent init` command supports the following AI assistants:
+The `aspire agent init` command supports project-local setup for the following AI assistants:
 
 - [VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) with GitHub Copilot
 - [Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli#add-an-mcp-server)
 - [Claude Code](https://docs.claude.com/en/docs/claude-code/mcp)
 - [OpenCode](https://opencode.ai/docs/mcp-servers/)
+
+The [Aspire Skills plugin pack](/get-started/aspire-skills/#install-as-an-agent-plugin-or-extension) also provides install paths for Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, and Ollama with Copilot CLI.
 
 <Aside type="note">
 The Aspire MCP server uses the STDIO transport protocol and may work with other agentic coding environments that support this MCP communication protocol.
@@ -198,6 +209,7 @@ The Aspire MCP server uses the STDIO transport protocol and may work with other 
 ## See also
 
 - [Aspire MCP server](/get-started/aspire-mcp-server/) — tools, security, and troubleshooting for the MCP server
+- [Aspire Skills](/get-started/aspire-skills/) — plugin installation, included skills, and eval coverage
 - [aspire agent command](/reference/cli/commands/aspire-agent/)
 - [aspire agent init command](/reference/cli/commands/aspire-agent-init/)
 - [aspire agent mcp command](/reference/cli/commands/aspire-agent-mcp/)

--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -4,24 +4,14 @@ seoTitle: Use AI coding agents with Aspire AppHost projects today
 description: Set up AI coding agents to work with Aspire — install skills, configure agent tooling, and enable browser automation for distributed-app development workflows.
 ---
 
-import { LinkCard, CardGrid } from '@astrojs/starlight/components';
-import {
-  Aside,
-  Steps,
-  Tabs,
-  TabItem,
-  FileTree,
-} from '@astrojs/starlight/components';
-import { Image } from 'astro:assets';
-import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
-import LoopingVideo from '@components/LoopingVideo.astro';
+import { Aside, Steps, FileTree } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 
 Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another agentic coding tool — can immediately understand, build, debug, and monitor your distributed applications. For global agent-host plugins and the shared Aspire skill pack, see [Aspire Skills](/get-started/aspire-skills/).
 
 ## Why Aspire for coding agents
 
-Aspire gives coding agents the same visibility into your running application that a developer has. The resource data, structured logs, and distributed traces you see in the [Aspire Dashboard](/dashboard/overview/) are available through the [Aspire CLI](/get-started/install-cli/) and, when configured, agent integrations such as the [Aspire MCP server](/get-started/aspire-mcp-server/). Whether a person is debugging in the dashboard or an agent is diagnosing from the terminal, they see the same picture.
+Aspire gives coding agents the same visibility into your running application that a developer has. The resource data, structured logs, and distributed traces you see in the [Aspire Dashboard](/dashboard/overview/) are available through the [Aspire CLI](/get-started/install-cli/). Whether a person is debugging in the dashboard or an agent is diagnosing from the terminal, they see the same picture.
 
 The Aspire CLI is built for agent-driven workflows — commands support non-interactive execution to avoid blocking on prompts, and many commands support `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
 
@@ -116,10 +106,6 @@ The skill enables your agent to inspect NuGet package API surfaces, compare API 
 The `dotnet-inspect` skill should not be installed alongside the Aspire skill. The Aspire skill already includes support for `aspire docs api` subcommands, providing a powerful way to query Aspire APIs across both C# and TypeScript.
 :::
 
-### Optional Aspire MCP server
-
-If your AI assistant supports MCP, the Aspire MCP server gives it direct runtime access to your running Aspire application — resource status, logs, traces, and commands. See [Aspire MCP server](/get-started/aspire-mcp-server/) for configuration details, available tools, and the security model.
-
 ### Aspire Skills plugin pack
 
 The [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) repository packages the Aspire skill, focused sub-skills, plugin metadata, and evals for agent hosts that support plugin or extension installation. Use it when you want Aspire guidance installed globally for tools such as Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, or Ollama with Copilot CLI.
@@ -159,73 +145,21 @@ Once configured, start your preferred AI coding environment. Try asking your age
 
 > "Add a Redis cache to my AppHost."
 
-<Tabs>
-  <TabItem label="VS Code" id="demo-vscode">
-    <LoopingVideo
-      aria-label="VS Code with GitHub Copilot using Aspire MCP to list resources"
-      controls={true}
-      sources={[
-        {
-          src: '/mcp-vscode-list-resources.mp4',
-          type: 'video/mp4',
-          title:
-            'VS Code demonstrating Aspire MCP integration with GitHub Copilot',
-        },
-      ]}
-    />
-  </TabItem>
-  <TabItem label="Claude Code" id="demo-claude">
-    <AsciinemaPlayer
-      src="/casts/mcp-claudecode-cli.cast"
-      poster="npt:0:27"
-      autoPlay={true}
-      cols={256}
-      rows={28}
-    />
-  </TabItem>
-  <TabItem label="Copilot CLI" id="demo-copilot">
-    <AsciinemaPlayer
-      src="/casts/mcp-copilot-cli.cast"
-      poster="npt:0:22"
-      autoPlay={true}
-      cols={256}
-      rows={28}
-    />
-  </TabItem>
-  <TabItem label="OpenCode" id="demo-opencode">
-    <AsciinemaPlayer
-      src="/casts/mcp-opencode-cli.cast"
-      poster="npt:0:14"
-      autoPlay={true}
-      cols={256}
-      rows={28}
-    />
-  </TabItem>
-</Tabs>
-
 ## Supported AI assistants
 
 The `aspire agent init` command supports project-local setup for the following AI assistants:
 
-- [VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) with GitHub Copilot
-- [Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli#add-an-mcp-server)
-- [Claude Code](https://docs.claude.com/en/docs/claude-code/mcp)
-- [OpenCode](https://opencode.ai/docs/mcp-servers/)
+- [VS Code](https://code.visualstudio.com/docs/copilot/overview) with GitHub Copilot
+- [Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli)
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/overview)
+- [OpenCode](https://opencode.ai/docs/)
 
 The [Aspire Skills plugin pack](/get-started/aspire-skills/#install-as-an-agent-plugin-or-extension) also provides install paths for Copilot CLI, Claude Code, Codex CLI, Gemini CLI, Cursor CLI, OpenCode, and Ollama with Copilot CLI.
-
-<Aside type="note">
-  The Aspire MCP server uses the STDIO transport protocol and may work with
-  other agentic coding environments that support this MCP communication
-  protocol.
-</Aside>
 
 ## See also
 
 - [Aspire Skills](/get-started/aspire-skills/) — plugin installation, included skills, and eval coverage
 - [aspire agent command](/reference/cli/commands/aspire-agent/)
 - [aspire agent init command](/reference/cli/commands/aspire-agent-init/)
-- [aspire agent mcp command](/reference/cli/commands/aspire-agent-mcp/)
-- [Aspire MCP server](/get-started/aspire-mcp-server/) — optional runtime data access for MCP-compatible tools
 - [Dashboard security considerations](/dashboard/security-considerations/)
 - [Dashboard and AI coding agents](/dashboard/ai-coding-agents/)

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -1,5 +1,6 @@
 ---
 title: Aspire Skills
+seoTitle: Install Aspire Skills for AI coding agents in Aspire
 description: Learn how to install and use the Aspire Skills plugin pack for AI coding agents.
 ---
 
@@ -10,7 +11,7 @@ import LearnMore from '@components/LearnMore.astro';
 
 Use the skills together with [`aspire agent init`](/reference/cli/commands/aspire-agent-init/):
 
-- Run `aspire agent init` inside an Aspire project to install project-local skill files and MCP configuration with app-specific context.
+- Run `aspire agent init` inside an Aspire project to install project-local skill files and agent configuration with app-specific context.
 - Install the Aspire Skills plugin pack in an agent host when you want global Aspire guardrails available before or alongside project-local guidance.
 - Let project-local skill files take precedence when both are present because they can include repository-specific instructions.
 
@@ -37,7 +38,7 @@ In Aspire 13.4, the Aspire CLI installs a limited skills catalog: `aspire`, `asp
 
 ## Install with the Aspire CLI
 
-The Aspire CLI is the first-party setup path. It installs Aspire skill files and MCP configuration into detected agent environments.
+The Aspire CLI is the first-party setup path. It installs Aspire skill files and agent configuration into detected environments.
 
 ```bash title="Aspire CLI"
 # Create a new Aspire app and opt into agent guidance when prompted.
@@ -149,7 +150,7 @@ This layering gives agents an Aspire-native path:
 1. The agent host loads Aspire Skills from its plugin, extension, or skill location.
 2. The top-level `aspire` skill detects an Aspire workspace and routes the task.
 3. Project-local guidance from `aspire agent init` adds repository-specific context.
-4. The agent uses the Aspire CLI and MCP server to inspect, change, run, and diagnose the app.
+4. The agent uses the Aspire CLI and configured agent integrations to inspect, change, run, and diagnose the app.
 
 The Aspire Skills repository also uses [waza](https://github.com/microsoft/waza) to evaluate skill quality. These evals exercise routing, content correctness, and behavior so the project-level guidance and plugin guardrails are checked before they ship.
 
@@ -160,8 +161,6 @@ The Aspire Skills repository also uses [waza](https://github.com/microsoft/waza)
 
 ## See also
 
-- [Aspire Skills public site](https://microsoft.github.io/aspire-skills/)
 - [Aspire Skills repository](https://github.com/microsoft/aspire-skills)
 - [Use AI coding agents](/get-started/ai-coding-agents/)
-- [Aspire MCP server](/get-started/aspire-mcp-server/)
 - [`aspire agent init` command reference](/reference/cli/commands/aspire-agent-init/)

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -31,6 +31,10 @@ The repository packages six skills that map common Aspire work to the right work
 | [`aspire-deployment`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-deployment)       | Publishes, deploys, and tears down Aspire apps through Aspire deployment workflows.          |
 | [`aspire-monitoring`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-monitoring)       | Routes logs, traces, dashboard, telemetry, and diagnostics work to the right tools.          |
 
+:::note[CLI-installed skills]
+In Aspire 13.4, the Aspire CLI installs a limited skills catalog: `aspire`, `aspireify`, and `aspire-deployment`. To install all skills from the Aspire Skills repository, use the skills.sh `npx` approach or an agent host plugin or extension. For background on the bundled catalog work, see [microsoft/aspire#17553](https://github.com/microsoft/aspire/pull/17553).
+:::
+
 ## Install with the Aspire CLI
 
 The Aspire CLI is the first-party setup path. It installs Aspire skill files and MCP configuration into detected agent environments.
@@ -147,20 +151,7 @@ This layering gives agents an Aspire-native path:
 3. Project-local guidance from `aspire agent init` adds repository-specific context.
 4. The agent uses the Aspire CLI and MCP server to inspect, change, run, and diagnose the app.
 
-## Evaluation coverage
-
-The Aspire Skills repository uses [waza](https://github.com/microsoft/waza) to evaluate skill quality. Evals exercise skill routing, content correctness, and behavior against an LLM-as-judge rubric.
-
-The current public eval coverage includes 54 scenario tasks and 113 trigger prompts across the six skills:
-
-| Skill                  | Tasks | Trigger prompts | Focus                                                                                            |
-| ---------------------- | ----: | --------------: | ------------------------------------------------------------------------------------------------ |
-| `aspire`               |     6 |              16 | Routing precision to sub-skills                                                                  |
-| `aspire-init`          |     5 |              15 | Skeleton drop, `aspire new` / `aspire init` decisions, and `aspireify` handoff                   |
-| `aspireify`            |     8 |              18 | AppHost wiring across C#, file-based C#, and TypeScript; validation; and generated module safety |
-| `aspire-orchestration` |    16 |              24 | Lifecycle, file lock recovery, hidden resources, and CLI self-updates                            |
-| `aspire-deployment`    |     8 |              21 | Multi-target deployment, `aspire destroy`, JavaScript publishing, and pipeline previews          |
-| `aspire-monitoring`    |    11 |              19 | Diagnostics bridge, standalone dashboard, browser logs, and hidden resources                     |
+The Aspire Skills repository also uses [waza](https://github.com/microsoft/waza) to evaluate skill quality. These evals exercise routing, content correctness, and behavior so the project-level guidance and plugin guardrails are checked before they ship.
 
 <LearnMore>
   For live eval details, see the [Aspire Skills eval

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -4,6 +4,7 @@ description: Learn how to install and use the Aspire Skills plugin pack for AI c
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
 
 [Aspire Skills](https://github.com/microsoft/aspire-skills) is a plugin and skill pack for AI coding agents that work on Aspire distributed applications. The skills help agents detect AppHosts, use the Aspire CLI, route common tasks to focused workflows, and avoid ad hoc `dotnet`, Docker, `curl`, or shell workflows when Aspire already provides the right command.
 
@@ -45,7 +46,23 @@ aspire init
 aspire agent init
 ```
 
-For more information, see the [`aspire agent init` command reference](/reference/cli/commands/aspire-agent-init/).
+<LearnMore>
+  For CLI setup details, see the [`aspire agent init` command
+  reference](/reference/cli/commands/aspire-agent-init/).
+</LearnMore>
+
+## Install with skills.sh
+
+Use the Skills-compatible installer when your agent host supports skills.sh-managed skill locations.
+
+```bash title="skills.sh"
+npx skills add microsoft/aspire-skills
+```
+
+<LearnMore>
+  For supported hosts and installer options, see
+  [skills.sh](https://www.skills.sh/).
+</LearnMore>
 
 ## Install as an agent plugin or extension
 
@@ -114,22 +131,10 @@ copilot plugin install aspire@aspire-skills
 </TabItem>
 </Tabs>
 
-## Install with skills.sh
-
-Use the Skills-compatible installer when your agent host supports skills.sh-managed skill locations.
-
-```bash title="skills.sh"
-npx skills add microsoft/aspire-skills
-```
-
-For hosts that need an explicit skills directory and target agent, install from the repository's `skills/` folder:
-
-```bash title="skills.sh with explicit target"
-npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
-  -a github-copilot -g -y
-```
-
-In this command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
+<LearnMore>
+  For the latest plugin-specific commands, see the [Aspire Skills
+  repository](https://github.com/microsoft/aspire-skills).
+</LearnMore>
 
 ## Project-local guidance and plugin guardrails
 
@@ -157,7 +162,10 @@ The current public eval coverage includes 54 scenario tasks and 113 trigger prom
 | `aspire-deployment`    |     8 |              21 | Multi-target deployment, `aspire destroy`, JavaScript publishing, and pipeline previews          |
 | `aspire-monitoring`    |    11 |              19 | Diagnostics bridge, standalone dashboard, browser logs, and hidden resources                     |
 
-For the live eval details, see the [Aspire Skills eval README](https://github.com/microsoft/aspire-skills/blob/main/evals/README.md).
+<LearnMore>
+  For live eval details, see the [Aspire Skills eval
+  README](https://github.com/microsoft/aspire-skills/blob/main/evals/README.md).
+</LearnMore>
 
 ## See also
 

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -1,0 +1,168 @@
+---
+title: Aspire Skills
+description: Learn how to install and use the Aspire Skills plugin pack for AI coding agents.
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+[Aspire Skills](https://github.com/microsoft/aspire-skills) is a plugin and skill pack for AI coding agents that work on Aspire distributed applications. The skills help agents detect AppHosts, use the Aspire CLI, route common tasks to focused workflows, and avoid ad hoc `dotnet`, Docker, `curl`, or shell workflows when Aspire already provides the right command.
+
+Use the skills together with [`aspire agent init`](/reference/cli/commands/aspire-agent-init/):
+
+- Run `aspire agent init` inside an Aspire project to install project-local skill files and MCP configuration with app-specific context.
+- Install the Aspire Skills plugin pack in an agent host when you want global Aspire guardrails available before or alongside project-local guidance.
+- Let project-local skill files take precedence when both are present because they can include repository-specific instructions.
+
+:::tip[Recommended setup]
+Start with `aspire agent init` in each Aspire project. Add the Aspire Skills plugin pack for agent hosts where you want the same Aspire-aware routing and guardrails available globally.
+:::
+
+## Included skills
+
+The repository packages six skills that map common Aspire work to the right workflow:
+
+| Skill                                                                                                      | Purpose                                                                                      |
+| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
+| [`aspire`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire)                             | Top-level router that detects Aspire context and routes work to focused skills.              |
+| [`aspire-init`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-init)                   | Creates a new Aspire project or adds an AppHost skeleton to an existing repository.          |
+| [`aspireify`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspireify)                       | Wires an AppHost after initialization, including C#, file-based C#, and TypeScript AppHosts. |
+| [`aspire-orchestration`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-orchestration) | Starts, stops, waits for, and manages Aspire app resources safely.                           |
+| [`aspire-deployment`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-deployment)       | Publishes, deploys, and tears down Aspire apps through Aspire deployment workflows.          |
+| [`aspire-monitoring`](https://github.com/microsoft/aspire-skills/tree/main/skills/aspire-monitoring)       | Routes logs, traces, dashboard, telemetry, and diagnostics work to the right tools.          |
+
+## Install with the Aspire CLI
+
+The Aspire CLI is the first-party setup path. It installs Aspire skill files and MCP configuration into detected agent environments.
+
+```bash title="Aspire CLI"
+# Create a new Aspire app and opt into agent guidance when prompted.
+aspire new
+
+# Or add Aspire to an existing repository and opt into agent guidance.
+aspire init
+
+# Add, update, or reconfigure Aspire guidance in an existing workspace.
+aspire agent init
+```
+
+For more information, see the [`aspire agent init` command reference](/reference/cli/commands/aspire-agent-init/).
+
+## Install as an agent plugin or extension
+
+Use the plugin or extension path when you want the Aspire Skills pack installed in a specific agent host.
+
+<Tabs syncKey="aspire-skills-install">
+<TabItem id="copilot-cli" label="Copilot CLI">
+
+```bash title="Copilot CLI"
+copilot plugin marketplace add microsoft/aspire-skills
+copilot plugin install aspire@aspire-skills
+```
+
+</TabItem>
+<TabItem id="claude-code" label="Claude Code">
+
+```bash title="Claude Code CLI"
+claude
+/plugin marketplace add microsoft/aspire-skills
+/plugin install aspire@aspire-skills
+```
+
+</TabItem>
+<TabItem id="codex-cli" label="Codex CLI">
+
+```bash title="Codex CLI"
+codex plugin marketplace add microsoft/aspire-skills
+codex
+```
+
+Then open `/plugins` and install `aspire`.
+
+</TabItem>
+<TabItem id="gemini-cli" label="Gemini CLI">
+
+```bash title="Gemini CLI"
+gemini extensions install https://github.com/microsoft/aspire-skills
+```
+
+</TabItem>
+<TabItem id="cursor-cli" label="Cursor CLI">
+
+```bash title="Cursor CLI"
+mkdir -p ~/.cursor/skills
+git clone https://github.com/microsoft/aspire-skills ~/.cursor/skills/aspire-skills
+agent
+```
+
+</TabItem>
+<TabItem id="opencode" label="OpenCode">
+
+```bash title="OpenCode"
+apm install microsoft/aspire-skills
+opencode
+```
+
+</TabItem>
+<TabItem id="ollama-copilot" label="Ollama + Copilot CLI">
+
+```bash title="Ollama and Copilot CLI"
+ollama launch copilot
+copilot plugin marketplace add microsoft/aspire-skills
+copilot plugin install aspire@aspire-skills
+```
+
+</TabItem>
+</Tabs>
+
+## Install with skills.sh
+
+Use the Skills-compatible installer when your agent host supports skills.sh-managed skill locations.
+
+```bash title="skills.sh"
+npx skills add microsoft/aspire-skills
+```
+
+For hosts that need an explicit skills directory and target agent, install from the repository's `skills/` folder:
+
+```bash title="skills.sh with explicit target"
+npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
+  -a github-copilot -g -y
+```
+
+In this command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
+
+## Project-local guidance and plugin guardrails
+
+Project-local skill files from `aspire agent init` should supply the app-specific context for a repository. When the plugin pack finds local Aspire skill files, it defers to them for deeper AppHost editing, Playwright handoffs, and investigation workflows while keeping the plugin's global Aspire safety guardrails available.
+
+This layering gives agents an Aspire-native path:
+
+1. The agent host loads Aspire Skills from its plugin, extension, or skill location.
+2. The top-level `aspire` skill detects an Aspire workspace and routes the task.
+3. Project-local guidance from `aspire agent init` adds repository-specific context.
+4. The agent uses the Aspire CLI and MCP server to inspect, change, run, and diagnose the app.
+
+## Evaluation coverage
+
+The Aspire Skills repository uses [waza](https://github.com/microsoft/waza) to evaluate skill quality. Evals exercise skill routing, content correctness, and behavior against an LLM-as-judge rubric.
+
+The current public eval coverage includes 54 scenario tasks and 113 trigger prompts across the six skills:
+
+| Skill                  | Tasks | Trigger prompts | Focus                                                                                            |
+| ---------------------- | ----: | --------------: | ------------------------------------------------------------------------------------------------ |
+| `aspire`               |     6 |              16 | Routing precision to sub-skills                                                                  |
+| `aspire-init`          |     5 |              15 | Skeleton drop, `aspire new` / `aspire init` decisions, and `aspireify` handoff                   |
+| `aspireify`            |     8 |              18 | AppHost wiring across C#, file-based C#, and TypeScript; validation; and generated module safety |
+| `aspire-orchestration` |    16 |              24 | Lifecycle, file lock recovery, hidden resources, and CLI self-updates                            |
+| `aspire-deployment`    |     8 |              21 | Multi-target deployment, `aspire destroy`, JavaScript publishing, and pipeline previews          |
+| `aspire-monitoring`    |    11 |              19 | Diagnostics bridge, standalone dashboard, browser logs, and hidden resources                     |
+
+For the live eval details, see the [Aspire Skills eval README](https://github.com/microsoft/aspire-skills/blob/main/evals/README.md).
+
+## See also
+
+- [Aspire Skills public site](https://microsoft.github.io/aspire-skills/)
+- [Aspire Skills repository](https://github.com/microsoft/aspire-skills)
+- [Use AI coding agents](/get-started/ai-coding-agents/)
+- [Aspire MCP server](/get-started/aspire-mcp-server/)
+- [`aspire agent init` command reference](/reference/cli/commands/aspire-agent-init/)

--- a/src/frontend/src/data/github-stats.json
+++ b/src/frontend/src/data/github-stats.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "microsoft/aspire",
-    "stars": 5938,
+    "stars": 5977,
     "description": "Aspire is the tool for code-first, extensible, observable dev and deploy.",
     "license": "https://github.com/microsoft/aspire/blob/main/LICENSE.TXT",
     "licenseName": "MIT License",
@@ -9,7 +9,7 @@
   },
   {
     "name": "microsoft/aspire-samples",
-    "stars": 1175,
+    "stars": 1177,
     "description": null,
     "license": "https://github.com/microsoft/aspire-samples/blob/main/LICENSE",
     "licenseName": "MIT License",
@@ -17,7 +17,7 @@
   },
   {
     "name": "CommunityToolkit/Aspire",
-    "stars": 601,
+    "stars": 603,
     "description": "A community project with additional components and extensions for Aspire",
     "license": "https://github.com/CommunityToolkit/Aspire/blob/main/LICENSE",
     "licenseName": "MIT License",
@@ -25,15 +25,23 @@
   },
   {
     "name": "microsoft/aspire.dev",
-    "stars": 158,
+    "stars": 160,
     "description": "The official website for all things aspire.dev.",
     "license": "https://github.com/microsoft/aspire.dev/blob/main/LICENSE",
     "licenseName": "MIT License",
     "repo": "https://github.com/microsoft/aspire.dev"
   },
   {
+    "name": "microsoft/aspire-skills",
+    "stars": 3,
+    "description": "Repository containing AI skills for Aspire",
+    "license": "https://github.com/microsoft/aspire-skills/blob/main/LICENSE",
+    "licenseName": "MIT License",
+    "repo": "https://github.com/microsoft/aspire-skills"
+  },
+  {
     "name": "microsoft/dcp",
-    "stars": 160,
+    "stars": 167,
     "description": "Developer Control Plane API server and CLI.",
     "license": "https://github.com/microsoft/dcp/blob/main/LICENSE",
     "licenseName": "MIT License",


### PR DESCRIPTION
## Summary
- Add a dedicated Aspire Skills docs page covering the microsoft/aspire-skills repo, included skills, installation paths, project-local precedence, and plugin guardrails.
- Cross-link the existing AI coding agents and dashboard agent docs, and add the page to the AI coding agents sidebar section.
- Add microsoft/aspire-skills to GitHub stats and the community contributors page.
- Remove the soon-to-be-deleted Aspire Skills public site link and remove MCP references from the affected agent guidance.

## Validation
- pnpm --dir .\src\frontend exec prettier --check --plugin prettier-plugin-astro .\src\content\docs\get-started\aspire-skills.mdx .\src\content\docs\get-started\ai-coding-agents.mdx .\src\content\docs\dashboard\ai-coding-agents.mdx
- pnpm --dir .\src\frontend run test:unit:docs
- pnpm --dir .\src\frontend exec vitest run --config vitest.config.ts tests/unit/seo-lengths.vitest.test.ts