### PR TITLE
Fix OG image fallback for API reference pages

### DIFF
--- a/src/frontend/src/utils/page-metadata.ts
+++ b/src/frontend/src/utils/page-metadata.ts
@@ -1,4 +1,5 @@
 import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+import { isApiReferencePath } from '@utils/api-reference-routes';
 
 /**
  * Shared page-metadata helpers used by both the structured-data JSON-LD
@@ -63,10 +64,7 @@ const NON_DEFAULT_LOCALE_PREFIXES = [
   'zh-cn',
 ] as const;
 
-const localePrefixPattern = new RegExp(
-  `^(?:${NON_DEFAULT_LOCALE_PREFIXES.join('|')})(?:/|$)`,
-  'i'
-);
+const localePrefixPattern = new RegExp(`^(?:${NON_DEFAULT_LOCALE_PREFIXES.join('|')})(?:/|$)`, 'i');
 
 const releaseNotePattern = /^whats-new\/aspire-/i;
 
@@ -81,7 +79,13 @@ type RouteEntryData = {
   template?: string;
 };
 
-type MinimalRoute = Pick<StarlightRouteData, 'entry' | 'entryMeta' | 'head' | 'lang' | 'locale'>;
+type MinimalRoute = Pick<StarlightRouteData, 'entryMeta' | 'head' | 'lang' | 'locale'> & {
+  entry: {
+    id: string;
+    data: Record<string, unknown>;
+    filePath?: string;
+  };
+};
 
 export type OgType = 'website' | 'article';
 
@@ -275,6 +279,8 @@ export function shouldSkipDynamicOgImage(route: MinimalRoute, contentBasePath: s
   const data = route.entry.data as RouteEntryData;
   if (data.og === false) return true;
   if (data.template === 'splash') return true;
+  if (isPagesRoute(route)) return true;
+  if (isApiReferencePath(contentBasePath)) return true;
   if (isHomePagePath(contentBasePath)) return true;
   if (contentBasePath === '404') return true;
   return false;
@@ -338,6 +344,11 @@ export function resolveSiteUrl(site: URL | string | undefined, currentUrl: URL):
 
 function normalizeEntryId(entryId: string): string {
   return entryId.replace(/\\/g, '/');
+}
+
+function isPagesRoute(route: MinimalRoute): boolean {
+  const filePath = normalizeEntryId(route.entry.filePath ?? '').replace(/^\/+/, '');
+  return filePath.startsWith('src/pages/');
 }
 
 function stripMarkdownExtension(value: string): string {

--- a/src/frontend/tests/e2e/og-metadata.spec.ts
+++ b/src/frontend/tests/e2e/og-metadata.spec.ts
@@ -115,3 +115,23 @@ test('falls back to the site-wide image for the home page', async ({ request, ba
   const imageResponse = await request.get(new URL('/og-image.png', baseURL).toString());
   expect(imageResponse.ok(), 'the fallback /og-image.png must exist').toBe(true);
 });
+
+test('falls back to the site-wide image for generated API reference pages', async ({
+  request,
+  baseURL,
+}) => {
+  const response = await request.get('/reference/api/typescript/aspire.hosting.redis/');
+  expect(response.ok(), 'API reference page should return 200').toBe(true);
+  const html = await response.text();
+
+  expect(html).toMatch(
+    new RegExp(
+      `<meta\\b[^>]*property="og:image"[^>]*content="[^"]*${escape('/og-image.png')}"`,
+      'i'
+    )
+  );
+  expect(html).not.toMatch(/\/og\/reference\/api\/typescript\//i);
+
+  const imageResponse = await request.get(new URL('/og-image.png', baseURL).toString());
+  expect(imageResponse.ok(), 'the fallback /og-image.png must exist').toBe(true);
+});

--- a/src/frontend/tests/unit/page-metadata.vitest.test.ts
+++ b/src/frontend/tests/unit/page-metadata.vitest.test.ts
@@ -20,6 +20,7 @@ type Route = Parameters<typeof getOgMetadata>[0];
 
 interface RouteOverrides {
   entryId?: string;
+  filePath?: string;
   title?: string;
   description?: string;
   locale?: string;
@@ -35,6 +36,7 @@ interface RouteOverrides {
 function createRoute(overrides: RouteOverrides = {}): Route {
   const {
     entryId = 'dashboard/enable-browser-telemetry.mdx',
+    filePath = `src/content/docs/${entryId}`,
     title = 'Enable browser telemetry',
     locale,
     lang = 'en',
@@ -55,7 +57,7 @@ function createRoute(overrides: RouteOverrides = {}): Route {
     entry: {
       id: entryId,
       slug: entryId.replace(/\.mdx?$/i, ''),
-      filePath: `src/content/docs/${entryId}`,
+      filePath,
       body: '',
       data: {
         title,
@@ -82,9 +84,9 @@ describe('getContentBasePath', () => {
   });
 
   it('strips a locale prefix when locale is set', () => {
-    expect(
-      getContentBasePath(createRoute({ entryId: 'de/foo/bar.mdx', locale: 'de' }))
-    ).toBe('foo/bar');
+    expect(getContentBasePath(createRoute({ entryId: 'de/foo/bar.mdx', locale: 'de' }))).toBe(
+      'foo/bar'
+    );
   });
 
   it('returns the index path for the home page', () => {
@@ -268,9 +270,7 @@ describe('resolveOgImage', () => {
 
   it('falls back to the global image when og is false', () => {
     const route = createRoute({ og: false });
-    expect(resolveOgImage(route, 'foo/bar', siteUrl, true)).toBe(
-      'https://aspire.dev/og-image.png'
-    );
+    expect(resolveOgImage(route, 'foo/bar', siteUrl, true)).toBe('https://aspire.dev/og-image.png');
   });
 
   it('falls back to the global image for non-default locales', () => {
@@ -297,8 +297,53 @@ describe('resolveOgImage', () => {
     expect(resolveOgImage(route, '404', siteUrl, true)).toBe('https://aspire.dev/og-image.png');
   });
 
+  it('falls back to the global image for generated pages routes', () => {
+    const route = createRoute({
+      entryId: 'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+      filePath: 'src/pages/reference/api/typescript/[module]/[item]/index.astro',
+      title: 'addOllamaLocal',
+    });
+
+    expect(
+      resolveOgImage(
+        route,
+        'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+        siteUrl,
+        true
+      )
+    ).toBe('https://aspire.dev/og-image.png');
+  });
+
+  it('falls back to the global image for virtual API reference routes without file paths', () => {
+    const route = createRoute({
+      entryId: 'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+      filePath: '',
+      title: 'addOllamaLocal',
+    });
+
+    expect(
+      resolveOgImage(
+        route,
+        'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+        siteUrl,
+        true
+      )
+    ).toBe('https://aspire.dev/og-image.png');
+  });
+
   it('emits a per-page URL for normal default-locale pages', () => {
     const route = createRoute();
+    expect(resolveOgImage(route, 'dashboard/enable-browser-telemetry', siteUrl, true)).toBe(
+      'https://aspire.dev/og/dashboard/enable-browser-telemetry.png'
+    );
+  });
+
+  it('emits a per-page URL for docs routes with extensionless entry ids', () => {
+    const route = createRoute({
+      entryId: 'dashboard/enable-browser-telemetry',
+      filePath: 'src/content/docs/dashboard/enable-browser-telemetry.mdx',
+    });
+
     expect(resolveOgImage(route, 'dashboard/enable-browser-telemetry', siteUrl, true)).toBe(
       'https://aspire.dev/og/dashboard/enable-browser-telemetry.png'
     );
@@ -324,6 +369,34 @@ describe('shouldSkipDynamicOgImage', () => {
   it('skips entries with og: false', () => {
     const route = createRoute({ og: false });
     expect(shouldSkipDynamicOgImage(route, 'whatever')).toBe(true);
+  });
+
+  it('skips generated pages routes', () => {
+    const route = createRoute({
+      entryId: 'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+      filePath: 'src/pages/reference/api/typescript/[module]/[item]/index.astro',
+    });
+
+    expect(
+      shouldSkipDynamicOgImage(
+        route,
+        'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal'
+      )
+    ).toBe(true);
+  });
+
+  it('skips virtual API reference routes without file paths', () => {
+    const route = createRoute({
+      entryId: 'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+      filePath: '',
+    });
+
+    expect(
+      shouldSkipDynamicOgImage(
+        route,
+        'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal'
+      )
+    ).toBe(true);
   });
 
   it('keeps normal pages', () => {
@@ -431,6 +504,26 @@ describe('getOgMetadata', () => {
     );
 
     expect(meta.image).toBe('https://aspire.dev/custom-image.png');
+  });
+
+  it('falls back to the static image for generated pages routes', () => {
+    const route = createRoute({
+      entryId: 'reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal',
+      filePath: 'src/pages/reference/api/typescript/[module]/[item]/index.astro',
+      title: 'addOllamaLocal',
+      description:
+        'Method — TypeScript API reference for addOllamaLocal in CommunityToolkit.Aspire.Hosting.Ollama',
+    });
+    const meta = getOgMetadata(
+      route,
+      new URL(
+        'https://aspire.dev/reference/api/typescript/communitytoolkit.aspire.hosting.ollama/addollamalocal/'
+      ),
+      site
+    );
+
+    expect(meta.image).toBe('https://aspire.dev/og-image.png');
+    expect(meta.ogTitle).toBe('addOllamaLocal · Aspire');
   });
 
   it('returns website type for the splash home page', () => {


### PR DESCRIPTION
## Summary
- Use the site-wide OG image for generated API reference and `src/pages` Starlight routes that do not have dynamic OG images.
- Preserve per-page dynamic OG images for normal docs collection pages.
- Add unit and Playwright regression coverage for the generated API reference fallback.

## Validation
- `pnpm --dir .\src\frontend exec prettier --check src\utils\page-metadata.ts tests\unit\page-metadata.vitest.test.ts tests\e2e\og-metadata.spec.ts`
- `pnpm --dir .\src\frontend exec eslint src\utils\page-metadata.ts tests\unit\page-metadata.vitest.test.ts tests\e2e\og-metadata.spec.ts --max-warnings 0`
- `pnpm --dir .\src\frontend exec vitest run --config vitest.config.ts tests/unit/page-metadata.vitest.test.ts`
- `$env:PLAYWRIGHT_TEST_PORT='4331'; pnpm --dir .\src\frontend exec playwright test og-metadata --project=desktop-chromium --grep "generated API reference"`