### PR TITLE
Update Aspire skills agent guidance

### DIFF
--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -4,14 +4,9 @@ seoTitle: Use AI coding agents with Aspire AppHost projects today
 description: Set up AI coding agents to work with Aspire — install skills, add optional tools, and guide agents through distributed-app workflows.
 ---
 
-import {
-  Aside,
-  FileTree,
-  Steps,
-  TabItem,
-  Tabs,
-} from '@astrojs/starlight/components';
+import { Aside, Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 import AsciinemaPlayer from '@components/AsciinemaPlayer.astro';
+import LearnMore from '@components/LearnMore.astro';
 import LoopingVideo from '@components/LoopingVideo.astro';
 
 Aspire provides a first-class setup experience for AI coding agents. Run `aspire agent init` in your project and your AI assistant — whether it's GitHub Copilot, Claude Code, or another <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr>-compatible tool — can immediately understand, build, debug, and monitor your distributed applications.
@@ -23,6 +18,11 @@ Aspire gives coding agents the same visibility into your running application tha
 The Aspire CLI is built for agent-driven workflows — commands support non-interactive execution to avoid blocking on prompts, and many commands support `--format Json` for structured plain text output. Key commands include `aspire start` (background execution), `aspire start --isolated` (parallel worktrees), `aspire wait` (block until healthy), `aspire describe`, `aspire logs`, and `aspire docs search`.
 
 Aspire workflow skills installed by `aspire agent init` teach agents these patterns automatically.
+
+<LearnMore>
+  For skill installation paths, skill locations, companion tools, and the full
+  skill list, see [Aspire skills](/get-started/aspire-skills/).
+</LearnMore>
 
 ## Get started
 
@@ -38,28 +38,12 @@ When you create a new Aspire project with `aspire new` or `aspire init`, you're 
    aspire agent init
    ```
 
-1. Select the **skill locations** where you want files installed. The **Standard** location is pre-selected by default:
+1. Select the **skill locations**, **skills and tools**, and optional MCP server configuration for the agent environments you use.
 
-   | Location          | Directory          | Notes                                              |
-   | ----------------- | ------------------ | -------------------------------------------------- |
-   | **Standard**      | `.agents/skills/`  | Supported by VS Code, GitHub Copilot, and OpenCode |
-   | **Claude Code**   | `.claude/skills/`  | Claude Code specific                               |
-   | **GitHub Skills** | `.github/skills/`  | VS Code / GitHub Copilot specific                  |
-   | **OpenCode**      | `.opencode/skill/` | OpenCode specific                                  |
-
-1. Select the **skills and tools** to install into those locations. The Aspire workflow skills from [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) are:
-   - **aspire** — routes Aspire tasks to the right workflow
-   - **aspire-init** — creates a new Aspire app or adds an Aspire skeleton to an existing repo
-   - **aspire-orchestration** — starts, stops, waits for, and manages Aspire resources
-   - **aspire-monitoring** — inspects logs, traces, metrics, resource state, and diagnostics data
-   - **aspire-deployment** — publishes, deploys, and tears down Aspire apps
-   - **aspireify** — wires an AppHost after `aspire init`
-
-   The flow pre-selects the workflow skills that apply to the command you're running. Add Playwright CLI for browser checks, dotnet-inspect for .NET API surface queries, or select **Install Aspire MCP server** if the agent needs live data from a running Aspire app.
-
-   :::note[Aspire workflow skills bundle]
-   Aspire workflow skills are distributed through the [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) GitHub release assets. Aspire 13.4 includes an embedded snapshot for default installs, and the optional remote fetch path can download matching release assets. Companion options such as Playwright CLI and dotnet-inspect are installed separately when selected.
-   :::
+   <LearnMore>
+     For details about skill locations, workflow skills, Playwright CLI, and
+     dotnet-inspect, see [Aspire skills](/get-started/aspire-skills/).
+   </LearnMore>
 
 </Steps>
 
@@ -67,66 +51,14 @@ When you create a new Aspire project with `aspire new` or `aspire init`, you're 
 
 The `aspire agent init` command detects your AI development environment and creates the appropriate configuration files:
 
-### Aspire workflow skill files
+### Aspire skill files
 
-Aspire workflow skills teach your AI coding agent how to work with Aspire. The top-level `aspire` skill routes requests to focused skills for initialization, orchestration, monitoring, deployment, and AppHost wiring.
+Aspire skill files teach your AI coding agent how to use Aspire CLI workflows, route tasks to focused skills, and use companion tools when selected.
 
-For example, a standard location can contain:
-
-<FileTree>
-
-- .agents/skills/
-  - aspire/
-    - SKILL.md
-    - reference/
-  - aspire-init/
-    - SKILL.md
-    - reference/
-  - aspire-orchestration/
-    - SKILL.md
-    - reference/
-  - aspire-monitoring/
-    - SKILL.md
-    - reference/
-  - aspire-deployment/
-    - SKILL.md
-    - reference/
-  - aspireify/
-    - SKILL.md
-    - reference/
-
-</FileTree>
-
-The skills guide your agent on how to:
-
-- Start and manage your Aspire application (`aspire start`, `aspire stop`, `aspire describe`)
-- Debug issues using structured logs and distributed traces
-- Add integrations with `aspire add` and search documentation with `aspire docs`
-- Use resource MCP tools for database queries and other resource-specific operations
-- Route first-run setup, AppHost wiring, monitoring, orchestration, and deployment work to focused workflows
-
-### dotnet-inspect skill
-
-The `dotnet-inspect` companion skill teaches your AI agent to query .NET API surfaces using the [`dotnet-inspect`](https://github.com/richlander/dotnet-inspect) tool. When selected, it's installed into each selected location:
-
-<FileTree>
-
-- .agents/skills/dotnet-inspect/
-  - SKILL.md
-- .github/skills/dotnet-inspect/
-  - SKILL.md
-- .claude/skills/dotnet-inspect/
-  - SKILL.md
-- .opencode/skill/dotnet-inspect/
-  - SKILL.md
-
-</FileTree>
-
-The skill enables your agent to inspect NuGet package API surfaces, compare API changes between package versions, and explore .NET types and members.
-
-:::note[When to use dotnet-inspect]
-Install `dotnet-inspect` when an agent needs broad .NET API surface queries. For Aspire-specific API docs, the Aspire skills guide agents to use `aspire docs api` commands across both C# and TypeScript.
-:::
+<LearnMore>
+  For the full skill bundle contents and installation details, see [Aspire
+  skills](/get-started/aspire-skills/).
+</LearnMore>
 
 ### Aspire MCP server
 

--- a/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
+++ b/src/frontend/src/content/docs/get-started/ai-coding-agents.mdx
@@ -53,7 +53,7 @@ The `aspire agent init` command detects your AI development environment and crea
 
 ### Aspire skill files
 
-Aspire skill files teach your AI coding agent how to use Aspire CLI workflows, route tasks to focused skills, and use companion tools when selected.
+Aspire skill files teach your AI coding agent how to use Aspire CLI workflows, route tasks to focused skills, and call selected companion tools such as Playwright CLI or dotnet-inspect.
 
 <LearnMore>
   For the full skill bundle contents and installation details, see [Aspire

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -41,7 +41,7 @@ Run `aspire agent init` in an existing Aspire project when you want to set up AI
 aspire new
 ```
 
-When prompted to configure AI agent environments, press <Kbd windows="Y" /> then <Kbd windows="Enter" />.
+When prompted to configure AI agent environments, press <Kbd windows="Y" mac="Y" linux="Y" /> then <Kbd windows="Enter" mac="Return" linux="Enter" />.
 
 <LearnMore>
   For template and command options, see the [`aspire new` command
@@ -54,7 +54,7 @@ When prompted to configure AI agent environments, press <Kbd windows="Y" /> then
 aspire init
 ```
 
-When prompted to install Aspire agent guidance, press <Kbd windows="Y" /> then <Kbd windows="Enter" />.
+When prompted to install Aspire agent guidance, press <Kbd windows="Y" mac="Y" linux="Y" /> then <Kbd windows="Enter" mac="Return" linux="Enter" />.
 
 <LearnMore>
   For command options and examples, see the [`aspire init` command

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -6,6 +6,8 @@ description: Learn how Aspire skills teach AI coding agents to initialize, opera
 
 import { FileTree, TabItem, Tabs } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
+import { Kbd } from 'starlight-kbd/components';
 
 Aspire skills are Markdown instruction bundles for AI coding agents. Each skill lives in a folder with a `SKILL.md` file that describes when the skill applies and what workflow the agent should follow. Skills don't run services or expose application data; they teach the agent how to use Aspire tools correctly.
 
@@ -18,36 +20,104 @@ Aspire ships multiple skills for different parts of the app lifecycle. The exact
 
 ## Install Aspire guidance
 
-Choose the tab that matches your coding agent or installer path. The Aspire CLI path is recommended for project-local setup because it installs Aspire skill files into detected agent environments.
+Use Aspire's first-party agent setup when creating a new app, adding Aspire to an existing repo, or refreshing agent guidance later. The Aspire CLI is the recommended path for project-local setup because it installs Aspire skill files into detected agent environments.
 
-<Tabs syncKey='agent-install'>
-<TabItem id='aspire-cli' label='Aspire CLI'>
-
-Use Aspire's first-party agent setup when creating a new app, adding Aspire to an existing repo, or refreshing agent guidance later.
+### Set up or refresh agent guidance
 
 ```bash title="Aspire CLI"
-aspire new
-# select y when prompted to configure AI agent environments
-
-aspire init
-# select y when prompted to install Aspire agent guidance
-
 aspire agent init
 ```
 
-For non-interactive setup, pass the skill and location options explicitly. To install all available skills and companion options into all supported locations, use `all`:
+Run `aspire agent init` in an existing Aspire project when you want to set up AI coding agents or refresh installed skill files.
+
+<LearnMore>
+  For command options and examples, see the [`aspire agent init` command
+  reference](/reference/cli/commands/aspire-agent-init/).
+</LearnMore>
+
+### Create a new Aspire app
 
 ```bash title="Aspire CLI"
-aspire agent init --skills all --skill-locations all
+aspire new
 ```
 
-To install a subset, pass a comma-separated list of skill names. This example installs every Aspire workflow skill from the bundle and the optional Playwright CLI companion skill:
+When prompted to configure AI agent environments, press <Kbd windows="Y" /> then <Kbd windows="Enter" />.
+
+<LearnMore>
+  For template and command options, see the [`aspire new` command
+  reference](/reference/cli/commands/aspire-new/).
+</LearnMore>
+
+### Add Aspire to an existing repo
 
 ```bash title="Aspire CLI"
-aspire agent init --skills aspire,aspire-init,aspire-orchestration,aspire-monitoring,aspire-deployment,aspireify,playwright-cli --skill-locations all
+aspire init
 ```
 
-</TabItem>
+When prompted to install Aspire agent guidance, press <Kbd windows="Y" /> then <Kbd windows="Enter" />.
+
+<LearnMore>
+  For command options and examples, see the [`aspire init` command
+  reference](/reference/cli/commands/aspire-init/).
+</LearnMore>
+
+### Configure non-interactive setup
+
+For non-interactive setup, add `--non-interactive` and pass the skill and location options explicitly. Install the Aspire workflow skills together; the top-level `aspire` skill routes work to workflow-specific skills and isn't useful as the only Aspire skill. This example installs all available skills into the standard skill location:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash title="Aspire CLI"
+aspire agent init \
+  --non-interactive \
+  --skills all \
+  --skill-locations standard
+```
+
+</div>
+<div slot="windows">
+
+```powershell title="Aspire CLI"
+aspire agent init `
+  --non-interactive `
+  --skills all `
+  --skill-locations standard
+```
+
+</div>
+</OsAwareTabs>
+
+When the same repo is intentionally used with both a Standard-compatible host and Claude Code, install the same skills into both locations:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash title="Aspire CLI"
+aspire agent init \
+  --non-interactive \
+  --skills all \
+  --skill-locations standard,claudecode
+```
+
+</div>
+<div slot="windows">
+
+```powershell title="Aspire CLI"
+aspire agent init `
+  --non-interactive `
+  --skills all `
+  --skill-locations standard,claudecode
+```
+
+</div>
+</OsAwareTabs>
+
+### Other installation options
+
+Use these tabs when you need to install from a coding agent's marketplace or a skills-compatible installer instead of using the Aspire CLI.
+
+<Tabs syncKey='agent-install'>
 <TabItem id='copilot-cli' label='Copilot CLI'>
 
 Add the Aspire skills marketplace once, then install the Aspire plugin by name.
@@ -59,30 +129,53 @@ copilot plugin install aspire@aspire-skills
 
 Use this path for terminal workflows where GitHub Copilot needs Aspire-specific guidance for AppHost, lifecycle, deployment, and diagnostics tasks.
 
+<LearnMore>
+  For plugin install details, see [Finding and installing plugins for GitHub
+  Copilot
+  CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing).
+</LearnMore>
+
 </TabItem>
 <TabItem id='claude-code' label='Claude Code'>
 
 Start Claude Code in your terminal, add the Aspire marketplace, then install the Aspire plugin.
 
-```bash title="Claude Code CLI"
+```bash title="Terminal"
 claude
+```
+
+```text title="Claude Code CLI session"
 /plugin marketplace add microsoft/aspire-skills
 /plugin install aspire@aspire-skills
 ```
 
 Run the slash commands inside the Claude Code CLI session.
 
+<LearnMore>
+  For plugin marketplace details, see [Discover and install prebuilt plugins
+  through marketplaces](https://code.claude.com/docs/en/discover-plugins).
+</LearnMore>
+
 </TabItem>
 <TabItem id='codex-cli' label='Codex CLI'>
 
-Add the Aspire marketplace, then install Aspire from the Codex plugins UI.
+Add the Aspire marketplace, then open the Codex plugin directory and install the Aspire plugin from the plugin browser.
 
-```bash title="Codex CLI"
+```bash title="Terminal"
 codex plugin marketplace add microsoft/aspire-skills
-# then open /plugins and install aspire
+codex
+```
+
+```text title="Codex CLI session"
+/plugins
 ```
 
 Use this path for terminal-first Codex work that needs repeatable Aspire setup, orchestration, and diagnostics guidance.
+
+<LearnMore>
+  For plugin install details, see the [Codex plugin
+  documentation](https://developers.openai.com/codex/plugins).
+</LearnMore>
 
 </TabItem>
 <TabItem id='opencode' label='OpenCode'>
@@ -96,6 +189,11 @@ opencode
 
 Use this path when APM is your preferred way to manage agent skills.
 
+<LearnMore>
+  For APM install details, see the [Agent Package Manager
+  quickstart](https://microsoft.github.io/apm/quickstart/).
+</LearnMore>
+
 </TabItem>
 <TabItem id='npx' label='skills.sh'>
 
@@ -108,11 +206,15 @@ npx skills add microsoft/aspire-skills
 For hosts that need an explicit skills directory and target agent, install from the `skills/` folder:
 
 ```bash title="skills.sh NPX with explicit target"
-npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills \
-  -a github-copilot -g -y
+npx skills add https://github.com/microsoft/aspire-skills/tree/main/skills -a github-copilot -g -y
 ```
 
 In that command, `-a github-copilot` selects the target agent, `-g` installs globally, and `-y` accepts prompts.
+
+<LearnMore>
+  For installer options, see the [skills.sh CLI
+  documentation](https://www.skills.sh/docs/cli).
+</LearnMore>
 
 </TabItem>
 </Tabs>
@@ -132,14 +234,23 @@ Use the top-level `aspire` skill when the request is about an Aspire app and the
 
 ## Companion skills and tools
 
-Companion options can be offered by `aspire agent init`, but they aren't part of the `microsoft/aspire-skills` workflow bundle.
+The Aspire CLI setup flow can offer companion options, but they aren't part of the `microsoft/aspire-skills` workflow bundle.
 
 | Skill            | Use it for                                 | What it teaches                                                                                                   |
 | ---------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
 | `playwright-cli` | Testing running web resources in a browser | Use Playwright CLI for browser automation, including navigation, form interaction, screenshots, and visual checks |
-| `dotnet-inspect` | Querying .NET API surfaces                 | Inspect available .NET APIs when the workspace contains a .NET AppHost                                            |
+| `dotnet-inspect` | Inspecting .NET APIs outside Aspire        | Query .NET package and type surfaces that aren't covered by Aspire API docs                                       |
 
-Use `playwright-cli` when an agent needs to test or inspect a running frontend. Use `dotnet-inspect` when an agent needs API-surface details for .NET AppHost work.
+Use `playwright-cli` when an agent needs to test or inspect a running frontend. For Playwright commands and options, see the [Playwright command line documentation](https://playwright.dev/docs/test-cli).
+
+:::caution[dotnet-inspect scope]
+Use `dotnet-inspect` only when an agent needs to inspect .NET code or packages outside Aspire. If you're only working with Aspire APIs, use the Aspire CLI instead: `aspire docs api` already provides C# and TypeScript API docs from aspire.dev.
+:::
+
+<LearnMore>
+  For more information, see the [`aspire docs api` command
+  reference](/reference/cli/commands/aspire-docs-api/).
+</LearnMore>
 
 ## Playwright handoff
 
@@ -148,6 +259,10 @@ The `playwright-cli` skill works best alongside the `aspire` skill. The agent wi
 ## Skill locations
 
 Aspire installs each selected skill into the selected skill locations. For example, a standard location can contain every Aspire workflow skill and selected companion skills:
+
+:::note[Prefer one location]
+Install skills to a single location for the agent environment you actively use. Select multiple locations only when the same repo is intentionally shared across different agent hosts.
+:::
 
 <FileTree>
 
@@ -182,7 +297,7 @@ Other supported locations use the same skill folder names:
 
 ## Troubleshoot skill bundle errors
 
-When `aspire agent init` installs Aspire workflow skills, it validates the Aspire skills bundle before copying files. If the embedded bundle that ships with the CLI is corrupted or inconsistent, you might see errors such as:
+When the Aspire CLI installs Aspire workflow skills, it validates the Aspire skills bundle before copying files. If the embedded bundle that ships with the CLI is corrupted or inconsistent, you might see errors such as:
 
 - `Embedded Aspire skills bundle metadata is invalid: <reason>`
 - `Embedded Aspire skills metadata must specify a version.`


### PR DESCRIPTION
## Summary
- make Aspire CLI the primary path for installing Aspire agent guidance
- add command-reference and installer documentation links for agent setup options
- deduplicate the AI coding agents overview by linking to the dedicated Aspire skills article

## Validation
- pnpm --dir .\src\frontend exec prettier --check .\src\content\docs\get-started\aspire-skills.mdx .\src\content\docs\get-started\ai-coding-agents.mdx
- pnpm --dir .\src\frontend run test:unit:docs