### PR TITLE
[docs] Fix Service Bus emulator companion container image name

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
@@ -374,7 +374,7 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-When you call `runAsEmulator`, Aspire provisions the `mcr.microsoft.com/azure-messaging/servicebus-emulator` container and its companion `mcr.microsoft.com/azure-sql-edge` container locally. The emulator starts alongside your AppHost instead of requiring an Azure subscription. For more information, see [Container resource lifecycle](/architecture/resource-model/#built-in-resources-and-lifecycle).
+When you call `runAsEmulator`, Aspire provisions the `mcr.microsoft.com/azure-messaging/servicebus-emulator` container and its companion `mcr.microsoft.com/mssql/server` container locally. The emulator starts alongside your AppHost instead of requiring an Azure subscription. For more information, see [Container resource lifecycle](/architecture/resource-model/#built-in-resources-and-lifecycle).
 
 By default, the Service Bus emulator container exposes the following endpoints:
 


### PR DESCRIPTION
## Description

The Azure Service Bus hosting docs said the emulator's companion container is `mcr.microsoft.com/azure-sql-edge`, but it has been `mcr.microsoft.com/mssql/server` since microsoft/aspire#10378 (Azure SQL Edge is retired and crashes on ARM/newer kernels).

This updates the prose at line 377 of `azure-service-bus-host.mdx` to match the endpoint table just below it, which already correctly lists `mcr.microsoft.com/mssql/server`. A repo-wide grep confirms no remaining `azure-sql-edge` references.

Fixes #1208