### PR TITLE
[docs] Add WithTerminal() interactive terminal sessions page

### DIFF
--- a/src/frontend/config/sidebar/docs.topics.ts
+++ b/src/frontend/config/sidebar/docs.topics.ts
@@ -940,6 +940,13 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
                 ja: '実行可能リソース',
               },
             },
+            {
+              label: 'Interactive terminals',
+              slug: 'app-host/withterminal',
+              translations: {
+                en: 'Interactive terminals',
+              },
+            },
           ],
         },
         {

--- a/src/frontend/config/sidebar/docs.topics.ts
+++ b/src/frontend/config/sidebar/docs.topics.ts
@@ -943,9 +943,6 @@ export const docsTopics: StarlightSidebarTopicsUserConfig = {
             {
               label: 'Interactive terminals',
               slug: 'app-host/withterminal',
-              translations: {
-                en: 'Interactive terminals',
-              },
             },
           ],
         },

--- a/src/frontend/src/content/docs/app-host/withterminal.mdx
+++ b/src/frontend/src/content/docs/app-host/withterminal.mdx
@@ -1,9 +1,9 @@
 ---
 title: Interactive terminal sessions
-description: Attach an interactive terminal to any Aspire resource using WithTerminal — lets you access a live PTY session from the dashboard or the aspire terminal CLI command.
+description: Attach an interactive terminal to any Aspire resource using WithTerminal — access live PTY sessions from the dashboard or the `aspire terminal` CLI commands.
 ---
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 :::danger[Experimental feature]
 `WithTerminal()` is an experimental API. Reference the `ASPIRETERMINAL001` diagnostic ID to opt in:
@@ -12,15 +12,10 @@ import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 #pragma warning disable ASPIRETERMINAL001
 builder.AddExecutable("repl", "my-repl", ".")
     .WithTerminal();
-#pragma warning restore ASPIRETERMINAL001
 ```
 :::
 
-The `WithTerminal()` extension method attaches an interactive pseudo-terminal (PTY) to any Aspire resource. When a resource is configured with `WithTerminal()`, the Aspire Dashboard replaces the standard console log view with a live [xterm.js](https://xtermjs.org/) terminal, and the `aspire terminal` CLI command lets you connect directly from your local shell.
-
-:::note
-`WithTerminal()` currently supports Windows executables. Linux, macOS, and container support are planned for future releases.
-:::
+The `WithTerminal()` extension method attaches an interactive pseudo-terminal (PTY) to any Aspire resource. When a resource is configured with `WithTerminal()`, the Aspire Dashboard replaces the standard console log view with a live terminal session, and the `aspire terminal` CLI command lets you connect directly from your local shell.
 
 ## Enable interactive terminals
 
@@ -36,7 +31,6 @@ var repl = builder.AddExecutable("repl", "my-repl", ".")
     .WithTerminal();
 
 builder.Build().Run();
-#pragma warning restore ASPIRETERMINAL001
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
@@ -67,12 +61,10 @@ var builder = DistributedApplication.CreateBuilder(args);
 var repl = builder.AddExecutable("repl", "my-repl", ".")
     .WithTerminal(options =>
     {
-        options.Columns = 200;
-        options.Rows = 50;
+        options.Columns = 100;
+        options.Rows = 28;
     });
-
 builder.Build().Run();
-#pragma warning restore ASPIRETERMINAL001
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
@@ -82,8 +74,6 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-// TypeScript AppHost does not yet support dimension options.
-// Use the default dimensions (120 columns × 30 rows).
 const repl = await builder
     .addNodeApp("guessing-game", "./guessing-game", "game.mjs")
     .withTerminal();
@@ -94,11 +84,13 @@ await builder.build().run();
 </TabItem>
 </Tabs>
 
-The default dimensions are **120 columns × 30 rows**. The xterm.js panel in the dashboard auto-fits to the browser window, so these values primarily affect the PTY allocation on the host side.
+TypeScript AppHost currently supports only the parameterless `withTerminal()` call. Support for configuring dimensions in TypeScript is tracked by [microsoft/aspire#18105](https://github.com/microsoft/aspire/issues/18105).
+
+The default dimensions are **120 columns × 30 rows**. The dashboard terminal panel auto-fits to the browser window, so these values primarily affect the PTY allocation on the host side.
 
 ## Use with replicated resources
 
-`WithTerminal()` and `WithReplicas()` can be called in any order. Aspire defers the per-replica terminal host creation until just before startup, so the final replica count is always honoured:
+Use `WithTerminal()` with `WithReplicas()` to give each replica its own interactive terminal session:
 
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
@@ -112,7 +104,6 @@ var agent = builder.AddExecutable("agent", "my-agent", ".")
     .WithTerminal();
 
 builder.Build().Run();
-#pragma warning restore ASPIRETERMINAL001
 ```
 </TabItem>
 <TabItem id='typescript' label='TypeScript'>
@@ -135,7 +126,7 @@ Each replica gets its own independent terminal session and appears as a separate
 
 ## Access terminals from the dashboard
 
-When a resource has `WithTerminal()` applied, the **Console Logs** tab for that resource in the Aspire Dashboard is replaced by a live xterm.js terminal. You can interact with the running process directly in the browser — type commands, scroll the scrollback buffer, and switch between replicas using the replica selector.
+When a resource has `WithTerminal()` applied, the **Console Logs** tab for that resource in the Aspire Dashboard is replaced by a live terminal session. You can interact with the running process directly in the browser — type commands, scroll the scrollback buffer, and switch between replicas using the replica selector.
 
 ## Access terminals from the CLI
 
@@ -177,4 +168,4 @@ aspire terminal attach agent --viewer
 
 - [Executable resources](/app-host/executable-resources/)
 - [Resource lifetimes](/app-host/resource-lifetimes/)
-- [Aspire CLI reference](/reference/cli/commands/)
+- [Aspire CLI reference](/reference/cli/overview/)

--- a/src/frontend/src/content/docs/app-host/withterminal.mdx
+++ b/src/frontend/src/content/docs/app-host/withterminal.mdx
@@ -1,0 +1,180 @@
+---
+title: Interactive terminal sessions
+description: Attach an interactive terminal to any Aspire resource using WithTerminal — lets you access a live PTY session from the dashboard or the aspire terminal CLI command.
+---
+
+import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+
+:::danger[Experimental feature]
+`WithTerminal()` is an experimental API. Reference the `ASPIRETERMINAL001` diagnostic ID to opt in:
+
+```csharp
+#pragma warning disable ASPIRETERMINAL001
+builder.AddExecutable("repl", "my-repl", ".")
+    .WithTerminal();
+#pragma warning restore ASPIRETERMINAL001
+```
+:::
+
+The `WithTerminal()` extension method attaches an interactive pseudo-terminal (PTY) to any Aspire resource. When a resource is configured with `WithTerminal()`, the Aspire Dashboard replaces the standard console log view with a live [xterm.js](https://xtermjs.org/) terminal, and the `aspire terminal` CLI command lets you connect directly from your local shell.
+
+:::note
+`WithTerminal()` currently supports Windows executables. Linux, macOS, and container support are planned for future releases.
+:::
+
+## Enable interactive terminals
+
+Call `WithTerminal()` on any executable or project resource in your AppHost:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+#pragma warning disable ASPIRETERMINAL001
+var builder = DistributedApplication.CreateBuilder(args);
+
+var repl = builder.AddExecutable("repl", "my-repl", ".")
+    .WithTerminal();
+
+builder.Build().Run();
+#pragma warning restore ASPIRETERMINAL001
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const repl = await builder
+    .addNodeApp("guessing-game", "./guessing-game", "game.mjs")
+    .withTerminal();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+## Configure terminal dimensions
+
+Use the optional `configure` callback to set the initial column and row count for the terminal window:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+#pragma warning disable ASPIRETERMINAL001
+var builder = DistributedApplication.CreateBuilder(args);
+
+var repl = builder.AddExecutable("repl", "my-repl", ".")
+    .WithTerminal(options =>
+    {
+        options.Columns = 200;
+        options.Rows = 50;
+    });
+
+builder.Build().Run();
+#pragma warning restore ASPIRETERMINAL001
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// TypeScript AppHost does not yet support dimension options.
+// Use the default dimensions (120 columns × 30 rows).
+const repl = await builder
+    .addNodeApp("guessing-game", "./guessing-game", "game.mjs")
+    .withTerminal();
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+The default dimensions are **120 columns × 30 rows**. The xterm.js panel in the dashboard auto-fits to the browser window, so these values primarily affect the PTY allocation on the host side.
+
+## Use with replicated resources
+
+`WithTerminal()` and `WithReplicas()` can be called in any order. Aspire defers the per-replica terminal host creation until just before startup, so the final replica count is always honoured:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+```csharp title="AppHost.cs"
+#pragma warning disable ASPIRETERMINAL001
+var builder = DistributedApplication.CreateBuilder(args);
+
+// Three replicas, each with its own interactive terminal.
+var agent = builder.AddExecutable("agent", "my-agent", ".")
+    .WithReplicas(3)
+    .WithTerminal();
+
+builder.Build().Run();
+#pragma warning restore ASPIRETERMINAL001
+```
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const agent = await builder
+    .addNodeApp("agent", "./agent", "index.mjs");
+await agent.withReplicas(3);
+await agent.withTerminal();
+
+await builder.build().run();
+```
+</TabItem>
+</Tabs>
+
+Each replica gets its own independent terminal session and appears as a separate entry in the dashboard resource list (for example, `agent-r0`, `agent-r1`, `agent-r2`).
+
+## Access terminals from the dashboard
+
+When a resource has `WithTerminal()` applied, the **Console Logs** tab for that resource in the Aspire Dashboard is replaced by a live xterm.js terminal. You can interact with the running process directly in the browser — type commands, scroll the scrollback buffer, and switch between replicas using the replica selector.
+
+## Access terminals from the CLI
+
+The `aspire terminal` command lets you attach to or inspect terminal sessions from your local shell.
+
+### List terminal-enabled resources
+
+```bash
+aspire terminal ps
+```
+
+This displays a table of every `WithTerminal()`-enabled resource in the connected AppHost, including the current terminal dimensions, the number of attached viewers, and per-replica health status.
+
+To emit structured JSON output for scripting:
+
+```bash
+aspire terminal ps --format json
+```
+
+### Attach to a terminal session
+
+```bash
+aspire terminal attach <resource-name>
+```
+
+If the resource has a single replica, the CLI attaches immediately. For multi-replica resources, pass `--replica` with the 0-based index:
+
+```bash
+aspire terminal attach agent --replica 1
+```
+
+To connect as a secondary viewer — receiving output without driving the session dimensions — add `--viewer`:
+
+```bash
+aspire terminal attach agent --viewer
+```
+
+## See also
+
+- [Executable resources](/app-host/executable-resources/)
+- [Resource lifetimes](/app-host/resource-lifetimes/)
+- [Aspire CLI reference](/reference/cli/commands/)


### PR DESCRIPTION
Adds documentation for the `WithTerminal()` experimental API introduced in Aspire 13.5 (microsoft/aspire#17866).

## Changes

- New page: `app-host/withterminal.mdx` — covers basic usage, custom dimensions, multi-replica support, dashboard terminal view, and the `aspire terminal attach` / `aspire terminal ps` CLI commands
- Sidebar entry added to **Resource types** section after "Executable resources"

## Source PR

microsoft/aspire#17866 — "WithTerminal(): per-replica interactive terminal sessions (Aspire side)"

## Notes

- The feature is marked experimental (`ASPIRETERMINAL001`); the page includes the required `#pragma warning disable` patterns
- TypeScript options overload (dimensions) is not yet supported — noted inline
- Windows executables only for 13.5; Linux/macOS/containers are noted as follow-ups

/cc @adamint (SME from source PR reviews)