### PR TITLE
Fix TypeScript documentation gaps

### DIFF
--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -186,13 +186,9 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
+import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
-
-const referenceExpression = (value: string): ReferenceExpression => ({
-  getValueAsync: () => value,
-});
 
 const api = await builder.addContainer("api", {
   image: "my-api",
@@ -203,9 +199,9 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withHttpsCertificateConfig(async () => ({
-    certificatePath: referenceExpression("/certs/tls.crt"),
-    keyPath: referenceExpression("/certs/tls.key"),
-    pfxPath: referenceExpression("/certs/tls.pfx"),
+    certificatePath: refExpr`/certs/tls.crt`,
+    keyPath: refExpr`/certs/tls.key`,
+    pfxPath: refExpr`/certs/tls.pfx`,
   }));
 
 await builder.build().run();
@@ -295,13 +291,9 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
+import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
-
-const referenceExpression = (value: string): ReferenceExpression => ({
-  getValueAsync: () => value,
-});
 
 const api = await builder.addContainer("api", {
   image: "myimage",
@@ -312,8 +304,8 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withCertificateTrustConfig(async () => ({
-    certificateBundlePath: referenceExpression("/certs/ca-bundle.crt"),
-    certificateDirectoriesPath: referenceExpression("/certs"),
+    certificateBundlePath: refExpr`/certs/ca-bundle.crt`,
+    certificateDirectoriesPath: refExpr`/certs`,
     rootCertificatesPath: "/etc/ssl/certs",
     isContainer: true,
   }));

--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -185,10 +185,14 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+```typescript title="apphost.mts" twoslash
+import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
+
+const referenceExpression = (value: string): ReferenceExpression => ({
+  getValueAsync: () => value,
+});
 
 const api = await builder.addContainer("api", {
   image: "my-api",
@@ -199,9 +203,9 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withHttpsCertificateConfig(async () => ({
-    certificatePath: builder.createReferenceExpression`/certs/tls.crt`,
-    keyPath: builder.createReferenceExpression`/certs/tls.key`,
-    pfxPath: builder.createReferenceExpression`/certs/tls.pfx`,
+    certificatePath: referenceExpression("/certs/tls.crt"),
+    keyPath: referenceExpression("/certs/tls.key"),
+    pfxPath: referenceExpression("/certs/tls.pfx"),
   }));
 
 await builder.build().run();
@@ -290,10 +294,14 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+```typescript title="apphost.mts" twoslash
+import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
+
+const referenceExpression = (value: string): ReferenceExpression => ({
+  getValueAsync: () => value,
+});
 
 const api = await builder.addContainer("api", {
   image: "myimage",
@@ -304,8 +312,8 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withCertificateTrustConfig(async () => ({
-    certificateBundlePath: builder.createReferenceExpression`/certs/ca-bundle.crt`,
-    certificateDirectoriesPath: builder.createReferenceExpression`/certs`,
+    certificateBundlePath: referenceExpression("/certs/ca-bundle.crt"),
+    certificateDirectoriesPath: referenceExpression("/certs"),
     rootCertificatesPath: "/etc/ssl/certs",
     isContainer: true,
   }));

--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -185,9 +185,27 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addContainer("api", {
+  image: "my-api",
+  tag: "latest",
+});
+
+api.createExecutionConfiguration()
+  .withArgumentsConfig()
+  .withEnvironmentVariablesConfig()
+  .withHttpsCertificateConfig(async () => ({
+    certificatePath: builder.createReferenceExpression`/certs/tls.crt`,
+    keyPath: builder.createReferenceExpression`/certs/tls.key`,
+    pfxPath: builder.createReferenceExpression`/certs/tls.pfx`,
+  }));
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 
@@ -272,9 +290,28 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addContainer("api", {
+  image: "myimage",
+  tag: "latest",
+});
+
+api.createExecutionConfiguration()
+  .withArgumentsConfig()
+  .withEnvironmentVariablesConfig()
+  .withCertificateTrustConfig(async () => ({
+    certificateBundlePath: builder.createReferenceExpression`/certs/ca-bundle.crt`,
+    certificateDirectoriesPath: builder.createReferenceExpression`/certs`,
+    rootCertificatesPath: "/etc/ssl/certs",
+    isContainer: true,
+  }));
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/app-host/container-files.mdx
+++ b/src/frontend/src/content/docs/app-host/container-files.mdx
@@ -90,9 +90,19 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-The `withContainerFiles` API is not yet available in the TypeScript AppHost SDK.
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const frontend = await builder.addViteApp("frontend", "../frontend");
+await frontend.withContainerFilesSource("/app/dist");
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.publishWithContainerFiles(frontend, "./wwwroot");
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/app-host/container-files.mdx
+++ b/src/frontend/src/content/docs/app-host/container-files.mdx
@@ -90,7 +90,7 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/app-host/withdockerfile.mdx
+++ b/src/frontend/src/content/docs/app-host/withdockerfile.mdx
@@ -280,7 +280,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -324,7 +324,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/app-host/withdockerfile.mdx
+++ b/src/frontend/src/content/docs/app-host/withdockerfile.mdx
@@ -280,7 +280,22 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-TypeScript AppHost support for Dockerfile factory APIs isn't available because `DockerfileFactoryContext` exposes .NET runtime types that aren't part of the polyglot SDK surface. Use the [Dockerfile builder APIs](#generate-a-dockerfile-programmatically) for TypeScript AppHosts.
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const container = await builder.addDockerfileFactory("myapp", "../myapp", async () => `
+FROM node:22-alpine
+WORKDIR /app
+COPY . .
+RUN npm ci
+EXPOSE 3000
+CMD ["node", "server.js"]
+`);
+
+await builder.build().run();
+```
 
 </TabItem>
 </Tabs>
@@ -309,7 +324,20 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-TypeScript AppHost support for Dockerfile factory APIs isn't available because `DockerfileFactoryContext` exposes .NET runtime types that aren't part of the polyglot SDK surface. Use the [Dockerfile builder APIs](#generate-a-dockerfile-programmatically) for TypeScript AppHosts.
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addContainer("myapp", { image: "placeholder", tag: "latest" })
+  .withDockerfileFactory("../myapp", async () => `
+FROM nginx:alpine
+COPY dist/ /usr/share/nginx/html
+EXPOSE 80
+`);
+
+await builder.build().run();
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/deployment/docker-compose.mdx
+++ b/src/frontend/src/content/docs/deployment/docker-compose.mdx
@@ -583,7 +583,7 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/deployment/docker-compose.mdx
+++ b/src/frontend/src/content/docs/deployment/docker-compose.mdx
@@ -583,9 +583,22 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-The `WithImagePushOptions` API is not yet available in the TypeScript AppHost SDK.
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('api', '../Api/Api.csproj');
+await api
+  .publishAsDockerComposeService(async (resource, service) => {
+    await service.name.set('api');
+  })
+  .withImagePushOptions(async (context) => {
+    const imageName = context.resource.getResourceName().toLowerCase();
+    context.options.setRemoteImageName(`myorg/${imageName}`);
+    context.options.setRemoteImageTag('latest');
+  });
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/deployment/pipelines.mdx
@@ -297,7 +297,7 @@ var api = builder.AddProject<Api>("api").WithReference(database);
 ````
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/deployment/pipelines.mdx
@@ -297,9 +297,29 @@ var api = builder.AddProject<Api>("api").WithReference(database);
 ````
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-The `builder.pipeline` API is not yet available in the TypeScript AppHost SDK, so this custom pipeline example is currently C#-only.
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// Add custom deployment validation
+builder.pipeline.addStep("validate-deployment", async (context) => {
+  // Custom validation logic
+  await validateApiHealth(context);
+  await validateDatabaseConnection(context);
+}, { requiredBy: ["deploy"] });
+
+// Define resources
+const database = await builder.addPostgres("myapp-db");
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(database);
+
+async function validateApiHealth(_context: unknown) {
+}
+
+async function validateDatabaseConnection(_context: unknown) {
+}
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -390,7 +390,7 @@ ollama.AddModel("llama3");
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -390,10 +390,18 @@ ollama.AddModel("llama3");
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
-<Aside type="note">
-  TypeScript AppHost support for `WithOpenWebUI` is not available in the current Community Toolkit TypeScript bindings. Use the C# AppHost to enable Open WebUI.
-</Aside>
+const builder = await createBuilder();
+
+const ollama = await builder.addOllama("ollama");
+await ollama.withOpenWebUI();
+
+await ollama.addModel("llama3");
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -408,4 +416,3 @@ The Ollama hosting integration automatically adds health checks for both the Oll
 
 - **Server health check.** Verifies that the Ollama server is running and that a connection can be established to it.
 - **Model health check.** Verifies that a model has been downloaded and is available. The model resource is marked as unhealthy until the download completes.
-

--- a/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
@@ -79,7 +79,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
@@ -4,7 +4,7 @@ description: Extend the functionality of your Redis hosting with community-built
 next: false
 ---
 
-import { Badge, Tabs, TabItem, Aside } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import { Image } from 'astro:assets';
 import redisIcon from '@assets/icons/redis-icon.png';
@@ -38,9 +38,19 @@ To get started with the Aspire Community Toolkit Redis hosting extensions, insta
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-<Aside type="note">
-  The Community Toolkit Redis extensions package (`CommunityToolkit.Aspire.Hosting.Redis.Extensions`) is a .NET-only package. The extension APIs such as `WithDbGate` are not available in TypeScript AppHosts. Use the official [Redis integration](/integrations/caching/redis/redis-get-started/) to add Redis to a TypeScript AppHost.
-</Aside>
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Redis.Extensions
+```
+
+This updates your `aspire.config.json` with the Redis extensions package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.Redis.Extensions": "*"
+  }
+}
+```
 
 </TabItem>
 </Tabs>
@@ -69,9 +79,21 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-<Aside type="note">
-  The `WithDbGate` extension is not available in TypeScript AppHosts. DbGate management UI configuration is a C#-only feature.
-</Aside>
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const redis = await builder.addRedis("redis");
+await redis.withDbGate();
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(redis);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
@@ -228,7 +228,7 @@ builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
@@ -228,7 +228,30 @@ builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose `withCreationScript` on the database resource. To initialise the emulator database schema from a TypeScript AppHost, apply schema through your application on startup instead.
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const kusto = await builder.addAzureKustoCluster("kusto")
+    .runAsEmulator();
+
+const database = await kusto.addReadWriteDatabase("analytics")
+    .withCreationScript(`
+        .create table Events (
+            Timestamp: datetime,
+            EventType: string,
+            Message: string
+        )
+        `);
+
+const exampleProject = await builder.addProject("example", "../ExampleProject/ExampleProject.csproj");
+await exampleProject
+    .withReference(database)
+    .waitFor(database);
+
+// After adding all resources, run the app...
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
@@ -42,9 +42,14 @@ builder.AddProject<Projects.DataProcessor>("data-processor")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="note">
-  The `PublishAsAzureContainerAppJob` and `PublishAsScheduledAzureContainerAppJob` APIs are not yet available in the TypeScript AppHost. To deploy a TypeScript-based worker as an Azure Container App Job, configure the job via the Azure portal or Bicep outside of the AppHost.
-</Aside>
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const dataProcessor = await builder.addProject("data-processor", "../DataProcessor/DataProcessor.csproj");
+await dataProcessor.publishAsScheduledAzureContainerAppJob("0 0 * * *"); // Every day at midnight
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
@@ -42,7 +42,7 @@ builder.AddProject<Projects.DataProcessor>("data-processor")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/compute/docker.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/docker.mdx
@@ -637,9 +637,22 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-The `WithImagePushOptions` API is not yet available in the TypeScript AppHost SDK. Use `withRemoteImageName` and `withRemoteImageTag` for static image naming and tagging.
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api
+  .publishAsDockerComposeService(async (resource, service) => {
+    await service.name.set("api");
+  })
+  .withImagePushOptions(async (context) => {
+    const imageName = context.resource.getResourceName().toLowerCase();
+    context.options.setRemoteImageName(`myorg/${imageName}`);
+    context.options.setRemoteImageTag("latest");
+  });
+```
 </TabItem>
 </Tabs>
 
@@ -666,9 +679,29 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-The asynchronous `WithImagePushOptions` callback overload is not yet available in the TypeScript AppHost SDK.
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api
+  .publishAsDockerComposeService(async (resource, service) => {
+    await service.name.set("api");
+  })
+  .withImagePushOptions(async (context) => {
+    const config = await loadImageConfiguration();
+    context.options.setRemoteImageName(config.imageName);
+    context.options.setRemoteImageTag(config.imageTag);
+  });
+
+async function loadImageConfiguration() {
+  return {
+    imageName: "myorg/api",
+    imageTag: "latest",
+  };
+}
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/compute/docker.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/docker.mdx
@@ -637,7 +637,7 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
@@ -679,7 +679,7 @@ var api = builder.AddProject<Projects.Api>("api")
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
@@ -65,7 +65,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
@@ -3,8 +3,7 @@ title: Use community extensions for MongoDB hosting
 description: Extend the functionality of your MongoDB hosting with the Aspire Community Toolkit, including the DbGate management UI.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-import { Aside } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import { Image } from 'astro:assets';
 import mongodbIcon from '@assets/icons/mongodb-icon.png';
@@ -32,16 +31,24 @@ To get started with the Aspire Community Toolkit MongoDB hosting extensions, ins
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.MongoDB.Extensions" />
 
-<Aside type="note">
-  TypeScript AppHost support for the Community Toolkit `withDbGate` extension is
-  not yet available.
-</Aside>
+For TypeScript AppHosts, add the Community Toolkit MongoDB extensions package to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.MongoDB.Extensions": "*"
+  }
+}
+```
 
 ## Add management UI
 
 ### DbGate management UI
 
 To add the [DbGate](https://dbgate.org/) management UI to your MongoDB resource, call the `WithDbGate` method on the `MongoDBResourceBuilder` instance:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -54,6 +61,26 @@ builder.AddProject<Projects.ExampleProject>("api")
 
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const mongodb = await builder.addMongoDB("mongodb");
+await mongodb.withDbGate();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(mongodb);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 This adds a new DbGate resource to the AppHost which is available from the Aspire dashboard. DbGate is a comprehensive database management tool that provides a web-based interface for managing your MongoDB databases.
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
@@ -66,7 +66,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -107,7 +107,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -149,7 +149,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
@@ -3,8 +3,7 @@ title: Use community extensions for MySQL hosting
 description: Extend the functionality of your MySQL hosting with the Aspire Community Toolkit, including management UIs like Adminer and DbGate.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-import { Aside } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import { Image } from 'astro:assets';
 import mysqlIcon from '@assets/icons/mysqlconnector-icon.png';
@@ -33,16 +32,24 @@ To get started with the Aspire Community Toolkit MySQL hosting extensions, insta
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.MySql.Extensions" />
 
-<Aside type="note">
-  TypeScript AppHost support for the Community Toolkit `withDbGate` and
-  `withAdminer` extensions is not yet available.
-</Aside>
+For TypeScript AppHosts, add the Community Toolkit MySQL extensions package to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.MySql.Extensions": "*"
+  }
+}
+```
 
 ## Add management UI
 
 ### DbGate management UI
 
 To add the [DbGate](https://dbgate.org/) management UI to your MySQL resource, call the `WithDbGate` method on the `MySqlServerResourceBuilder` instance:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -56,16 +63,34 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  TypeScript AppHost support for combining these Community Toolkit management UI
-  extension methods isn't yet available.
-</Aside>
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const mysql = await builder.addMySql("mysql");
+await mysql.withDbGate();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(mysql);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 This adds a new DbGate resource to the AppHost which is available from the Aspire dashboard. DbGate is a comprehensive database management tool that provides a web-based interface for managing your MySQL databases.
 
 ### Adminer management UI
 
 To add the [Adminer](https://adminer.org/) management UI to your MySQL resource, call the `WithAdminer` method on the `MySqlServerResourceBuilder` instance:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -79,11 +104,34 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const mysql = await builder.addMySql("mysql");
+await mysql.withAdminer();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(mysql);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 This adds a new Adminer resource to the AppHost which is available from the Aspire dashboard. Adminer is a lightweight database management tool that provides a simple web interface for database operations.
 
 ### Using both management UIs
 
 You can use both management UIs together on the same MySQL resource:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -97,6 +145,27 @@ builder.AddProject<Projects.ExampleProject>("api")
 
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const mysql = await builder.addMySql("mysql");
+await mysql.withDbGate();
+await mysql.withAdminer();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(mysql);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 ## See also
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
@@ -94,11 +94,13 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 ```typescript title="TypeScript — apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 const mysql = await builder.addMySql("mysql");
+await mysql.withLifetime(ContainerLifetime.Persistent);
+
 const mysqldb = await mysql.addDatabase("mysqldb");
 
 await builder.addNodeApp("api", "./api", "index.js")
@@ -122,8 +124,6 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 <Aside type="note">
     The MySQL container can be slow to start, so it's best to use a _persistent_ lifetime to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
-
-    The TypeScript AppHost doesn't currently expose a `withLifetime(...)` API. Use the C# AppHost when persistent container lifetime is required.
 </Aside>
 
 <Aside type="note">
@@ -160,7 +160,30 @@ var myService = builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-The TypeScript AppHost doesn't currently expose a `withCreationScript(...)` API for MySQL database resources. To initialize a MySQL database from a TypeScript AppHost, use [`withInitFiles(...)`](#add-mysql-resource-with-init-files) to copy SQL initialization scripts into the container's init directory instead.
+```typescript title="apphost.mts" twoslash
+import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const mysql = await builder.addMySql("mysql");
+await mysql.withLifetime(ContainerLifetime.Persistent);
+
+const mysqldb = await mysql.addDatabase("mysqldb")
+    .withCreationScript(`
+        CREATE TABLE IF NOT EXISTS users (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            email VARCHAR(255) NOT NULL
+        );
+        `);
+
+const myService = await builder.addProject("example", "../ExampleProject/ExampleProject.csproj");
+await myService
+    .withReference(mysqldb)
+    .waitFor(mysqldb);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
@@ -160,7 +160,7 @@ var myService = builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
@@ -66,7 +66,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -109,7 +109,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -153,7 +153,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
@@ -3,8 +3,7 @@ title: Use community extensions for PostgreSQL hosting
 description: Extend the functionality of your PostgreSQL hosting with community-built extensions, including management UIs like Adminer and DbGate.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-import { Aside } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import { Image } from 'astro:assets';
 import postgresqlIcon from '@assets/icons/postgresql-icon.png';
@@ -33,10 +32,15 @@ To get started with the Aspire Community Toolkit PostgreSQL hosting extensions, 
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions" />
 
-<Aside type="note">
-  TypeScript AppHost support for the Community Toolkit `withDbGate` and
-  `withAdminer` extensions is not yet available.
-</Aside>
+For TypeScript AppHosts, add the Community Toolkit PostgreSQL extensions package to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions": "*"
+  }
+}
+```
 
 ## Add management UI
 
@@ -44,22 +48,42 @@ To get started with the Aspire Community Toolkit PostgreSQL hosting extensions, 
 
 To add the DbGate management UI to your PostgreSQL resource, call the `WithDbGate` method on the `PostgresServerResource` instance:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-                      .WithDbGate();
+    .WithDbGate();
 
 builder.AddProject<Projects.ExampleProject>()
-       .WithReference(postgres);
+    .WithReference(postgres);
 
 // After adding all resources, run the app...
 ```
 
-<Aside type="note">
-  TypeScript AppHost support for combining these Community Toolkit management UI
-  extension methods isn't yet available.
-</Aside>
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("postgres");
+await postgres.withDbGate();
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(postgres);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 This adds a new DbGate resource to the app host which is available from the Aspire dashboard. DbGate is a comprehensive database management tool that provides a web-based interface for managing your PostgreSQL databases.
 
@@ -67,17 +91,42 @@ This adds a new DbGate resource to the app host which is available from the Aspi
 
 To add the Adminer management UI to your PostgreSQL resource, call the `WithAdminer` method on the `PostgresServerResource` instance:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-                      .WithAdminer();
+    .WithAdminer();
 
 builder.AddProject<Projects.ExampleProject>()
-       .WithReference(postgres);
+    .WithReference(postgres);
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("postgres");
+await postgres.withAdminer();
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(postgres);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 This adds a new Adminer resource to the app host which is available from the Aspire dashboard. Adminer is a lightweight database management tool that provides a simple web interface for database operations.
 
@@ -85,18 +134,44 @@ This adds a new Adminer resource to the app host which is available from the Asp
 
 You can use both management UIs together on the same PostgreSQL resource:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-                      .WithDbGate()
-                      .WithAdminer();
+    .WithDbGate()
+    .WithAdminer();
 
 builder.AddProject<Projects.ExampleProject>()
-       .WithReference(postgres);
+    .WithReference(postgres);
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("postgres");
+await postgres.withDbGate();
+await postgres.withAdminer();
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(postgres);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 ## See also
 

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
@@ -66,7 +66,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -107,7 +107,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -149,7 +149,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
@@ -3,8 +3,7 @@ title: Use community extensions for SQL Server hosting
 description: Extend the functionality of your SQL Server hosting with the Aspire Community Toolkit, including management UIs like Adminer and DbGate.
 ---
 
-import { Badge } from '@astrojs/starlight/components';
-import { Aside } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import { Image } from 'astro:assets';
 import sqlIcon from '@assets/icons/sql-icon.png';
@@ -33,16 +32,24 @@ To get started with the Aspire Community Toolkit SQL Server hosting extensions, 
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.SqlServer.Extensions" />
 
-<Aside type="note">
-  TypeScript AppHost support for the Community Toolkit `withDbGate` and
-  `withAdminer` extensions is not yet available.
-</Aside>
+For TypeScript AppHosts, add the Community Toolkit SQL Server extensions package to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.SqlServer.Extensions": "*"
+  }
+}
+```
 
 ## Add management UI
 
 ### DbGate management UI
 
 To add the [DbGate](https://dbgate.org/) management UI to your SQL Server resource, call the `WithDbGate` method on the `SqlServerResourceBuilder` instance:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -56,16 +63,34 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  TypeScript AppHost support for combining these Community Toolkit management UI
-  extension methods isn't yet available.
-</Aside>
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sqlserver = await builder.addSqlServer("sqlserver");
+await sqlserver.withDbGate();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(sqlserver);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 This adds a new DbGate resource to the AppHost which is available from the Aspire dashboard. DbGate is a comprehensive database management tool that provides a web-based interface for managing your SQL Server databases.
 
 ### Adminer management UI
 
 To add the [Adminer](https://adminer.org/) management UI to your SQL Server resource, call the `WithAdminer` method on the `SqlServerResourceBuilder` instance:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -79,11 +104,34 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sqlserver = await builder.addSqlServer("sqlserver");
+await sqlserver.withAdminer();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(sqlserver);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 This adds a new Adminer resource to the AppHost which is available from the Aspire dashboard. Adminer is a lightweight database management tool that provides a simple web interface for database operations.
 
 ### Using both management UIs
 
 You can use both management UIs together on the same SQL Server resource:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -97,6 +145,27 @@ builder.AddProject<Projects.ExampleProject>("api")
 
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sqlserver = await builder.addSqlServer("sqlserver");
+await sqlserver.withDbGate();
+await sqlserver.withAdminer();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(sqlserver);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 ## See also
 

--- a/src/frontend/src/content/docs/integrations/devtools/dab.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/dab.mdx
@@ -99,7 +99,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -149,7 +149,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -191,7 +191,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -234,7 +234,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/devtools/dab.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/dab.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Aspire Data API Builder hosting integration to
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 import dabIcon from '@assets/icons/data-api-builder-icon.png';
 
@@ -21,10 +21,6 @@ import dabIcon from '@assets/icons/data-api-builder-icon.png';
 />
 
 This article is the reference for the Aspire Data API Builder hosting integration. It enumerates the AppHost APIs that you use to model a [Data API Builder](https://learn.microsoft.com/azure/data-api-builder/overview) (DAB) resource in your [`AppHost`](/get-started/app-host/) project. DAB is an open-source tool that generates REST and GraphQL APIs directly from your database schema.
-
-:::note
-TypeScript AppHost support for the Data API Builder integration is not yet available. The examples on this page use the C# AppHost only.
-:::
 
 ## Installation
 
@@ -54,7 +50,25 @@ Or, choose a manual installation approach:
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the Data API Builder integration is not yet available.
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder
+```
+
+<LearnMore>
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+</LearnMore>
+
+This updates your `aspire.config.json` with the Data API Builder hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder": "*"
+  }
+}
+```
+
+The TypeScript AppHost bindings for Data API Builder are provided by the Community Toolkit package. After installation, the `.aspire/modules/aspire.mjs` file in your project includes `addDataAPIBuilder` and related APIs.
 
 </TabItem>
 </Tabs>
@@ -85,7 +99,23 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the Data API Builder integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sqldb = await (await builder.addSqlServer("sql")).addDatabase("sqldb");
+
+const dab = await builder.addDataAPIBuilder("dab");
+await dab.withReference(sqldb);
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(dab);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -94,7 +124,7 @@ The Data API Builder integration automatically discovers and uses `dab-config.js
 
 ## Multiple configuration files
 
-Data API Builder supports multiple configuration files for different databases. To specify multiple configuration files, pass an array of config file paths to `AddDataAPIBuilder`:
+Data API Builder supports multiple configuration files for different databases. To specify multiple configuration files, pass an array of config file paths to `AddDataAPIBuilder` or `addDataAPIBuilder`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -119,7 +149,22 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the Data API Builder integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await (await builder.addSqlServer("sql")).addDatabase("sqldb");
+const postgres = await (await builder.addPostgres("postgres")).addDatabase("postgresdb");
+
+const dab = await builder.addDataAPIBuilder("dab", {
+    configFilePaths: ["dab-config.SqlServer.json", "dab-config.PostgreSQL.json"],
+});
+await dab.withReference(sql);
+await dab.withReference(postgres);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -146,14 +191,25 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the Data API Builder integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const dab = await builder.addDataAPIBuilder("dab");
+await dab.withImageRegistry("myregistry.azurecr.io");
+await dab.withImage("custom-dab");
+await dab.withImageTag("1.0.0");
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
 
 ## Database references
 
-Data API Builder requires references to the databases it exposes. Use `WithReference` to connect Data API Builder to your databases:
+Data API Builder requires references to the databases it exposes. Use `WithReference` or `withReference` to connect Data API Builder to your databases:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -178,7 +234,20 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the Data API Builder integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await (await builder.addSqlServer("sql")).addDatabase("sqldb");
+const cosmos = await (await builder.addAzureCosmosDB("cosmos")).addCosmosDatabase("cosmosdb");
+
+const dab = await builder.addDataAPIBuilder("dab");
+await dab.withReference(sql);
+await dab.withReference(cosmos);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/integrations/devtools/k6.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/k6.mdx
@@ -21,10 +21,6 @@ import k6Icon from '@assets/icons/k6-icon.svg';
 
 This article is the reference for the Aspire k6 Hosting integration. It enumerates the AppHost APIs that you use to model a [Grafana k6](https://k6.io/) performance and load-testing resource in your [`AppHost`](/get-started/app-host/) project.
 
-:::note
-TypeScript AppHost support for the k6 integration is not yet available. The examples on this page use the C# AppHost only.
-:::
-
 ## Installation
 
 To start building an Aspire app that uses k6, install the [📦 CommunityToolkit.Aspire.Hosting.k6](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.k6) NuGet package:
@@ -53,7 +49,25 @@ Or, choose a manual installation approach:
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the k6 integration is not yet available.
+```bash title="Terminal"
+aspire add k6
+```
+
+<LearnMore>
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+</LearnMore>
+
+This updates your `aspire.config.json` with the k6 hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.k6": "*"
+  }
+}
+```
+
+The TypeScript AppHost bindings for k6 are provided by the Community Toolkit package. After installation, the `.aspire/modules/aspire.mjs` file in your project includes `addK6` and related APIs.
 
 </TabItem>
 </Tabs>
@@ -83,7 +97,21 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the k6 integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const myService = await builder.addProject("myService", "../MyService/MyService.csproj");
+
+const k6 = await builder.addK6("k6");
+await k6.withBindMount("scripts", "/scripts", { isReadOnly: true });
+await k6.withScript("/scripts/main.js");
+await k6.withReference(myService);
+await k6.waitFor(myService);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -91,7 +119,7 @@ TypeScript AppHost support for the k6 integration is not yet available.
 When Aspire adds a container image to the AppHost, as shown in the preceding example with the `docker.io/grafana/k6` image, it creates a new k6 instance on your local machine.
 
 <Aside type="caution">
-The k6 container requires a JavaScript entrypoint to run successfully. Use `WithBindMount` to mount the directory that contains your scripts, and `WithScript` to specify the JavaScript entrypoint file.
+The k6 container requires a JavaScript entrypoint to run successfully. Use `WithBindMount` (or `withBindMount`) to mount the directory that contains your scripts, and `WithScript` (or `withScript`) to specify the JavaScript entrypoint file.
 </Aside>
 
 ## Scripts configuration
@@ -115,7 +143,7 @@ For more information on writing k6 scripts, see [Write your first test with Graf
 
 ## Customize ports
 
-To use a fixed host port instead of a randomly assigned one, pass the `port` parameter to `AddK6`:
+To use a fixed host port instead of a randomly assigned one, pass the `port` parameter to `AddK6` or `addK6`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -138,7 +166,21 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the k6 integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const myService = await builder.addProject("myService", "../MyService/MyService.csproj");
+
+const k6 = await builder.addK6("k6", { port: 6565 });
+await k6.withBindMount("scripts", "/scripts", { isReadOnly: true });
+await k6.withScript("/scripts/main.js");
+await k6.withReference(myService);
+await k6.waitFor(myService);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -147,7 +189,7 @@ The `port` parameter sets the host port for the k6 HTTP API endpoint. When omitt
 
 ## Enable browser extensions
 
-To enable the k6 browser module — which adds browser-level APIs and frontend performance metrics to your k6 tests — pass `enableBrowserExtensions: true` to `AddK6`:
+To enable the k6 browser module — which adds browser-level APIs and frontend performance metrics to your k6 tests — pass `enableBrowserExtensions: true` to `AddK6` or `addK6`:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -170,7 +212,21 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-TypeScript AppHost support for the k6 integration is not yet available.
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const myService = await builder.addProject("myService", "../MyService/MyService.csproj");
+
+const k6 = await builder.addK6("k6", { enableBrowserExtensions: true });
+await k6.withBindMount("scripts", "/scripts", { isReadOnly: true });
+await k6.withScript("/scripts/main.js");
+await k6.withReference(myService);
+await k6.waitFor(myService);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/integrations/devtools/k6.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/k6.mdx
@@ -97,7 +97,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -166,7 +166,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -212,7 +212,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
@@ -90,7 +90,7 @@ Your SQL database project must use either [MSBuild.Sdk.SqlProj](https://github.c
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -178,7 +178,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -225,7 +225,7 @@ sql.AddSqlProject<Projects.DatabaseProject>("database-project")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -280,7 +280,7 @@ db2.AddSqlProject<Projects.Database2Project>("db2-project");
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -324,7 +324,7 @@ db1.AddSqlProject<Projects.Database1Project>("db1-project")
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects.mdx
@@ -26,11 +26,32 @@ The Aspire SQL Database Projects hosting integration enables you to deploy SQL d
 
 To get started with the Aspire SQL Database Projects hosting integration, install the [CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects) NuGet package in the app host project.
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects" />
 
-<Aside type="note">
-  This integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is only available for C# AppHost projects. TypeScript AppHost support is not currently provided.
-</Aside>
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects
+```
+
+This updates your `aspire.config.json` with the SQL Database Projects hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects": "*"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
+The TypeScript AppHost bindings for SQL Database Projects are provided by the Community Toolkit package. After installation, the `.aspire/modules/aspire.mjs` file in your project includes `addSqlProject` and related APIs.
 
 ### Add SQL project
 
@@ -68,9 +89,26 @@ Your SQL database project must use either [MSBuild.Sdk.SqlProj](https://github.c
 </Aside>
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
-</Aside>
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await builder.addSqlServer("sql");
+const sqldb = await sql.addDatabase("sqldb");
+
+const databaseProject = await builder.addSqlProject("database-project");
+await databaseProject.withReference(sqldb);
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(sqldb);
+
+// After adding all resources, run the app...
+```
+
 </TabItem>
 </Tabs>
 
@@ -110,9 +148,11 @@ When using NuGet packages, mark them with the `IsAspirePackageResource` metadata
 </Aside>
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
+
+<Aside type="note">
+  The current TypeScript AppHost bindings for this integration don't expose an `addSqlPackage` API. Use the C# AppHost to deploy a SQL database schema directly from a NuGet package.
 </Aside>
+
 </TabItem>
 </Tabs>
 
@@ -137,9 +177,27 @@ builder.AddProject<Projects.ExampleProject>()
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
-</Aside>
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await builder.addSqlServer("sql");
+const sqldb = await sql.addDatabase("sqldb");
+
+const databaseProject = await builder.addSqlProject("database-project");
+await databaseProject.withDacpac("path/to/database.dacpac");
+await databaseProject.withReference(sqldb);
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(sqldb);
+
+// After adding all resources, run the app...
+```
+
 </TabItem>
 </Tabs>
 
@@ -166,9 +224,26 @@ sql.AddSqlProject<Projects.DatabaseProject>("database-project")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await builder.addSqlServer("sql");
+const sqldb = await sql.addDatabase("sqldb");
+
+const databaseProject = await builder.addSqlProject("database-project");
+await databaseProject.withReference(sqldb);
+await databaseProject.withDacDeployOptions("path/to/database.publish.xml");
+
+// After adding all resources, run the app...
+```
+
+<Aside type="note">
+  The current TypeScript AppHost bindings expose `withDacDeployOptions` for publish profile paths, but don't expose the `WithConfigureDacDeployOptions` callback API. Use the C# AppHost when you need to configure DAC deployment options inline.
 </Aside>
+
 </TabItem>
 </Tabs>
 
@@ -204,9 +279,25 @@ db2.AddSqlProject<Projects.Database2Project>("db2-project");
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
-</Aside>
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await builder.addSqlServer("sql");
+
+const db1 = await sql.addDatabase("db1");
+const db1Project = await builder.addSqlProject("db1-project");
+await db1Project.withReference(db1);
+
+const db2 = await sql.addDatabase("db2");
+const db2Project = await builder.addSqlProject("db2-project");
+await db2Project.withReference(db2);
+
+// After adding all resources, run the app...
+```
+
 </TabItem>
 </Tabs>
 
@@ -232,9 +323,25 @@ db1.AddSqlProject<Projects.Database1Project>("db1-project")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-<Aside type="caution">
-  TypeScript AppHost support is not available for this Community Toolkit integration.
-</Aside>
+
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const sql = await builder.addSqlServer("sql");
+await sql.withDataVolume("data");
+await sql.withLifetime("Persistent");
+
+const db1 = await sql.addDatabase("db1");
+
+const db1Project = await builder.addSqlProject("db1-project");
+await db1Project.withReference(db1);
+await db1Project.withSkipWhenDeployed();
+
+// After adding all resources, run the app...
+```
+
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
@@ -367,7 +367,18 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose an `asExisting(...)` API for Kafka. To connect to an existing Kafka instance from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const kafka = await builder.addConnectionString("kafka");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(kafka);
+
+// After adding all resources, run the app...
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
@@ -367,7 +367,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Aspire LavinMQ Hosting integration to orchestr
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import lavinmqIcon from '@assets/icons/lavinmq-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
@@ -20,10 +20,6 @@ import lavinmqIcon from '@assets/icons/lavinmq-icon.png';
 />
 
 This article is the reference for the Aspire LavinMQ Hosting integration. It enumerates the AppHost APIs that you use to model a LavinMQ resource in your [`AppHost`](/get-started/app-host/) project. [LavinMQ](https://lavinmq.com/) is a high-performance message broker that implements the AMQP 0.9.1 protocol and is wire-compatible with RabbitMQ. The integration provisions a LavinMQ instance using the `docker.io/cloudamqp/lavinmq` container image.
-
-<Aside type="note">
-  TypeScript AppHost support for the LavinMQ integration is not yet available. The examples on this page use the C# AppHost only.
-</Aside>
 
 ## Installation
 
@@ -49,9 +45,21 @@ Or, choose a manual installation approach:
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-<Aside type="caution">
-  TypeScript AppHost support (`addLavinMQ` and related APIs) is not yet available for this community integration. Use the C# AppHost tab for installation instructions.
-</Aside>
+```bash title="Terminal"
+aspire add lavinmq
+```
+
+This updates your `aspire.config.json` with the LavinMQ hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.LavinMQ": "*"
+  }
+}
+```
+
+The TypeScript AppHost bindings for LavinMQ are provided by the Community Toolkit package. After installation, the `.aspire/modules/aspire.mjs` file in your project includes `addLavinMQ` and related APIs.
 
 </TabItem>
 </Tabs>
@@ -75,9 +83,20 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-<Aside type="caution">
-  TypeScript AppHost support for the LavinMQ integration is not yet available.
-</Aside>
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const lavinmq = await builder.addLavinMQ("lavinmq");
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(lavinmq);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -86,7 +105,7 @@ When Aspire adds a container image to the AppHost, as shown in the preceding exa
 
 ## Add LavinMQ resource with data volume
 
-To add data volumes for persisting LavinMQ data, call the `WithDataVolume` method:
+To add data volumes for persisting LavinMQ data, call the `WithDataVolume` or `withDataVolume` method:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -104,9 +123,21 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-<Aside type="caution">
-  TypeScript AppHost support for the LavinMQ integration is not yet available.
-</Aside>
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const lavinmq = await builder.addLavinMQ("lavinmq");
+await lavinmq.withDataVolume("lavinmq-data");
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(lavinmq);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -115,7 +146,7 @@ The data volume is used to persist the LavinMQ data outside the lifecycle of the
 
 ## Add LavinMQ resource with data bind mount
 
-For development scenarios, you may want to use bind mounts instead of data volumes. To add a data bind mount, call the `WithDataBindMount` method:
+For development scenarios, you may want to use bind mounts instead of data volumes. To add a data bind mount, call the `WithDataBindMount` or `withDataBindMount` method:
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -133,9 +164,21 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-<Aside type="caution">
-  TypeScript AppHost support for the LavinMQ integration is not yet available.
-</Aside>
+```typescript title="TypeScript — apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const lavinmq = await builder.addLavinMQ("lavinmq");
+await lavinmq.withDataBindMount("/LavinMQ/Data");
+
+const exampleProject = await builder.addProject(
+    "example-project",
+    "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(lavinmq);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq.mdx
@@ -83,7 +83,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -123,7 +123,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();
@@ -164,7 +164,7 @@ builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="TypeScript — apphost.mts" twoslash
+```typescript title="TypeScript — apphost.mts"
 import { createBuilder } from "./.aspire/modules/aspire.mjs";
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
@@ -163,7 +163,8 @@ import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const seq = await builder.addSeq("seq", "admin-password");
+const adminPassword = await builder.addParameter("seq-admin-password", { secret: true });
+const seq = await builder.addSeq("seq", adminPassword);
 await seq.withDataVolume();
 await seq.excludeFromManifest();
 await seq.withLifetime(ContainerLifetime.Persistent);

--- a/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
@@ -158,7 +158,24 @@ var myService = builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-The TypeScript AppHost doesn't currently expose a `withDataVolume(...)` API for Seq. To persist Seq data from a TypeScript AppHost, use [`withBindMount`](/get-started/app-host/) to map a host directory into the container at `/data` instead.
+```typescript title="apphost.mts" twoslash
+import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const seq = await builder.addSeq("seq", "admin-password");
+await seq.withDataVolume();
+await seq.excludeFromManifest();
+await seq.withLifetime(ContainerLifetime.Persistent);
+await seq.withEnvironment("ACCEPT_EULA", "Y");
+
+const myService = await builder.addProject("example", "../ExampleProject/ExampleProject.csproj");
+await myService
+    .withReference(seq)
+    .waitFor(seq);
+
+// After adding all resources, run the app...
+```
 
 </TabItem>
 </Tabs>
@@ -231,4 +248,3 @@ For the full reference of Seq connection properties — and how consuming apps i
 ## Hosting integration health checks
 
 The Seq hosting integration does not automatically register a health check. Seq availability is typically verified by the consuming app's client integration or by using `.WaitFor(seq)` in the AppHost to delay dependent resources until the Seq container is ready.
-

--- a/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
@@ -158,7 +158,7 @@ var myService = builder.AddProject<Projects.ExampleProject>()
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
@@ -189,13 +189,9 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
+import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
-
-const referenceExpression = (value: string): ReferenceExpression => ({
-  getValueAsync: () => value,
-});
 
 const api = await builder.addContainer("api", {
   image: "my-api",
@@ -206,9 +202,9 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withHttpsCertificateConfig(async () => ({
-    certificatePath: referenceExpression("/certs/tls.crt"),
-    keyPath: referenceExpression("/certs/tls.key"),
-    pfxPath: referenceExpression("/certs/tls.pfx"),
+    certificatePath: refExpr`/certs/tls.crt`,
+    keyPath: refExpr`/certs/tls.key`,
+    pfxPath: refExpr`/certs/tls.pfx`,
   }));
 
 await builder.build().run();
@@ -298,13 +294,9 @@ builder.Build().Run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
+import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
-
-const referenceExpression = (value: string): ReferenceExpression => ({
-  getValueAsync: () => value,
-});
 
 const api = await builder.addContainer("api", {
   image: "myimage",
@@ -315,8 +307,8 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withCertificateTrustConfig(async () => ({
-    certificateBundlePath: referenceExpression("/certs/ca-bundle.crt"),
-    certificateDirectoriesPath: referenceExpression("/certs"),
+    certificateBundlePath: refExpr`/certs/ca-bundle.crt`,
+    certificateDirectoriesPath: refExpr`/certs`,
     rootCertificatesPath: "/etc/ssl/certs",
     isContainer: true,
   }));

--- a/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
@@ -188,9 +188,27 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-<Aside type="note">
-  この API はまだ TypeScript AppHost では利用できません。
-</Aside>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addContainer("api", {
+  image: "my-api",
+  tag: "latest",
+});
+
+api.createExecutionConfiguration()
+  .withArgumentsConfig()
+  .withEnvironmentVariablesConfig()
+  .withHttpsCertificateConfig(async () => ({
+    certificatePath: builder.createReferenceExpression`/certs/tls.crt`,
+    keyPath: builder.createReferenceExpression`/certs/tls.key`,
+    pfxPath: builder.createReferenceExpression`/certs/tls.pfx`,
+  }));
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 
@@ -275,9 +293,28 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-<Aside type="note">
-  この API はまだ TypeScript AppHost では利用できません。
-</Aside>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addContainer("api", {
+  image: "myimage",
+  tag: "latest",
+});
+
+api.createExecutionConfiguration()
+  .withArgumentsConfig()
+  .withEnvironmentVariablesConfig()
+  .withCertificateTrustConfig(async () => ({
+    certificateBundlePath: builder.createReferenceExpression`/certs/ca-bundle.crt`,
+    certificateDirectoriesPath: builder.createReferenceExpression`/certs`,
+    rootCertificatesPath: "/etc/ssl/certs",
+    isContainer: true,
+  }));
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/ja/app-host/certificate-configuration.mdx
@@ -188,10 +188,14 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+```typescript title="apphost.mts" twoslash
+import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
+
+const referenceExpression = (value: string): ReferenceExpression => ({
+  getValueAsync: () => value,
+});
 
 const api = await builder.addContainer("api", {
   image: "my-api",
@@ -202,9 +206,9 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withHttpsCertificateConfig(async () => ({
-    certificatePath: builder.createReferenceExpression`/certs/tls.crt`,
-    keyPath: builder.createReferenceExpression`/certs/tls.key`,
-    pfxPath: builder.createReferenceExpression`/certs/tls.pfx`,
+    certificatePath: referenceExpression("/certs/tls.crt"),
+    keyPath: referenceExpression("/certs/tls.key"),
+    pfxPath: referenceExpression("/certs/tls.pfx"),
   }));
 
 await builder.build().run();
@@ -293,10 +297,14 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+```typescript title="apphost.mts" twoslash
+import { createBuilder, type ReferenceExpression } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
+
+const referenceExpression = (value: string): ReferenceExpression => ({
+  getValueAsync: () => value,
+});
 
 const api = await builder.addContainer("api", {
   image: "myimage",
@@ -307,8 +315,8 @@ api.createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withCertificateTrustConfig(async () => ({
-    certificateBundlePath: builder.createReferenceExpression`/certs/ca-bundle.crt`,
-    certificateDirectoriesPath: builder.createReferenceExpression`/certs`,
+    certificateBundlePath: referenceExpression("/certs/ca-bundle.crt"),
+    certificateDirectoriesPath: referenceExpression("/certs"),
     rootCertificatesPath: "/etc/ssl/certs",
     isContainer: true,
   }));

--- a/src/frontend/src/content/docs/ja/app-host/container-files.mdx
+++ b/src/frontend/src/content/docs/ja/app-host/container-files.mdx
@@ -89,7 +89,7 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/app-host/container-files.mdx
+++ b/src/frontend/src/content/docs/ja/app-host/container-files.mdx
@@ -89,9 +89,19 @@ builder.Build().Run();
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-`withContainerFiles` API は、TypeScript AppHost SDK ではまだ利用できません。
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const frontend = await builder.addViteApp("frontend", "../frontend");
+await frontend.withContainerFilesSource("/app/dist");
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.publishWithContainerFiles(frontend, "./wwwroot");
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/ja/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/ja/deployment/pipelines.mdx
@@ -295,7 +295,7 @@ var api = builder.AddProject<Api>("api").WithReference(database);
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/ja/deployment/pipelines.mdx
@@ -295,9 +295,29 @@ var api = builder.AddProject<Api>("api").WithReference(database);
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
-:::note
-TypeScript AppHost SDK では `builder.pipeline` API はまだ利用できないため、このカスタムパイプラインの例は現在 C# のみです。
-:::
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// カスタムデプロイ検証を追加
+builder.pipeline.addStep("validate-deployment", async (context) => {
+  // カスタム検証ロジック
+  await validateApiHealth(context);
+  await validateDatabaseConnection(context);
+}, { requiredBy: ["deploy"] });
+
+// リソースを定義
+const database = await builder.addPostgres("myapp-db");
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withReference(database);
+
+async function validateApiHealth(_context: unknown) {
+}
+
+async function validateDatabaseConnection(_context: unknown) {
+}
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
@@ -236,7 +236,7 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { InputType, createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/ja/fundamentals/external-parameters.mdx
@@ -236,9 +236,27 @@ builder.Build().Run();
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-:::note
-`withDescription` と `withCustomInput` API は、TypeScript AppHost SDK ではまだ利用できません。
-:::
+```typescript title="apphost.mts" twoslash
+import { InputType, createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const externalServiceUrl = await builder.addParameter('external-service-url');
+await externalServiceUrl
+  .withDescription(
+    'The URL of the external service. See [example.com](https://example.com) for details.',
+    { enableMarkdown: true }
+  )
+  .withCustomInput({
+    inputType: InputType.Text,
+    label: 'External service URL',
+    placeholder: 'Enter value for external-service-url',
+  });
+
+await builder.addExternalService('external-service', externalServiceUrl);
+
+await builder.build().run();
+```
 
 </TabItem>
 </Tabs>

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -189,7 +189,7 @@ await builder.build().run();
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
-```typescript title="apphost.mts" twoslash
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -187,6 +187,23 @@ await builder.build().run();
 ```
 
 </TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const blazorApp = await builder.addBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj");
+
+const gateway = await builder.addBlazorGateway("gateway");
+await gateway.withExternalHttpEndpoints();
+await gateway.withBlazorClientApp(blazorApp);
+
+await builder.build().run();
+```
+
+</TabItem>
 </Tabs>
 
 <Aside type="note">


### PR DESCRIPTION
## Summary
- Add supported TypeScript AppHost examples for docs-only gaps identified by the language audit
- Add TypeScript package/config guidance for Community Toolkit integrations
- Keep C#-only notes where TypeScript APIs are still unavailable

## Validation
- pnpm --dir ./src/frontend test:unit:twoslash-blocks
- git --no-pager diff --check