### PR TITLE
Update footer theme toggle UX

### DIFF
--- a/src/frontend/src/components/FooterPreferences.astro
+++ b/src/frontend/src/components/FooterPreferences.astro
@@ -170,7 +170,6 @@ const themeLabels = {
         for (const button of themeButtons) {
           const isSelected = button.dataset.themeOption === theme;
           button.setAttribute('aria-checked', String(isSelected));
-          button.toggleAttribute('data-active', isSelected);
           button.tabIndex = isSelected ? 0 : -1;
         }
       }
@@ -191,9 +190,9 @@ const themeLabels = {
         updateThemeToggle(theme);
 
         // Sync with Starlight's header theme select if present
-        const headerThemeSelect = document.querySelector(
+        const headerThemeSelect = document.querySelector<HTMLSelectElement>(
           'starlight-theme-select select'
-        ) as HTMLSelectElement;
+        );
         if (headerThemeSelect) {
           headerThemeSelect.value = theme;
         }

--- a/src/frontend/src/components/FooterPreferences.astro
+++ b/src/frontend/src/components/FooterPreferences.astro
@@ -7,6 +7,12 @@ const kbdTypes = [
   { id: 'windows', label: 'Windows', detector: 'windows', default: true },
   { id: 'linux', label: 'Linux', detector: 'linux' },
 ];
+
+const themeLabels = {
+  light: Astro.locals.t('themeSelect.light' as any) || 'Light',
+  auto: Astro.locals.t('themeSelect.auto' as any) || 'Auto',
+  dark: Astro.locals.t('themeSelect.dark' as any) || 'Dark',
+};
 ---
 
 <section
@@ -22,15 +28,43 @@ const kbdTypes = [
   <div class="preference-controls">
     <!-- Theme selector -->
     <div class="preference-item">
-      <div class="select-wrapper">
-        <Icon name="sun" class="select-icon theme-icon light-icon" />
-        <Icon name="moon" class="select-icon theme-icon dark-icon" />
-        <select id="footer-theme-select" class="preference-select" aria-label="Select theme">
-          <option value="auto">{Astro.locals.t('themeSelect.auto' as any) || 'Auto'}</option>
-          <option value="dark">{Astro.locals.t('themeSelect.dark' as any) || 'Dark'}</option>
-          <option value="light">{Astro.locals.t('themeSelect.light' as any) || 'Light'}</option>
-        </select>
-        <Icon name="down-caret" class="select-caret" />
+      <div
+        id="footer-theme-toggle"
+        class="theme-toggle"
+        role="radiogroup"
+        aria-label="Select theme"
+        data-theme-choice="auto"
+      >
+        <button
+          type="button"
+          class="theme-toggle-option"
+          role="radio"
+          aria-checked="false"
+          aria-label={themeLabels.light}
+          data-theme-option="light"
+        >
+          <Icon name="sun" />
+        </button>
+        <button
+          type="button"
+          class="theme-toggle-option"
+          role="radio"
+          aria-checked="true"
+          aria-label={themeLabels.auto}
+          data-theme-option="auto"
+        >
+          <Icon name="laptop" />
+        </button>
+        <button
+          type="button"
+          class="theme-toggle-option"
+          role="radio"
+          aria-checked="false"
+          aria-label={themeLabels.dark}
+          data-theme-option="dark"
+        >
+          <Icon name="moon" />
+        </button>
       </div>
     </div>
 
@@ -107,9 +141,19 @@ const kbdTypes = [
   } from '@utils/locale-routes';
 
   function initFooterPreferences() {
-    const themeSelect = document.getElementById('footer-theme-select') as HTMLSelectElement;
+    const themeToggle = document.getElementById('footer-theme-toggle') as HTMLElement | null;
+    const themeButtons = Array.from(
+      themeToggle?.querySelectorAll<HTMLButtonElement>('[data-theme-option]') ?? []
+    );
     const languageSelect = document.getElementById('footer-language-select') as HTMLSelectElement;
     const kbdSelect = document.getElementById('footer-kbd-select') as HTMLSelectElement;
+    const themeOptions = ['light', 'auto', 'dark'] as const;
+
+    type ThemeOption = (typeof themeOptions)[number];
+
+    function isThemeOption(value: string | null | undefined): value is ThemeOption {
+      return value === 'light' || value === 'auto' || value === 'dark';
+    }
 
     function getLanguageOptionValue(locale: string): string {
       const option = Array.from(languageSelect?.options ?? []).find(
@@ -119,17 +163,19 @@ const kbdTypes = [
       return option?.value ?? locale;
     }
 
-    if (themeSelect) {
-      // Get current theme from Starlight's storage
-      const storedTheme = getStoredPreference('starlight-theme');
-      if (storedTheme) {
-        themeSelect.value = storedTheme;
+    if (themeToggle && themeButtons.length > 0) {
+      function updateThemeToggle(theme: ThemeOption) {
+        themeToggle.dataset.themeChoice = theme;
+
+        for (const button of themeButtons) {
+          const isSelected = button.dataset.themeOption === theme;
+          button.setAttribute('aria-checked', String(isSelected));
+          button.toggleAttribute('data-active', isSelected);
+          button.tabIndex = isSelected ? 0 : -1;
+        }
       }
 
-      themeSelect.addEventListener('change', (e) => {
-        const target = e.target as HTMLSelectElement;
-        const theme = target.value;
-
+      function applyTheme(theme: ThemeOption) {
         // Use Starlight's theme system
         setStoredPreference('starlight-theme', theme);
 
@@ -142,13 +188,56 @@ const kbdTypes = [
           root.dataset.theme = theme;
         }
 
+        updateThemeToggle(theme);
+
         // Sync with Starlight's header theme select if present
         const headerThemeSelect = document.querySelector(
           'starlight-theme-select select'
         ) as HTMLSelectElement;
-        if (headerThemeSelect && headerThemeSelect !== themeSelect) {
+        if (headerThemeSelect) {
           headerThemeSelect.value = theme;
         }
+      }
+
+      // Get current theme from Starlight's storage
+      const storedTheme = getStoredPreference('starlight-theme');
+      updateThemeToggle(isThemeOption(storedTheme) ? storedTheme : 'auto');
+
+      for (const button of themeButtons) {
+        button.addEventListener('click', () => {
+          const theme = button.dataset.themeOption;
+
+          if (isThemeOption(theme)) {
+            applyTheme(theme);
+          }
+        });
+      }
+
+      themeToggle.addEventListener('keydown', (e) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
+          return;
+        }
+
+        e.preventDefault();
+
+        const currentTheme = isThemeOption(themeToggle.dataset.themeChoice)
+          ? themeToggle.dataset.themeChoice
+          : 'auto';
+        const currentIndex = themeOptions.indexOf(currentTheme);
+        const nextIndex =
+          e.key === 'Home'
+            ? 0
+            : e.key === 'End'
+              ? themeOptions.length - 1
+              : e.key === 'ArrowLeft'
+                ? (currentIndex - 1 + themeOptions.length) % themeOptions.length
+                : (currentIndex + 1) % themeOptions.length;
+        const nextTheme = themeOptions[nextIndex];
+
+        applyTheme(nextTheme);
+
+        const nextButton = themeButtons.find((button) => button.dataset.themeOption === nextTheme);
+        nextButton?.focus();
       });
     }
 
@@ -158,9 +247,10 @@ const kbdTypes = [
       const storedPreferredLocale = normalizeLocale(
         getStoredPreference(PREFERRED_LOCALE_STORAGE_KEY)
       );
-      const currentLang = getLocaleFromPath(currentPath)
-        ?? (isApiReferencePath(currentPath) ? storedPreferredLocale : undefined)
-        ?? DEFAULT_LOCALE;
+      const currentLang =
+        getLocaleFromPath(currentPath) ??
+        (isApiReferencePath(currentPath) ? storedPreferredLocale : undefined) ??
+        DEFAULT_LOCALE;
       languageSelect.value = getLanguageOptionValue(currentLang);
 
       languageSelect.addEventListener('change', (e) => {
@@ -171,12 +261,19 @@ const kbdTypes = [
         setStoredPreference(PREFERRED_LOCALE_STORAGE_KEY, newLang);
 
         // Remove current language prefix if present
-        const pathWithoutLang = stripApiReferenceLocale(currentPath) ?? stripLocaleFromPath(currentPath);
+        const pathWithoutLang =
+          stripApiReferenceLocale(currentPath) ?? stripLocaleFromPath(currentPath);
 
         // Build new URL
-        const newPath = isApiReference ? pathWithoutLang : addLocaleToPath(pathWithoutLang, newLang);
+        const newPath = isApiReference
+          ? pathWithoutLang
+          : addLocaleToPath(pathWithoutLang, newLang);
 
-        window.location.href = appendSearchAndHash(newPath, window.location.search, window.location.hash);
+        window.location.href = appendSearchAndHash(
+          newPath,
+          window.location.search,
+          window.location.hash
+        );
       });
     }
 
@@ -284,21 +381,6 @@ const kbdTypes = [
     height: 1rem;
   }
 
-  /* Show/hide sun/moon based on current theme */
-  :global([data-theme='dark']) .light-icon,
-  :global(:root:not([data-theme])) .light-icon {
-    display: none;
-  }
-
-  :global([data-theme='light']) .dark-icon {
-    display: none;
-  }
-
-  :global([data-theme='dark']) .dark-icon,
-  :global(:root:not([data-theme])) .dark-icon {
-    display: flex;
-  }
-
   .preference-select {
     appearance: none;
     background: var(--sl-color-gray-6);
@@ -334,5 +416,95 @@ const kbdTypes = [
   .select-caret :global(svg) {
     width: 0.625rem;
     height: 0.625rem;
+  }
+
+  .theme-toggle {
+    position: relative;
+    isolation: isolate;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    align-items: center;
+    width: 100%;
+    min-height: 2rem;
+    padding: 0.1875rem;
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.375rem;
+    transition:
+      border-color 0.15s ease,
+      background-color 0.15s ease;
+  }
+
+  .theme-toggle::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 0.1875rem;
+    bottom: 0.1875rem;
+    left: 0.1875rem;
+    width: calc((100% - 0.375rem) / 3);
+    box-sizing: border-box;
+    border: 1px solid var(--aspire-color-primary, #7455dd);
+    border-radius: 0.25rem;
+    background: color-mix(
+      in srgb,
+      var(--aspire-color-primary, #7455dd) 32%,
+      var(--sl-color-gray-5)
+    );
+    transition: transform 0.18s ease;
+  }
+
+  .theme-toggle[data-theme-choice='auto']::before {
+    transform: translateX(100%);
+  }
+
+  .theme-toggle[data-theme-choice='dark']::before {
+    transform: translateX(200%);
+  }
+
+  .theme-toggle:hover {
+    border-color: var(--sl-color-gray-4);
+  }
+
+  .theme-toggle:focus-within {
+    outline: 2px solid var(--aspire-color-primary, #7455dd);
+    outline-offset: 2px;
+  }
+
+  .theme-toggle-option {
+    position: relative;
+    z-index: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 0;
+    height: 1.625rem;
+    padding: 0;
+    color: var(--sl-color-gray-3);
+    background: transparent;
+    border: 0;
+    border-radius: 0.25rem;
+    cursor: pointer;
+    transition:
+      color 0.15s ease,
+      transform 0.15s ease;
+  }
+
+  .theme-toggle-option:hover {
+    color: var(--sl-color-gray-1);
+    transform: scale(1.05);
+  }
+
+  .theme-toggle-option:focus {
+    outline: none;
+  }
+
+  .theme-toggle-option[aria-checked='true'] {
+    color: var(--sl-color-white);
+  }
+
+  .theme-toggle-option :global(svg) {
+    width: 1rem;
+    height: 1rem;
   }
 </style>

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -247,16 +247,18 @@ test('footer preferences persist theme and keyboard style selections', async ({ 
   await page.goto('/get-started/aspire-vscode-extension/');
   await dismissCookieConsentIfVisible(page);
 
-  const themeSelect = page.locator('#footer-theme-select');
+  const themeToggle = page.locator('#footer-theme-toggle');
+  const darkThemeButton = themeToggle.getByRole('radio', { name: 'Dark' });
+  const lightThemeButton = themeToggle.getByRole('radio', { name: 'Light' });
   const kbdSelect = page.locator('#footer-kbd-select');
 
-  await themeSelect.selectOption('dark');
+  await darkThemeButton.click();
   await expect.poll(() => page.evaluate(() => document.documentElement.dataset.theme)).toBe('dark');
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem('starlight-theme')))
     .toBe('dark');
 
-  await themeSelect.selectOption('light');
+  await lightThemeButton.click();
   await expect
     .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
     .toBe('light');
@@ -268,7 +270,7 @@ test('footer preferences persist theme and keyboard style selections', async ({ 
 
   await page.reload();
 
-  await expect(themeSelect).toHaveValue('light');
+  await expect(lightThemeButton).toHaveAttribute('aria-checked', 'true');
   await expect(kbdSelect).toHaveValue('mac');
 });
 

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -250,15 +250,27 @@ test('footer preferences persist theme and keyboard style selections', async ({ 
   const themeToggle = page.locator('#footer-theme-toggle');
   const darkThemeButton = themeToggle.getByRole('radio', { name: 'Dark' });
   const lightThemeButton = themeToggle.getByRole('radio', { name: 'Light' });
+  const autoThemeButton = themeToggle.getByRole('radio', { name: 'Auto' });
   const kbdSelect = page.locator('#footer-kbd-select');
 
+  async function expectThemeSelection(selectedTheme: 'light' | 'auto' | 'dark') {
+    await expect(lightThemeButton).toHaveAttribute(
+      'aria-checked',
+      String(selectedTheme === 'light')
+    );
+    await expect(autoThemeButton).toHaveAttribute('aria-checked', String(selectedTheme === 'auto'));
+    await expect(darkThemeButton).toHaveAttribute('aria-checked', String(selectedTheme === 'dark'));
+  }
+
   await darkThemeButton.click();
+  await expectThemeSelection('dark');
   await expect.poll(() => page.evaluate(() => document.documentElement.dataset.theme)).toBe('dark');
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem('starlight-theme')))
     .toBe('dark');
 
   await lightThemeButton.click();
+  await expectThemeSelection('light');
   await expect
     .poll(() => page.evaluate(() => document.documentElement.dataset.theme))
     .toBe('light');
@@ -270,7 +282,7 @@ test('footer preferences persist theme and keyboard style selections', async ({ 
 
   await page.reload();
 
-  await expect(lightThemeButton).toHaveAttribute('aria-checked', 'true');
+  await expectThemeSelection('light');
   await expect(kbdSelect).toHaveValue('mac');
 });
 

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -460,10 +460,11 @@ const basicRenderCases: BasicRenderCase[] = [
     ],
   },
   {
-    name: 'FooterPreferences renders selectors and storage keys',
+    name: 'FooterPreferences renders theme toggle, selectors, and storage keys',
     Component: FooterPreferences,
     includes: [
-      'id="footer-theme-select"',
+      'id="footer-theme-toggle"',
+      'role="radiogroup"',
       'id="footer-language-select"',
       'id="footer-kbd-select"',
       'Select theme',


### PR DESCRIPTION
## Summary
- Replace the footer theme dropdown with a static three-way icon toggle for light, auto, and dark themes.
- Keep the control full-width with a sliding selected segment, accent border, and no native tooltip flicker.
- Update component and e2e coverage for the new toggle behavior.

**Before**

<img width="386" height="277" alt="image" src="https://github.com/user-attachments/assets/b9bb8219-6d94-4659-9d6b-95b345b638a0" />

**After**

<img width="356" height="264" alt="image" src="https://github.com/user-attachments/assets/ad56931f-25a1-4818-ad5b-93569654ff57" />

## Testing
- pnpm test:unit:components
- pnpm exec eslint tests\e2e\ui-regressions.spec.ts tests\unit\custom-components.vitest.test.ts --max-warnings 0
- PLAYWRIGHT_TEST_PORT=4500 pnpm exec playwright test --grep "footer preferences persist theme and keyboard style selections"