### PR TITLE
Fix Orleans TypeScript reference samples

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/orleans.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/orleans.mdx
@@ -164,7 +164,7 @@ Any project that references the Orleans resource also inherits a reference to th
 
 ### Add an Orleans server project
 
-Add a project to your solution as an Orleans server (a silo). Reference the Orleans resource from the server project so that it receives the clustering and storage configuration:
+Add a project to your solution as an Orleans server (a silo). Reference the Orleans resource from the server project so that it receives the clustering and storage configuration. In TypeScript AppHosts, use `withOrleansReference` to configure a project as a silo:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -204,7 +204,7 @@ const orleans = await builder.addOrleans("default")
     .withGrainStorage("Default", grainStorage);
 
 const server = await builder.addProject("orleans-server", "../OrleansServer/OrleansServer.csproj")
-    .withReference(orleans);
+    .withOrleansReference(orleans);
 
 await builder.build().run();
 ```
@@ -216,7 +216,7 @@ When you reference the Orleans resource from a project, the dependent storage re
 
 ### Add an Orleans client project
 
-Orleans clients communicate with grains hosted in an Orleans cluster. For example, a frontend web app calls grains running on Orleans servers. Reference the Orleans resource using `asClient()` (or `AsClient()`) so the project is configured as a client rather than a silo:
+Orleans clients communicate with grains hosted in an Orleans cluster. For example, a frontend web app calls grains running on Orleans servers. Reference the Orleans resource using `asClient()` (or `AsClient()`) so the project is configured as a client rather than a silo. In TypeScript AppHosts, use `withOrleansClientReference` for Orleans client references:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -256,7 +256,7 @@ const orleans = await builder.addOrleans("default")
     .withGrainStorage("Default", grainStorage);
 
 const client = await builder.addProject("orleans-client", "../OrleansClient/OrleansClient.csproj")
-    .withReference(await orleans.asClient());
+    .withOrleansClientReference(orleans.asClient());
 
 await builder.build().run();
 ```


### PR DESCRIPTION
The Orleans integration docs had TypeScript AppHost samples that used the generic `withReference` pattern for Orleans silo and client references. In 13.4, the TypeScript exports use Orleans-specific methods, so the examples should match those APIs.

This updates the server project sample to use `withOrleansReference(orleans)` and the client project sample to use `withOrleansClientReference(orleans.asClient())`, while leaving the C# `WithReference` examples unchanged.

Validation:
- `pnpm --dir ./src/frontend run test:unit:twoslash-blocks`

Note: `pnpm --dir ./src/frontend exec astro check` was not runnable because this repo does not include `@astrojs/check` as a dependency and the command prompts to install it.