### PR TITLE
Document PostgreSQL 18 data volume breaking change (13.4)

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -402,7 +402,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 The data volume is used to persist the PostgreSQL server data outside the lifecycle of its container. The container data directory depends on the PostgreSQL image version: PostgreSQL 17 and earlier use `/var/lib/postgresql/data`, while PostgreSQL 18 and later use `/var/lib/postgresql`. `WithDataVolume(...)` selects the correct path automatically based on the configured image tag. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-postgresql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
-  Aspire 13.4 bumped the default PostgreSQL image to 18, which uses a different on-disk data layout than PostgreSQL 17. A data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading. See [PostgreSQL 18 data directory change](#postgresql-18-data-directory-change) for recovery options.
+  Aspire 13.4 bumped the default PostgreSQL image to 18, which uses a different on-disk data layout than PostgreSQL 17. A data volume or data bind mount created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading. See [PostgreSQL 18 data directory change](#postgresql-18-data-directory-change) for recovery options.
 </Aside>
 
 <Aside type="caution">
@@ -599,7 +599,7 @@ Starting with Aspire 13.4, the default PostgreSQL container image used by `AddPo
 
 `WithDataVolume(...)` and `WithDataBindMount(...)` are version-aware: Aspire chooses the container data directory from the configured image tag at the time the method is called. PostgreSQL 17 and earlier map to `/var/lib/postgresql/data`; PostgreSQL 18 and later map to `/var/lib/postgresql`.
 
-Because of this layout change, a data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to Aspire 13.4. The container fails to start with an error similar to:
+Because of this layout change, PostgreSQL 17 data persisted with `WithDataVolume(...)` or `WithDataBindMount(...)` (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to Aspire 13.4. The container fails to start with an error similar to:
 
 ```text
 Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" ... Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -399,7 +399,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </TabItem>
 </Tabs>
 
-The data volume is used to persist the PostgreSQL server data outside the lifecycle of its container. The data volume is mounted at the `/var/lib/postgresql/data` path in the PostgreSQL server container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-postgresql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
+The data volume is used to persist the PostgreSQL server data outside the lifecycle of its container. The container data directory depends on the PostgreSQL image version: PostgreSQL 17 and earlier use `/var/lib/postgresql/data`, while PostgreSQL 18 and later use `/var/lib/postgresql`. `WithDataVolume(...)` selects the correct path automatically based on the configured image tag. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-postgresql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
+
+<Aside type="caution">
+  Aspire 13.4 bumped the default PostgreSQL image to 18, which uses a different on-disk data layout than PostgreSQL 17. A data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading. See [PostgreSQL 18 data directory change](#postgresql-18-data-directory-change) for recovery options.
+</Aside>
 
 <Aside type="caution">
     Some database integrations, including the Aspire PostgreSQL integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
@@ -588,6 +592,68 @@ await builder.build().run();
 ```
 </TabItem>
 </Tabs>
+
+## PostgreSQL 18 data directory change
+
+Starting with Aspire 13.4, the default PostgreSQL container image used by `AddPostgres` is **18.3** (previously 17.6). PostgreSQL 18 changed the on-disk data layout: the official `postgres` image now stores cluster files under a major-version-specific subdirectory of `/var/lib/postgresql` (for example, `/var/lib/postgresql/18/docker`), whereas PostgreSQL 17 and earlier stored data directly in `/var/lib/postgresql/data`. For upstream details, see [docker-library/postgres#1259](https://github.com/docker-library/postgres/issues/1259) and [docker-library/postgres#37](https://github.com/docker-library/postgres/issues/37).
+
+`WithDataVolume(...)` and `WithDataBindMount(...)` are version-aware: Aspire chooses the container data directory from the configured image tag at the time the method is called. PostgreSQL 17 and earlier map to `/var/lib/postgresql/data`; PostgreSQL 18 and later map to `/var/lib/postgresql`.
+
+Because of this layout change, a data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to Aspire 13.4. The container fails to start with an error similar to:
+
+```text
+Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" ... Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql
+```
+
+You have two ways to recover.
+
+### Option 1: Stay on PostgreSQL 17 (recommended, no migration)
+
+Pin the image back to a PostgreSQL 17 tag with `WithImageTag(...)` **before** calling `WithDataVolume(...)`. Aspire then selects the legacy `/var/lib/postgresql/data` path and your existing volume keeps working with no migration:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+```csharp title="C# — AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var postgres = builder.AddPostgres("pgsql")
+    .WithImageTag("17.6")
+    .WithDataVolume();
+
+// After adding all resources, run the app...
+```
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+```typescript title="TypeScript — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("pgsql");
+await postgres.withImageTag("17.6");
+await postgres.withDataVolume();
+
+// After adding all resources, run the app...
+```
+</TabItem>
+</Tabs>
+
+<Aside type="caution">
+  Call `WithImageTag(...)` **before** `WithDataVolume(...)`. The data directory is chosen from the configured tag at the time `WithDataVolume(...)` runs, so the tag must be set first.
+</Aside>
+
+### Option 2: Upgrade the data volume to PostgreSQL 18
+
+Follow the official [PostgreSQL upgrade documentation](https://www.postgresql.org/docs/current/upgrading.html) using `pg_dumpall`/restore or `pg_upgrade`. Always back up the volume before migrating.
+
+If the data is disposable, you can start fresh. Stop the app, remove any container still referencing the old volume (`docker volume rm` fails while the volume is in use), then remove the volume so Aspire creates a new PostgreSQL 18 volume on the next run:
+
+```bash
+docker volume ls
+docker ps -a --filter volume=<old-volume-name>
+docker rm -f <container-id>
+docker volume rm <old-volume-name>
+```
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -837,7 +837,7 @@ Update references that assumed an HTTP primary endpoint to use the HTTPS endpoin
 
 The default PostgreSQL container image used by `AddPostgres` moved from 17.6 to 18.3. PostgreSQL 18 changed the on-disk data layout: the official `postgres` image now stores cluster files under a major-version-specific subdirectory of `/var/lib/postgresql` (for example, `/var/lib/postgresql/18/docker`), whereas PostgreSQL 17 and earlier stored data directly in `/var/lib/postgresql/data`.
 
-As a result, an existing `WithDataVolume()` (or `WithDataBindMount()`) data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to 13.4. The container fails to start with an error similar to:
+As a result, existing PostgreSQL data persisted with `WithDataVolume()` (a Docker volume) or `WithDataBindMount()` (a host bind mount) on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to 13.4. The container fails to start with an error similar to:
 
 ```text
 Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" ... Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql
@@ -851,7 +851,7 @@ You have two ways to recover:
   var db = builder.AddPostgres("pgsql").WithImageTag("17.6").WithDataVolume();
   ```
 
-- **Upgrade the data volume to PostgreSQL 18.** Follow the official [PostgreSQL upgrade documentation](https://www.postgresql.org/docs/current/upgrading.html) using `pg_dumpall`/restore or `pg_upgrade`, and always back up the volume first. If the data is disposable, stop the app, remove any container still referencing the volume, then remove the volume so Aspire creates a fresh PostgreSQL 18 volume on the next run.
+- **Upgrade the persisted data to PostgreSQL 18.** Follow the official [PostgreSQL upgrade documentation](https://www.postgresql.org/docs/current/upgrading.html) using `pg_dumpall`/restore or `pg_upgrade`, and always back up the data first. If the data is disposable, stop the app, remove any container still referencing it, then remove the volume or bind mount data so Aspire creates fresh PostgreSQL 18 data on the next run.
 
 For full guidance and the container path mapping, see [PostgreSQL 18 data directory change](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
 
@@ -862,7 +862,7 @@ For full guidance and the container path mapping, see [PostgreSQL 18 data direct
 - TypeScript AppHosts are validated before startup, so invalid TypeScript fails earlier.
 - `CreateHttpClient` and `GetEndpointUriString` in `Aspire.Hosting.Testing` now prefer the `https` endpoint when no endpoint name is given; pass an explicit endpoint name if your tests relied on the previous `http`-first behavior.
 - The default RabbitMQ container image moved from 4.2 to 4.3, which rejects transient non-exclusive queue declarations by default.
-- The default PostgreSQL container image moved from 17.6 to 18.3, which changes the on-disk data layout and breaks data volumes created on PostgreSQL 17.
+- The default PostgreSQL container image moved from 17.6 to 18.3, which changes the on-disk data layout and breaks PostgreSQL 17 data persisted with `WithDataVolume()` or `WithDataBindMount()`.
 - `AddNatsClient` now also registers `INatsClient` and a default serializer registry; user-provided registries still take precedence.
 
 #### Migration from Aspire 13.3 to 13.4
@@ -877,7 +877,7 @@ For full guidance and the container path mapping, see [PostgreSQL 18 data direct
 6. **Update renamed APIs** — `PublishAsNpmPackageScript` → `PublishAsPackageScript`, and Foundry hosted agents `PublishAsHostedAgent` → `WithComputeEnvironment` (with the new `AddPromptAgent` parameter order).
 7. **Review Keycloak references** for the HTTPS primary endpoint, and **review Azure Front Door deployments**, setting explicit names if existing resources conflict with Azure.Provisioning name generation.
 8. **Review RabbitMQ queue declarations** if your app creates transient, non-exclusive queues. The default RabbitMQ image is now 4.3, which rejects that deprecated queue pattern by default. For migration guidance, see [RabbitMQ 4.3 queue declaration requirements](/integrations/messaging/rabbitmq/rabbitmq-host/#rabbitmq-4-3-queue-declaration-requirements).
-9. **Review PostgreSQL data volumes** if your app uses `WithDataVolume()` or `WithDataBindMount()`. The default PostgreSQL image is now 18.3, which changes the on-disk data layout and breaks volumes created on PostgreSQL 17. Pin `WithImageTag("17.6")` before `WithDataVolume()` to keep using the existing volume, or migrate the data. See [PostgreSQL 18 data directory change](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
+9. **Review PostgreSQL data persistence** if your app uses `WithDataVolume()` or `WithDataBindMount()`. The default PostgreSQL image is now 18.3, which changes the on-disk data layout and breaks PostgreSQL 17 data persisted by either API. Pin `WithImageTag("17.6")` before `WithDataVolume()` to keep using the existing volume, or migrate the data. See [PostgreSQL 18 data directory change](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
 
 </Steps>
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -650,6 +650,14 @@ The default RabbitMQ container image has been bumped from 4.2 to 4.3. Existing A
   For RabbitMQ hosting setup, see the [RabbitMQ integration](/integrations/messaging/rabbitmq/rabbitmq-host/).
 </LearnMore>
 
+### PostgreSQL default image
+
+The default PostgreSQL container image has been bumped from 17.6 to 18.3. PostgreSQL 18 changed the on-disk data layout, so an existing `WithDataVolume()` data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading and the container fails to start. Pin the image back to `17.6` with `WithImageTag("17.6")` before `WithDataVolume()` to keep using the existing volume with no migration. See [Breaking changes](#breaking-changes) for recovery options.
+
+<LearnMore>
+  For PostgreSQL hosting setup and data volume guidance, see the [PostgreSQL integration](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
+</LearnMore>
+
 ## 🐛 Bug fixes and full changelog
 
 For the complete list of bug fixes and smaller changes in this release, see the [Aspire 13.4 release notes on GitHub](https://github.com/microsoft/aspire/releases/tag/v13.4.0).
@@ -825,6 +833,28 @@ The primary Keycloak endpoint is now HTTPS when the developer certificate is ena
 
 Update references that assumed an HTTP primary endpoint to use the HTTPS endpoint.
 
+#### PostgreSQL default image bumped to 18.3, breaking existing data volumes
+
+The default PostgreSQL container image used by `AddPostgres` moved from 17.6 to 18.3. PostgreSQL 18 changed the on-disk data layout: the official `postgres` image now stores cluster files under a major-version-specific subdirectory of `/var/lib/postgresql` (for example, `/var/lib/postgresql/18/docker`), whereas PostgreSQL 17 and earlier stored data directly in `/var/lib/postgresql/data`.
+
+As a result, an existing `WithDataVolume()` (or `WithDataBindMount()`) data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible with PostgreSQL 18 after upgrading to 13.4. The container fails to start with an error similar to:
+
+```text
+Error: in 18+, these Docker images are configured to store database data in a format which is compatible with "pg_ctlcluster" ... Counter to that, there appears to be PostgreSQL data in: /var/lib/postgresql
+```
+
+You have two ways to recover:
+
+- **Stay on PostgreSQL 17 (recommended, no migration).** Pin the image back to a 17 tag with `WithImageTag("17.6")` **before** calling `WithDataVolume()`. The data directory is selected from the configured tag at the time `WithDataVolume()` runs, so the tag must be set first. Aspire then chooses the legacy `/var/lib/postgresql/data` path and your existing volume keeps working:
+
+  ```csharp
+  var db = builder.AddPostgres("pgsql").WithImageTag("17.6").WithDataVolume();
+  ```
+
+- **Upgrade the data volume to PostgreSQL 18.** Follow the official [PostgreSQL upgrade documentation](https://www.postgresql.org/docs/current/upgrading.html) using `pg_dumpall`/restore or `pg_upgrade`, and always back up the volume first. If the data is disposable, stop the app, remove any container still referencing the volume, then remove the volume so Aspire creates a fresh PostgreSQL 18 volume on the next run.
+
+For full guidance and the container path mapping, see [PostgreSQL 18 data directory change](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
+
 #### Behavior changes to audit
 
 - `aspire update` now requires `--yes` in non-interactive mode, matching `aspire destroy`.
@@ -832,6 +862,7 @@ Update references that assumed an HTTP primary endpoint to use the HTTPS endpoin
 - TypeScript AppHosts are validated before startup, so invalid TypeScript fails earlier.
 - `CreateHttpClient` and `GetEndpointUriString` in `Aspire.Hosting.Testing` now prefer the `https` endpoint when no endpoint name is given; pass an explicit endpoint name if your tests relied on the previous `http`-first behavior.
 - The default RabbitMQ container image moved from 4.2 to 4.3, which rejects transient non-exclusive queue declarations by default.
+- The default PostgreSQL container image moved from 17.6 to 18.3, which changes the on-disk data layout and breaks data volumes created on PostgreSQL 17.
 - `AddNatsClient` now also registers `INatsClient` and a default serializer registry; user-provided registries still take precedence.
 
 #### Migration from Aspire 13.3 to 13.4
@@ -846,6 +877,7 @@ Update references that assumed an HTTP primary endpoint to use the HTTPS endpoin
 6. **Update renamed APIs** — `PublishAsNpmPackageScript` → `PublishAsPackageScript`, and Foundry hosted agents `PublishAsHostedAgent` → `WithComputeEnvironment` (with the new `AddPromptAgent` parameter order).
 7. **Review Keycloak references** for the HTTPS primary endpoint, and **review Azure Front Door deployments**, setting explicit names if existing resources conflict with Azure.Provisioning name generation.
 8. **Review RabbitMQ queue declarations** if your app creates transient, non-exclusive queues. The default RabbitMQ image is now 4.3, which rejects that deprecated queue pattern by default. For migration guidance, see [RabbitMQ 4.3 queue declaration requirements](/integrations/messaging/rabbitmq/rabbitmq-host/#rabbitmq-4-3-queue-declaration-requirements).
+9. **Review PostgreSQL data volumes** if your app uses `WithDataVolume()` or `WithDataBindMount()`. The default PostgreSQL image is now 18.3, which changes the on-disk data layout and breaks volumes created on PostgreSQL 17. Pin `WithImageTag("17.6")` before `WithDataVolume()` to keep using the existing volume, or migrate the data. See [PostgreSQL 18 data directory change](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
 
 </Steps>
 


### PR DESCRIPTION
## Summary

Aspire 13.4 bumped the default PostgreSQL container image from `17.6` to `18.3` (microsoft/aspire#17065). PostgreSQL 18 changed the on-disk data layout: the official `postgres` image now stores cluster files under a major-version-specific subdirectory of `/var/lib/postgresql` (for example, `/var/lib/postgresql/18/docker`), whereas PostgreSQL 17 and earlier stored data directly in `/var/lib/postgresql/data`.

As a result, an existing `WithDataVolume()` / `WithDataBindMount()` data volume created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading to 13.4, and the container fails to start. This PR documents the breaking change and the recovery guidance on the aspire.dev site.

## Changes

### `whats-new/aspire-13-4.mdx`
- New `### PostgreSQL default image` changelog entry under **Integration updates** (mirrors the RabbitMQ 4.3 treatment).
- New `#### PostgreSQL default image bumped to 18.3, breaking existing data volumes` subsection under **Breaking changes**, including the startup error, the cause, and two recovery options.
- Added a bullet to **Behavior changes to audit** and a step to the **Migration from 13.3 to 13.4** list.

### `integrations/databases/postgres/postgres-host.mdx`
- Made the data-volume path description version-aware (PG17 and earlier -> `/var/lib/postgresql/data`; PG18+ -> `/var/lib/postgresql`; `WithDataVolume(...)` selects the path automatically from the configured tag).
- New `## PostgreSQL 18 data directory change` section documenting the layout change and recovery guidance.

## Recovery guidance documented
1. **Stay on PostgreSQL 17 (recommended, no migration):** pin `WithImageTag("17.6")` **before** `WithDataVolume()` so Aspire selects the legacy data path. Ordering matters because the data directory is chosen from the configured tag at the time `WithDataVolume()` runs.
2. **Upgrade the data volume to PostgreSQL 18:** follow the official PostgreSQL upgrade docs (`pg_dumpall`/restore or `pg_upgrade`), or, if the data is disposable, stop the app and remove referencing containers before `docker volume rm` (which fails while the volume is in use) so Aspire creates a fresh PostgreSQL 18 volume.

## Related
- Tracks microsoft/aspire#17907
- Companion to the integration README change in microsoft/aspire#18416

## Notes
- Content-only changes. Cross-link anchors verified against the heading/span slugs.
- Base is `main`: the requested `release/13.4` branch does not exist on the remote (only `release/13.5`), and this branch forked from `main`, where the 13.4 docs pages live.
