### PR TITLE
[docs] Update Bun guidance to first-party Aspire.Hosting.JavaScript

### DIFF
--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -1,16 +1,14 @@
 ---
-title: Bun integration
-seoTitle: Bun integration for Aspire AppHost (Community Toolkit)
-description: Learn how to use the Aspire Community Toolkit Bun hosting integration to orchestrate Bun applications alongside other resources in the Aspire app host.
+title: Set up Bun apps in the AppHost
+seoTitle: Set up Bun apps in the Aspire AppHost with JavaScript hosting
+description: Learn how to use Aspire.Hosting.JavaScript to run Bun applications directly and configure Bun-backed JavaScript resources in your Aspire AppHost.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import InstallPackage from '@components/InstallPackage.astro';
+import LearnMore from '@components/LearnMore.astro';
 import bunIcon from '@assets/icons/bun-icon.png';
-
-<Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <Image
   src={bunIcon}
@@ -21,44 +19,28 @@ import bunIcon from '@assets/icons/bun-icon.png';
   data-zoom-off
 />
 
-The Aspire Bun hosting integration enables you to run [Bun](https://bun.sh/) applications alongside your other Aspire resources in the app host. Bun apps participate in the same service discovery, health checks, OpenTelemetry export, and Aspire dashboard support as the rest of your solution.
+This article is the reference for Bun support in `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to run a [Bun](https://bun.sh/) application directly in your [`AppHost`](/get-started/app-host/) project, and use `WithBun` / `withBun` when you want other JavaScript resources to use Bun as their package manager.
 
-:::note
-TypeScript AppHost support for this integration is not yet available. The examples on this page use the C# AppHost only.
+:::caution[Community Toolkit package superseded]
+Before Aspire 13.4, Bun hosting was commonly delivered through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For Aspire 13.4 and later, use the official `Aspire.Hosting.JavaScript` package and the APIs on this page for new applications.
+:::
+
+:::note[Prerequisites]
+Install [Bun](https://bun.sh/docs/installation) and make sure the `bun` command is available on your `PATH`.
 :::
 
 ## Hosting integration
 
-To access the Bun hosting APIs in your [`AppHost`](/get-started/app-host/) project, install the [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun) NuGet package:
+To access the Bun hosting APIs in your AppHost, install the [📦 Aspire.Hosting.JavaScript](https://www.nuget.org/packages/Aspire.Hosting.JavaScript) package:
 
-<InstallPackage packageName="CommunityToolkit.Aspire.Hosting.Bun" />
+<InstallPackage packageName="Aspire.Hosting.JavaScript" />
 
 ### Add Bun app
 
-Add a Bun application to your app host using the `AddBunApp` extension method:
+Use `AddBunApp` / `addBunApp` to run a Bun script directly from your AppHost:
 
-```csharp title="C# — AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var bunApp = builder.AddBunApp("bun-api", "../bun-app")
-    .WithHttpEndpoint(port: 3000, env: "PORT");
-
-builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(bunApp);
-
-builder.Build().Run();
-```
-
-`AddBunApp` requires:
-
-- **name**: The name of the resource in the Aspire dashboard.
-- **workingDirectory**: The path to the directory containing your Bun application, relative to the AppHost project.
-
-By default, the integration looks for an `index.ts` file as the entrypoint.
-
-### Specify a custom entrypoint
-
-Pass an explicit entrypoint path to run a different script:
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -69,50 +51,130 @@ var bunApp = builder.AddBunApp("bun-api", "../bun-app", "server.ts")
 builder.Build().Run();
 ```
 
-### Install packages before startup
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
 
-Call `WithBunPackageInstallation` to run `bun install` before starting the application:
+```typescript title="TypeScript — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const bunApp = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
+await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+`AddBunApp` / `addBunApp` requires:
+
+- **name**: The name of the resource in the Aspire dashboard.
+- **appDirectory**: The path to the directory containing your Bun application, relative to the AppHost project.
+- **scriptPath**: The script to run relative to `appDirectory`, such as `server.ts`.
+
+If `appDirectory` contains a `package.json` file, Aspire automatically uses Bun as the default package manager for the app. When you publish to a container, Aspire uses `oven/bun:1` for the build and runtime stages by default.
+
+### Specify a custom entrypoint
+
+Pass an explicit entrypoint path to run a different script:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var bunApp = builder.AddBunApp("bun-api", "../bun-app")
-    .WithBunPackageInstallation()
+var bunApp = builder.AddBunApp("bun-api", "../bun-app", "src/http/server.ts")
     .WithHttpEndpoint(port: 3000, env: "PORT");
 
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="TypeScript — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const bunApp = await builder.addBunApp(
+  'bun-api',
+  '../bun-app',
+  'src/http/server.ts'
+);
+await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 ### Configure HTTP endpoints
 
-Bun applications typically read the port from an environment variable. Use `WithHttpEndpoint` to declare the HTTP endpoint and bind it to a named environment variable:
+Bun applications typically read the port from an environment variable. Use `WithHttpEndpoint` / `withHttpEndpoint` to bind the AppHost endpoint to a named environment variable such as `PORT`:
 
-```csharp title="C# — AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
+```typescript title="server.ts"
+const port = Number(process.env.PORT || 3000);
 
-var bunApp = builder.AddBunApp("bun-api", "../bun-app")
-    .WithHttpEndpoint(port: 3000, env: "PORT");
-
-builder.Build().Run();
-```
-
-Your Bun application reads the `PORT` variable at startup:
-
-```typescript title="TypeScript — server.ts"
 const server = Bun.serve({
-    port: process.env.PORT || 3000,
-    fetch(request) {
-        return new Response("Hello from Bun!");
-    },
+  port,
+  fetch(request) {
+    return new Response('Hello from Bun!');
+  },
 });
 
 console.log(`Server listening on port ${server.port}`);
 ```
 
+### Use Bun with other JavaScript resources
+
+Call `WithBun` / `withBun` on JavaScript resources such as Vite or Next.js apps when you want Bun to handle package installation and container build defaults:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="C# — AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var frontend = builder.AddViteApp("frontend", "../frontend")
+    .WithBun()
+    .WithExternalHttpEndpoints();
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="TypeScript — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const frontend = await builder.addViteApp('frontend', '../frontend');
+await frontend.withBun();
+await frontend.withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+<LearnMore>
+  For more details on JavaScript resources and Bun package-manager options, see
+  [Set up JavaScript apps in the
+  AppHost](/integrations/frameworks/javascript/#use-bun).
+</LearnMore>
+
 ## See also
 
-- [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun)
+- [📦 Aspire.Hosting.JavaScript](https://www.nuget.org/packages/Aspire.Hosting.JavaScript)
+- [Set up JavaScript apps in the AppHost](/integrations/frameworks/javascript/)
 - [Bun documentation](https://bun.sh/docs)
-- [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire)
 - [Aspire integrations overview](/integrations/overview/)
 - [Aspire GitHub repo](https://github.com/microsoft/aspire)

--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -17,10 +17,10 @@ import bunIcon from '@assets/icons/bun-icon.png';
   data-zoom-off
 />
 
-The Aspire Bun hosting integration is available in `Aspire.Hosting.JavaScript`. It enables you to run [Bun](https://bun.sh/) applications alongside your other Aspire resources in the app host. Bun apps participate in the same service discovery, health checks, OpenTelemetry export, and Aspire dashboard support as the rest of your solution.
+The Aspire Bun hosting integration enables you to run [Bun](https://bun.sh/) applications alongside your other Aspire resources in the app host. Bun apps participate in the same service discovery, health checks, OpenTelemetry export, and Aspire dashboard support as the rest of your solution.
 
 :::note
-Before Aspire 13.4, Bun hosting was commonly delivered through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For Aspire 13.4 and later, use `Aspire.Hosting.JavaScript`.
+If you're looking at older Bun documentation or existing apps, Bun hosting was previously documented through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For current Aspire applications, use `Aspire.Hosting.JavaScript`.
 :::
 
 ## Hosting integration
@@ -31,7 +31,7 @@ To access the Bun hosting APIs in your [`AppHost`](/get-started/app-host/) proje
 
 ### Add Bun app
 
-Add a Bun application to your app host using the `AddBunApp` extension method. The same API is available as `addBunApp` in TypeScript AppHosts:
+Add a Bun application to your app host using the `AddBunApp` extension method:
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -51,6 +51,10 @@ builder.Build().Run();
 - **appDirectory**: The path to the directory containing your Bun application, relative to the AppHost project.
 - **scriptPath**: The script to run relative to `appDirectory`, such as `server.ts`.
 
+### Install packages before startup
+
+When your Bun app includes a `package.json` file, Aspire uses Bun as the package manager and installs packages automatically before the application starts.
+
 ### Specify a custom entrypoint
 
 Pass a different `scriptPath` to run a different script:
@@ -68,7 +72,18 @@ builder.Build().Run();
 
 Bun applications typically read the port from an environment variable. Use `WithHttpEndpoint` to declare the HTTP endpoint and bind it to a named environment variable:
 
-```typescript title="server.ts"
+```csharp title="C# — AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var bunApp = builder.AddBunApp("bun-api", "../bun-app", "server.ts")
+    .WithHttpEndpoint(port: 3000, env: "PORT");
+
+builder.Build().Run();
+```
+
+Your Bun application reads the `PORT` variable at startup:
+
+```typescript title="TypeScript — server.ts"
 const port = Number(process.env.PORT || 3000);
 
 const server = Bun.serve({

--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -1,13 +1,11 @@
 ---
-title: Set up Bun apps in the AppHost
-seoTitle: Set up Bun apps in the Aspire AppHost with JavaScript hosting
-description: Learn how to use Aspire.Hosting.JavaScript to run Bun applications directly and configure Bun-backed JavaScript resources in your Aspire AppHost.
+title: Bun integration
+seoTitle: Bun integration for Aspire AppHost
+description: Learn how to use the Aspire.Hosting.JavaScript Bun hosting APIs to orchestrate Bun applications alongside other resources in the Aspire app host.
 ---
 
-import { TabItem, Tabs } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import InstallPackage from '@components/InstallPackage.astro';
-import LearnMore from '@components/LearnMore.astro';
 import bunIcon from '@assets/icons/bun-icon.png';
 
 <Image
@@ -19,28 +17,21 @@ import bunIcon from '@assets/icons/bun-icon.png';
   data-zoom-off
 />
 
-This article is the reference for Bun support in `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to run a [Bun](https://bun.sh/) application directly in your [`AppHost`](/get-started/app-host/) project, and use `WithBun` / `withBun` when you want other JavaScript resources to use Bun as their package manager.
+The Aspire Bun hosting integration is available in `Aspire.Hosting.JavaScript`. It enables you to run [Bun](https://bun.sh/) applications alongside your other Aspire resources in the app host. Bun apps participate in the same service discovery, health checks, OpenTelemetry export, and Aspire dashboard support as the rest of your solution.
 
-:::caution[Community Toolkit package superseded]
-Before Aspire 13.4, Bun hosting was commonly delivered through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For Aspire 13.4 and later, use the official `Aspire.Hosting.JavaScript` package and the APIs on this page for new applications.
-:::
-
-:::note[Prerequisites]
-Install [Bun](https://bun.sh/docs/installation) and make sure the `bun` command is available on your `PATH`.
+:::note
+Before Aspire 13.4, Bun hosting was commonly delivered through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For Aspire 13.4 and later, use `Aspire.Hosting.JavaScript`.
 :::
 
 ## Hosting integration
 
-To access the Bun hosting APIs in your AppHost, install the [📦 Aspire.Hosting.JavaScript](https://www.nuget.org/packages/Aspire.Hosting.JavaScript) package:
+To access the Bun hosting APIs in your [`AppHost`](/get-started/app-host/) project, install the [📦 Aspire.Hosting.JavaScript](https://www.nuget.org/packages/Aspire.Hosting.JavaScript) NuGet package:
 
 <InstallPackage packageName="Aspire.Hosting.JavaScript" />
 
 ### Add Bun app
 
-Use `AddBunApp` / `addBunApp` to run a Bun script directly from your AppHost:
-
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
+Add a Bun application to your app host using the `AddBunApp` extension method. The same API is available as `addBunApp` in TypeScript AppHosts:
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -48,40 +39,21 @@ var builder = DistributedApplication.CreateBuilder(args);
 var bunApp = builder.AddBunApp("bun-api", "../bun-app", "server.ts")
     .WithHttpEndpoint(port: 3000, env: "PORT");
 
+builder.AddProject<Projects.ExampleProject>("apiservice")
+    .WithReference(bunApp);
+
 builder.Build().Run();
 ```
 
-</TabItem>
-<TabItem id='typescript' label='TypeScript'>
-
-```typescript title="TypeScript — apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-
-const builder = await createBuilder();
-
-const bunApp = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
-await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
-
-await builder.build().run();
-```
-
-</TabItem>
-</Tabs>
-
-`AddBunApp` / `addBunApp` requires:
+`AddBunApp` requires:
 
 - **name**: The name of the resource in the Aspire dashboard.
 - **appDirectory**: The path to the directory containing your Bun application, relative to the AppHost project.
 - **scriptPath**: The script to run relative to `appDirectory`, such as `server.ts`.
 
-If `appDirectory` contains a `package.json` file, Aspire automatically uses Bun as the default package manager for the app. When you publish to a container, Aspire uses `oven/bun:1` for the build and runtime stages by default.
-
 ### Specify a custom entrypoint
 
-Pass an explicit entrypoint path to run a different script:
-
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
+Pass a different `scriptPath` to run a different script:
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -92,30 +64,9 @@ var bunApp = builder.AddBunApp("bun-api", "../bun-app", "src/http/server.ts")
 builder.Build().Run();
 ```
 
-</TabItem>
-<TabItem id='typescript' label='TypeScript'>
-
-```typescript title="TypeScript — apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-
-const builder = await createBuilder();
-
-const bunApp = await builder.addBunApp(
-  'bun-api',
-  '../bun-app',
-  'src/http/server.ts'
-);
-await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
-
-await builder.build().run();
-```
-
-</TabItem>
-</Tabs>
-
 ### Configure HTTP endpoints
 
-Bun applications typically read the port from an environment variable. Use `WithHttpEndpoint` / `withHttpEndpoint` to bind the AppHost endpoint to a named environment variable such as `PORT`:
+Bun applications typically read the port from an environment variable. Use `WithHttpEndpoint` to declare the HTTP endpoint and bind it to a named environment variable:
 
 ```typescript title="server.ts"
 const port = Number(process.env.PORT || 3000);
@@ -130,51 +81,9 @@ const server = Bun.serve({
 console.log(`Server listening on port ${server.port}`);
 ```
 
-### Use Bun with other JavaScript resources
-
-Call `WithBun` / `withBun` on JavaScript resources such as Vite or Next.js apps when you want Bun to handle package installation and container build defaults:
-
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-
-```csharp title="C# — AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var frontend = builder.AddViteApp("frontend", "../frontend")
-    .WithBun()
-    .WithExternalHttpEndpoints();
-
-builder.Build().Run();
-```
-
-</TabItem>
-<TabItem id='typescript' label='TypeScript'>
-
-```typescript title="TypeScript — apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-
-const builder = await createBuilder();
-
-const frontend = await builder.addViteApp('frontend', '../frontend');
-await frontend.withBun();
-await frontend.withExternalHttpEndpoints();
-
-await builder.build().run();
-```
-
-</TabItem>
-</Tabs>
-
-<LearnMore>
-  For more details on JavaScript resources and Bun package-manager options, see
-  [Set up JavaScript apps in the
-  AppHost](/integrations/frameworks/javascript/#use-bun).
-</LearnMore>
-
 ## See also
 
 - [📦 Aspire.Hosting.JavaScript](https://www.nuget.org/packages/Aspire.Hosting.JavaScript)
-- [Set up JavaScript apps in the AppHost](/integrations/frameworks/javascript/)
 - [Bun documentation](https://bun.sh/docs)
 - [Aspire integrations overview](/integrations/overview/)
 - [Aspire GitHub repo](https://github.com/microsoft/aspire)

--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -20,7 +20,7 @@ import bunIcon from '@assets/icons/bun-icon.png';
 The Aspire Bun hosting integration enables you to run [Bun](https://bun.sh/) applications alongside your other Aspire resources in the app host. Bun apps participate in the same service discovery, health checks, OpenTelemetry export, and Aspire dashboard support as the rest of your solution.
 
 :::note
-If you're looking at older Bun documentation or existing apps, Bun hosting was previously documented through [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun). For current Aspire applications, use `Aspire.Hosting.JavaScript`.
+The `AddBunApp(...)` integration was previously implemented as part of the [📦 CommunityToolkit.Aspire.Hosting.Bun](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Bun) package but is now built in to `Aspire.Hosting.JavaScript`.
 :::
 
 ## Hosting integration
@@ -51,10 +51,6 @@ builder.Build().Run();
 - **appDirectory**: The path to the directory containing your Bun application, relative to the AppHost project.
 - **scriptPath**: The script to run relative to `appDirectory`, such as `server.ts`.
 
-### Install packages before startup
-
-When your Bun app includes a `package.json` file, Aspire uses Bun as the package manager and installs packages automatically before the application starts.
-
 ### Specify a custom entrypoint
 
 Pass a different `scriptPath` to run a different script:
@@ -67,6 +63,10 @@ var bunApp = builder.AddBunApp("bun-api", "../bun-app", "src/http/server.ts")
 
 builder.Build().Run();
 ```
+
+### Install packages before startup
+
+When your Bun app includes a `package.json` file, Aspire uses Bun as the package manager and installs packages automatically before the application starts.
 
 ### Configure HTTP endpoints
 
@@ -84,13 +84,11 @@ builder.Build().Run();
 Your Bun application reads the `PORT` variable at startup:
 
 ```typescript title="TypeScript — server.ts"
-const port = Number(process.env.PORT || 3000);
-
 const server = Bun.serve({
-  port,
-  fetch(request) {
-    return new Response('Hello from Bun!');
-  },
+    port: process.env.PORT || 3000,
+    fetch(request) {
+        return new Response("Hello from Bun!");
+    },
 });
 
 console.log(`Server listening on port ${server.port}`);

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What's new in Aspire 13.4"
-description: 'Explore Aspire 13.4: GA TypeScript AppHost, new Go, Blazor WebAssembly, and Bun hosting integrations, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates.'
+description: "Explore Aspire 13.4: GA TypeScript AppHost, new Go, Blazor WebAssembly, and Bun hosting integrations, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates."
 sidebar:
   label: Aspire 13.4
   order: 0
@@ -42,8 +42,7 @@ This release introduces:
 <br />
 
 <Aside type="caution">
-  Aspire 13.4 includes breaking changes. Please review the [Breaking
-  changes](#breaking-changes) section before upgrading.
+Aspire 13.4 includes breaking changes. Please review the [Breaking changes](#breaking-changes) section before upgrading.
 </Aside>
 
 <Aside type="note">
@@ -113,8 +112,7 @@ Or install the CLI from scratch:
 </OsAwareTabs>
 
 <LearnMore>
-  For more details on installing the Aspire CLI, see [Install the
-  CLI](/get-started/install-cli/).
+  For more details on installing the Aspire CLI, see [Install the CLI](/get-started/install-cli/).
 </LearnMore>
 
 ## 🌐 TypeScript AppHost general availability
@@ -122,16 +120,16 @@ Or install the CLI from scratch:
 TypeScript AppHosts are now fully supported alongside C#, so both are first-class ways to model Aspire apps. TypeScript AppHosts use `apphost.mts`, the same code-first orchestration model as C#, and generated SDK modules for Aspire resources and integrations.
 
 ```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis('cache');
+const cache = await builder.addRedis("cache");
 
 const api = await builder
-  .addNodeApp('api', './api', 'src/index.ts')
-  .withHttpEndpoint({ env: 'PORT' })
-  .withReference(cache);
+    .addNodeApp("api", "./api", "src/index.ts")
+    .withHttpEndpoint({ env: "PORT" })
+    .withReference(cache);
 
 await builder.build().run();
 ```
@@ -145,10 +143,9 @@ The [Aspire Type System (ATS)](/extensibility/multi-language-integration-authori
 Existing TypeScript AppHosts scaffolded by earlier CLI versions continue to work on 13.4 without changes. If your project uses `apphost.ts` and `./.modules/aspire.js`, see [Legacy `apphost.ts` projects (pre-13.4)](#legacy-apphostts-projects-pre-134) for compatibility details and an opt-in migration to the new `apphost.mts` layout.
 
 <LearnMore>
-  For preview polyglot AppHosts behind feature flags, see [`aspire config
-  set`](/reference/cli/commands/aspire-config-set/). For setup details, see
-  [TypeScript AppHosts](/app-host/typescript-apphost/). To explore working
-  examples, browse the [Aspire samples](/reference/samples/).
+  For preview polyglot AppHosts behind feature flags, see [`aspire config set`](/reference/cli/commands/aspire-config-set/).
+  For setup details, see [TypeScript AppHosts](/app-host/typescript-apphost/).
+  To explore working examples, browse the [Aspire samples](/reference/samples/).
 </LearnMore>
 
 ## 🧱 Go and Bun hosting integrations
@@ -193,15 +190,13 @@ await builder.build().run();
 </Tabs>
 
 <Aside type="note">
-  The previous `CommunityToolkit.Aspire.Hosting.Golang` package is deprecated
-  now that Go support has graduated into core Aspire. Use `Aspire.Hosting.Go`
-  and `AddGoApp` for new Aspire 13.4+ applications.
+  The previous `CommunityToolkit.Aspire.Hosting.Golang` package is deprecated now
+  that Go support has graduated into core Aspire. Use `Aspire.Hosting.Go` and
+  `AddGoApp` for new Aspire 13.4+ applications.
 </Aside>
 
 <LearnMore>
-  For setup details, see [Get started with the Go
-  integration](/integrations/frameworks/go/go-get-started/) and [Set up Go apps
-  in the AppHost](/integrations/frameworks/go/go-host/).
+  For setup details, see [Get started with the Go integration](/integrations/frameworks/go/go-get-started/) and [Set up Go apps in the AppHost](/integrations/frameworks/go/go-host/).
 </LearnMore>
 
 ### 🥟 Bun apps
@@ -224,12 +219,12 @@ builder.Build().Run();
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
 
-const bunApi = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
-await bunApi.withHttpEndpoint({ port: 3000, env: 'PORT' });
+const bunApi = await builder.addBunApp("bun-api", "../bun-app", "server.ts");
+await bunApi.withHttpEndpoint({ port: 3000, env: "PORT" });
 
 await builder.build().run();
 ```
@@ -238,8 +233,7 @@ await builder.build().run();
 </Tabs>
 
 <LearnMore>
-  For setup details, see the [Bun
-  integration](/integrations/frameworks/bun-apps/).
+  For setup details, see the [Bun integration](/integrations/frameworks/bun-apps/).
 </LearnMore>
 
 ## 🌐 Blazor WebAssembly hosting preview
@@ -265,15 +259,14 @@ builder.Build().Run();
 </Tabs>
 
 <LearnMore>
-  For setup details, see [Set up Blazor hosting in the
-  AppHost](/integrations/dotnet/blazor-hosting/).
+  For setup details, see [Set up Blazor hosting in the AppHost](/integrations/dotnet/blazor-hosting/).
 </LearnMore>
 
 ## 🛠️ CLI enhancements
 
 ### Search logs and telemetry
 
-`aspire logs` and the `aspire otel` commands now support `--search`, so you can filter logs and telemetry by keyword directly from the CLI.
+`aspire logs` and the `aspire otel` commands now support `--search`, so you can filter logs and telemetry by keyword directly from the CLI. 
 
 - For console logs, Aspire searches the log message text and resource prefix.
 - For structured logs, Aspire searches the message, attributes, scope name, event name, trace and span IDs, severity, and resource name.
@@ -291,8 +284,7 @@ aspire otel traces --search "@http.status_code:500"
 Search now also supports field filters, so you can narrow telemetry results by matching attributes, names, sources, IDs, and other telemetry fields.
 
 <LearnMore>
-  See [`aspire logs`](/reference/cli/commands/aspire-logs/) and [`aspire otel
-  logs`](/reference/cli/commands/aspire-otel-logs/) for telemetry CLI usage.
+  See [`aspire logs`](/reference/cli/commands/aspire-logs/) and [`aspire otel logs`](/reference/cli/commands/aspire-otel-logs/) for telemetry CLI usage.
 </LearnMore>
 
 ### Better environment diagnostics
@@ -338,8 +330,7 @@ aspire resource mydb-password set-parameter --help
 Boolean resource command options require explicit `true` or `false` values. For example, `--delete-from-user-secrets true` requests deletion from user secrets.
 
 <LearnMore>
-  For more information, see [`aspire
-  resource`](/reference/cli/commands/aspire-resource/#built-in-parameter-commands).
+  For more information, see [`aspire resource`](/reference/cli/commands/aspire-resource/#built-in-parameter-commands).
 </LearnMore>
 
 ### AI agent readiness with Aspire skills
@@ -400,8 +391,7 @@ Custom resource commands can now declare typed input arguments with labels, desc
 Command results can be configured to display immediately in the dashboard, making interactive commands easier to use when they return structured output or captured text.
 
 <LearnMore>
-  For the full API surface, see [Custom resource
-  commands](/fundamentals/custom-resource-commands/).
+  For the full API surface, see [Custom resource commands](/fundamentals/custom-resource-commands/).
 </LearnMore>
 
 ### Hide implementation-detail resources
@@ -413,10 +403,7 @@ AppHost authors can keep resource views focused with `WithHidden()` and `WithHid
 Aspire 13.4 adds the experimental `WithProcessCommand` API for exposing local tools, scripts, and CLIs as resource commands. The helper starts a process on the AppHost machine, passes arguments without going through a shell, streams stdout and stderr to the command logger, captures bounded output, and maps process exit codes to resource command results.
 
 <Aside type="caution">
-  `WithProcessCommand`, `ProcessCommandSpec`, and `ProcessCommandOptions` are
-  experimental APIs. C# callers must suppress
-  [`ASPIREPROCESSCOMMAND001`](/diagnostics/aspireprocesscommand001/) to use
-  them.
+  `WithProcessCommand`, `ProcessCommandSpec`, and `ProcessCommandOptions` are experimental APIs. C# callers must suppress [`ASPIREPROCESSCOMMAND001`](/diagnostics/aspireprocesscommand001/) to use them.
 </Aside>
 
 <Tabs syncKey='aspire-lang'>
@@ -459,9 +446,7 @@ await builder.build().run();
 </Tabs>
 
 <LearnMore>
-  For static commands, dynamic process specs, stdin, environment variables, and
-  result options, see [Process-backed resource
-  commands](/fundamentals/custom-resource-commands/#process-backed-resource-commands).
+  For static commands, dynamic process specs, stdin, environment variables, and result options, see [Process-backed resource commands](/fundamentals/custom-resource-commands/#process-backed-resource-commands).
 </LearnMore>
 
 ### 🔄 Persistent executable and project lifetimes
@@ -469,17 +454,16 @@ await builder.build().run();
 Persistent lifetimes now extend beyond containers to executables and projects. Call `WithPersistentLifetime()` to leave a resource running when the AppHost exits and reuse the same instance on the next run, and `WithSessionLifetime()` to return a resource to the default behavior. This is useful for resources that are expensive to initialize, need stable local endpoints, or should stay available while you restart or rebuild the AppHost.
 
 <Aside type="caution">
-  The shared persistent and session lifetime APIs are experimental and emit the
-  `ASPIREPERSISTENCE001` diagnostic, which C# callers must suppress to use them.
-  Persistent resources default to proxyless endpoints, must use concrete ports
-  for executables, don't support replicas, and aren't compatible with Aspire IDE
-  debugging sessions. The existing container-specific
+  The shared persistent and session lifetime APIs are experimental and emit
+  the `ASPIREPERSISTENCE001` diagnostic, which C# callers must suppress to use
+  them. Persistent resources default to proxyless endpoints, must use concrete
+  ports for executables, don't support replicas, and aren't compatible with
+  Aspire IDE debugging sessions. The existing container-specific
   `WithLifetime(ContainerLifetime.Persistent)` API is unchanged.
 </Aside>
 
 <LearnMore>
-  For the full lifetime model, see [Configure resource
-  lifetimes](/app-host/resource-lifetimes/).
+  For the full lifetime model, see [Configure resource lifetimes](/app-host/resource-lifetimes/).
 </LearnMore>
 
 ### AppHost and runtime reliability
@@ -500,9 +484,7 @@ Aspire 13.4 also improves the AppHost runtime:
 C# AppHost projects can opt in to using the installed Aspire CLI bundle as the source for DCP and Dashboard orchestration dependencies by setting `<AspireUseCliBundle>true</AspireUseCliBundle>`. This is a preview transition path for the upcoming shift where AppHost orchestration dependencies come from the CLI bundle by default, instead of being restored from platform-specific NuGet packages per AppHost project.
 
 <LearnMore>
-  For setup details, see [Use the Aspire CLI bundle for orchestration
-  dependencies](/get-started/aspire-sdk/#use-the-aspire-cli-bundle-for-orchestration-dependencies)
-  in the Aspire SDK documentation.
+  For setup details, see [Use the Aspire CLI bundle for orchestration dependencies](/get-started/aspire-sdk/#use-the-aspire-cli-bundle-for-orchestration-dependencies) in the Aspire SDK documentation.
 </LearnMore>
 
 ## 🚢 Kubernetes, AKS, and Azure deployment
@@ -528,8 +510,7 @@ Aspire 13.4 adds a Kubernetes manifest resource API for arbitrary manifests and 
 Helm chart name, version, description, release name, and namespace are now configured through the `WithHelm(...)` extension method. This replaces the previous parallel property-based configuration surface on `KubernetesEnvironmentResource` with one fluent entry point.
 
 <LearnMore>
-  For examples of `WithHelm(...)`, see the [Kubernetes
-  integration](/integrations/compute/kubernetes/#configure-helm-chart-options).
+  For examples of `WithHelm(...)`, see the [Kubernetes integration](/integrations/compute/kubernetes/#configure-helm-chart-options).
 </LearnMore>
 
 ### Reuse an existing ACR pull identity
@@ -537,8 +518,7 @@ Helm chart name, version, description, release name, and namespace are now confi
 When deploying to Azure Container Apps, Aspire normally emits a new user-assigned managed identity and an `AcrPull` role assignment so container apps can pull their images. If your deployment principal can't create identities or role assignments, or you want to reuse an existing identity, supply one with `WithAcrPullIdentity` / `withAcrPullIdentity`. The same API is available for both Azure Container App Environments and Azure App Service Environments.
 
 <LearnMore>
-  For details, see [Configure Azure Container
-  Apps](/integrations/cloud/azure/configure-container-apps/).
+  For details, see [Configure Azure Container Apps](/integrations/cloud/azure/configure-container-apps/).
 </LearnMore>
 
 ### Azure Container Apps jobs are stable
@@ -546,8 +526,7 @@ When deploying to Azure Container Apps, Aspire normally emits a new user-assigne
 The Azure Container Apps jobs APIs — `PublishAsAzureContainerAppJob` and `PublishAsScheduledAzureContainerAppJob` — have graduated to stable. You can declare any project, container, or executable resource as a finite-duration job for batch processing, scheduled tasks, and event-driven workloads directly from your AppHost, without suppressing an experimental diagnostic.
 
 <LearnMore>
-  For trigger types and scheduling, see [Azure Container Apps
-  jobs](/integrations/cloud/azure/container-app-jobs/).
+  For trigger types and scheduling, see [Azure Container Apps jobs](/integrations/cloud/azure/container-app-jobs/).
 </LearnMore>
 
 ## 📊 Dashboard improvements
@@ -561,9 +540,7 @@ Administrators can hide the header button with the `Dashboard:UI:DisableAgentHel
 The MCP AI tools also return more telemetry context this release — trace and structured-log limits increased from 200 to 800 entries, and console logs from 500 to 2000 — so agents get a fuller picture when they query your app.
 
 <LearnMore>
-  For the agent workflow, see [Dashboard and AI coding
-  agents](/dashboard/ai-coding-agents/). For the dashboard setting, see
-  [Dashboard configuration](/dashboard/configuration/).
+  For the agent workflow, see [Dashboard and AI coding agents](/dashboard/ai-coding-agents/). For the dashboard setting, see [Dashboard configuration](/dashboard/configuration/).
 </LearnMore>
 
 ### Structured search and trace filtering
@@ -593,8 +570,7 @@ The extension also uses VS Code terminal shell integration when sending Aspire C
 The [Go hosting integration](#go-hosting-integration) section covers the new Go debugging flow. This release also expands what the extension can do across workspaces: it adds live support for workspaces that contain multiple AppHosts, an AppHost logs viewer, resource command argument inputs collected through QuickInput, and faster, parser-backed AppHost and resource detection.
 
 <LearnMore>
-  Learn more about the [Aspire Visual Studio Code
-  extension](/get-started/aspire-vscode-extension/).
+  Learn more about the [Aspire Visual Studio Code extension](/get-started/aspire-vscode-extension/).
 </LearnMore>
 
 ## 📦 Integration updates
@@ -604,15 +580,11 @@ The [Go hosting integration](#go-hosting-integration) section covers the new Go 
 Azure Front Door CDN resources now use Azure.Provisioning's built-in name-generation algorithm instead of Aspire's custom logic. This removes Aspire's manual name-length cap and aligns generated resource names with Azure.Provisioning behavior.
 
 <Aside type="caution">
-  Upgrading from Aspire 13.3 can produce duplicate Front Door endpoint, origin
-  group, or route names in existing deployments. Remove and re-add the affected
-  resource, or set the resource `Name` explicitly with
-  `ConfigureInfrastructure`, to avoid conflicts.
+  Upgrading from Aspire 13.3 can produce duplicate Front Door endpoint, origin group, or route names in existing deployments. Remove and re-add the affected resource, or set the resource `Name` explicitly with `ConfigureInfrastructure`, to avoid conflicts.
 </Aside>
 
 <LearnMore>
-  For Front Door setup, see the [Azure Front Door
-  integration](/integrations/cloud/azure/azure-front-door/).
+  For Front Door setup, see the [Azure Front Door integration](/integrations/cloud/azure/azure-front-door/).
 </LearnMore>
 
 ### NATS client updates
@@ -620,15 +592,15 @@ Azure Front Door CDN resources now use Azure.Provisioning's built-in name-genera
 `AddNatsClient` now also registers `INatsClient` and defaults the serializer registry to `NatsClientDefaultSerializerRegistry`. This enables typed publish/subscribe scenarios without requiring explicit serializer configuration. User-provided serializer registries still take precedence, and primitive/raw byte scenarios are unaffected.
 
 <LearnMore>
-  For client setup, see [Connect to
-  NATS](/integrations/messaging/nats/nats-connect/).
+  For client setup, see [Connect to NATS](/integrations/messaging/nats/nats-connect/).
 </LearnMore>
 
 ### Foundry hosted agent commands and fixes
 
-You can now turn any project or app resource into a Microsoft Foundry hosted agent, interact directly with it via the Aspire dashboard, and deploy it with Aspire.
+You can now turn any project or app resource into a Microsoft Foundry hosted agent, interact directly with it via the Aspire dashboard, and deploy it with Aspire. 
 
 The [Foundry Hosted Agent Service](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents) is a way to write code as runnable, debuggable, containerized AI agents with streamlined deployment and management as part of your app. If your code implements the Foundry Hosted Agents responses or invocations protocols, tell Aspire to treat it as a hosted agent in the apphost:
+
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
@@ -643,8 +615,7 @@ builder.AddPythonApp("hostedagent", "./agent-code", "main.py")
 <TabItem id='typescript' label="TypeScript">
 
 ```typescript title="apphost.mts"
-builder
-  .addPythonApp('hostedagent', './agent-code', 'main.py')
+builder.addPythonApp("hostedagent", "./agent-code", "main.py")
   .withUv()
   .asHostedAgent();
 ```
@@ -659,8 +630,7 @@ Microsoft Foundry hosted agents also include deployment fixes: project endpoints
 The default RabbitMQ container image has been bumped from 4.2 to 4.3. Existing AppHosts pick up the new image automatically on the next run; pin a specific tag with `WithImageTag(...)` if you need to stay on a particular version.
 
 <LearnMore>
-  For RabbitMQ hosting setup, see the [RabbitMQ
-  integration](/integrations/messaging/rabbitmq/rabbitmq-host/).
+  For RabbitMQ hosting setup, see the [RabbitMQ integration](/integrations/messaging/rabbitmq/rabbitmq-host/).
 </LearnMore>
 
 ## 🐛 Bug fixes and full changelog
@@ -678,12 +648,12 @@ TypeScript AppHosts scaffolded by Aspire CLI versions earlier than 13.4 use a sl
 <FileTree>
 
 - my-apphost/
-  - .modules/ Generated TypeScript SDK (do not edit)
+  - .modules/  Generated TypeScript SDK (do not edit)
     - aspire.ts
     - base.ts
     - transport.ts
-  - apphost.ts Your AppHost entry point
-  - aspire.config.json Aspire configuration
+  - apphost.ts  Your AppHost entry point
+  - aspire.config.json  Aspire configuration
   - package.json
   - tsconfig.apphost.json
 
@@ -706,10 +676,7 @@ The 13.4 Aspire CLI keeps these projects working without any changes:
 `aspire add`, `aspire restore`, `aspire run`, and `aspire start` all continue to work against an existing `apphost.ts` project with no edits required.
 
 <Aside type="tip">
-  You don't need to migrate to keep your existing TypeScript AppHost running on
-  Aspire 13.4. The compatibility path is automatic. Migrate only if you want the
-  new default layout — for example, to match the file tree shown in newer
-  documentation and samples.
+You don't need to migrate to keep your existing TypeScript AppHost running on Aspire 13.4. The compatibility path is automatic. Migrate only if you want the new default layout — for example, to match the file tree shown in newer documentation and samples.
 </Aside>
 
 ### Migrating to the new `apphost.mts` layout
@@ -747,9 +714,7 @@ If you'd like to move an existing project to the new default layout, the migrati
 
    ```json title="tsconfig.apphost.json" del={4,5} ins={6,7}
    {
-     "compilerOptions": {
-       /* ... */
-     },
+     "compilerOptions": { /* ... */ },
      "include": [
        "apphost.ts",
        ".modules/**/*.ts",
@@ -797,8 +762,8 @@ Generated polyglot SDK modules now live under a single `.aspire/modules/` direct
 Re-run `aspire run` (or your code-generation step) to regenerate references, and update any custom tooling or `.gitignore` entries that referenced the old `.modules/` path.
 
 <Aside type="note">
-  Existing `apphost.ts` projects continue to use the legacy `./.modules/` layout
-  for compatibility; new projects use `.aspire/modules/`.
+  Existing `apphost.ts` projects continue to use the legacy `./.modules/`
+  layout for compatibility; new projects use `.aspire/modules/`.
 </Aside>
 
 #### Persistent executable and project lifetimes

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What's new in Aspire 13.4"
-description: "Explore Aspire 13.4: GA TypeScript AppHost, new Go, Blazor WebAssembly, and Bun hosting integrations, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates."
+description: 'Explore Aspire 13.4: GA TypeScript AppHost, new Go hosting and first-party Bun support, Blazor WebAssembly hosting, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates.'
 sidebar:
   label: Aspire 13.4
   order: 0
@@ -20,14 +20,14 @@ import {
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 
-Aspire 13.4 is here, with a release focused on broadening the app model and smoothing day-to-day operations — led by **TypeScript AppHost support reaching general availability** alongside first-class C# AppHosts, new **Go**, **Blazor WebAssembly**, and **Bun** hosting integrations, a new set of **TypeScript samples**, **TypeScript documentation parity with C#**, expanded **Kubernetes and AKS deployment APIs**, **AI agent readiness** through the Aspire skills bundle, **process-backed resource commands**, **integration discovery** from the CLI, server-side **log and telemetry search**, a dashboard **AI Agents** entry point, and a more capable Aspire extension for Visual Studio Code.
+Aspire 13.4 is here, with a release focused on broadening the app model and smoothing day-to-day operations — led by **TypeScript AppHost support reaching general availability** alongside first-class C# AppHosts, new **Go** hosting, **Blazor WebAssembly** hosting, and first-party **Bun** support in `Aspire.Hosting.JavaScript`, a new set of **TypeScript samples**, **TypeScript documentation parity with C#**, expanded **Kubernetes and AKS deployment APIs**, **AI agent readiness** through the Aspire skills bundle, **process-backed resource commands**, **integration discovery** from the CLI, server-side **log and telemetry search**, a dashboard **AI Agents** entry point, and a more capable Aspire extension for Visual Studio Code.
 
 We'd love to hear what you think. Drop by [<Icon name="discord" class='d-inline' /> Discord](https://aka.ms/aspire-discord) to chat with the team and the community, or file feedback and issues on [<Icon name="github" class='d-inline' /> GitHub](https://github.com/microsoft/aspire/issues).
 
 This release introduces:
 
 - **C# and TypeScript AppHosts are first class and supported** with stronger TypeScript startup validation, more complete SDK generation, new TypeScript samples, and documentation parity with C# AppHost examples.
-- **Go and Bun hosting integrations** with new AppHost APIs for [Go](/integrations/frameworks/go/go-get-started/) (`AddGoApp`) and [Bun](/integrations/frameworks/bun-apps/) (`AddBunApp`).
+- **Go hosting and first-party Bun support** with `Aspire.Hosting.Go` for [Go](/integrations/frameworks/go/go-get-started/) (`AddGoApp`) and `Aspire.Hosting.JavaScript` for [Bun](/integrations/frameworks/bun-apps/) (`AddBunApp`, `WithBun`).
 - **Kubernetes and AKS deployment improvements** including [cert-manager integration, Gateway API and Azure Application Gateway for Containers (AGC) support](/deployment/kubernetes/aks/#expose-your-app-to-the-internet), Kubernetes manifest resources, external Helm charts, and consolidated Helm chart configuration.
 - **AI agent readiness** with Aspire workflow skills moving into the new [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) bundle, clearer separation between first-run setup, lifecycle orchestration, monitoring, AppHost wiring, and deployment guidance, and eval-driven iteration on agent routing.
 - **Richer resource commands** with typed arguments, visibility controls, immediate result display, named CLI options, resource-scoped help, built-in parameter command options, and the experimental `WithProcessCommand` API.
@@ -42,7 +42,8 @@ This release introduces:
 <br />
 
 <Aside type="caution">
-Aspire 13.4 includes breaking changes. Please review the [Breaking changes](#breaking-changes) section before upgrading.
+  Aspire 13.4 includes breaking changes. Please review the [Breaking
+  changes](#breaking-changes) section before upgrading.
 </Aside>
 
 <Aside type="note">
@@ -112,7 +113,8 @@ Or install the CLI from scratch:
 </OsAwareTabs>
 
 <LearnMore>
-  For more details on installing the Aspire CLI, see [Install the CLI](/get-started/install-cli/).
+  For more details on installing the Aspire CLI, see [Install the
+  CLI](/get-started/install-cli/).
 </LearnMore>
 
 ## 🌐 TypeScript AppHost general availability
@@ -120,16 +122,16 @@ Or install the CLI from scratch:
 TypeScript AppHosts are now fully supported alongside C#, so both are first-class ways to model Aspire apps. TypeScript AppHosts use `apphost.mts`, the same code-first orchestration model as C#, and generated SDK modules for Aspire resources and integrations.
 
 ```typescript title="apphost.mts"
-import { createBuilder } from "./.aspire/modules/aspire.mjs";
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis("cache");
+const cache = await builder.addRedis('cache');
 
 const api = await builder
-    .addNodeApp("api", "./api", "src/index.ts")
-    .withHttpEndpoint({ env: "PORT" })
-    .withReference(cache);
+  .addNodeApp('api', './api', 'src/index.ts')
+  .withHttpEndpoint({ env: 'PORT' })
+  .withReference(cache);
 
 await builder.build().run();
 ```
@@ -143,14 +145,15 @@ The [Aspire Type System (ATS)](/extensibility/multi-language-integration-authori
 Existing TypeScript AppHosts scaffolded by earlier CLI versions continue to work on 13.4 without changes. If your project uses `apphost.ts` and `./.modules/aspire.js`, see [Legacy `apphost.ts` projects (pre-13.4)](#legacy-apphostts-projects-pre-134) for compatibility details and an opt-in migration to the new `apphost.mts` layout.
 
 <LearnMore>
-  For preview polyglot AppHosts behind feature flags, see [`aspire config set`](/reference/cli/commands/aspire-config-set/).
-  For setup details, see [TypeScript AppHosts](/app-host/typescript-apphost/).
-  To explore working examples, browse the [Aspire samples](/reference/samples/).
+  For preview polyglot AppHosts behind feature flags, see [`aspire config
+  set`](/reference/cli/commands/aspire-config-set/). For setup details, see
+  [TypeScript AppHosts](/app-host/typescript-apphost/). To explore working
+  examples, browse the [Aspire samples](/reference/samples/).
 </LearnMore>
 
-## 🧱 Go and Bun hosting integrations
+## 🧱 Go hosting and Bun support
 
-Beyond TypeScript, Aspire 13.4 adds first-class hosting integrations for Go and Bun, so you can orchestrate those apps directly from the AppHost.
+Beyond TypeScript, Aspire 13.4 adds first-class Go hosting and first-party Bun support, so you can orchestrate those apps directly from the AppHost.
 
 <span id="go-hosting-integration"></span>
 
@@ -190,18 +193,20 @@ await builder.build().run();
 </Tabs>
 
 <Aside type="note">
-  The previous `CommunityToolkit.Aspire.Hosting.Golang` package is deprecated now
-  that Go support has graduated into core Aspire. Use `Aspire.Hosting.Go` and
-  `AddGoApp` for new Aspire 13.4+ applications.
+  The previous `CommunityToolkit.Aspire.Hosting.Golang` package is deprecated
+  now that Go support has graduated into core Aspire. Use `Aspire.Hosting.Go`
+  and `AddGoApp` for new Aspire 13.4+ applications.
 </Aside>
 
 <LearnMore>
-  For setup details, see [Get started with the Go integration](/integrations/frameworks/go/go-get-started/) and [Set up Go apps in the AppHost](/integrations/frameworks/go/go-host/).
+  For setup details, see [Get started with the Go
+  integration](/integrations/frameworks/go/go-get-started/) and [Set up Go apps
+  in the AppHost](/integrations/frameworks/go/go-host/).
 </LearnMore>
 
 ### 🥟 Bun apps
 
-Aspire 13.4 adds `AddBunApp` for orchestrating [Bun](https://bun.sh/) applications alongside the rest of your resources, so JavaScript and TypeScript apps that run on the Bun runtime can participate in the app model just like Node.js apps.
+Aspire 13.4 adds first-party Bun support to `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to orchestrate [Bun](https://bun.sh/) applications directly, and use `WithBun` / `withBun` when you want other JavaScript resources to use Bun as their package manager and container build image.
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
@@ -209,7 +214,7 @@ Aspire 13.4 adds `AddBunApp` for orchestrating [Bun](https://bun.sh/) applicatio
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var bunApi = builder.AddBunApp("bun-api", "../bun-app")
+var bunApi = builder.AddBunApp("bun-api", "../bun-app", "server.ts")
   .WithHttpEndpoint(port: 3000, env: "PORT");
 
 builder.Build().Run();
@@ -219,12 +224,12 @@ builder.Build().Run();
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts"
-import { createBuilder } from "./.aspire/modules/aspire.mjs";
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const bunApi = await builder.addBunApp("bun-api", "../bun-app");
-await bunApi.withHttpEndpoint({ port: 3000, env: "PORT" });
+const bunApi = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
+await bunApi.withHttpEndpoint({ port: 3000, env: 'PORT' });
 
 await builder.build().run();
 ```
@@ -233,7 +238,9 @@ await builder.build().run();
 </Tabs>
 
 <LearnMore>
-  For setup details, see the [Bun integration](/integrations/frameworks/bun-apps/).
+  For setup details, see [Set up Bun apps in the
+  AppHost](/integrations/frameworks/bun-apps/) and [Set up JavaScript apps in
+  the AppHost](/integrations/frameworks/javascript/#use-bun).
 </LearnMore>
 
 ## 🌐 Blazor WebAssembly hosting preview
@@ -259,14 +266,15 @@ builder.Build().Run();
 </Tabs>
 
 <LearnMore>
-  For setup details, see [Set up Blazor hosting in the AppHost](/integrations/dotnet/blazor-hosting/).
+  For setup details, see [Set up Blazor hosting in the
+  AppHost](/integrations/dotnet/blazor-hosting/).
 </LearnMore>
 
 ## 🛠️ CLI enhancements
 
 ### Search logs and telemetry
 
-`aspire logs` and the `aspire otel` commands now support `--search`, so you can filter logs and telemetry by keyword directly from the CLI. 
+`aspire logs` and the `aspire otel` commands now support `--search`, so you can filter logs and telemetry by keyword directly from the CLI.
 
 - For console logs, Aspire searches the log message text and resource prefix.
 - For structured logs, Aspire searches the message, attributes, scope name, event name, trace and span IDs, severity, and resource name.
@@ -284,7 +292,8 @@ aspire otel traces --search "@http.status_code:500"
 Search now also supports field filters, so you can narrow telemetry results by matching attributes, names, sources, IDs, and other telemetry fields.
 
 <LearnMore>
-  See [`aspire logs`](/reference/cli/commands/aspire-logs/) and [`aspire otel logs`](/reference/cli/commands/aspire-otel-logs/) for telemetry CLI usage.
+  See [`aspire logs`](/reference/cli/commands/aspire-logs/) and [`aspire otel
+  logs`](/reference/cli/commands/aspire-otel-logs/) for telemetry CLI usage.
 </LearnMore>
 
 ### Better environment diagnostics
@@ -330,7 +339,8 @@ aspire resource mydb-password set-parameter --help
 Boolean resource command options require explicit `true` or `false` values. For example, `--delete-from-user-secrets true` requests deletion from user secrets.
 
 <LearnMore>
-  For more information, see [`aspire resource`](/reference/cli/commands/aspire-resource/#built-in-parameter-commands).
+  For more information, see [`aspire
+  resource`](/reference/cli/commands/aspire-resource/#built-in-parameter-commands).
 </LearnMore>
 
 ### AI agent readiness with Aspire skills
@@ -391,7 +401,8 @@ Custom resource commands can now declare typed input arguments with labels, desc
 Command results can be configured to display immediately in the dashboard, making interactive commands easier to use when they return structured output or captured text.
 
 <LearnMore>
-  For the full API surface, see [Custom resource commands](/fundamentals/custom-resource-commands/).
+  For the full API surface, see [Custom resource
+  commands](/fundamentals/custom-resource-commands/).
 </LearnMore>
 
 ### Hide implementation-detail resources
@@ -403,7 +414,10 @@ AppHost authors can keep resource views focused with `WithHidden()` and `WithHid
 Aspire 13.4 adds the experimental `WithProcessCommand` API for exposing local tools, scripts, and CLIs as resource commands. The helper starts a process on the AppHost machine, passes arguments without going through a shell, streams stdout and stderr to the command logger, captures bounded output, and maps process exit codes to resource command results.
 
 <Aside type="caution">
-  `WithProcessCommand`, `ProcessCommandSpec`, and `ProcessCommandOptions` are experimental APIs. C# callers must suppress [`ASPIREPROCESSCOMMAND001`](/diagnostics/aspireprocesscommand001/) to use them.
+  `WithProcessCommand`, `ProcessCommandSpec`, and `ProcessCommandOptions` are
+  experimental APIs. C# callers must suppress
+  [`ASPIREPROCESSCOMMAND001`](/diagnostics/aspireprocesscommand001/) to use
+  them.
 </Aside>
 
 <Tabs syncKey='aspire-lang'>
@@ -446,7 +460,9 @@ await builder.build().run();
 </Tabs>
 
 <LearnMore>
-  For static commands, dynamic process specs, stdin, environment variables, and result options, see [Process-backed resource commands](/fundamentals/custom-resource-commands/#process-backed-resource-commands).
+  For static commands, dynamic process specs, stdin, environment variables, and
+  result options, see [Process-backed resource
+  commands](/fundamentals/custom-resource-commands/#process-backed-resource-commands).
 </LearnMore>
 
 ### 🔄 Persistent executable and project lifetimes
@@ -454,16 +470,17 @@ await builder.build().run();
 Persistent lifetimes now extend beyond containers to executables and projects. Call `WithPersistentLifetime()` to leave a resource running when the AppHost exits and reuse the same instance on the next run, and `WithSessionLifetime()` to return a resource to the default behavior. This is useful for resources that are expensive to initialize, need stable local endpoints, or should stay available while you restart or rebuild the AppHost.
 
 <Aside type="caution">
-  The shared persistent and session lifetime APIs are experimental and emit
-  the `ASPIREPERSISTENCE001` diagnostic, which C# callers must suppress to use
-  them. Persistent resources default to proxyless endpoints, must use concrete
-  ports for executables, don't support replicas, and aren't compatible with
-  Aspire IDE debugging sessions. The existing container-specific
+  The shared persistent and session lifetime APIs are experimental and emit the
+  `ASPIREPERSISTENCE001` diagnostic, which C# callers must suppress to use them.
+  Persistent resources default to proxyless endpoints, must use concrete ports
+  for executables, don't support replicas, and aren't compatible with Aspire IDE
+  debugging sessions. The existing container-specific
   `WithLifetime(ContainerLifetime.Persistent)` API is unchanged.
 </Aside>
 
 <LearnMore>
-  For the full lifetime model, see [Configure resource lifetimes](/app-host/resource-lifetimes/).
+  For the full lifetime model, see [Configure resource
+  lifetimes](/app-host/resource-lifetimes/).
 </LearnMore>
 
 ### AppHost and runtime reliability
@@ -484,7 +501,9 @@ Aspire 13.4 also improves the AppHost runtime:
 C# AppHost projects can opt in to using the installed Aspire CLI bundle as the source for DCP and Dashboard orchestration dependencies by setting `<AspireUseCliBundle>true</AspireUseCliBundle>`. This is a preview transition path for the upcoming shift where AppHost orchestration dependencies come from the CLI bundle by default, instead of being restored from platform-specific NuGet packages per AppHost project.
 
 <LearnMore>
-  For setup details, see [Use the Aspire CLI bundle for orchestration dependencies](/get-started/aspire-sdk/#use-the-aspire-cli-bundle-for-orchestration-dependencies) in the Aspire SDK documentation.
+  For setup details, see [Use the Aspire CLI bundle for orchestration
+  dependencies](/get-started/aspire-sdk/#use-the-aspire-cli-bundle-for-orchestration-dependencies)
+  in the Aspire SDK documentation.
 </LearnMore>
 
 ## 🚢 Kubernetes, AKS, and Azure deployment
@@ -510,7 +529,8 @@ Aspire 13.4 adds a Kubernetes manifest resource API for arbitrary manifests and 
 Helm chart name, version, description, release name, and namespace are now configured through the `WithHelm(...)` extension method. This replaces the previous parallel property-based configuration surface on `KubernetesEnvironmentResource` with one fluent entry point.
 
 <LearnMore>
-  For examples of `WithHelm(...)`, see the [Kubernetes integration](/integrations/compute/kubernetes/#configure-helm-chart-options).
+  For examples of `WithHelm(...)`, see the [Kubernetes
+  integration](/integrations/compute/kubernetes/#configure-helm-chart-options).
 </LearnMore>
 
 ### Reuse an existing ACR pull identity
@@ -518,7 +538,8 @@ Helm chart name, version, description, release name, and namespace are now confi
 When deploying to Azure Container Apps, Aspire normally emits a new user-assigned managed identity and an `AcrPull` role assignment so container apps can pull their images. If your deployment principal can't create identities or role assignments, or you want to reuse an existing identity, supply one with `WithAcrPullIdentity` / `withAcrPullIdentity`. The same API is available for both Azure Container App Environments and Azure App Service Environments.
 
 <LearnMore>
-  For details, see [Configure Azure Container Apps](/integrations/cloud/azure/configure-container-apps/).
+  For details, see [Configure Azure Container
+  Apps](/integrations/cloud/azure/configure-container-apps/).
 </LearnMore>
 
 ### Azure Container Apps jobs are stable
@@ -526,7 +547,8 @@ When deploying to Azure Container Apps, Aspire normally emits a new user-assigne
 The Azure Container Apps jobs APIs — `PublishAsAzureContainerAppJob` and `PublishAsScheduledAzureContainerAppJob` — have graduated to stable. You can declare any project, container, or executable resource as a finite-duration job for batch processing, scheduled tasks, and event-driven workloads directly from your AppHost, without suppressing an experimental diagnostic.
 
 <LearnMore>
-  For trigger types and scheduling, see [Azure Container Apps jobs](/integrations/cloud/azure/container-app-jobs/).
+  For trigger types and scheduling, see [Azure Container Apps
+  jobs](/integrations/cloud/azure/container-app-jobs/).
 </LearnMore>
 
 ## 📊 Dashboard improvements
@@ -540,7 +562,9 @@ Administrators can hide the header button with the `Dashboard:UI:DisableAgentHel
 The MCP AI tools also return more telemetry context this release — trace and structured-log limits increased from 200 to 800 entries, and console logs from 500 to 2000 — so agents get a fuller picture when they query your app.
 
 <LearnMore>
-  For the agent workflow, see [Dashboard and AI coding agents](/dashboard/ai-coding-agents/). For the dashboard setting, see [Dashboard configuration](/dashboard/configuration/).
+  For the agent workflow, see [Dashboard and AI coding
+  agents](/dashboard/ai-coding-agents/). For the dashboard setting, see
+  [Dashboard configuration](/dashboard/configuration/).
 </LearnMore>
 
 ### Structured search and trace filtering
@@ -570,7 +594,8 @@ The extension also uses VS Code terminal shell integration when sending Aspire C
 The [Go hosting integration](#go-hosting-integration) section covers the new Go debugging flow. This release also expands what the extension can do across workspaces: it adds live support for workspaces that contain multiple AppHosts, an AppHost logs viewer, resource command argument inputs collected through QuickInput, and faster, parser-backed AppHost and resource detection.
 
 <LearnMore>
-  Learn more about the [Aspire Visual Studio Code extension](/get-started/aspire-vscode-extension/).
+  Learn more about the [Aspire Visual Studio Code
+  extension](/get-started/aspire-vscode-extension/).
 </LearnMore>
 
 ## 📦 Integration updates
@@ -580,11 +605,15 @@ The [Go hosting integration](#go-hosting-integration) section covers the new Go 
 Azure Front Door CDN resources now use Azure.Provisioning's built-in name-generation algorithm instead of Aspire's custom logic. This removes Aspire's manual name-length cap and aligns generated resource names with Azure.Provisioning behavior.
 
 <Aside type="caution">
-  Upgrading from Aspire 13.3 can produce duplicate Front Door endpoint, origin group, or route names in existing deployments. Remove and re-add the affected resource, or set the resource `Name` explicitly with `ConfigureInfrastructure`, to avoid conflicts.
+  Upgrading from Aspire 13.3 can produce duplicate Front Door endpoint, origin
+  group, or route names in existing deployments. Remove and re-add the affected
+  resource, or set the resource `Name` explicitly with
+  `ConfigureInfrastructure`, to avoid conflicts.
 </Aside>
 
 <LearnMore>
-  For Front Door setup, see the [Azure Front Door integration](/integrations/cloud/azure/azure-front-door/).
+  For Front Door setup, see the [Azure Front Door
+  integration](/integrations/cloud/azure/azure-front-door/).
 </LearnMore>
 
 ### NATS client updates
@@ -592,15 +621,15 @@ Azure Front Door CDN resources now use Azure.Provisioning's built-in name-genera
 `AddNatsClient` now also registers `INatsClient` and defaults the serializer registry to `NatsClientDefaultSerializerRegistry`. This enables typed publish/subscribe scenarios without requiring explicit serializer configuration. User-provided serializer registries still take precedence, and primitive/raw byte scenarios are unaffected.
 
 <LearnMore>
-  For client setup, see [Connect to NATS](/integrations/messaging/nats/nats-connect/).
+  For client setup, see [Connect to
+  NATS](/integrations/messaging/nats/nats-connect/).
 </LearnMore>
 
 ### Foundry hosted agent commands and fixes
 
-You can now turn any project or app resource into a Microsoft Foundry hosted agent, interact directly with it via the Aspire dashboard, and deploy it with Aspire. 
+You can now turn any project or app resource into a Microsoft Foundry hosted agent, interact directly with it via the Aspire dashboard, and deploy it with Aspire.
 
 The [Foundry Hosted Agent Service](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents) is a way to write code as runnable, debuggable, containerized AI agents with streamlined deployment and management as part of your app. If your code implements the Foundry Hosted Agents responses or invocations protocols, tell Aspire to treat it as a hosted agent in the apphost:
-
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
@@ -615,7 +644,8 @@ builder.AddPythonApp("hostedagent", "./agent-code", "main.py")
 <TabItem id='typescript' label="TypeScript">
 
 ```typescript title="apphost.mts"
-builder.addPythonApp("hostedagent", "./agent-code", "main.py")
+builder
+  .addPythonApp('hostedagent', './agent-code', 'main.py')
   .withUv()
   .asHostedAgent();
 ```
@@ -630,7 +660,8 @@ Microsoft Foundry hosted agents also include deployment fixes: project endpoints
 The default RabbitMQ container image has been bumped from 4.2 to 4.3. Existing AppHosts pick up the new image automatically on the next run; pin a specific tag with `WithImageTag(...)` if you need to stay on a particular version.
 
 <LearnMore>
-  For RabbitMQ hosting setup, see the [RabbitMQ integration](/integrations/messaging/rabbitmq/rabbitmq-host/).
+  For RabbitMQ hosting setup, see the [RabbitMQ
+  integration](/integrations/messaging/rabbitmq/rabbitmq-host/).
 </LearnMore>
 
 ## 🐛 Bug fixes and full changelog
@@ -648,12 +679,12 @@ TypeScript AppHosts scaffolded by Aspire CLI versions earlier than 13.4 use a sl
 <FileTree>
 
 - my-apphost/
-  - .modules/  Generated TypeScript SDK (do not edit)
+  - .modules/ Generated TypeScript SDK (do not edit)
     - aspire.ts
     - base.ts
     - transport.ts
-  - apphost.ts  Your AppHost entry point
-  - aspire.config.json  Aspire configuration
+  - apphost.ts Your AppHost entry point
+  - aspire.config.json Aspire configuration
   - package.json
   - tsconfig.apphost.json
 
@@ -676,7 +707,10 @@ The 13.4 Aspire CLI keeps these projects working without any changes:
 `aspire add`, `aspire restore`, `aspire run`, and `aspire start` all continue to work against an existing `apphost.ts` project with no edits required.
 
 <Aside type="tip">
-You don't need to migrate to keep your existing TypeScript AppHost running on Aspire 13.4. The compatibility path is automatic. Migrate only if you want the new default layout — for example, to match the file tree shown in newer documentation and samples.
+  You don't need to migrate to keep your existing TypeScript AppHost running on
+  Aspire 13.4. The compatibility path is automatic. Migrate only if you want the
+  new default layout — for example, to match the file tree shown in newer
+  documentation and samples.
 </Aside>
 
 ### Migrating to the new `apphost.mts` layout
@@ -714,7 +748,9 @@ If you'd like to move an existing project to the new default layout, the migrati
 
    ```json title="tsconfig.apphost.json" del={4,5} ins={6,7}
    {
-     "compilerOptions": { /* ... */ },
+     "compilerOptions": {
+       /* ... */
+     },
      "include": [
        "apphost.ts",
        ".modules/**/*.ts",
@@ -762,8 +798,8 @@ Generated polyglot SDK modules now live under a single `.aspire/modules/` direct
 Re-run `aspire run` (or your code-generation step) to regenerate references, and update any custom tooling or `.gitignore` entries that referenced the old `.modules/` path.
 
 <Aside type="note">
-  Existing `apphost.ts` projects continue to use the legacy `./.modules/`
-  layout for compatibility; new projects use `.aspire/modules/`.
+  Existing `apphost.ts` projects continue to use the legacy `./.modules/` layout
+  for compatibility; new projects use `.aspire/modules/`.
 </Aside>
 
 #### Persistent executable and project lifetimes

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -201,7 +201,7 @@ await builder.build().run();
 
 ### 🥟 Bun apps
 
-Aspire 13.4 adds first-party Bun support in `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to orchestrate [Bun](https://bun.sh/) applications alongside the rest of your resources.
+Aspire 13.4 adds `AddBunApp` / `addBunApp` for orchestrating [Bun](https://bun.sh/) applications alongside the rest of your resources. Bun support is now part of `Aspire.Hosting.JavaScript`.
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -1,6 +1,6 @@
 ---
 title: "What's new in Aspire 13.4"
-description: 'Explore Aspire 13.4: GA TypeScript AppHost, new Go hosting and first-party Bun support, Blazor WebAssembly hosting, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates.'
+description: 'Explore Aspire 13.4: GA TypeScript AppHost, new Go, Blazor WebAssembly, and Bun hosting integrations, richer Kubernetes and AKS deployment APIs, AI agent readiness, process resource commands, CLI integration discovery, and dashboard updates.'
 sidebar:
   label: Aspire 13.4
   order: 0
@@ -20,14 +20,14 @@ import {
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 
-Aspire 13.4 is here, with a release focused on broadening the app model and smoothing day-to-day operations — led by **TypeScript AppHost support reaching general availability** alongside first-class C# AppHosts, new **Go** hosting, **Blazor WebAssembly** hosting, and first-party **Bun** support in `Aspire.Hosting.JavaScript`, a new set of **TypeScript samples**, **TypeScript documentation parity with C#**, expanded **Kubernetes and AKS deployment APIs**, **AI agent readiness** through the Aspire skills bundle, **process-backed resource commands**, **integration discovery** from the CLI, server-side **log and telemetry search**, a dashboard **AI Agents** entry point, and a more capable Aspire extension for Visual Studio Code.
+Aspire 13.4 is here, with a release focused on broadening the app model and smoothing day-to-day operations — led by **TypeScript AppHost support reaching general availability** alongside first-class C# AppHosts, new **Go**, **Blazor WebAssembly**, and **Bun** hosting integrations, a new set of **TypeScript samples**, **TypeScript documentation parity with C#**, expanded **Kubernetes and AKS deployment APIs**, **AI agent readiness** through the Aspire skills bundle, **process-backed resource commands**, **integration discovery** from the CLI, server-side **log and telemetry search**, a dashboard **AI Agents** entry point, and a more capable Aspire extension for Visual Studio Code.
 
 We'd love to hear what you think. Drop by [<Icon name="discord" class='d-inline' /> Discord](https://aka.ms/aspire-discord) to chat with the team and the community, or file feedback and issues on [<Icon name="github" class='d-inline' /> GitHub](https://github.com/microsoft/aspire/issues).
 
 This release introduces:
 
 - **C# and TypeScript AppHosts are first class and supported** with stronger TypeScript startup validation, more complete SDK generation, new TypeScript samples, and documentation parity with C# AppHost examples.
-- **Go hosting and first-party Bun support** with `Aspire.Hosting.Go` for [Go](/integrations/frameworks/go/go-get-started/) (`AddGoApp`) and `Aspire.Hosting.JavaScript` for [Bun](/integrations/frameworks/bun-apps/) (`AddBunApp`, `WithBun`).
+- **Go and Bun hosting integrations** with new AppHost APIs for [Go](/integrations/frameworks/go/go-get-started/) (`AddGoApp`) and first-party Bun support in `Aspire.Hosting.JavaScript` for [Bun](/integrations/frameworks/bun-apps/) (`AddBunApp`).
 - **Kubernetes and AKS deployment improvements** including [cert-manager integration, Gateway API and Azure Application Gateway for Containers (AGC) support](/deployment/kubernetes/aks/#expose-your-app-to-the-internet), Kubernetes manifest resources, external Helm charts, and consolidated Helm chart configuration.
 - **AI agent readiness** with Aspire workflow skills moving into the new [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) bundle, clearer separation between first-run setup, lifecycle orchestration, monitoring, AppHost wiring, and deployment guidance, and eval-driven iteration on agent routing.
 - **Richer resource commands** with typed arguments, visibility controls, immediate result display, named CLI options, resource-scoped help, built-in parameter command options, and the experimental `WithProcessCommand` API.
@@ -151,9 +151,9 @@ Existing TypeScript AppHosts scaffolded by earlier CLI versions continue to work
   examples, browse the [Aspire samples](/reference/samples/).
 </LearnMore>
 
-## 🧱 Go hosting and Bun support
+## 🧱 Go and Bun hosting integrations
 
-Beyond TypeScript, Aspire 13.4 adds first-class Go hosting and first-party Bun support, so you can orchestrate those apps directly from the AppHost.
+Beyond TypeScript, Aspire 13.4 adds first-class hosting integrations for Go and Bun, so you can orchestrate those apps directly from the AppHost.
 
 <span id="go-hosting-integration"></span>
 
@@ -206,7 +206,7 @@ await builder.build().run();
 
 ### 🥟 Bun apps
 
-Aspire 13.4 adds first-party Bun support to `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to orchestrate [Bun](https://bun.sh/) applications directly, and use `WithBun` / `withBun` when you want other JavaScript resources to use Bun as their package manager and container build image.
+Aspire 13.4 adds first-party Bun support in `Aspire.Hosting.JavaScript`. Use `AddBunApp` / `addBunApp` to orchestrate [Bun](https://bun.sh/) applications alongside the rest of your resources.
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
@@ -238,9 +238,8 @@ await builder.build().run();
 </Tabs>
 
 <LearnMore>
-  For setup details, see [Set up Bun apps in the
-  AppHost](/integrations/frameworks/bun-apps/) and [Set up JavaScript apps in
-  the AppHost](/integrations/frameworks/javascript/#use-bun).
+  For setup details, see the [Bun
+  integration](/integrations/frameworks/bun-apps/).
 </LearnMore>
 
 ## 🌐 Blazor WebAssembly hosting preview


### PR DESCRIPTION
## Why this PR is needed

The Bun docs in aspire.dev still centered `CommunityToolkit.Aspire.Hosting.Bun`, even though Bun support now ships in first-party `Aspire.Hosting.JavaScript`. The 13.4 release notes also showed `AddBunApp` examples without the required `scriptPath` argument.

## Changes

- Updated `src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx` to keep the existing structure but make `Aspire.Hosting.JavaScript` the primary guidance
- Replaced the outdated Community Toolkit badge and C#-only availability note with a small historical note at the top of the page
- Corrected the Bun package reference and `AddBunApp` examples to use the current first-party API shape
- Updated `src/frontend/src/content/docs/whats-new/aspire-13-4.mdx` to describe Bun as first-party support and fixed the `AddBunApp` / `addBunApp` examples to include `scriptPath`
- Removed unrelated line-wrapping churn from the release-notes diff

## Files modified

- `src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx`
- `src/frontend/src/content/docs/whats-new/aspire-13-4.mdx`

## Validation

- `pnpm --dir ./src/frontend run test:unit:docs`
- `pnpm --dir ./src/frontend run build:skip-search`