### PR TITLE
Fix contributors page title mojibake and unbounded map SVG

### DIFF
--- a/src/frontend/src/components/AspireMap.astro
+++ b/src/frontend/src/components/AspireMap.astro
@@ -26,6 +26,15 @@ import mapDark from '../assets/maps/map-darkdots.svg';
     border: 1px solid var(--sl-color-gray-3);
   }
 
+  /* The map lives inside a `.not-content` wrapper, which strips Starlight's
+     default `img { max-width: 100%; height: auto }`. Restore it so the SVG
+     (which only declares a viewBox, no intrinsic width/height) scales to fit
+     its container instead of overflowing at its viewBox width. */
+  .map :global(img) {
+    max-width: 100%;
+    height: auto;
+  }
+
   .map {
     background-color: var(--sl-color-gray-5);
     border: 1px solid var(--sl-color-gray-4);

--- a/src/frontend/src/content/docs/community/contributors.mdx
+++ b/src/frontend/src/content/docs/community/contributors.mdx
@@ -1,5 +1,5 @@
 ---
-title: Contributors ≡ƒñ¥
+title: Contributors 🤝
 seoTitle: Aspire contributors and the open-source community team
 description: Meet the contributors who help make Aspire better every day. Explore the global community of engineers, writers, and translators powering the Aspire ecosystem.
 lastUpdated: false


### PR DESCRIPTION
## Summary

Fixes two rendering issues on the [contributors page](https://aspire.dev/community/contributors/).

### 1. Title mojibake (h1 / `<title>`)
The page title rendered as `Contributors ≡ƒñ¥`. The handshake emoji (🤝, UTF-8 `F0 9F A4 9D`) had been corrupted into the CP437 characters those bytes map to. Restored the correct emoji in the frontmatter `title`.

### 2. Unbounded AspireMap SVG
The community map overflowed its container, spilling map dots into the right sidebar and below the box.

**Root cause:** `map-darkdots.svg` / `map-lightdots.svg` declare only a `viewBox` (`0 0 1295.5 700.7`) with no intrinsic `width`/`height`. Since #1228, `ThemeImage` renders via `astro:assets` `<Image>`, which always stamps `width`/`height` equal to the viewBox (`1296×701`). The map lives inside a `.not-content` wrapper, which strips Starlight's default `img { max-width: 100% }`, so the image rendered at its full 1296px viewBox width and overflowed.

**Fix:** Restore responsive sizing (`max-width: 100%; height: auto`) for the image scoped to `.map`.

## Verification
Validated the CSS fix against the live page DOM: the map image went from rendering 1296px wide (overflowing ~489px past the container into the sidebar) to fitting within the padded container with aspect ratio preserved and no right/bottom overflow.