### PR TITLE
Disable 'On this page' TOC on sample detail pages

### DIFF
--- a/src/frontend/src/components/SampleDetail.astro
+++ b/src/frontend/src/components/SampleDetail.astro
@@ -6,6 +6,7 @@ import { marked } from 'marked';
 
 import SampleReadmeBlocks from '@components/SampleReadmeBlocks.astro';
 import { tagLabel } from '@utils/sample-tags';
+import { stripReadmeTitle } from '@utils/sample-readme-headings';
 import {
   appHostCodeLang,
   appHostCodeTitle,
@@ -31,10 +32,6 @@ type SampleImage = {
   src: ImageMetadata;
   alt: string;
 };
-
-function stripReadmeTitle(readme: string): string {
-  return readme.replace(/^#\s+.+\r?\n+/, '');
-}
 
 function getStandaloneImage(token: marked.Token): SampleImage | null {
   if (token.type !== 'paragraph') {

--- a/src/frontend/src/components/SampleReadmeBlocks.astro
+++ b/src/frontend/src/components/SampleReadmeBlocks.astro
@@ -3,6 +3,12 @@ import { Aside, Steps } from '@astrojs/starlight/components';
 import { Code } from 'astro-expressive-code/components';
 import { marked } from 'marked';
 
+import {
+  normalizeHeadingTokens,
+  slugifyHeading,
+  toSentenceCase,
+} from '@utils/sample-readme-headings';
+
 interface Props {
   blocks: marked.Token[];
   sampleHref: string;
@@ -89,73 +95,6 @@ function createRenderer(): marked.Renderer {
   };
 
   return renderer;
-}
-
-function slugifyHeading(value: string): string {
-  const slug = value
-    .toLowerCase()
-    .trim()
-    .replace(/<[^>]*>/g, '')
-    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
-    .replace(/\s+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-
-  return slug || 'section';
-}
-
-function toSentenceCase(value: string): string {
-  const words = value.trim().split(/(\s+)/);
-  let firstWordSeen = false;
-
-  return words
-    .map((word) => {
-      if (/^\s+$/.test(word) || shouldPreserveWord(word)) {
-        if (!firstWordSeen && !/^\s+$/.test(word)) {
-          firstWordSeen = true;
-        }
-        return word;
-      }
-
-      if (!firstWordSeen) {
-        firstWordSeen = true;
-        return word.charAt(0).toLocaleUpperCase() + word.slice(1).toLocaleLowerCase();
-      }
-
-      return word.toLocaleLowerCase();
-    })
-    .join('');
-}
-
-function shouldPreserveWord(word: string): boolean {
-  const trimmed = word.replace(/^[^\p{Letter}\p{Number}]+|[^\p{Letter}\p{Number}]+$/gu, '');
-  return (
-    trimmed.length === 0 ||
-    /[a-z][A-Z]/.test(trimmed) ||
-    /\d/.test(trimmed) ||
-    /^[A-Z]{2,}$/.test(trimmed) ||
-    /[.#/+_-]/.test(trimmed)
-  );
-}
-
-function normalizeHeadingTokens(tokens: marked.Token[] = []): marked.Token[] {
-  let remainingText: string | null = toSentenceCase(
-    tokens.map((token: any) => token.text || token.raw || '').join('')
-  );
-
-  return tokens.map((token: any) => {
-    if (remainingText === null || typeof token.text !== 'string') {
-      return token;
-    }
-
-    const normalized = remainingText.slice(0, token.text.length);
-    remainingText = remainingText.slice(token.text.length);
-    return {
-      ...token,
-      raw: normalized,
-      text: normalized,
-    };
-  });
 }
 
 const markdownRenderer = createRenderer();

--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -1267,13 +1267,20 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
      Collapse/expand stays available across all widths where the
      sidebar itself is visible.
 
+     Sample detail pages (`.sample-detail`) opt out of this treatment —
+     they removed the mobile TOC bar but the flat in-bar styling reads
+     as a stray bar fragment next to the hero. They use the base
+     floating-tab style instead (rounded right edge, drop shadow,
+     page background) so the toggle reads as a tab projecting from the
+     sidebar rather than a leftover bar.
+
      Use a literal 3rem instead of var(--sl-mobile-toc-height, 3rem)
      because the variable is explicitly set to 0rem outside of the
      data-has-toc scope (see site.css), which would defeat the
      fallback. */
   @media (min-width: 50rem) and (max-width: 99.999rem) {
-    :global(html:not([data-has-toc])) .sidebar-collapse-btn,
-    :global(html:not([data-has-toc])) .sidebar-expand-btn {
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-collapse-btn,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-expand-btn {
       top: calc(var(--sl-nav-height, 4rem) + var(--aspire-banner-height, 0px) - 1px);
       height: 3rem;
       border-radius: 0;
@@ -1284,8 +1291,8 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
       z-index: calc(var(--sl-z-index-toc, 10) + 1);
     }
 
-    :global(html:not([data-has-toc])) .sidebar-collapse-btn:hover,
-    :global(html:not([data-has-toc])) .sidebar-expand-btn:hover {
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-collapse-btn:hover,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-expand-btn:hover {
       box-shadow: none;
       background: var(--sl-color-bg);
     }

--- a/src/frontend/src/pages/reference/samples/[sample]/index.astro
+++ b/src/frontend/src/pages/reference/samples/[sample]/index.astro
@@ -5,6 +5,7 @@ import { getImage } from 'astro:assets';
 import Breadcrumb from '@components/Breadcrumb.astro';
 import SampleDetail from '@components/SampleDetail.astro';
 import samplesJson from '@data/samples.json';
+import { collectSampleReadmeHeadings } from '@utils/sample-readme-headings';
 import { sampleDescriptionText, sampleSlug, type Sample } from '@utils/samples';
 
 export function getStaticPaths() {
@@ -38,6 +39,24 @@ const description =
     ?.split('\n')
     .find((line) => line.trim().length > 0)
     ?.trim() ?? `Explore the ${sample.title} Aspire sample.`;
+
+// Build the "On this page" TOC from the README's real h2/h3 headings.
+// Without this, `StarlightPage` would receive `headings: []` and the
+// generated TOC would consist of just the auto "Overview" entry — which
+// still renders the mobile TOC bar (and the right-rail at ≥100rem) but
+// gives the reader nothing useful to click. Disable the TOC entirely
+// when the README has no headings in the configured range so the bar
+// doesn't render at all.
+const tocMinHeadingLevel = 2;
+const tocMaxHeadingLevel = 3;
+const readmeHeadings = collectSampleReadmeHeadings(sample.readme, {
+  minHeadingLevel: tocMinHeadingLevel,
+  maxHeadingLevel: tocMaxHeadingLevel,
+});
+const tableOfContents =
+  readmeHeadings.length > 0
+    ? { minHeadingLevel: tocMinHeadingLevel, maxHeadingLevel: tocMaxHeadingLevel }
+    : false;
 ---
 
 <StarlightPage
@@ -49,12 +68,13 @@ const description =
     category: 'sample',
     prev: false,
     next: false,
-    tableOfContents: { minHeadingLevel: 2, maxHeadingLevel: 3 },
+    tableOfContents,
     lastUpdated: false,
     editUrl: false,
     giscus: false,
     pageActions: true,
   }}
+  headings={readmeHeadings}
 >
   <Breadcrumb
     crumbs={[

--- a/src/frontend/src/pages/reference/samples/[sample]/index.astro
+++ b/src/frontend/src/pages/reference/samples/[sample]/index.astro
@@ -5,7 +5,6 @@ import { getImage } from 'astro:assets';
 import Breadcrumb from '@components/Breadcrumb.astro';
 import SampleDetail from '@components/SampleDetail.astro';
 import samplesJson from '@data/samples.json';
-import { collectSampleReadmeHeadings } from '@utils/sample-readme-headings';
 import { sampleDescriptionText, sampleSlug, type Sample } from '@utils/samples';
 
 export function getStaticPaths() {
@@ -39,24 +38,6 @@ const description =
     ?.split('\n')
     .find((line) => line.trim().length > 0)
     ?.trim() ?? `Explore the ${sample.title} Aspire sample.`;
-
-// Build the "On this page" TOC from the README's real h2/h3 headings.
-// Without this, `StarlightPage` would receive `headings: []` and the
-// generated TOC would consist of just the auto "Overview" entry — which
-// still renders the mobile TOC bar (and the right-rail at ≥100rem) but
-// gives the reader nothing useful to click. Disable the TOC entirely
-// when the README has no headings in the configured range so the bar
-// doesn't render at all.
-const tocMinHeadingLevel = 2;
-const tocMaxHeadingLevel = 3;
-const readmeHeadings = collectSampleReadmeHeadings(sample.readme, {
-  minHeadingLevel: tocMinHeadingLevel,
-  maxHeadingLevel: tocMaxHeadingLevel,
-});
-const tableOfContents =
-  readmeHeadings.length > 0
-    ? { minHeadingLevel: tocMinHeadingLevel, maxHeadingLevel: tocMaxHeadingLevel }
-    : false;
 ---
 
 <StarlightPage
@@ -68,13 +49,12 @@ const tableOfContents =
     category: 'sample',
     prev: false,
     next: false,
-    tableOfContents,
+    tableOfContents: false,
     lastUpdated: false,
     editUrl: false,
     giscus: false,
     pageActions: true,
   }}
-  headings={readmeHeadings}
 >
   <Breadcrumb
     crumbs={[

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1520,38 +1520,6 @@ it configures at which point the mobile toc should be replaced with the normal t
   }
 }
 
-/* Sample detail pages opted back into Starlight's TOC so the mobile
-   "On this page" dropdown stays available on narrow and medium widths
-   (the affordance vanished when `tableOfContents: false` was set), but
-   the desktop right-rail TOC is intentionally suppressed — sample
-   pages render a custom hero/code layout that owns its own column and
-   does not benefit from a duplicated heading list at the side.
-   At ≥100rem widths Starlight would normally hide the mobile dropdown
-   and show only the right-rail; force the right-rail panel down and
-   keep the mobile dropdown so the page still has an "On this page"
-   entry point at every breakpoint. The mobile dropdown lives inside
-   `.right-sidebar` alongside the right-rail panel, so hide the panel
-   specifically (`.right-sidebar-panel`) and leave the wrapper intact.
-   Also widen `--sl-content-width` to reclaim the column the right-rail
-   would have occupied so the hero/code expands into the freed space
-   instead of leaving an empty band on the right. */
-@media (min-width: 100rem) {
-  :root[data-has-toc]:has(.sample-detail) {
-    --sl-mobile-toc-height: 3rem;
-    --sl-content-width: calc(
-      100vw - var(--sl-sidebar-width) - 4 * var(--sl-content-pad-x)
-    );
-  }
-
-  :root[data-has-toc]:has(.sample-detail) .right-sidebar-panel {
-    display: none;
-  }
-
-  :root[data-has-toc]:has(.sample-detail) .lg\:sl-hidden {
-    display: block;
-  }
-}
-
 @media (prefers-reduced-motion: no-preference) {
   @view-transition {
     navigation: auto;

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1467,9 +1467,14 @@ it configures at which point the mobile toc should be replaced with the normal t
    title container so the H1 starts cleanly below the toggle. Targets
    the first `.content-panel` (the title-row container) only, to
    avoid introducing a gap between the title and the body content
-   that lives in the second `.content-panel`. */
+   that lives in the second `.content-panel`.
+
+   Sample detail pages (`.sample-detail`) are excluded — they use the
+   base floating-tab toggle styling (see Sidebar.astro) which sits at
+   the sidebar's right edge rather than spanning a synthetic bar row,
+   so the synthetic-bar padding would just leave a gap above the hero. */
 @media (min-width: 50rem) and (max-width: 99.999rem) {
-  :root:not([data-has-toc]):has(.topics-sidebar[data-topic-nav])
+  :root:not([data-has-toc]):not(:has(.sample-detail)):has(.topics-sidebar[data-topic-nav])
     .content-panel:first-of-type
     > .sl-container {
     padding-block-start: 3rem;
@@ -1477,7 +1482,7 @@ it configures at which point the mobile toc should be replaced with the normal t
 }
 
 @media (min-width: 72rem) and (max-width: 99.999rem) {
-  :root:not([data-has-toc]):has(.topics-sidebar[data-api-ref])
+  :root:not([data-has-toc]):not(:has(.sample-detail)):has(.topics-sidebar[data-api-ref])
     .content-panel:first-of-type
     > .sl-container {
     padding-block-start: 3rem;

--- a/src/frontend/src/utils/sample-readme-headings.ts
+++ b/src/frontend/src/utils/sample-readme-headings.ts
@@ -1,5 +1,4 @@
-import type { MarkdownHeading } from 'astro';
-import { lexer, type Token, type Tokens } from 'marked';
+import type { Token } from 'marked';
 
 /**
  * Drops the leading `# Title` line from a sample README so the page's own
@@ -114,77 +113,3 @@ export function normalizeHeadingTokens(tokens: Token[] = []): Token[] {
   });
 }
 
-/**
- * Mirrors how `SampleReadmeBlocks` extracts the raw concatenated text of a
- * heading from its child tokens. The slug is derived from this raw string,
- * so the collector must use the same expression as the renderer or the
- * generated TOC anchors won't resolve to the rendered `<h*>` `id`s.
- */
-function getHeadingRawText(tokens: Token[] | undefined): string {
-  return tokens?.map(tokenText).join('') ?? '';
-}
-
-export interface CollectHeadingsOptions {
-  minHeadingLevel?: number;
-  maxHeadingLevel?: number;
-}
-
-/**
- * Parses a sample README and returns a flat `MarkdownHeading[]` whose
- * `slug` values match the `id` attributes `SampleReadmeBlocks` emits at
- * render time. Pass the result to `<StarlightPage headings={…}>` so the
- * "On this page" TOC lists the README's real h2/h3 entries.
- *
- * Slug counting walks **every** heading (regardless of depth) so a
- * non-TOC heading (e.g. an h4) with the same text as a later h2 still
- * bumps the suffix counter the same way the renderer does. Only headings
- * within `[minHeadingLevel, maxHeadingLevel]` are returned, but the
- * counter state stays in sync.
- */
-export function collectSampleReadmeHeadings(
-  readme: string,
-  { minHeadingLevel = 2, maxHeadingLevel = 3 }: CollectHeadingsOptions = {}
-): MarkdownHeading[] {
-  const tokens = lexer(stripReadmeTitle(readme), { gfm: true });
-  const headingCounts = new Map<string, number>();
-  const headings: MarkdownHeading[] = [];
-
-  const walk = (blocks: Token[]): void => {
-    for (const block of blocks) {
-      if (block.type === 'heading') {
-        const heading = block as Tokens.Heading;
-        const rawText = getHeadingRawText(heading.tokens);
-        const baseSlug = slugifyHeading(rawText);
-        const seen = headingCounts.get(baseSlug) ?? 0;
-        headingCounts.set(baseSlug, seen + 1);
-        const slug = seen === 0 ? baseSlug : `${baseSlug}-${seen}`;
-
-        if (heading.depth >= minHeadingLevel && heading.depth <= maxHeadingLevel) {
-          headings.push({
-            depth: heading.depth,
-            slug,
-            text: toSentenceCase(rawText),
-          });
-        }
-        continue;
-      }
-
-      if (block.type === 'list') {
-        const list = block as Tokens.List;
-        for (const item of list.items ?? []) {
-          walk(item.tokens ?? []);
-        }
-        continue;
-      }
-
-      if (block.type === 'blockquote') {
-        const blockquote = block as Tokens.Blockquote;
-        walk(blockquote.tokens ?? []);
-        continue;
-      }
-    }
-  };
-
-  walk(tokens);
-  return headings;
-}

--- a/src/frontend/src/utils/sample-readme-headings.ts
+++ b/src/frontend/src/utils/sample-readme-headings.ts
@@ -1,0 +1,190 @@
+import type { MarkdownHeading } from 'astro';
+import { lexer, type Token, type Tokens } from 'marked';
+
+/**
+ * Drops the leading `# Title` line from a sample README so the page's own
+ * hero/title isn't duplicated as the first heading rendered into the body.
+ */
+export function stripReadmeTitle(readme: string): string {
+  return readme.replace(/^#\s+.+\r?\n+/, '');
+}
+
+/**
+ * Lower-cases, strips punctuation, and collapses whitespace into a stable
+ * `kebab-case` id, mirroring Starlight's heading-slugger so anchor links
+ * resolve. Returns `'section'` as a fallback when the input collapses to
+ * an empty string.
+ */
+export function slugifyHeading(value: string): string {
+  const slug = value
+    .toLowerCase()
+    .trim()
+    .replace(/<[^>]*>/g, '')
+    .replace(/[^\p{Letter}\p{Number}\s-]/gu, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return slug || 'section';
+}
+
+/**
+ * Identifies tokens that should bypass the `toSentenceCase` lower-casing —
+ * camelCase identifiers, anything with digits, all-caps acronyms (≥2 chars),
+ * and words containing technical punctuation (`.#/+_-`) so e.g. `.NET`,
+ * `AppHost`, `OTel`, `PostgreSQL` round-trip unchanged.
+ */
+export function shouldPreserveWord(word: string): boolean {
+  const trimmed = word.replace(/^[^\p{Letter}\p{Number}]+|[^\p{Letter}\p{Number}]+$/gu, '');
+  return (
+    trimmed.length === 0 ||
+    /[a-z][A-Z]/.test(trimmed) ||
+    /\d/.test(trimmed) ||
+    /^[A-Z]{2,}$/.test(trimmed) ||
+    /[.#/+_-]/.test(trimmed)
+  );
+}
+
+/**
+ * Converts a string to sentence case while preserving words that look like
+ * code identifiers / acronyms (see `shouldPreserveWord`). Only the first
+ * non-preserved word is capitalised — the rest are lower-cased.
+ */
+export function toSentenceCase(value: string): string {
+  const words = value.trim().split(/(\s+)/);
+  let firstWordSeen = false;
+
+  return words
+    .map((word) => {
+      if (/^\s+$/.test(word) || shouldPreserveWord(word)) {
+        if (!firstWordSeen && !/^\s+$/.test(word)) {
+          firstWordSeen = true;
+        }
+        return word;
+      }
+
+      if (!firstWordSeen) {
+        firstWordSeen = true;
+        return word.charAt(0).toLocaleUpperCase() + word.slice(1).toLocaleLowerCase();
+      }
+
+      return word.toLocaleLowerCase();
+    })
+    .join('');
+}
+
+/**
+ * Marked's inline token types all expose a `text` field but the union type
+ * doesn't declare a common shape, so we narrow to the few token variants
+ * the README headings use ({@link Tokens.Text}, {@link Tokens.Codespan},
+ * etc.) when concatenating raw heading text. `raw` is the fallback for
+ * tokens where `text` is empty (e.g. some inline HTML tokens).
+ */
+type HeadingChildToken = { text?: unknown; raw?: unknown };
+
+function tokenText(token: Token): string {
+  const candidate = token as HeadingChildToken;
+  if (typeof candidate.text === 'string') return candidate.text;
+  if (typeof candidate.raw === 'string') return candidate.raw;
+  return '';
+}
+
+/**
+ * Rewrites a heading's inline tokens so their visible text matches the
+ * sentence-cased heading. Preserves token order and lengths so each token's
+ * share of the heading text stays aligned with the original token (e.g. a
+ * `<strong>` over the second word still wraps the second word).
+ */
+export function normalizeHeadingTokens(tokens: Token[] = []): Token[] {
+  let remainingText: string | null = toSentenceCase(tokens.map(tokenText).join(''));
+
+  return tokens.map((token) => {
+    const original = token as HeadingChildToken;
+    if (remainingText === null || typeof original.text !== 'string') {
+      return token;
+    }
+
+    const normalized = remainingText.slice(0, original.text.length);
+    remainingText = remainingText.slice(original.text.length);
+    return {
+      ...token,
+      raw: normalized,
+      text: normalized,
+    };
+  });
+}
+
+/**
+ * Mirrors how `SampleReadmeBlocks` extracts the raw concatenated text of a
+ * heading from its child tokens. The slug is derived from this raw string,
+ * so the collector must use the same expression as the renderer or the
+ * generated TOC anchors won't resolve to the rendered `<h*>` `id`s.
+ */
+function getHeadingRawText(tokens: Token[] | undefined): string {
+  return tokens?.map(tokenText).join('') ?? '';
+}
+
+export interface CollectHeadingsOptions {
+  minHeadingLevel?: number;
+  maxHeadingLevel?: number;
+}
+
+/**
+ * Parses a sample README and returns a flat `MarkdownHeading[]` whose
+ * `slug` values match the `id` attributes `SampleReadmeBlocks` emits at
+ * render time. Pass the result to `<StarlightPage headings={…}>` so the
+ * "On this page" TOC lists the README's real h2/h3 entries.
+ *
+ * Slug counting walks **every** heading (regardless of depth) so a
+ * non-TOC heading (e.g. an h4) with the same text as a later h2 still
+ * bumps the suffix counter the same way the renderer does. Only headings
+ * within `[minHeadingLevel, maxHeadingLevel]` are returned, but the
+ * counter state stays in sync.
+ */
+export function collectSampleReadmeHeadings(
+  readme: string,
+  { minHeadingLevel = 2, maxHeadingLevel = 3 }: CollectHeadingsOptions = {}
+): MarkdownHeading[] {
+  const tokens = lexer(stripReadmeTitle(readme), { gfm: true });
+  const headingCounts = new Map<string, number>();
+  const headings: MarkdownHeading[] = [];
+
+  const walk = (blocks: Token[]): void => {
+    for (const block of blocks) {
+      if (block.type === 'heading') {
+        const heading = block as Tokens.Heading;
+        const rawText = getHeadingRawText(heading.tokens);
+        const baseSlug = slugifyHeading(rawText);
+        const seen = headingCounts.get(baseSlug) ?? 0;
+        headingCounts.set(baseSlug, seen + 1);
+        const slug = seen === 0 ? baseSlug : `${baseSlug}-${seen}`;
+
+        if (heading.depth >= minHeadingLevel && heading.depth <= maxHeadingLevel) {
+          headings.push({
+            depth: heading.depth,
+            slug,
+            text: toSentenceCase(rawText),
+          });
+        }
+        continue;
+      }
+
+      if (block.type === 'list') {
+        const list = block as Tokens.List;
+        for (const item of list.items ?? []) {
+          walk(item.tokens ?? []);
+        }
+        continue;
+      }
+
+      if (block.type === 'blockquote') {
+        const blockquote = block as Tokens.Blockquote;
+        walk(blockquote.tokens ?? []);
+        continue;
+      }
+    }
+  };
+
+  walk(tokens);
+  return headings;
+}

--- a/src/frontend/src/utils/sample-readme-headings.ts
+++ b/src/frontend/src/utils/sample-readme-headings.ts
@@ -83,8 +83,9 @@ type HeadingChildToken = { text?: unknown; raw?: unknown };
 
 function tokenText(token: Token): string {
   const candidate = token as HeadingChildToken;
-  if (typeof candidate.text === 'string') return candidate.text;
+  if (typeof candidate.text === 'string' && candidate.text.length > 0) return candidate.text;
   if (typeof candidate.raw === 'string') return candidate.raw;
+  if (typeof candidate.text === 'string') return candidate.text;
   return '';
 }
 

--- a/src/frontend/tests/unit/sample-readme-headings.vitest.test.ts
+++ b/src/frontend/tests/unit/sample-readme-headings.vitest.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  collectSampleReadmeHeadings,
   slugifyHeading,
   stripReadmeTitle,
   toSentenceCase,
@@ -48,79 +47,5 @@ describe('toSentenceCase', () => {
     // Version-number-shaped tokens stay intact; surrounding plain words
     // still get sentence-cased.
     expect(toSentenceCase('Use version 13.4 features')).toBe('Use version 13.4 features');
-  });
-});
-
-describe('collectSampleReadmeHeadings', () => {
-  it('returns only headings within the configured depth range', () => {
-    const readme = [
-      '# Title to strip',
-      '',
-      'Intro paragraph.',
-      '',
-      '## Prerequisites',
-      '',
-      'Some text.',
-      '',
-      '### Setting up the SDK',
-      '',
-      '#### Skipped because it is too deep',
-      '',
-      '## Running the App',
-    ].join('\n');
-
-    expect(collectSampleReadmeHeadings(readme)).toEqual([
-      { depth: 2, slug: 'prerequisites', text: 'Prerequisites' },
-      { depth: 3, slug: 'setting-up-the-sdk', text: 'Setting up the SDK' },
-      { depth: 2, slug: 'running-the-app', text: 'Running the app' },
-    ]);
-  });
-
-  it('returns an empty array when the README has no headings in range', () => {
-    const readme = '# Title only\n\nNo subheadings in this sample.\n';
-    expect(collectSampleReadmeHeadings(readme)).toEqual([]);
-  });
-
-  it('matches the rendered slug suffix for duplicate headings', () => {
-    // SampleReadmeBlocks counts duplicates across all rendered headings;
-    // the second occurrence of `Setup` must surface as `setup-1` so anchor
-    // links resolve to the second rendered <h2>.
-    const readme = ['## Setup', '', 'First section.', '', '## Setup', '', 'Second section.'].join(
-      '\n'
-    );
-
-    expect(collectSampleReadmeHeadings(readme)).toEqual([
-      { depth: 2, slug: 'setup', text: 'Setup' },
-      { depth: 2, slug: 'setup-1', text: 'Setup' },
-    ]);
-  });
-
-  it('keeps the duplicate counter in sync when out-of-range headings collide with TOC headings', () => {
-    // The counter has to advance for every heading regardless of depth so
-    // a later in-range duplicate gets the suffix the renderer assigns. An
-    // h4 named "Setup" before an h2 "Setup" pushes the h2 to `setup-1`.
-    const readme = [
-      '#### Setup',
-      '',
-      'Pre-step.',
-      '',
-      '## Setup',
-      '',
-      'Main section.',
-    ].join('\n');
-
-    expect(collectSampleReadmeHeadings(readme)).toEqual([
-      { depth: 2, slug: 'setup-1', text: 'Setup' },
-    ]);
-  });
-
-  it('honours custom min/max heading levels', () => {
-    const readme = ['## H2', '', '### H3', '', '#### H4'].join('\n');
-    expect(
-      collectSampleReadmeHeadings(readme, { minHeadingLevel: 3, maxHeadingLevel: 4 })
-    ).toEqual([
-      { depth: 3, slug: 'h3', text: 'H3' },
-      { depth: 4, slug: 'h4', text: 'H4' },
-    ]);
   });
 });

--- a/src/frontend/tests/unit/sample-readme-headings.vitest.test.ts
+++ b/src/frontend/tests/unit/sample-readme-headings.vitest.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectSampleReadmeHeadings,
+  slugifyHeading,
+  stripReadmeTitle,
+  toSentenceCase,
+} from '@utils/sample-readme-headings';
+
+describe('stripReadmeTitle', () => {
+  it('drops the leading h1 line', () => {
+    const readme = '# Redis sample\n\nThis sample shows...\n## Prerequisites\n';
+    expect(stripReadmeTitle(readme)).toBe('This sample shows...\n## Prerequisites\n');
+  });
+
+  it('returns the input unchanged when there is no leading h1', () => {
+    const readme = 'No title here\n\n## Heading';
+    expect(stripReadmeTitle(readme)).toBe(readme);
+  });
+});
+
+describe('slugifyHeading', () => {
+  it('lowercases and kebab-cases the input', () => {
+    expect(slugifyHeading('Running the App')).toBe('running-the-app');
+  });
+
+  it('strips punctuation while preserving hyphens', () => {
+    expect(slugifyHeading('AppHost: deep-dive!')).toBe('apphost-deep-dive');
+  });
+
+  it('returns "section" for collapsed inputs', () => {
+    expect(slugifyHeading('???')).toBe('section');
+  });
+});
+
+describe('toSentenceCase', () => {
+  it('capitalises the first word and lowercases the rest', () => {
+    expect(toSentenceCase('Running the App')).toBe('Running the app');
+  });
+
+  it('preserves tokens containing technical punctuation (filenames, namespaces)', () => {
+    expect(toSentenceCase('Configure the AppHost.cs File')).toBe(
+      'Configure the AppHost.cs file'
+    );
+  });
+
+  it('preserves tokens containing digits (version numbers, etc.)', () => {
+    // Version-number-shaped tokens stay intact; surrounding plain words
+    // still get sentence-cased.
+    expect(toSentenceCase('Use version 13.4 features')).toBe('Use version 13.4 features');
+  });
+});
+
+describe('collectSampleReadmeHeadings', () => {
+  it('returns only headings within the configured depth range', () => {
+    const readme = [
+      '# Title to strip',
+      '',
+      'Intro paragraph.',
+      '',
+      '## Prerequisites',
+      '',
+      'Some text.',
+      '',
+      '### Setting up the SDK',
+      '',
+      '#### Skipped because it is too deep',
+      '',
+      '## Running the App',
+    ].join('\n');
+
+    expect(collectSampleReadmeHeadings(readme)).toEqual([
+      { depth: 2, slug: 'prerequisites', text: 'Prerequisites' },
+      { depth: 3, slug: 'setting-up-the-sdk', text: 'Setting up the SDK' },
+      { depth: 2, slug: 'running-the-app', text: 'Running the app' },
+    ]);
+  });
+
+  it('returns an empty array when the README has no headings in range', () => {
+    const readme = '# Title only\n\nNo subheadings in this sample.\n';
+    expect(collectSampleReadmeHeadings(readme)).toEqual([]);
+  });
+
+  it('matches the rendered slug suffix for duplicate headings', () => {
+    // SampleReadmeBlocks counts duplicates across all rendered headings;
+    // the second occurrence of `Setup` must surface as `setup-1` so anchor
+    // links resolve to the second rendered <h2>.
+    const readme = ['## Setup', '', 'First section.', '', '## Setup', '', 'Second section.'].join(
+      '\n'
+    );
+
+    expect(collectSampleReadmeHeadings(readme)).toEqual([
+      { depth: 2, slug: 'setup', text: 'Setup' },
+      { depth: 2, slug: 'setup-1', text: 'Setup' },
+    ]);
+  });
+
+  it('keeps the duplicate counter in sync when out-of-range headings collide with TOC headings', () => {
+    // The counter has to advance for every heading regardless of depth so
+    // a later in-range duplicate gets the suffix the renderer assigns. An
+    // h4 named "Setup" before an h2 "Setup" pushes the h2 to `setup-1`.
+    const readme = [
+      '#### Setup',
+      '',
+      'Pre-step.',
+      '',
+      '## Setup',
+      '',
+      'Main section.',
+    ].join('\n');
+
+    expect(collectSampleReadmeHeadings(readme)).toEqual([
+      { depth: 2, slug: 'setup-1', text: 'Setup' },
+    ]);
+  });
+
+  it('honours custom min/max heading levels', () => {
+    const readme = ['## H2', '', '### H3', '', '#### H4'].join('\n');
+    expect(
+      collectSampleReadmeHeadings(readme, { minHeadingLevel: 3, maxHeadingLevel: 4 })
+    ).toEqual([
+      { depth: 3, slug: 'h3', text: 'H3' },
+      { depth: 4, slug: 'h4', text: 'H4' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Problem

The sample detail page (`/reference/samples/{name}/`) always renders the "On this page" TOC bar. Sample pages use a custom hero/AppHost/README layout that owns its own column and doesn't benefit from a duplicated heading list — the TOC adds clutter at every breakpoint and isn't something readers expect on a sample page.

## Fix

- Set `tableOfContents: false` unconditionally on the sample detail route and drop the `headings` prop entirely. Starlight's default no-TOC layout now applies cleanly: no mobile dropdown, no desktop right-rail.
- Remove the `>=100rem` CSS workaround that was widening content and hiding the right-rail panel for sample-detail pages — it keyed off `[data-has-toc]` which is no longer set, so the rule was dead.
- Drop the `collectSampleReadmeHeadings` collector (and the `marked.lexer` dependency from this util) along with its tests. The shared util still exports `stripReadmeTitle`, `slugifyHeading`, `toSentenceCase`, and `normalizeHeadingTokens` because `SampleReadmeBlocks` and `SampleDetail` still consume them.

## Why the shared util is still worth keeping

The two earlier commits also extracted heading helpers (slug/sentence-case/title-strip) out of `SampleReadmeBlocks.astro` and `SampleDetail.astro` into `src/utils/sample-readme-headings.ts` so they share a single implementation. That extraction is preserved — only the TOC collector that's no longer needed has been removed.

## Tests

- 8 vitest cases in `tests/unit/sample-readme-headings.vitest.test.ts` cover `stripReadmeTitle`, `slugifyHeading`, and `toSentenceCase`.
- All 68 existing component tests still pass (`pnpm test:unit:components`).
- `pnpm lint` is clean.