### PR TITLE
Update docs banners for Aspire 13.4

### DIFF
--- a/src/frontend/src/content/docs/community/index.mdx
+++ b/src/frontend/src/content/docs/community/index.mdx
@@ -7,7 +7,7 @@ next: false
 description: Connect with the Aspire team and community across Discord, GitHub Discussions, livestreams, social channels, and contribution platforms for distributed apps.
 banner:
   content: |
-    <strong>Aspire 13.3 is here!</strong> — <a href="/whats-new/aspire-13-3/">See what's new</a>
+    <strong>Aspire 13.4 is here!</strong> — <a href="/whats-new/aspire-13-4/">See what's new</a>
 editUrl: false
 giscus: false
 tableOfContents: false

--- a/src/frontend/src/content/docs/docs.mdx
+++ b/src/frontend/src/content/docs/docs.mdx
@@ -7,7 +7,7 @@ next:
 description: "Browse the official Aspire documentation: get started with C# and TypeScript AppHosts, model distributed apps, deploy to Azure and Kubernetes, and observe in the dashboard."
 banner:
   content: |
-    <strong>🆕 Aspire 13.3 is here!</strong> — <a href="/whats-new/aspire-13-3/">See what's new</a>
+    <strong>🆕 Aspire 13.4 is here!</strong> — <a href="/whats-new/aspire-13-4/">See what's new</a>
 editUrl: false
 tableOfContents: false
 pageActions: false

--- a/src/frontend/src/content/docs/ja/docs.mdx
+++ b/src/frontend/src/content/docs/ja/docs.mdx
@@ -7,7 +7,7 @@ next:
 description: Aspire を使って、C#、TypeScript、JavaScript、Python などの分散アプリケーションを設計・実行・観測・デプロイする方法を学べます。
 banner:
   content: |
-    <strong>🆕 Aspire 13.3 が登場！</strong> — <a href="/ja/whats-new/aspire-13-3/">新機能を見る</a>
+    <strong>🆕 Aspire 13.4 が登場！</strong> — <a href="/ja/whats-new/aspire-13-4/">新機能を見る</a>
 editUrl: false
 tableOfContents: false
 pageActions: false


### PR DESCRIPTION
## Summary
- Update stale latest-version banners from Aspire 13.3 to Aspire 13.4 on the docs home route, Japanese docs home route, and community page.
- Point banner links at the Aspire 13.4 what's-new pages.

## Validation
- Searched docs banner frontmatter for remaining Aspire 13.3 / aspire-13-3 references.