### PR TITLE
Clarify AppHost role in deployment pipelines

### DIFF
--- a/src/frontend/src/content/docs/deployment/ci-cd.mdx
+++ b/src/frontend/src/content/docs/deployment/ci-cd.mdx
@@ -18,7 +18,7 @@ with Aspire has two layers that work together:
 - Your **CI/CD pipeline** decides when jobs run, which approvals they require, how artifacts move between stages, and which credentials are available.
 - Aspire's **pipeline system** decides how your AppHost is evaluated, which application-specific steps run, and how build, publish, push, and deploy work is ordered.
 
-Your AppHost remains the single source of truth for the application model across local development, automation, and production targets. Use this page to decide how those layers fit together, how environments and parameters flow into the AppHost, and when to use `aspire do`, `aspire publish`, or `aspire deploy`.
+Your AppHost remains the single source of truth for the application model across local development, automation, and production targets. In CI/CD, the Aspire CLI runs the AppHost on the runner as part of the deployment pipeline to produce artifacts, run named steps, or apply deployment changes. Use this page to decide how those layers fit together, how environments and parameters flow into the AppHost, and when to use `aspire do`, `aspire publish`, or `aspire deploy`.
 
 ## Two pipelines, different responsibilities
 

--- a/src/frontend/src/content/docs/deployment/deploy-with-aspire.mdx
+++ b/src/frontend/src/content/docs/deployment/deploy-with-aspire.mdx
@@ -81,7 +81,7 @@ A **compute environment** is a resource that represents a deployment target and 
 
 Compute environments answer **where does this resource go?** Compatible compute resources attach to a matching compute environment by default. When you add more than one matching compute environment, you explicitly bind resources to the target environment that should own them.
 
-This makes hybrid deployments possible: different compute resources in the same AppHost can go to different targets while still participating in the same overall pipeline.
+This makes hybrid deployments possible: different compute resources in the same AppHost can go to different targets while still participating in the same overall pipeline. One resource graph can produce different target-specific deployment output without duplicating topology in each deployment workflow.
 
 <LearnMore>
   For concrete examples of compute environments, see [Docker

--- a/src/frontend/src/content/docs/deployment/index.mdx
+++ b/src/frontend/src/content/docs/deployment/index.mdx
@@ -22,7 +22,7 @@ import CTABanner from '@components/CTABanner.astro';
   icon="rocket"
   title="From dev to production,"
   highlight="seamlessly."
-  subtitle="Use `aspire publish` to emit deployment artifacts as a one-way handoff for external or manual use, or use `aspire deploy` to let Aspire generate, resolve, and apply changes directly."
+  subtitle="Use `aspire publish` to emit deployment artifacts as a one-way handoff, or use `aspire deploy` to generate, resolve, and apply changes directly. Both workflows run the AppHost as part of the deployment pipeline to produce target-specific output."
   accent="orange"
   floatingIcons={[
     'cloud-download',
@@ -148,7 +148,7 @@ Aspire is not locked to a single cloud. Your local dev topology translates direc
 
 <CTABanner
   title="Ship with confidence"
-  description="Your local AppHost model is your deployment model. No configuration drift, no surprises — just consistent, repeatable deployments."
+  description="Your AppHost model drives deployment output for each target platform. No configuration drift, no surprises — just consistent, repeatable deployments."
   primaryCta={{
     label: 'Deploy your first app',
     href: '/get-started/deploy-first-app/',

--- a/src/frontend/src/content/docs/get-started/faq.mdx
+++ b/src/frontend/src/content/docs/get-started/faq.mdx
@@ -147,6 +147,14 @@ The key idea is that the same AppHost configuration flows across these stages.
 
 Learn more: [Aspire app lifecycle guide](/deployment/app-lifecycle/), [`aspire run`](/reference/cli/commands/aspire-run/), [`aspire deploy`](/reference/cli/commands/aspire-deploy/), [`aspire publish`](/reference/cli/commands/aspire-publish/)
 
+## Where does the AppHost run when I deploy?
+
+A useful mental model is that the AppHost runs in your deployment pipeline. It defines the application model — resources, relationships, parameters, deployment targets, and target-specific deployment behavior — and Aspire starts it when `aspire publish`, `aspire deploy`, or `aspire do <step>` runs.
+
+If you deploy locally, that pipeline runs on your development machine. If you deploy from CI/CD, it runs on the CI/CD runner. The command uses the AppHost model to produce artifacts, run pipeline steps, or apply deployment changes, then exits. The deployed apps and target platform handle runtime behavior such as routing, scaling, health checks, restarts, configuration, and service lifecycle.
+
+Learn more: [How Aspire deployment works](/deployment/deploy-with-aspire/), [CI/CD overview](/deployment/ci-cd/)
+
 ## Does Aspire support hot reload?
 
 Aspire supports an opt-in watch mode through the `defaultWatchEnabled` feature flag. It supports both AppHost languages, C# and TypeScript, by restarting the AppHost-managed application after AppHost changes. C# project resources are also controlled by this setting today. For other resources, keep the AppHost running and use the resource's framework, runtime, Aspire CLI action, or dashboard action for resource-specific reloads, restarts, and rebuilds.


### PR DESCRIPTION
Aspire deployment docs did not clearly answer where the AppHost fits once an app is deployed. This clarifies the mental model: the AppHost runs as part of the deployment pipeline, locally or on the CI/CD runner, and the deployed apps plus target platform own runtime behavior afterward.

## Changes

- Add a site FAQ entry explaining where the AppHost runs during deployment.
- Reinforce the same model in the deployment overview and CI/CD overview.
- Clarify that one AppHost resource graph can produce target-specific deployment output without duplicating topology.

## Validation

- Reviewed the rendered local docs with `playwright-cli` through the doc-tester workflow.
- Verified the new FAQ links navigate to the deployment model and CI/CD pages.
- No production build run per maintainer request.