### PR TITLE
Add mise to Aspire CLI install docs

### DIFF
--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -1,7 +1,7 @@
 ---
 title: Install Aspire CLI
-seoTitle: Install Aspire CLI with a script or package manager
-description: Learn how to install the Aspire CLI with the install script or a package manager — npm, NuGet, WinGet, or Homebrew — to build and run cloud-native apps.
+seoTitle: Install Aspire CLI with a package manager or script
+description: Install the Aspire CLI with package managers or install scripts, then verify your setup with aspire --version before building distributed apps.
 lastUpdated: true
 tableOfContents: true
 ---
@@ -16,7 +16,7 @@ import {
   Tabs,
 } from '@astrojs/starlight/components';
 
-Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system. Use the install script for the fastest setup, or choose the package manager that fits your environment — npm, NuGet, WinGet, or Homebrew.
+Aspire provides a command-line interface (CLI) tool to help you create and manage Aspire-based apps. The CLI streamlines your development workflow with an interactive-first experience. This guide shows you how to install the Aspire CLI on your system. Choose the package manager that fits your environment — Homebrew, npm, NuGet, WinGet, or mise — or use the install script for direct setup.
 
 :::tip[Using VS Code?]
 The [Aspire VS Code extension](/get-started/aspire-vscode-extension/) can install the CLI for you. From the Command Palette, run:
@@ -24,6 +24,7 @@ The [Aspire VS Code extension](/get-started/aspire-vscode-extension/) can instal
 ```text title="Command Palette"
 > Aspire: Install Aspire CLI (stable)
 ```
+
 :::
 
 <LearnMore>
@@ -31,36 +32,9 @@ The [Aspire VS Code extension](/get-started/aspire-vscode-extension/) can instal
   prerequisites](/get-started/prerequisites/) set up.
 </LearnMore>
 
-## Install with the install script
-
-Download and run the installation script in a single command:
-
-<OsAwareTabs syncKey="terminal">
-  <Code
-    slot="unix"
-    lang="bash"
-    title="Install script (macOS/Linux)"
-    code="curl -sSL https://aspire.dev/install.sh | bash"
-  />
-  <Code
-    slot="windows"
-    lang="powershell"
-    title="Install script (Windows)"
-    code="irm https://aspire.dev/install.ps1 | iex"
-  />
-</OsAwareTabs>
-
-The script installs the latest stable release of Aspire CLI. During installation, you might be asked `Do you want to continue?`. Reply with `Y` for Yes or `A` for Yes to All to continue downloading and running the install script. See [Validation](#validation) to verify the installation.
-
-:::tip
-At any time, you can reopen the **Install Aspire CLI** command modal from the top navigation (download icon <Icon name='download' class='d-inline' size='large' />). The modal shows the download-and-install command for your OS, so you can run the installer again when needed.
-:::
-
-You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
-
 ## Install with a package manager
 
-The install script works on every supported platform. If you prefer to manage the Aspire CLI alongside your other developer tooling, install it with a package manager instead. Choose the option that fits your environment:
+Install the Aspire CLI with a package manager to manage it alongside your other developer tooling. Choose the option that fits your environment:
 
 <Tabs syncKey='install-pkg'>
 <TabItem label='Homebrew'>
@@ -113,7 +87,43 @@ winget install Microsoft.Aspire
 ```
 
 </TabItem>
+<TabItem label='mise'>
+
+Install the Aspire CLI with [mise](https://mise.jdx.dev/) when you manage developer tooling with a shared tool version manager. The Aspire CLI is available from the mise registry as `aspire`, backed by `github:microsoft/aspire`.
+
+```bash title="Install with mise"
+mise use -g aspire
+```
+
+</TabItem>
 </Tabs>
+
+## Install with the install script
+
+Download and run the installation script in a single command:
+
+<OsAwareTabs syncKey="terminal">
+  <Code
+    slot="unix"
+    lang="bash"
+    title="Install script (macOS/Linux)"
+    code="curl -sSL https://aspire.dev/install.sh | bash"
+  />
+  <Code
+    slot="windows"
+    lang="powershell"
+    title="Install script (Windows)"
+    code="irm https://aspire.dev/install.ps1 | iex"
+  />
+</OsAwareTabs>
+
+The script installs the latest stable release of Aspire CLI. During installation, you might be asked `Do you want to continue?`. Reply with `Y` for Yes or `A` for Yes to All to continue downloading and running the install script. See [Validation](#validation) to verify the installation.
+
+:::tip
+At any time, you can reopen the **Install Aspire CLI** command modal from the top navigation (download icon <Icon name='download' class='d-inline' size='large' />). The modal shows the download-and-install command for your OS, so you can run the installer again when needed.
+:::
+
+You only need to download the script separately if you want to inspect it or run the installer as separate commands. For more information, see the [aspire-install script reference](/reference/cli/install-script/).
 
 ## Validation
 

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -89,7 +89,7 @@ winget install Microsoft.Aspire
 </TabItem>
 <TabItem label='mise'>
 
-Install the Aspire CLI with [mise](https://mise.jdx.dev/) when you manage developer tooling with a shared tool version manager. The Aspire CLI is available from the mise registry as `aspire`, backed by `github:microsoft/aspire`.
+Install the Aspire CLI with [mise](https://mise.jdx.dev/) when you manage developer tooling with a shared tool version manager. The Aspire CLI is available from the mise registry as `aspire`.
 
 ```bash title="Install with mise"
 mise use -g aspire


### PR DESCRIPTION
## Summary

Aspire CLI is now available in the mise registry, so the install guide should surface mise alongside the existing package-manager options. This updates the install page to show package-manager installs before the install script, adds a mise tab with `mise use -g aspire`, and keeps the script path available as an alternate setup option.

The SEO description now focuses on the install task and verification rather than listing every package manager.

## Validation

- `pnpm --dir ./src/frontend exec prettier --check src/content/docs/get-started/install-cli.mdx`
- `pnpm --dir ./src/frontend exec vitest run --config vitest.config.ts tests/unit/seo-lengths.vitest.test.ts tests/unit/filetree-format.vitest.test.ts`
- Reviewed the rendered install page locally