### PR TITLE
Fix cookie consent scanner flow and preference-action reload

### DIFF
--- a/src/frontend/config/cookie.config.ts
+++ b/src/frontend/config/cookie.config.ts
@@ -1,7 +1,7 @@
 import type { CookieConsentConfig } from '@jop-software/astro-cookieconsent';
 
 export const cookieConfig: CookieConsentConfig = {
-  hideFromBots: process.env.E2E_TESTS !== '1',
+  hideFromBots: false,
   guiOptions: {
     consentModal: {
       layout: 'box',

--- a/src/frontend/src/components/starlight/Head.astro
+++ b/src/frontend/src/components/starlight/Head.astro
@@ -200,6 +200,30 @@ function computeSourceUrl() {
   })();
 </script>
 
+<script is:inline>
+  (function () {
+    if (window.__aspireCookieConsentReloadInitialized) return;
+    window.__aspireCookieConsentReloadInitialized = true;
+
+    var saveRoles = new Set(['all', 'necessary', 'save']);
+
+    document.addEventListener('click', function (event) {
+      var target = event.target;
+      if (!(target instanceof Element)) return;
+
+      var actionButton = target.closest('.pm__btn[data-role]');
+      if (!(actionButton instanceof HTMLButtonElement)) return;
+
+      var actionRole = actionButton.getAttribute('data-role');
+      if (!actionRole || !saveRoles.has(actionRole)) return;
+
+      window.setTimeout(function () {
+        window.location.reload();
+      }, 0);
+    });
+  })();
+</script>
+
 <!-- WebMCP: register a single `search-aspire-docs` tool for in-page agents. -->
 <script>
   import '@scripts/webmcp';

--- a/src/frontend/tests/e2e/helpers.ts
+++ b/src/frontend/tests/e2e/helpers.ts
@@ -2,11 +2,6 @@ import { expect, type Page } from '@playwright/test';
 
 export async function resetCookieConsentState(page: Page): Promise<void> {
   await page.context().clearCookies();
-  await page.addInitScript(() => {
-    localStorage.removeItem('cc_cookie');
-    sessionStorage.removeItem('cc_cookie');
-    document.cookie = 'cc_cookie=; Max-Age=0; path=/';
-  });
 }
 
 export async function openCookiePreferences(page: Page): Promise<void> {
@@ -28,6 +23,20 @@ export async function dismissCookieConsentIfVisible(page: Page): Promise<void> {
   if (await rejectAllButton.isVisible().catch(() => false)) {
     await rejectAllButton.click();
   }
+}
+
+export async function clickCookiePreferencesAction(
+  page: Page,
+  actionName: RegExp
+): Promise<void> {
+  const actionButton = page.getByRole('button', { name: actionName }).last();
+  await Promise.all([
+    page.waitForEvent('framenavigated', {
+      predicate: (frame) => frame === page.mainFrame(),
+    }),
+    actionButton.click(),
+  ]);
+  await page.waitForLoadState('domcontentloaded');
 }
 
 export async function waitForAccessibilityEnhancements(page: Page): Promise<void> {

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, type Page } from '@playwright/test';
 import {
+  clickCookiePreferencesAction,
   dismissCookieConsentIfVisible,
   isNarrowViewport,
   openCookiePreferences,
@@ -219,10 +220,7 @@ test('cookie consent reject-all keeps analytics disabled', async ({ page }) => {
   await page.goto('/get-started/prerequisites/');
   await openCookiePreferences(page);
 
-  await page
-    .getByRole('button', { name: /reject all/i })
-    .last()
-    .click();
+  await clickCookiePreferencesAction(page, /reject all/i);
   await waitForConsentRecorded(page);
   await waitForAnalyticsConsent(page, false);
   await waitForConsentCategories(page, ['necessary']);
@@ -233,10 +231,7 @@ test('cookie preferences and accept-all enable analytics tracking consent', asyn
   await page.goto('/get-started/prerequisites/');
   await openCookiePreferences(page);
 
-  await page
-    .getByRole('button', { name: /accept all/i })
-    .last()
-    .click();
+  await clickCookiePreferencesAction(page, /accept all/i);
 
   await waitForConsentRecorded(page);
   await waitForAnalyticsConsent(page, true);


### PR DESCRIPTION
## Summary
- disable cookie consent `hideFromBots` so scanner traffic can see the banner/modal
- reload the page after preferences-modal save actions (Accept all, Reject all, Save preferences) to ensure post-consent cookie state is immediately reflected
- update consent e2e helpers/tests to handle the new reload behavior and avoid clearing consent state on reload

## Validation
- `pnpm -C src/frontend lint`
- `pnpm -C src/frontend test:e2e -- tests/e2e/ui-regressions.spec.ts --grep "cookie consent reject-all keeps analytics disabled|cookie preferences and accept-all enable analytics tracking consent"`