### PR TITLE
Restore AI coding agent tab recordings

### DIFF
--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -181,7 +181,9 @@ Once configured, start your preferred AI coding environment. Try asking your age
     <AsciinemaPlayer
       src="/casts/mcp-claudecode-cli.cast"
       poster="npt:0:27"
-      autoPlay={true}
+      autoPlay={false}
+      preload={false}
+      loop={false}
       cols={256}
       rows={28}
     />
@@ -190,7 +192,9 @@ Once configured, start your preferred AI coding environment. Try asking your age
     <AsciinemaPlayer
       src="/casts/mcp-copilot-cli.cast"
       poster="npt:0:22"
-      autoPlay={true}
+      autoPlay={false}
+      preload={false}
+      loop={false}
       cols={256}
       rows={28}
     />
@@ -199,7 +203,9 @@ Once configured, start your preferred AI coding environment. Try asking your age
     <AsciinemaPlayer
       src="/casts/mcp-opencode-cli.cast"
       poster="npt:0:14"
-      autoPlay={true}
+      autoPlay={false}
+      preload={false}
+      loop={false}
       cols={256}
       rows={28}
     />

--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -11,6 +11,7 @@ import {
   TabItem,
   Tabs,
 } from '@astrojs/starlight/components';
+import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
 import LoopingVideo from '@components/LoopingVideo.astro';
 
 Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr>-compatible tool — can immediately understand, build, debug, and monitor your distributed applications.
@@ -77,16 +78,22 @@ For example, a standard location can contain:
 - .agents/skills/
   - aspire/
     - SKILL.md
+    - reference/
   - aspire-init/
     - SKILL.md
+    - reference/
   - aspire-orchestration/
     - SKILL.md
+    - reference/
   - aspire-monitoring/
     - SKILL.md
+    - reference/
   - aspire-deployment/
     - SKILL.md
+    - reference/
   - aspireify/
     - SKILL.md
+    - reference/
 
 </FileTree>
 
@@ -171,22 +178,31 @@ Once configured, start your preferred AI coding environment. Try asking your age
     />
   </TabItem>
   <TabItem label="Claude Code" id="demo-claude">
-    <p>
-      Configure the Aspire MCP server in Claude Code, then ask Claude Code to
-      inspect running Aspire resources from the terminal.
-    </p>
+    <AsciinemaPlayer
+      src="/casts/mcp-claudecode-cli.cast"
+      poster="npt:0:27"
+      autoPlay={true}
+      cols={256}
+      rows={28}
+    />
   </TabItem>
   <TabItem label="Copilot CLI" id="demo-copilot">
-    <p>
-      Configure the Aspire MCP server in Copilot CLI to query resource status,
-      logs, and traces for your Aspire app.
-    </p>
+    <AsciinemaPlayer
+      src="/casts/mcp-copilot-cli.cast"
+      poster="npt:0:22"
+      autoPlay={true}
+      cols={256}
+      rows={28}
+    />
   </TabItem>
   <TabItem label="OpenCode" id="demo-opencode">
-    <p>
-      Configure the Aspire MCP server in OpenCode to investigate your running
-      Aspire application from an agentic terminal workflow.
-    </p>
+    <AsciinemaPlayer
+      src="/casts/mcp-opencode-cli.cast"
+      poster="npt:0:14"
+      autoPlay={true}
+      cols={256}
+      rows={28}
+    />
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
## Summary
- Restore the Claude Code, Copilot CLI, and OpenCode Asciinema recordings in the `get-started/ai-coding-agents` tab set.
- Add empty `reference/` folders under each Aspire workflow skill in the standard skill tree example.

## Branch hygiene
- Rebased onto current `upstream/main` (`2621ca1b520d9348288ba32f636571196b83edd8`).
- The PR now changes only `src/frontend/src/content/docs/get-started/ai-coding-agents.mdx`.

## Validation
- `git diff --check upstream/main...HEAD`

No local `pnpm build` was run; full build validation is left to CI.