### PR TITLE
docs: add `dnx skillz` install command for .NET developers

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -225,7 +225,7 @@ On the .NET 10 SDK or later, `dnx` runs [`skillz`](https://www.nuget.org/package
 dnx skillz add microsoft/aspire-skills
 ```
 
-Use this path when you already have the .NET SDK and prefer not to depend on Node.js.
+Use this option when you already have the .NET SDK and prefer not to depend on Node.js.
 
 <LearnMore>
   `skillz` is open source at

--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -217,6 +217,22 @@ In that command, `-a github-copilot` selects the target agent, `-g` installs glo
 </LearnMore>
 
 </TabItem>
+<TabItem id='dotnet' label='.NET (dnx)'>
+
+On the .NET 10 SDK or later, `dnx` runs [`skillz`](https://www.nuget.org/packages/skillz), which is like `skills` but natively a .NET tool, no Node.js required.
+
+```bash title="dnx"
+dnx skillz add microsoft/aspire-skills
+```
+
+Use this path when you already have the .NET SDK and prefer not to depend on Node.js.
+
+<LearnMore>
+  `skillz` is open source at
+  [chillicream/skillz](https://github.com/chillicream/skillz).
+</LearnMore>
+
+</TabItem>
 </Tabs>
 
 ## Aspire workflow skills


### PR DESCRIPTION
## What

On the [Aspire skills page](https://aspire.dev/get-started/aspire-skills/), the *Other installation options* section already lists install methods as tabs (Copilot CLI, Claude Code, Codex CLI, OpenCode, skills.sh). This adds one more sibling tab, **.NET (dnx)**:

```bash
dnx skillz add microsoft/aspire-skills
```

## Why

We built [`skillz`](https://github.com/chillicream/skillz) to give .NET a native way to install agent skills: with the .NET 10 SDK, `dnx skillz add ...` runs the installer directly from NuGet, so the whole workflow stays in the .NET toolchain instead of requiring Node.js and the Vercel `skills` CLI.

i know aspire is not just .NET but probably a big chunk of the audience already has .net 10 installed. `skillz` is  [completely open source and ships with no telemetry]( https://github.com/chillicream/skillz), so it's a transparent, dependency-light alternative for anyone who'd rather not pull in the Node toolchain.