### PR TITLE
Fix Markdown table rendering

### DIFF
--- a/.agents/skills/doc-writer/SKILL.md
+++ b/.agents/skills/doc-writer/SKILL.md
@@ -146,6 +146,18 @@ When you introduce or change a custom component that is used by docs pages:
 - Prefer moving heavier shared logic into colocated `.ts` helpers when the `.astro` frontmatter becomes large or is duplicated across components.
 - Treat user-visible behavior, accessibility, and responsive behavior as part of the documentation contract, not as optional polish.
 
+### Common Markdown syntax
+
+Use the rendered examples in `src/frontend/src/content/docs/community/contributor-guide.mdx` as the canonical reference for common Markdown syntax. When adding tables, use padded pipes, a separator row with at least three hyphens per cell, and blank lines before and after the table:
+
+```md
+| Feature | Description | Status |
+| ------- | ----------- | ------ |
+| Dashboard | Web-based monitoring | Available |
+```
+
+Do not replace standard Markdown with ad hoc HTML unless a component or layout requirement cannot be expressed clearly in Markdown.
+
 #### Aside (Callouts)
 
 Prefer fenced `:::` callouts for tips, notes, cautions, and warnings. Use the `Aside` component only when a JSX-only composition pattern is required.

--- a/src/frontend/astro.config.mjs
+++ b/src/frontend/astro.config.mjs
@@ -10,6 +10,7 @@ import { socialConfig } from './config/socials.config.ts';
 import catppuccin from '@catppuccin/starlight';
 import lunaria from './config/lunaria-starlight.mjs';
 import mermaid from 'astro-mermaid';
+import mdx from '@astrojs/mdx';
 import starlight from '@astrojs/starlight';
 import starlightGitHubAlerts from 'starlight-github-alerts';
 import starlightImageZoom from 'starlight-image-zoom';
@@ -223,6 +224,10 @@ export default defineConfig({
           ],
         }),
       ],
+    }),
+    mdx({
+      optimize: true,
+      gfm: true,
     }),
     jopSoftwarecookieconsent(cookieConfig),
     ...(isBuildTimingEnabled ? [buildTiming()] : []),

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@astro-community/astro-embed-vimeo": "^0.3.12",
     "@astro-community/astro-embed-youtube": "^0.5.10",
+    "@astrojs/mdx": "^5.0.6",
     "@astrojs/rss": "^4.0.18",
     "@astrojs/starlight": "^0.39.3",
     "@catppuccin/starlight": "^2.0.1",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@astro-community/astro-embed-youtube':
         specifier: ^0.5.10
         version: 0.5.10
+      '@astrojs/mdx':
+        specifier: ^5.0.6
+        version: 5.0.6(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))
       '@astrojs/rss':
         specifier: ^4.0.18
         version: 4.0.18
@@ -265,14 +268,8 @@ packages:
   '@astrojs/internal-helpers@0.10.0':
     resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
 
-  '@astrojs/internal-helpers@0.9.0':
-    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
-
   '@astrojs/internal-helpers@0.9.1':
     resolution: {integrity: sha512-1pWuARqYom/TzuU3+0ZugsTrKlUydWKuULmDqSMTuonY+9IRDUEGKX/8PXQ1nBxRq3w85uGtd9q9SXfqEldMIQ==}
-
-  '@astrojs/markdown-remark@7.1.1':
-    resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
 
   '@astrojs/markdown-remark@7.1.2':
     resolution: {integrity: sha512-caXZ4Dc2St2dW8luEg22GlP0gupLdztCTQE4EzZOxW1pqWXz9mbeJEuHUkgDYcKWW8tjIHkydYDhWLVoxJ327Q==}
@@ -280,21 +277,11 @@ packages:
   '@astrojs/markdown-remark@7.2.0':
     resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
-  '@astrojs/mdx@5.0.4':
-    resolution: {integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==}
-    engines: {node: '>=22.12.0'}
-    peerDependencies:
-      astro: ^6.0.0
-
   '@astrojs/mdx@5.0.6':
     resolution: {integrity: sha512-4dKe0ZMmqujofPNDHahzClkwinn9f8jHPcaXcgdGvPAlboD2mjzkUCofli2cBnxYAkdfhC6d50gBJ8i/cH8gHw==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       astro: ^6.0.0
-
-  '@astrojs/prism@4.0.1':
-    resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
-    engines: {node: '>=22.12.0'}
 
   '@astrojs/prism@4.0.2':
     resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
@@ -3840,39 +3827,9 @@ snapshots:
       smol-toml: 1.6.1
       unified: 11.0.5
 
-  '@astrojs/internal-helpers@0.9.0':
-    dependencies:
-      picomatch: 4.0.4
-
   '@astrojs/internal-helpers@0.9.1':
     dependencies:
       picomatch: 4.0.4
-
-  '@astrojs/markdown-remark@7.1.1':
-    dependencies:
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/prism': 4.0.1
-      github-slugger: 2.0.0
-      hast-util-from-html: 2.0.3
-      hast-util-to-text: 4.0.2
-      js-yaml: 4.2.0
-      mdast-util-definitions: 6.0.0
-      rehype-raw: 7.0.0
-      rehype-stringify: 10.0.1
-      remark-gfm: 4.0.1
-      remark-parse: 11.0.0
-      remark-rehype: 11.1.2
-      remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.2.0
-      smol-toml: 1.6.1
-      unified: 11.0.5
-      unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.1.0
-      unist-util-visit-parents: 6.0.2
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
 
   '@astrojs/markdown-remark@7.1.2':
     dependencies:
@@ -3922,25 +3879,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.4(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))':
-    dependencies:
-      '@astrojs/markdown-remark': 7.1.1
-      '@mdx-js/mdx': 3.1.1
-      acorn: 8.16.0
-      astro: 6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3)
-      es-module-lexer: 2.1.0
-      estree-util-visit: 2.0.0
-      hast-util-to-html: 9.0.5
-      piccolore: 0.1.3
-      rehype-raw: 7.0.0
-      remark-gfm: 4.0.1
-      remark-smartypants: 3.0.2
-      source-map: 0.7.6
-      unist-util-visit: 5.1.0
-      vfile: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
   '@astrojs/mdx@5.0.6(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.2
@@ -3959,10 +3897,6 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  '@astrojs/prism@4.0.1':
-    dependencies:
-      prismjs: 1.30.0
 
   '@astrojs/prism@4.0.2':
     dependencies:
@@ -7567,7 +7501,7 @@ snapshots:
 
   starlight-llms-txt@0.8.1(patch_hash=7658403d32d5d5b5ab83d2a08f9c41a41f2d4df7f9138db45e52e6336c4599bb)(@astrojs/starlight@0.39.3(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))(typescript@6.0.3))(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3)):
     dependencies:
-      '@astrojs/mdx': 5.0.4(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@astrojs/mdx': 5.0.6(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))
       '@astrojs/starlight': 0.39.3(astro@6.4.4(@types/node@24.12.4)(jiti@1.21.7)(rollup@4.61.0)(tsx@4.22.4)(yaml@2.8.3))(typescript@6.0.3)
       '@types/hast': 3.0.4
       '@types/micromatch': 4.0.10

--- a/src/frontend/src/content/docs/community/contributor-guide.mdx
+++ b/src/frontend/src/content/docs/community/contributor-guide.mdx
@@ -391,23 +391,23 @@ Renders as:
 
 ### Tables
 
-Create tables using pipes `|` and hyphens `-`:
+Create tables using pipes `|` and hyphens `-`. Keep a blank line before and after the table, include one separator cell for each heading, and use at least three hyphens in each separator cell:
 
 ```md title="src/content/docs/example.md"
 | Feature | Description | Status |
-|--|--|--|
-| Dashboard | Web-based monitoring | ✅ Available |
-| Telemetry | OpenTelemetry support | ✅ Available |
-| Deployment | Kubernetes deployment | 🚧 Preview |
+| ------- | ----------- | ------ |
+| Dashboard | Web-based monitoring | Available |
+| Telemetry | OpenTelemetry support | Available |
+| Deployment | Kubernetes deployment | Preview |
 ```
 
 Renders as:
 
 | Feature | Description | Status |
-|--|--|--|
-| Dashboard | Web-based monitoring | ✅ Available |
-| Telemetry | OpenTelemetry support | ✅ Available |
-| Deployment | Kubernetes deployment | 🚧 Preview |
+| ------- | ----------- | ------ |
+| Dashboard | Web-based monitoring | Available |
+| Telemetry | OpenTelemetry support | Available |
+| Deployment | Kubernetes deployment | Preview |
 
 <Aside type="tip">
   You can align columns using colons: `| :--- |` for left, `| :---: |` for center, and `| ---: |` for right alignment.

--- a/src/frontend/tests/e2e/markdown-rendering.spec.ts
+++ b/src/frontend/tests/e2e/markdown-rendering.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from '@playwright/test';
+
+import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
+
+test('contributor guide renders common Markdown as semantic HTML', async ({ page }) => {
+  await page.goto('/community/contributor-guide/#write-markdown');
+  await dismissCookieConsentIfVisible(page);
+
+  const main = page.locator('main');
+  await expect(page.getByRole('heading', { name: /Write Markdown/i })).toBeVisible();
+
+  const markdownTable = main
+    .locator('table')
+    .filter({ hasText: 'Dashboard' })
+    .filter({ hasText: 'OpenTelemetry support' })
+    .first();
+
+  await expect(markdownTable).toBeVisible();
+  await expect(markdownTable.locator('thead th')).toHaveText([
+    'Feature',
+    'Description',
+    'Status',
+  ]);
+  await expect(markdownTable.locator('tbody tr')).toHaveCount(3);
+  await expect(markdownTable).toContainText('Kubernetes deployment');
+
+  await expect(main.locator('p').filter({ hasText: /^\|\s*Feature\s*\|/ })).toHaveCount(0);
+  await expect(main.getByRole('complementary', { name: 'Tip' }).first()).toBeVisible();
+  await expect(main.getByRole('link', { name: 'David Pine' })).toHaveAttribute(
+    'href',
+    /https:\/\/davidpine\.net\/?/
+  );
+  await expect(main.locator('p code').filter({ hasText: 'Inline code' })).toBeVisible();
+  await expect(
+    main.locator('pre code').filter({ hasText: 'builder.AddProject<Projects.ApiService>' }).first()
+  ).toBeVisible();
+  await expect(
+    main.locator('blockquote').filter({ hasText: 'This is a note or important callout.' })
+  ).toBeVisible();
+  await expect(main.locator('hr')).toHaveCount(1);
+  await expect(main.locator('del').filter({ hasText: 'This text is crossed out' })).toBeVisible();
+
+  const completedTask = main
+    .locator('li')
+    .filter({ hasText: 'Add Aspire to your project' })
+    .locator('input[type="checkbox"]');
+  const pendingTask = main
+    .locator('li')
+    .filter({ hasText: 'Deploy to Azure' })
+    .locator('input[type="checkbox"]');
+
+  await expect(completedTask).toBeChecked();
+  await expect(pendingTask).not.toBeChecked();
+  await expect(main.locator('ul').filter({ hasText: 'First item' }).first()).toBeVisible();
+  await expect(main.locator('ol').filter({ hasText: 'First step' }).first()).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Fixes #1215

- Configure the MDX integration explicitly with `gfm: true` so Starlight docs render Markdown tables as semantic `<table>` elements again without using deprecated `markdown.gfm`.
- Expand the contributor guide's Markdown section into a stable common-Markdown fixture with canonical table syntax.
- Add Playwright e2e coverage that validates common Markdown renders as HTML and catches raw pipe-table paragraphs.

## Source version

The deployed broken site is built from commit `cbc71c5a2f449e0ceea81b097923443645ac60ab` with Astro `6.4.4` and Starlight `0.39.3`. The regression entered through dependency bump PR #1207, commit `6314551f0d9fe13df0e41a60b62c434d6415adca`, which moved Astro from `6.3.7` to `6.4.4` and Starlight from `0.39.2` to `0.39.3`.

The likely upstream source is Astro `6.4.0`'s Markdown processor abstraction (`withastro/astro#16848`, commit `f732f3c`), consumed by the `6.4.4` bump. Canonical table formatting alone was not enough under the current dependency set, so this PR explicitly restores GFM parsing for MDX.

## Notes

Astro 6.4 deprecates the top-level `markdown.gfm` flag in favor of processor-level configuration. For this Starlight site, the affected docs are `.mdx` files rendered by `@astrojs/mdx`, so this PR configures `mdx({ optimize: true, gfm: true })` directly and adds `@astrojs/mdx` as an explicit dependency. The remaining runtime deprecation warning is from Starlight's internal `markdown.remarkPlugins`/`rehypePlugins` injection, not this GFM setting.

## Validation

- `pnpm --dir .\src\frontend exec playwright test tests/e2e/markdown-rendering.spec.ts`
- `pnpm --dir .\src\frontend exec eslint astro.config.mjs tests/e2e/markdown-rendering.spec.ts --max-warnings 0`
- `pnpm --dir .\src\frontend run test:unit:llms-txt`
- `pnpm --dir .\src\frontend run test:unit:llms-small-whitespace`
- Dashboard DOM spot-check: `/dashboard/configuration/#common-configuration` rendered 9 `main table` elements and 0 raw pipe-table paragraphs.

`pnpm build` was not run locally per contributor preference.