### PR TITLE
Simplify `aspire ps` command removal

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -749,12 +749,6 @@ The experimental `aspire exec` command — along with its AppHost backchannel an
 
 Remove scripts or workflows that call `aspire exec`. For resource-specific actions, use [`aspire resource`](/reference/cli/commands/aspire-resource/) when the resource exposes a command.
 
-#### `aspire ps` no longer takes `--resources` or `--include-hidden`
-
-The `aspire ps` command has been simplified and no longer supports the `--resources` and `--include-hidden` flags, which overlapped with `aspire describe`.
-
-For per-resource data, use `aspire describe --follow --apphost <path>` instead.
-
 #### Generated TypeScript modules consolidated under `.aspire/modules/`
 
 Generated polyglot SDK modules now live under a single `.aspire/modules/` directory instead of being split across `.modules/` and `.aspire/`. Generated language references — TypeScript imports, Go replace directives, Python editable paths, Java source lists, and Rust module paths — are updated automatically to point at the new location.

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -824,7 +824,7 @@ Update references that assumed an HTTP primary endpoint to use the HTTPS endpoin
 1. **Update the CLI** — run `aspire update --self`. This step is **required** for TypeScript AppHosts; running `aspire update` against a 13.3.x TypeScript project before updating the CLI fails with `No code generator found for language: TypeScript` and leaves the project in a partially-upgraded, unrunnable state (see [microsoft/aspire#17077](https://github.com/microsoft/aspire/issues/17077)).
 2. **Update your projects** — run `aspire update` from the root of your repository. For polyglot AppHosts, this regenerates SDK modules under `.aspire/modules/`.
 3. **Run `aspire doctor`** to check your environment setup and spot conflicting CLI installs.
-4. **Audit scripts and CI** for removed/changed commands — `aspire exec`, `aspire ps --resources`/`--include-hidden`, and non-interactive `aspire update` calls.
+4. **Audit scripts and CI** for removed/changed commands — `aspire exec` and non-interactive `aspire update` calls.
 5. **Update Kubernetes deployment code** — move Helm chart properties into `WithHelm(...)`, rename `ingress.WithRoute(...)` to `ingress.WithPath(...)`, and mark routed endpoints external with `WithExternalHttpEndpoints()`.
 6. **Update renamed APIs** — `PublishAsNpmPackageScript` → `PublishAsPackageScript`, and Foundry hosted agents `PublishAsHostedAgent` → `WithComputeEnvironment` (with the new `AddPromptAgent` parameter order).
 7. **Review Keycloak references** for the HTTPS primary endpoint, and **review Azure Front Door deployments**, setting explicit names if existing resources conflict with Azure.Provisioning name generation.


### PR DESCRIPTION
This feature was added and removed in 13.4. It shouldn't be listed as a breaking change.