### PR TITLE
Filter RSS feed to default locale

### DIFF
--- a/src/frontend/src/pages/rss.xml.ts
+++ b/src/frontend/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import type { APIContext } from 'astro';
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
+import { isDefaultLocaleEntry } from '@utils/page-metadata';
 
 type FeedDocData = Record<string, unknown>;
 
@@ -39,6 +40,7 @@ export async function GET(context: APIContext) {
     if (data.draft) return false;
     if (!data.description) return false;
     if (data.title === '404') return false;
+    if (!isDefaultLocaleEntry(doc.id)) return false;
 
     return true;
   });

--- a/src/frontend/src/utils/page-metadata.ts
+++ b/src/frontend/src/utils/page-metadata.ts
@@ -1,4 +1,5 @@
 import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+import { locales } from '../../config/locales';
 import { isApiReferencePath } from '@utils/api-reference-routes';
 
 /**
@@ -41,30 +42,11 @@ export const FALLBACK_DESCRIPTION =
 /** Maximum length we trim Open Graph descriptions to. */
 const OG_DESCRIPTION_MAX_LENGTH = 200;
 
-/**
- * Known locale path segments. Mirrors `config/locales.ts` but lives here so
- * the OG image endpoint (which runs at build time outside the Astro/Starlight
- * route context) can detect translated entries without importing the locale
- * config from a different module graph.
- */
-const NON_DEFAULT_LOCALE_PREFIXES = [
-  'da',
-  'de',
-  'es',
-  'fr',
-  'hi',
-  'id',
-  'it',
-  'ja',
-  'ko',
-  'pt-br',
-  'ru',
-  'tr',
-  'uk',
-  'zh-cn',
-] as const;
-
-const localePrefixPattern = new RegExp(`^(?:${NON_DEFAULT_LOCALE_PREFIXES.join('|')})(?:/|$)`, 'i');
+const nonDefaultLocalePrefixes = Object.keys(locales).filter((locale) => locale !== 'root');
+const localePrefixPattern = new RegExp(
+  `^(?:${nonDefaultLocalePrefixes.map(escapeRegExp).join('|')})(?:/|$)`,
+  'i'
+);
 
 const releaseNotePattern = /^whats-new\/aspire-/i;
 
@@ -344,6 +326,10 @@ export function resolveSiteUrl(site: URL | string | undefined, currentUrl: URL):
 
 function normalizeEntryId(entryId: string): string {
   return entryId.replace(/\\/g, '/');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function isPagesRoute(route: MinimalRoute): boolean {

--- a/src/frontend/tests/e2e/rss.spec.ts
+++ b/src/frontend/tests/e2e/rss.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 
+import { locales } from '../../config/locales';
 import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
 
 test('rss feed endpoint returns XML with stylesheet and items', async ({ request }) => {
@@ -18,6 +19,10 @@ test('rss feed endpoint returns XML with stylesheet and items', async ({ request
   expect(body).toContain('<description>Latest updates to the documentation</description>');
   expect(body).toContain('https://aspire.dev');
   expect(body).toMatch(/<item>[\s\S]*<\/item>/);
+
+  for (const locale of Object.keys(locales).filter((locale) => locale !== 'root')) {
+    expect(body).not.toContain(`<link>https://aspire.dev/${locale}/`);
+  }
 });
 
 test('rss link opens the feed in a new tab', async ({ page }) => {


### PR DESCRIPTION
## Summary
- filter rss.xml entries to default-locale docs only
- derive non-default locale detection from config/locales.ts instead of duplicating locale lists
- add RSS coverage to prevent localized links from appearing in the feed

## Tests
- pnpm --dir .\\src\\frontend exec vitest run tests\\unit\\page-metadata.vitest.test.ts
- pnpm --dir .\\src\\frontend exec playwright test rss.spec.ts