### PR TITLE
[docs] Fix persistent container endpoint proxy default docs

### DIFF
--- a/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
+++ b/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
@@ -38,7 +38,7 @@ Use persistent lifetime for resources that are expensive to initialize, need sta
 Persistent resources are automatically recreated when the AppHost detects meaningful configuration changes. If the configuration differs, the resource is recreated with the new settings.
 :::
 
-Persistent containers use proxied endpoints by default, just like session containers. The proxy runs while the AppHost is running and keeps the endpoint reachable for the container's lifetime. Persistent executables and projects default to proxyless endpoints so their direct addresses stay stable and reachable even after the AppHost stops.
+Persistent containers use proxied endpoints by default, just like session containers. The proxy runs only while the AppHost is running, so the proxy address isn't reachable after the AppHost stops. Persistent executables and projects default to proxyless endpoints so their direct addresses stay stable and reachable even after the AppHost stops.
 
 You can still configure endpoint proxy behavior explicitly on any persistent resource. Set `isProxied: false` on an individual endpoint, or call `WithEndpointProxySupport(false)` to make every endpoint on a resource proxyless. Persistent executable endpoints must have a concrete `port` or `targetPort`; automatically persisted random executable ports aren't supported. For proxyless container endpoints with only a `targetPort`, Aspire immediately uses the target port as the allocated host port.
 

--- a/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
+++ b/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
@@ -38,7 +38,9 @@ Use persistent lifetime for resources that are expensive to initialize, need sta
 Persistent resources are automatically recreated when the AppHost detects meaningful configuration changes. If the configuration differs, the resource is recreated with the new settings.
 :::
 
-Persistent resources default to proxyless endpoints so a stable local endpoint can remain reachable after the AppHost stops. You can still configure endpoint proxy behavior explicitly. For example, set `isProxied: true` or `IsProxied = true` when you need Aspire's proxy for a specific endpoint, or disable endpoint proxy support when you intentionally want every endpoint on a resource to be proxyless. Persistent executable endpoints must have a concrete `port` or `targetPort`; automatically persisted random executable ports aren't supported.
+Persistent containers use proxied endpoints by default, just like session containers. The proxy runs while the AppHost is running and keeps the endpoint reachable for the container's lifetime. Persistent executables and projects default to proxyless endpoints so their direct addresses stay stable and reachable even after the AppHost stops.
+
+You can still configure endpoint proxy behavior explicitly on any persistent resource. Set `isProxied: false` on an individual endpoint, or call `WithEndpointProxySupport(false)` to make every endpoint on a resource proxyless. Persistent executable endpoints must have a concrete `port` or `targetPort`; automatically persisted random executable ports aren't supported. For proxyless container endpoints with only a `targetPort`, Aspire immediately uses the target port as the allocated host port.
 
 :::danger[Persistent container &ne; persistent data]
 Persistent container lifetime doesn't guarantee data durability. For details, see [Container lifetime vs. data durability](#container-lifetime-vs-data-durability).

--- a/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
+++ b/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
@@ -55,7 +55,7 @@ The inner loop is the process of developing and testing your app locally before 
 
 - **Endpoints/Endpoint configurations**: Endpoints are the connections between your app and the services it depends on, such as databases, message queues, or APIs. Endpoints provide information such as the service name, host port, scheme, and environment variable. Aspire can create endpoints automatically from resource configuration, and you can also add them explicitly by calling `WithEndpoint`.
 - **Proxies**: Aspire automatically launches a proxy for each proxied service binding you add to your app, and assigns a port for the proxy to listen on. The proxy then forwards the requests to the port that your app listens on, which might be different from the proxy port. This way, you can avoid port conflicts and access your app and services using consistent and predictable URLs.
-- **Proxyless endpoints**: Endpoints with `IsProxied` set to `false` connect directly to the resource instead of routing through an Aspire-managed proxy. Starting in Aspire 13.4, endpoints on persistent resources are proxyless by default. Proxyless endpoints must specify a target port so Aspire knows which port the resource listens on.
+- **Proxyless endpoints**: Endpoints with `IsProxied` set to `false` connect directly to the resource instead of routing through an Aspire-managed proxy. Starting in Aspire 13.4, endpoints on persistent executables and projects are proxyless by default. Persistent containers use proxied endpoints by default, the same as session containers. Proxyless endpoints must specify a target port so Aspire knows which port the resource listens on.
 - **Container networks**: Aspire creates and manages dedicated networks for container resources so containers can discover and communicate with each other during local development.
 
 ## How endpoints work
@@ -230,7 +230,9 @@ The underlying service still listens on its own port, and Aspire makes that allo
 
 Most endpoints are proxied by default. A proxyless endpoint skips the Aspire-managed proxy and exposes the resource's listener directly. Use a proxyless endpoint when a proxy would interfere with the resource's lifetime or networking behavior.
 
-Starting in Aspire 13.4, endpoints on persistent resources are proxyless by default. This lets the persistent resource keep using its direct endpoint across AppHost runs instead of depending on a new proxy instance each time. This also ensures that the ports your service is reachable on stay stable whether the AppHost is running or not.
+Starting in Aspire 13.4, endpoints on persistent executables and projects are proxyless by default. This lets the persistent resource keep using its direct endpoint across AppHost runs instead of depending on a new proxy instance each time. This also ensures that the ports your service is reachable on stay stable whether the AppHost is running or not. Persistent containers use proxied endpoints by default, the same as session containers, so integrations that depend on endpoint allocation before startup continue to work.
+
+For proxyless container endpoints, Aspire resolves the host port immediately when only a `targetPort` is specified — there is no deferred allocation. For example, `.WithEndpoint(targetPort: 6379, isProxied: false)` allocates host port `6379` right away.
 
 Because there's no proxy to listen on one port and forward to another, every proxyless endpoint must include a target port. The target port tells Aspire which port the resource listens on. You can also set `port` when you need a specific host port, but `targetPort` is still required for proxyless endpoints.
 
@@ -405,7 +407,7 @@ The `AllocatedEndpoint` property allows you to get or set the endpoint for a ser
   on.
 </Aside>
 
-The `Name` property identifies the service, whereas the `Port` and `TargetPort` properties specify the desired and listening ports, respectively. `TargetPort` is required for proxyless endpoints, including endpoints with `IsProxied` set to `false` and, starting in Aspire 13.4, endpoints on persistent resources by default.
+The `Name` property identifies the service, whereas the `Port` and `TargetPort` properties specify the desired and listening ports, respectively. `TargetPort` is required for proxyless endpoints, including endpoints with `IsProxied` set to `false` and, starting in Aspire 13.4, endpoints on persistent executables and projects by default.
 
 For network communication, the `Protocol` property supports **TCP** and **UDP**, with potential for more in the future, and the `Transport` property indicates the transport protocol (**HTTP**, **HTTP2**, **HTTP3**). Lastly, if the service is URI-addressable, the `UriScheme` property provides the URI scheme for constructing the service URI.
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -473,10 +473,11 @@ Persistent lifetimes now extend beyond containers to executables and projects. C
 <Aside type="caution">
   The shared persistent and session lifetime APIs are experimental and emit
   the `ASPIREPERSISTENCE001` diagnostic, which C# callers must suppress to use
-  them. Persistent resources default to proxyless endpoints, must use concrete
-  ports for executables, don't support replicas, and aren't compatible with
-  Aspire IDE debugging sessions. The existing container-specific
-  `WithLifetime(ContainerLifetime.Persistent)` API is unchanged.
+  them. Persistent executables and projects default to proxyless endpoints,
+  must use concrete ports for executables, don't support replicas, and aren't
+  compatible with Aspire IDE debugging sessions. Persistent containers use
+  proxied endpoints by default, the same as session containers. The existing
+  container-specific `WithLifetime(ContainerLifetime.Persistent)` API is unchanged.
 </Aside>
 
 <LearnMore>
@@ -779,7 +780,7 @@ Re-run `aspire run` (or your code-generation step) to regenerate references, and
 
 #### Persistent executable and project lifetimes
 
-Support for persistent lifetimes on executables and projects updates the underlying DCP executable model (new `persistent`, `start`, and `stop` fields). Persistent resources default to proxyless endpoints, require concrete ports for executables, don't support replicas, and aren't compatible with Aspire IDE debugging sessions.
+Support for persistent lifetimes on executables and projects updates the underlying DCP executable model (new `persistent`, `start`, and `stop` fields). Persistent executables and projects default to proxyless endpoints, require concrete ports for executables, don't support replicas, and aren't compatible with Aspire IDE debugging sessions. Persistent containers use proxied endpoints by default, matching session container behavior, so integrations that depend on endpoint allocation before startup work correctly without changes.
 
 If you adopt `WithPersistentLifetime()`, review endpoint and port configuration. Tooling pinned to the previous DCP executable schema may need to be updated. See [Configure resource lifetimes](/app-host/resource-lifetimes/).
 


### PR DESCRIPTION
Reopens #1219 against `release/13.5` after it was merged into `release/13.4`.

Documents changes from [microsoft/aspire#17960](https://github.com/microsoft/aspire/pull/17960) by `@danegsta`.

## Why this PR is needed

PR #17960 corrected a regression in Aspire 13.4 where persistent containers incorrectly defaulted to proxyless endpoints. The fix makes persistent containers behave like session containers — using proxied endpoints by default — while persistent executables and projects retain their proxyless-by-default behavior. The existing docs stated that *all* persistent resources default to proxyless endpoints, which is now incorrect for containers.

In addition, the PR restores the previous behavior for proxyless container endpoints that specify only a `targetPort`: the target port is immediately used as the allocated host port, with no delayed allocation.

## Changes made

- **`app-host/resource-lifetimes.mdx`** — Updated the persistent lifetime section to distinguish between containers (proxied by default) and executables/projects (proxyless by default). Added a note that proxyless container endpoints with only a `targetPort` immediately allocate the target port as the host port.
- **`fundamentals/networking-overview.mdx`** — Corrected three locations:
  - Proxyless endpoints definition in the concepts list
  - The "Proxyless endpoints" section (clarifies containers vs. executables, and documents immediate targetPort allocation)
  - The `EndpointAnnotation` properties reference paragraph
- **`whats-new/aspire-13-4.mdx`** — Corrected two locations in the persistent executable/project lifetime sections (feature spotlight Aside and breaking changes entry) to scope the proxyless-by-default statement to executables and projects only.

## Files modified

- `src/frontend/src/content/docs/app-host/resource-lifetimes.mdx`
- `src/frontend/src/content/docs/fundamentals/networking-overview.mdx`
- `src/frontend/src/content/docs/whats-new/aspire-13-4.mdx`