### PR TITLE
Use Twoslash for Helm chart AppHost samples

### DIFF
--- a/src/frontend/src/content/docs/deployment/kubernetes/helm-charts.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/helm-charts.mdx
@@ -47,7 +47,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -94,7 +94,13 @@ k8s.AddHelmChart("cert-manager", "oci://quay.io/jetstack/charts/cert-manager", "
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const k8s = await builder.addKubernetesEnvironment('k8s');
+
 const certManager = await k8s.addHelmChart(
   'cert-manager',
   'oci://quay.io/jetstack/charts/cert-manager',
@@ -126,7 +132,13 @@ k8s.AddHelmChart("ingress-nginx", "oci://ghcr.io/nginx/helm/nginx-ingress", "2.0
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const k8s = await builder.addKubernetesEnvironment('k8s');
+
 const ingressNginx = await k8s.addHelmChart(
   'ingress-nginx',
   'oci://ghcr.io/nginx/helm/nginx-ingress',
@@ -161,7 +173,13 @@ k8s.AddHelmChart("podinfo", "oci://ghcr.io/stefanprodan/charts/podinfo", "6.7.1"
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const k8s = await builder.addKubernetesEnvironment('k8s');
+
 const podinfo = await k8s.addHelmChart(
   'podinfo',
   'oci://ghcr.io/stefanprodan/charts/podinfo',
@@ -205,7 +223,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -260,7 +278,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();


### PR DESCRIPTION
## Summary
- Enable Twoslash on the TypeScript AppHost samples in the external Helm charts deployment guide
- Make the partial TypeScript snippets self-contained so the Twoslash audit can type-check them

## Validation
- pnpm --dir .\src\frontend run test:unit:twoslash-blocks