### PR TITLE
Add AKS to Azure deployment docs

### DIFF
--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -181,7 +181,7 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
               slug: 'deployment/azure/container-apps',
             },
             {
-              label: 'Azure Kubernetes Service',
+              label: 'Azure Kubernetes Service (AKS)',
               slug: 'deployment/kubernetes/aks',
             },
             {

--- a/src/frontend/config/sidebar/deployment.topics.ts
+++ b/src/frontend/config/sidebar/deployment.topics.ts
@@ -181,6 +181,10 @@ export const deploymentTopics: StarlightSidebarTopicsUserConfig = {
               slug: 'deployment/azure/container-apps',
             },
             {
+              label: 'Azure Kubernetes Service',
+              slug: 'deployment/kubernetes/aks',
+            },
+            {
               label: 'Azure App Service',
               slug: 'deployment/azure/app-service',
             },

--- a/src/frontend/src/content/docs/deployment/azure/index.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy to Azure
-seoTitle: Deploy Aspire apps to Azure with the Azure Developer CLI
+seoTitle: Deploy Aspire apps to Azure targets with aspire deploy
 description: Learn how Azure deployment works in Aspire, the shared prerequisites, and how to choose between Azure App Service, Container Apps, and AKS for production workloads.
 ---
 
@@ -105,7 +105,7 @@ Azure deployment starts from the compute environments in your AppHost. Each comp
 
 </Steps>
 
-Both Azure Container Apps and Azure App Service provision or attach an Azure Container Registry by default. Aspire uses the active deployment credential to log the local container runtime in for image push, and the deployed resources later pull those images with managed identity and `AcrPull` permissions instead of stored registry usernames or passwords.
+Azure Container Apps, Azure App Service, and AKS provision or attach an Azure Container Registry by default. Aspire uses the active deployment credential to log the local container runtime in for image push, and the deployed resources later pull those images with managed identity and `AcrPull` permissions instead of stored registry usernames or passwords.
 
 ## Resource naming
 
@@ -122,6 +122,7 @@ For ACA naming details, see [Configure Azure Container Apps environments](/integ
 | Target | Endpoint model | Best fit |
 | --- | --- | --- |
 | [Azure Container Apps](/deployment/azure/container-apps/) | Public or internal endpoints, with one primary HTTP ingress per app. | Distributed apps and containerized services that fit the Container Apps environment model. |
+| [Azure Kubernetes Service](/deployment/kubernetes/aks/) | Internal Kubernetes services by default, with public ingress or Gateway API when configured. | Teams that need Kubernetes control, cluster-level add-ons, node pools, and Azure-managed cluster provisioning. |
 | [Azure App Service](/deployment/azure/app-service/) | Public website model with external `http`/`https` endpoints only. | Web apps and APIs that fit the App Service website and deployment slot model and use managed services for backing infrastructure such as databases and caches. |
 
 :::note
@@ -135,6 +136,11 @@ Azure Container Apps can also host supporting service containers such as databas
     title="Azure Container Apps"
     description="Understand ingress, registry, identity, and optional dashboard settings for Container Apps deployments."
     href="/deployment/azure/container-apps/"
+  />
+  <LinkCard
+    title="Azure Kubernetes Service"
+    description="Provision AKS clusters, container registries, ingress, identity, and observability with Aspire."
+    href="/deployment/kubernetes/aks/"
   />
   <LinkCard
     title="Azure App Service"

--- a/src/frontend/src/content/docs/deployment/azure/index.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/index.mdx
@@ -105,7 +105,7 @@ Azure deployment starts from the compute environments in your AppHost. Each comp
 
 </Steps>
 
-Azure Container Apps, Azure App Service, and AKS provision or attach an Azure Container Registry by default. Aspire uses the active deployment credential to log the local container runtime in for image push, and the deployed resources later pull those images with managed identity and `AcrPull` permissions instead of stored registry usernames or passwords.
+Azure Container Apps, Azure App Service, and Azure Kubernetes Service (AKS) provision or attach an Azure Container Registry by default. Aspire uses the active deployment credential to log the local container runtime in for image push, and the deployed resources later pull those images with managed identity and `AcrPull` permissions instead of stored registry usernames or passwords.
 
 ## Resource naming
 
@@ -122,7 +122,7 @@ For ACA naming details, see [Configure Azure Container Apps environments](/integ
 | Target | Endpoint model | Best fit |
 | --- | --- | --- |
 | [Azure Container Apps](/deployment/azure/container-apps/) | Public or internal endpoints, with one primary HTTP ingress per app. | Distributed apps and containerized services that fit the Container Apps environment model. |
-| [Azure Kubernetes Service](/deployment/kubernetes/aks/) | Internal Kubernetes services by default, with public ingress or Gateway API when configured. | Teams that need Kubernetes control, cluster-level add-ons, node pools, and Azure-managed cluster provisioning. |
+| [Azure Kubernetes Service (AKS)](/deployment/kubernetes/aks/) | Internal Kubernetes services by default, with public ingress or Gateway API when configured. | Teams that need Kubernetes control, cluster-level add-ons, node pools, and Azure-managed cluster provisioning. |
 | [Azure App Service](/deployment/azure/app-service/) | Public website model with external `http`/`https` endpoints only. | Web apps and APIs that fit the App Service website and deployment slot model and use managed services for backing infrastructure such as databases and caches. |
 
 :::note
@@ -138,7 +138,7 @@ Azure Container Apps can also host supporting service containers such as databas
     href="/deployment/azure/container-apps/"
   />
   <LinkCard
-    title="Azure Kubernetes Service"
+    title="Azure Kubernetes Service (AKS)"
     description="Provision AKS clusters, container registries, ingress, identity, and observability with Aspire."
     href="/deployment/kubernetes/aks/"
   />


### PR DESCRIPTION
Azure deployment docs listed Azure Container Apps and Azure App Service but did not surface Azure Kubernetes Service as an Azure deployment target. This adds AKS to the Azure deployment overview while linking to the existing AKS deployment guide.

## Changes

- Add Azure Kubernetes Service to the Azure target comparison table.
- Add an Azure Kubernetes Service deployment target card that links to the existing AKS guide.
- Add Azure Kubernetes Service to the Azure deployment target sidebar group.
- Update the Azure page SEO title to describe the `aspire deploy` target flow.

## Validation

- `pnpm exec vitest run tests/unit/seo-lengths.vitest.test.ts --config vitest.config.ts --reporter=dot`
- Rendered the local Azure deployment page and verified the Azure Kubernetes Service links with `playwright-cli`.