### PR TITLE
Address CLI install feedback

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,16 +1,22 @@
 ---
 title: Install Aspire CLI
-seoTitle: 'Install Aspire CLI: install script or npm'
-description: Learn how to install the Aspire CLI using the install script or npm to manage your cloud-native applications.
+seoTitle: 'Install Aspire CLI: install script, .NET tool, or npm'
+description: Learn how to install the Aspire CLI using the install script, .NET global tool, or npm to manage your cloud-native applications.
 lastUpdated: true
 tableOfContents: true
 ---
 
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
-import { Aside, Code, Icon } from '@astrojs/starlight/components';
+import {
+  Aside,
+  Code,
+  Icon,
+  TabItem,
+  Tabs,
+} from '@astrojs/starlight/components';
 
-Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system. You can install the CLI with the install script or from npm. Use the install script for the fastest setup, or use npm if you already manage developer tooling there.
+Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system. You can install the CLI with the install script, .NET global tool, or npm. Use the install script for the fastest setup, or choose the package manager that matches your AppHost language.
 
 <LearnMore>
   Before installing the Aspire CLI, ensure you have the [required
@@ -44,9 +50,25 @@ At any time, you can reopen the **Install Aspire CLI** command modal from the to
 
 You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
 
-## Install with npm
+## Install for your AppHost language
 
-Starting with Aspire 13.4, install the Aspire CLI from npm if you already manage developer tooling with npm or work in a JavaScript or TypeScript project. This option requires [Node.js](https://nodejs.org/).
+The install script works for all AppHost languages. If you prefer to manage the Aspire CLI with a language-specific package manager, use the option that matches your AppHost project:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+Use the .NET global tool when you want to manage the Aspire CLI with the .NET SDK in a C# AppHost project. This option requires the [.NET SDK](/get-started/prerequisites/).
+
+To install the latest stable release globally, run:
+
+```bash title="Install with .NET global tool"
+dotnet tool install -g Aspire.Cli
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+Starting with Aspire 13.4, install the Aspire CLI from npm if you already manage developer tooling with npm or work in a TypeScript AppHost project. This option requires [Node.js](https://nodejs.org/).
 
 To install the latest stable release globally, run:
 
@@ -59,6 +81,9 @@ The same command works on Windows, macOS, and Linux (including musl-based distri
 :::note
 When you install from npm, the Aspire CLI routes self-updates through npm. Running `aspire update --self` prints the `npm install -g @microsoft/aspire-cli@latest` command to run rather than downloading a new binary directly. For more information, see [`aspire update`](/reference/cli/commands/aspire-update/).
 :::
+
+</TabItem>
+</Tabs>
 
 ## Validation
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -377,7 +377,7 @@ Aspire 13.4 includes a set of smaller CLI improvements and fixes:
 - `aspire logs` dims timestamps for readability and shows `No logs found.` when there are no entries, while preserving JSON output for automation.
 - Log file paths in CLI output are clickable terminal links when the terminal supports hyperlinks and degrade gracefully to plain text otherwise.
 - Package-manager installs such as WinGet, Homebrew, and `dotnet tool` keep the CLI bundle beside the CLI binary, so uninstall and upgrade flows clean up the bundle correctly.
-- The Aspire CLI can now be installed from npm (`npm install -g @microsoft/aspire-cli`). When installed this way, `aspire update --self` and update notices print the matching `npm install -g @microsoft/aspire-cli@latest` command instead of overwriting the npm-managed binary. See [Install with npm](/get-started/install-cli/#install-with-npm).
+- The Aspire CLI can now be installed from npm (`npm install -g @microsoft/aspire-cli`). When installed this way, `aspire update --self` and update notices print the matching `npm install -g @microsoft/aspire-cli@latest` command instead of overwriting the npm-managed binary. See [Install for your AppHost language](/get-started/install-cli/#install-for-your-apphost-language).
 - `aspire update` now requires `--yes` in non-interactive mode, matching `aspire destroy`.
 - `aspire stop --all` output includes the AppHost name and, when needed, the PID for clearer multi-instance shutdown output.
 - `aspire new`, `aspire init`, `aspire run`, and `aspire update` include fixes for NuGet feed errors, output paths, generated files, disabled dashboards, detached shutdown, and AppHost package-reference cleanup.


### PR DESCRIPTION
Addresses review feedback from microsoft/aspire.dev#907 by moving npm install guidance under the TypeScript AppHost option and restoring the .NET global tool guidance for C# AppHost projects.

This branch is rebased on the latest `release/13.4` and intentionally contains only the install-feedback fix commit.