### PR TITLE
Add SAMPLES_BRANCH env override to update-samples script

### DIFF
--- a/.agents/skills/update-samples/SKILL.md
+++ b/.agents/skills/update-samples/SKILL.md
@@ -141,6 +141,7 @@ After running the script:
 | Variable | Required | Description |
 |---|---|---|
 | `GITHUB_TOKEN` | No | GitHub personal access token for higher API rate limits (60 → 5000 requests/hour) |
+| `SAMPLES_BRANCH` | No | Override the `microsoft/aspire-samples` ref to fetch from (default `main`). Useful for staging `samples.json` against a still-open upstream PR — set to the PR's head ref. The generated `href` fields stay anchored to `main` so links remain valid after the PR branch is deleted. |
 
 ### 7. Integration with build
 

--- a/src/frontend/scripts/update-samples.ts
+++ b/src/frontend/scripts/update-samples.ts
@@ -13,12 +13,20 @@ const DEFAULT_BRANCH = 'main';
 // is identical to what the next normal run will produce after that PR merges,
 // so the staged data PR is idempotent with the upstream merge.
 const BRANCH = process.env.SAMPLES_BRANCH ?? DEFAULT_BRANCH;
+// PR head refs frequently contain `/` (e.g. `feature/foo`,
+// `user/dapine-aspire-api-updates`). GitHub accepts `/` in path positions for
+// the raw, contents, and git/trees endpoints, but other URL-significant
+// characters in a ref (`#`, `?`, `%`, `&`, etc.) need to be percent-encoded.
+// Encoding per `/`-separated segment preserves the `/` boundaries while
+// safely escaping every other special character within each segment.
+const BRANCH_PATH = BRANCH.split('/').map(encodeURIComponent).join('/');
+const BRANCH_QUERY = encodeURIComponent(BRANCH);
 const SAMPLES_DIR = 'samples';
 const OUTPUT_PATH = './src/data/samples.json';
 const ASSETS_DIR = './src/assets/samples';
 const ASSETS_IMPORT_PREFIX = '~/assets/samples';
 const GITHUB_API = 'https://api.github.com';
-const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
+const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/${BRANCH_PATH}`;
 // `TREE_BASE` is intentionally pinned to `main` (never the override) so the
 // generated `href` fields on each sample stay valid after a PR branch goes
 // away. The branch override is for fetching content, not for cementing links.
@@ -374,7 +382,7 @@ async function fetchText(url: string): Promise<string | null> {
 
 async function listSampleDirs(): Promise<string[]> {
   const contents = await fetchJson<GitHubContentEntry[]>(
-    `${GITHUB_API}/repos/${REPO}/contents/${SAMPLES_DIR}?ref=${BRANCH}`
+    `${GITHUB_API}/repos/${REPO}/contents/${SAMPLES_DIR}?ref=${BRANCH_QUERY}`
   );
 
   return contents
@@ -390,7 +398,7 @@ async function listSampleDirs(): Promise<string[]> {
  */
 async function fetchSamplePaths(): Promise<Map<string, string[]>> {
   const tree = await fetchJson<GitTreeResponse>(
-    `${GITHUB_API}/repos/${REPO}/git/trees/${BRANCH}?recursive=1`
+    `${GITHUB_API}/repos/${REPO}/git/trees/${BRANCH_PATH}?recursive=1`
   );
 
   if (tree.truncated) {

--- a/src/frontend/scripts/update-samples.ts
+++ b/src/frontend/scripts/update-samples.ts
@@ -5,14 +5,24 @@ import { pipeline } from 'stream/promises';
 import fetch from 'node-fetch';
 
 const REPO = 'microsoft/aspire-samples';
-const BRANCH = 'main';
+const DEFAULT_BRANCH = 'main';
+// `BRANCH` controls which ref of `microsoft/aspire-samples` is fetched (README,
+// AppHost code, raw assets, tree listing). The override exists so contributors
+// can stage `samples.json` against a still-open upstream PR by running the
+// script with `SAMPLES_BRANCH=<head-ref> pnpm run update:samples` — the output
+// is identical to what the next normal run will produce after that PR merges,
+// so the staged data PR is idempotent with the upstream merge.
+const BRANCH = process.env.SAMPLES_BRANCH ?? DEFAULT_BRANCH;
 const SAMPLES_DIR = 'samples';
 const OUTPUT_PATH = './src/data/samples.json';
 const ASSETS_DIR = './src/assets/samples';
 const ASSETS_IMPORT_PREFIX = '~/assets/samples';
 const GITHUB_API = 'https://api.github.com';
 const RAW_BASE = `https://raw.githubusercontent.com/${REPO}/${BRANCH}`;
-const TREE_BASE = `https://github.com/${REPO}/tree/${BRANCH}`;
+// `TREE_BASE` is intentionally pinned to `main` (never the override) so the
+// generated `href` fields on each sample stay valid after a PR branch goes
+// away. The branch override is for fetching content, not for cementing links.
+const TREE_BASE = `https://github.com/${REPO}/tree/${DEFAULT_BRANCH}`;
 const LEGACY_DOCS_HOST = 'https://learn.microsoft.com';
 const ASPIRE_DOC_URL_REWRITES = [
   [
@@ -471,7 +481,10 @@ async function processSample(
 }
 
 async function main(): Promise<void> {
-  console.log(`📦 Fetching sample directories from ${REPO}...`);
+  console.log(`📦 Fetching sample directories from ${REPO}@${BRANCH}...`);
+  if (BRANCH !== DEFAULT_BRANCH) {
+    console.log(`   (branch override via SAMPLES_BRANCH; href links stay anchored to ${DEFAULT_BRANCH})`);
+  }
   const [dirs, pathsBySample] = await Promise.all([listSampleDirs(), fetchSamplePaths()]);
   console.log(`📂 Found ${dirs.length} sample directories`);
 


### PR DESCRIPTION
Promotes the temporary script edit used to generate #1190 into a permanent feature so contributors can stage `samples.json` regenerations against a still-open upstream microsoft/aspire-samples PR without a temp-edit-and-revert dance.

## What changes

**`src/frontend/scripts/update-samples.ts`**

- `BRANCH` (the ref the script fetches READMEs, AppHost code, and raw assets from) now reads from `process.env.SAMPLES_BRANCH`, falling back to `'main'`.
- The `tree/...` URL used to build each sample's `href` field is now pinned to a new `DEFAULT_BRANCH` constant - it never follows the override. This keeps generated links valid after the PR branch is deleted, so the staged data PR is idempotent with the upstream merge.
- Startup log echoes the active branch and surfaces an extra line when the override is active.

**`.agents/skills/update-samples/SKILL.md`**

- Documents the new `SAMPLES_BRANCH` env var alongside the existing `GITHUB_TOKEN` row.

## How to use

```sh
# Default behavior unchanged
pnpm run update:samples

# Stage data from an open upstream PR
SAMPLES_BRANCH=<pr-head-ref> pnpm run update:samples
```

After running the override variant, commit only the regenerated `samples.json` - no script changes need to ride along, because the override is now first-class.

## Why pin `TREE_BASE` to `main`

The override is for fetching content from a yet-to-be-merged branch, but each sample's `href` ends up rendered on aspire.dev. If `href` followed the override, the link would 404 the moment the PR's branch was deleted post-merge. Pinning `TREE_BASE` to `main` means: contributors get pre-merge data preview without breaking links after merge.

## Verification

- `pnpm lint` clean (astro sync + verify-skill-digests + eslint --max-warnings 0).
- Scratch run of the const block confirmed: no env var -> both `RAW_BASE` and `TREE_BASE` point at `main` (byte-identical to today); env var set -> `RAW_BASE` follows it, `TREE_BASE` stays on `main`.

## Drafting

Drafted because #1190 (which used the temporary version of this change) is itself a draft pending microsoft/aspire-samples#1668 merging. Will flip to "Ready for review" once #1190 lands or independently once reviewed.
