### PR TITLE
Document Aspire CLI npm install method

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -10,16 +10,16 @@ import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 import { Aside, Code, Icon } from '@astrojs/starlight/components';
 
-Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system.
+Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system. You can install the CLI with the install script or from npm. Use the install script for the fastest setup, or use npm if you already manage developer tooling there.
 
 <LearnMore>
   Before installing the Aspire CLI, ensure you have the [required
   prerequisites](/get-started/prerequisites/) set up.
 </LearnMore>
 
-## Install the Aspire CLI
+## Install with the install script
 
-To install the Aspire CLI, download and run the installation script in a single command:
+Download and run the installation script in a single command:
 
 <OsAwareTabs syncKey="terminal">
   <Code
@@ -46,7 +46,7 @@ You only need to download the script separately if you want to inspect it or run
 
 ## Install with npm
 
-Starting with Aspire 13.4, you can install the Aspire CLI from npm. This is useful if you already manage your developer tooling with npm, or if you're working in a JavaScript or TypeScript project. Installing from npm requires [Node.js](https://nodejs.org/).
+Starting with Aspire 13.4, install the Aspire CLI from npm if you already manage developer tooling with npm or work in a JavaScript or TypeScript project. This option requires [Node.js](https://nodejs.org/).
 
 To install the latest stable release globally, run:
 
@@ -71,7 +71,7 @@ aspire --version
 If that command works, you're presented with the version of the Aspire CLI tool:
 
 ```bash title="Aspire CLI — Output" data-disable-copy
-13.3.0+{commitSHA}
+13.4.0+{commitSHA}
 ```
 
 The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CLI was built.

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -46,7 +46,7 @@ You only need to download the script separately if you want to inspect it or run
 
 ## Install with npm
 
-Starting with Aspire 13.4, you can install the Aspire CLI from npm. This is useful if you already manage your developer tooling with npm, or if you're working in a JavaScript or TypeScript project. Installing from npm requires [Node.js](https://nodejs.org/) (which includes npm).
+Starting with Aspire 13.4, you can install the Aspire CLI from npm. This is useful if you already manage your developer tooling with npm, or if you're working in a JavaScript or TypeScript project. Installing from npm requires [Node.js](https://nodejs.org/).
 
 To install the latest stable release globally, run:
 

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install Aspire CLI
-seoTitle: 'Install Aspire CLI: native executable or .NET tool'
-description: Learn how to install the Aspire CLI as a native executable or .NET global tool to manage your cloud-native applications.
+seoTitle: 'Install Aspire CLI: install script or npm'
+description: Learn how to install the Aspire CLI using the install script or npm to manage your cloud-native applications.
 lastUpdated: true
 tableOfContents: true
 ---
@@ -43,6 +43,22 @@ At any time, you can reopen the **Install Aspire CLI** command modal from the to
 :::
 
 You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
+
+## Install with npm
+
+Starting with Aspire 13.4, you can install the Aspire CLI from npm. This is useful if you already manage your developer tooling with npm, or if you're working in a JavaScript or TypeScript project. Installing from npm requires [Node.js](https://nodejs.org/) (which includes npm).
+
+To install the latest stable release globally, run:
+
+```bash title="Install with npm"
+npm install -g @microsoft/aspire-cli
+```
+
+The same command works on Windows, macOS, and Linux (including musl-based distributions such as Alpine). npm selects the correct native binary for your operating system and architecture automatically.
+
+:::note
+When you install from npm, the Aspire CLI routes self-updates through npm. Running `aspire update --self` prints the `npm install -g @microsoft/aspire-cli@latest` command to run rather than downloading a new binary directly. For more information, see [`aspire update`](/reference/cli/commands/aspire-update/).
+:::
 
 ## Validation
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-update.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-update.mdx
@@ -58,7 +58,7 @@ When updating a guest AppHost project, such as a TypeScript AppHost, `aspire upd
 The selected Aspire SDK is newer than this Aspire CLI. Update the Aspire CLI now and re-run `aspire update` to update this project?
 ```
 
-If you confirm, the CLI updates itself and skips the project update. When the CLI is installed as a .NET tool, the command prints the `dotnet tool update` command to run manually instead:
+If you confirm, the CLI updates itself and skips the project update. When the CLI is installed from npm or as a .NET tool, the command prints the matching package-manager update command to run manually instead:
 
 ```text title="Output"
 Project update skipped. Update the Aspire CLI, then re-run `aspire update`.
@@ -81,8 +81,8 @@ To update the CLI without being prompted, run `aspire update --self` before runn
     npm install -g @microsoft/aspire-cli@latest
   ```
 
+- When the CLI was installed with the **install script** or another **binary install**, `aspire update --self` downloads and installs the latest CLI binary directly.
 - When the CLI was installed as a **.NET tool**, the command prints the `dotnet tool update` command to run.
-- Otherwise, `aspire update --self` downloads and installs the latest CLI binary directly.
 
 ## Options
 
@@ -92,7 +92,7 @@ The following options are available:
 
 - **`--self`**
 
-  Update the Aspire CLI itself to the latest version. The CLI adapts to how it was installed: npm and .NET tool installs print the matching package-manager command to run, while other installs download the latest binary directly. See [Updating the CLI based on how it was installed](#updating-the-cli-based-on-how-it-was-installed).
+  Update the Aspire CLI itself to the latest version. The CLI adapts to how it was installed: npm and .NET tool installs print the matching package-manager command to run, while install-script and other binary installs download the latest binary directly. See [Updating the CLI based on how it was installed](#updating-the-cli-based-on-how-it-was-installed).
 
 - **`--channel`**
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-update.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-update.mdx
@@ -70,6 +70,20 @@ After updating the CLI, re-run `aspire update` to complete the project update. T
 To update the CLI without being prompted, run `aspire update --self` before running `aspire update` on a guest AppHost project.
 :::
 
+### Updating the CLI based on how it was installed
+
+`aspire update --self` (and the update notice shown when a newer version is available) adapts to how the CLI was installed so it doesn't overwrite files owned by a package manager:
+
+- When the CLI was installed from **npm** (the `@microsoft/aspire-cli` package), the command prints the npm update command to run instead of downloading a new binary:
+
+  ```text title="Output"
+  To update the Aspire CLI when installed from npm, run:
+    npm install -g @microsoft/aspire-cli@latest
+  ```
+
+- When the CLI was installed as a **.NET tool**, the command prints the `dotnet tool update` command to run.
+- Otherwise, `aspire update --self` downloads and installs the latest CLI binary directly.
+
 ## Options
 
 The following options are available:
@@ -78,7 +92,7 @@ The following options are available:
 
 - **`--self`**
 
-  Update the Aspire CLI itself to the latest version.
+  Update the Aspire CLI itself to the latest version. The CLI adapts to how it was installed: npm and .NET tool installs print the matching package-manager command to run, while other installs download the latest binary directly. See [Updating the CLI based on how it was installed](#updating-the-cli-based-on-how-it-was-installed).
 
 - **`--channel`**
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -115,6 +115,14 @@ Or install the CLI from scratch:
   CLI](/get-started/install-cli/).
 </LearnMore>
 
+Aspire 13.4 also adds a new way to install the CLI: from npm. If you already use npm for your developer tooling, install the CLI globally with a single cross-platform command:
+
+```bash title="Aspire CLI — Install from npm"
+npm install -g @microsoft/aspire-cli
+```
+
+See [Install with npm](/get-started/install-cli/#install-with-npm) for details.
+
 ## 🌐 TypeScript AppHost general availability
 
 TypeScript AppHost support is now generally available. You can author Aspire app models in `apphost.mts` as a first-class AppHost experience, with the same code-first orchestration model used by C# AppHosts and a generated TypeScript SDK for Aspire resources and integrations.
@@ -184,6 +192,7 @@ Aspire 13.4 includes a set of smaller CLI improvements and fixes:
 - `aspire logs` dims timestamps for readability and shows `No logs found.` when there are no entries, while preserving JSON output for automation.
 - Log file paths in CLI output are clickable terminal links when the terminal supports hyperlinks and degrade gracefully to plain text otherwise.
 - Package-manager installs such as WinGet, Homebrew, and `dotnet tool` keep the CLI bundle beside the CLI binary, so uninstall and upgrade flows clean up the bundle correctly.
+- The Aspire CLI can now be installed from npm (`npm install -g @microsoft/aspire-cli`). When installed this way, `aspire update --self` and update notices print the matching `npm install -g @microsoft/aspire-cli@latest` command instead of overwriting the npm-managed binary. See [Install with npm](/get-started/install-cli/#install-with-npm).
 - `aspire update` now requires `--yes` in non-interactive mode, matching `aspire destroy`.
 - `aspire stop --all` output includes the AppHost name and, when needed, the PID for clearer multi-instance shutdown output.
 - `aspire new`, `aspire init`, `aspire run`, and `aspire update` include fixes for NuGet feed errors, output paths, generated files, disabled dashboards, detached shutdown, and AppHost package-reference cleanup.

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -175,7 +175,7 @@ aspire otel traces --search "POST /orders"
 Resource command inputs are now passed as named CLI options instead of positional arguments. This makes optional inputs easier to skip and lets users supply values in any order. Running `aspire resource <resource> --help` also shows the commands available for that specific resource.
 
 ```bash title="Aspire CLI — Resource command arguments"
-aspire resource cache seed-data --dataset small --force true
+aspire resource cache seed-data --dataset small --force
 aspire resource cache --help
 ```
 

--- a/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
+++ b/src/frontend/src/content/docs/whats-new/upgrade-aspire.mdx
@@ -23,6 +23,8 @@ If you're new to Aspire, there's no reason to upgrade anything. See [prerequisit
     aspire update --self
     ```
 
+    If you installed the CLI from npm or as a .NET tool, `aspire update --self` prints the matching package-manager command to run (for example, `npm install -g @microsoft/aspire-cli@latest`) instead of replacing a package-manager-owned binary. See [Updating the CLI based on how it was installed](/reference/cli/commands/aspire-update/#updating-the-cli-based-on-how-it-was-installed).
+
 2. **Update your Aspire app** by running:
 
     ```bash title="Update your Aspire app"


### PR DESCRIPTION
Documents the npm distribution of the Aspire CLI added in microsoft/aspire#17297. Targeting `release/13.4` since the npm packages ship as part of the 13.4 release.

The PR adds `@microsoft/aspire-cli` (a pointer package plus RID-specific packages) and makes `aspire update --self` npm-aware, so the docs need to cover the new install path and the update behavior.

## Changes

- **`get-started/install-cli.mdx`** — new "Install with npm" section (`npm install -g @microsoft/aspire-cli`), Node.js prerequisite, cross-platform note, and the npm self-update behavior. Updated the frontmatter SEO title/description, which still referenced a ".NET tool" method the page no longer documents.
- **`reference/cli/commands/aspire-update.mdx`** — documents how `aspire update --self` adapts to the install source (npm vs `dotnet tool` vs direct binary). The npm output text matches what the CLI actually prints (`npm install -g @microsoft/aspire-cli@latest`).
- **`whats-new/aspire-13-4.mdx`** — notes npm as an install option in the upgrade section and a CLI bullet.

## Notes

- I scoped the install-cli wording to "Starting with Aspire 13.4" since the npm package isn't on the registry yet — it publishes through the 13.4 release pipeline.
- I used the exact update string from `NpmInstallDetection.GetNpmUpdateCommand` (`@latest`), not the looser `npm update -g` wording in the source PR description.

## Validation

- Built the site / rendered all three pages on the dev server (HTTP 200), confirmed the npm content and heading anchors resolve. The only build failure was the unrelated Lunaria `/i18n` page, which needs full git history (shallow clone).
