### PR TITLE
Add npx dashboard run instructions

### DIFF
--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -29,7 +29,13 @@ Choose the startup path that best fits your workflow. The Aspire CLI provides th
 
 ### Aspire CLI
 
-Install the [Aspire CLI](/get-started/install-cli/), then start the dashboard:
+Run the CLI package with `npx`:
+
+```bash title="Run with npx"
+npx -y @microsoft/aspire-cli dashboard run
+```
+
+Or install the [Aspire CLI](/get-started/install-cli/), then start the dashboard:
 
 ```bash title="Aspire CLI"
 aspire dashboard run

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -29,7 +29,9 @@ Choose the startup path that best fits your workflow. The Aspire CLI provides th
 
 ### Aspire CLI
 
-Run the CLI package with `npx`:
+The `npx` command is a package runner that's included with npm. If `npx` isn't
+available, install [Node.js](https://nodejs.org/) to get npm and `npx`. Then run
+the Aspire CLI package with `npx`:
 
 ```bash title="Run with npx"
 npx -y @microsoft/aspire-cli dashboard run

--- a/src/frontend/src/content/docs/dashboard/standalone.mdx
+++ b/src/frontend/src/content/docs/dashboard/standalone.mdx
@@ -29,9 +29,10 @@ Choose the startup path that best fits your workflow. The Aspire CLI provides th
 
 ### Aspire CLI
 
-The `npx` command is a package runner that's included with npm. If `npx` isn't
-available, install [Node.js](https://nodejs.org/) to get npm and `npx`. Then run
-the Aspire CLI package with `npx`:
+The quickest way to start the standalone dashboard is to use the Aspire CLI via `npx`.
+The `npx` command is a package runner included with [Node.js](https://nodejs.org/).
+
+To run the Aspire CLI package with `npx`:
 
 ```bash title="Run with npx"
 npx -y @microsoft/aspire-cli dashboard run


### PR DESCRIPTION
Adds an npm-based path for starting the standalone Aspire dashboard so readers with Node.js can try it without first installing the Aspire CLI globally.

The `npx -y @microsoft/aspire-cli dashboard run` command is shown first in the Aspire CLI startup section, with the globally installed `aspire dashboard run` command kept as the alternate path.