### PR TITLE
Fix broken WithTerminal link in 13.5 whats-new

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -106,7 +106,7 @@ Or install the CLI from scratch:
 AppHost authors can now call `WithTerminal()` on a resource to enable interactive terminal sessions. The Dashboard and CLI can attach to and detach from the session at will, enabling live use of REPLs, shells, and other terminal programs running as Aspire resources. This is particularly powerful for resource orchestration workflows where you need to interact with services in real-time.
 
 <LearnMore>
-  For details, see [WithTerminal() interactive terminal sessions](/app-host/interactive-terminal-sessions/).
+  For details, see [WithTerminal() interactive terminal sessions](/app-host/withterminal/).
 </LearnMore>
 
 ## 🌐 IInteractionService available across polyglot AppHosts


### PR DESCRIPTION
## Summary

Fixes the `starlight-links-validator` CI failure on `release/13.5`.

In `src/frontend/src/content/docs/whats-new/aspire-13-5.mdx` the "WithTerminal() interactive terminal sessions" link pointed to `/app-host/interactive-terminal-sessions/`, which does not exist. The correct page is `src/frontend/src/content/docs/app-host/withterminal.mdx`, whose slug is `/app-host/withterminal/`.

## Changes

- Update the link in `aspire-13-5.mdx` to `/app-host/withterminal/`.

Verified with a grep across `src/frontend/src/content/docs` that no other references to the wrong path remain.