### PR TITLE
Add CI check for forbidden words in pull requests

### DIFF
--- a/.github/forbidden-words.json
+++ b/.github/forbidden-words.json
@@ -1,0 +1,23 @@
+{
+  "$comment": "Forbidden words/phrases checked against newly added lines in pull requests by .github/scripts/check-forbidden-words.sh. Each rule has a regex 'pattern' (extended POSIX, evaluated case-insensitively unless 'caseSensitive' is true) and a 'message' shown when matched. Add 'excludePaths' globs to skip files for a specific rule.",
+  "excludePaths": [
+    "**/*.lock.yml",
+    "pnpm-lock.yaml",
+    ".github/forbidden-words.json",
+    ".github/scripts/check-forbidden-words.sh"
+  ],
+  "rules": [
+    {
+      "pattern": "\\.NET Aspire",
+      "message": "Use \"Aspire\" instead of \".NET Aspire\"."
+    },
+    {
+      "pattern": "dotnet aspire",
+      "message": "Use \"Aspire\" instead of \"dotnet aspire\"."
+    },
+    {
+      "pattern": "\\bapp host\\b",
+      "message": "Use \"AppHost\" instead of \"app host\"."
+    }
+  ]
+}

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 
 BASE_SHA="${1:?base SHA required}"
 HEAD_SHA="${2:?head SHA required}"
+MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || { echo "::error::Unable to compute merge-base of $BASE_SHA and $HEAD_SHA"; exit 2; }
 CONFIG_FILE="${CONFIG_FILE:-.github/forbidden-words.json}"
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
@@ -30,7 +31,7 @@ command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
 # Read global exclude globs (newline separated).
 mapfile -t GLOBAL_EXCLUDES < <(jq -r '.excludePaths // [] | .[]' "$CONFIG_FILE")
 
-rule_count=$(jq '.rules | length' "$CONFIG_FILE")
+rule_count=$(jq '(.rules // []) | length' "$CONFIG_FILE")
 if [[ "$rule_count" -eq 0 ]]; then
   echo "No rules defined in $CONFIG_FILE; nothing to check."
   exit 0
@@ -53,7 +54,7 @@ matches_any_glob() {
 violations=0
 
 # List the files changed between base and head (added/copied/modified/renamed).
-mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "$MERGE_BASE" "$HEAD_SHA")
 
 for file in "${CHANGED_FILES[@]}"; do
   [[ -z "$file" ]] && continue
@@ -65,7 +66,7 @@ for file in "${CHANGED_FILES[@]}"; do
 
   # Collect added lines as "<line_number>:<content>". --unified=0 keeps hunks
   # tight so we can track new-file line numbers from the @@ headers.
-  diff_output=$(git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- "$file" || true)
+  diff_output=$(git diff --unified=0 "$MERGE_BASE" "$HEAD_SHA" -- "$file")
   [[ -z "$diff_output" ]] && continue
 
   added_lines=$(awk '
@@ -101,7 +102,7 @@ for file in "${CHANGED_FILES[@]}"; do
       continue
     fi
 
-    grep_opts=(-E)
+    grep_opts=(-P)
     if [[ "$case_sensitive" != "true" ]]; then
       grep_opts+=(-i)
     fi

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# Scans the lines added by a pull request for forbidden words/phrases.
+#
+# Only newly added lines (those prefixed with '+' in the diff) are checked, so
+# pre-existing text is never flagged. Rules are defined in
+# .github/forbidden-words.json.
+#
+# Usage:
+#   check-forbidden-words.sh <base_sha> <head_sha>
+#
+# Environment overrides:
+#   CONFIG_FILE  Path to the rules file (default: .github/forbidden-words.json)
+#
+# Exits non-zero when at least one forbidden phrase is found.
+
+set -euo pipefail
+
+BASE_SHA="${1:?base SHA required}"
+HEAD_SHA="${2:?head SHA required}"
+CONFIG_FILE="${CONFIG_FILE:-.github/forbidden-words.json}"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "::error::Config file not found: $CONFIG_FILE"
+  exit 2
+fi
+
+command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
+
+# Read global exclude globs (newline separated).
+mapfile -t GLOBAL_EXCLUDES < <(jq -r '.excludePaths // [] | .[]' "$CONFIG_FILE")
+
+rule_count=$(jq '.rules | length' "$CONFIG_FILE")
+if [[ "$rule_count" -eq 0 ]]; then
+  echo "No rules defined in $CONFIG_FILE; nothing to check."
+  exit 0
+fi
+
+# Returns 0 if $1 matches any of the shell globs passed as remaining args.
+matches_any_glob() {
+  local path="$1"; shift
+  local glob
+  for glob in "$@"; do
+    [[ -z "$glob" ]] && continue
+    # shellcheck disable=SC2053
+    if [[ "$path" == $glob ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+violations=0
+
+# List the files changed between base and head (added/copied/modified/renamed).
+mapfile -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA")
+
+for file in "${CHANGED_FILES[@]}"; do
+  [[ -z "$file" ]] && continue
+
+  # Skip files excluded for every rule.
+  if matches_any_glob "$file" "${GLOBAL_EXCLUDES[@]}"; then
+    continue
+  fi
+
+  # Collect added lines as "<line_number>:<content>". --unified=0 keeps hunks
+  # tight so we can track new-file line numbers from the @@ headers.
+  diff_output=$(git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- "$file" || true)
+  [[ -z "$diff_output" ]] && continue
+
+  added_lines=$(awk '
+    /^@@/ {
+      for (i = 1; i <= NF; i++) {
+        if (substr($i, 1, 1) == "+") {
+          s = substr($i, 2)
+          split(s, parts, ",")
+          line = parts[1] + 0
+          break
+        }
+      }
+      next
+    }
+    /^\+\+\+/ { next }
+    /^\+/ {
+      content = substr($0, 2)
+      printf "%d:%s\n", line, content
+      line++
+    }
+  ' <<< "$diff_output")
+
+  [[ -z "$added_lines" ]] && continue
+
+  for ((r = 0; r < rule_count; r++)); do
+    pattern=$(jq -r ".rules[$r].pattern" "$CONFIG_FILE")
+    message=$(jq -r ".rules[$r].message // \"\"" "$CONFIG_FILE")
+    case_sensitive=$(jq -r ".rules[$r].caseSensitive // false" "$CONFIG_FILE")
+
+    # Per-rule path excludes.
+    mapfile -t RULE_EXCLUDES < <(jq -r ".rules[$r].excludePaths // [] | .[]" "$CONFIG_FILE")
+    if ((${#RULE_EXCLUDES[@]} > 0)) && matches_any_glob "$file" "${RULE_EXCLUDES[@]}"; then
+      continue
+    fi
+
+    grep_opts=(-E)
+    if [[ "$case_sensitive" != "true" ]]; then
+      grep_opts+=(-i)
+    fi
+
+    # Check each added line's content (line number stripped) against the rule.
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      lineno="${entry%%:*}"
+      content="${entry#*:}"
+      if printf '%s' "$content" | grep -q "${grep_opts[@]}" -- "$pattern"; then
+        printf '::error file=%s,line=%s::Forbidden phrase (/%s/): %s\n' \
+          "$file" "$lineno" "$pattern" "$message"
+        printf '    %s:%s: %s\n' "$file" "$lineno" "$content"
+        violations=$((violations + 1))
+      fi
+    done <<< "$added_lines"
+  done
+done
+
+echo
+if [[ "$violations" -gt 0 ]]; then
+  echo "Found $violations forbidden phrase occurrence(s) in added lines."
+  echo "Update the wording, or adjust .github/forbidden-words.json if a rule is wrong."
+  exit 1
+fi
+
+echo "No forbidden phrases found in added lines."

--- a/.github/workflows/forbidden-words.yml
+++ b/.github/workflows/forbidden-words.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Resolve base and head SHAs
         id: shas
@@ -42,16 +42,14 @@ jobs:
           if [[ "$EVENT_NAME" == "pull_request" ]]; then
             base="$PR_BASE_SHA"
             head="$PR_HEAD_SHA"
-            git fetch --depth=1 origin "$base"
-            git fetch --depth=1 origin "$head"
           else
             base="$INPUT_BASE_SHA"
             head="${INPUT_HEAD_SHA:-$(git rev-parse HEAD)}"
             if [[ -z "$base" ]]; then
-              git fetch --depth=1 origin "${GITHUB_REF_NAME}" || true
+              git fetch origin "${GITHUB_REF_NAME}" || true
               base="$(git rev-parse "origin/${GITHUB_REF_NAME}" 2>/dev/null || git rev-parse HEAD~1)"
             else
-              git fetch --depth=1 origin "$base" || true
+              git fetch origin "$base" || true
             fi
           fi
           echo "base=$base" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/forbidden-words.yml
+++ b/.github/workflows/forbidden-words.yml
@@ -1,0 +1,65 @@
+name: Forbidden Words
+
+on:
+  pull_request:
+    branches: [ main, release/* ]
+  workflow_dispatch:
+    inputs:
+      base_sha:
+        description: 'Base SHA to diff from (defaults to origin/<default branch>)'
+        required: false
+      head_sha:
+        description: 'Head SHA to diff to (defaults to HEAD)'
+        required: false
+
+# Group by PR so new commits cancel the in-flight run for the same PR.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  forbidden-words:
+    name: Check forbidden words
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+
+      - name: Resolve base and head SHAs
+        id: shas
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          INPUT_BASE_SHA: ${{ github.event.inputs.base_sha }}
+          INPUT_HEAD_SHA: ${{ github.event.inputs.head_sha }}
+        run: |
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            base="$PR_BASE_SHA"
+            head="$PR_HEAD_SHA"
+            git fetch --depth=1 origin "$base"
+            git fetch --depth=1 origin "$head"
+          else
+            base="$INPUT_BASE_SHA"
+            head="${INPUT_HEAD_SHA:-$(git rev-parse HEAD)}"
+            if [[ -z "$base" ]]; then
+              git fetch --depth=1 origin "${GITHUB_REF_NAME}" || true
+              base="$(git rev-parse "origin/${GITHUB_REF_NAME}" 2>/dev/null || git rev-parse HEAD~1)"
+            else
+              git fetch --depth=1 origin "$base" || true
+            fi
+          fi
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "head=$head" >> "$GITHUB_OUTPUT"
+
+      - name: Scan added lines for forbidden words
+        shell: bash
+        run: |
+          .github/scripts/check-forbidden-words.sh \
+            "${{ steps.shas.outputs.base }}" \
+            "${{ steps.shas.outputs.head }}"


### PR DESCRIPTION
## Why

We want consistent terminology across the site and docs. Certain phrasings keep slipping into PRs (for example ".NET Aspire" instead of "Aspire", or "app host" instead of "AppHost"). This adds a lightweight CI guard so those get caught at review time instead of after merge.

## What

A new **Forbidden Words** workflow that scans a PR for banned phrases and fails when any are found.

- **Only newly added lines are checked.** The script parses the PR diff and inspects lines prefixed with `+`, so pre-existing text is never flagged and the check stays noise-free on unrelated changes.
- **Rules are data, not code.** Banned phrases live in `.github/forbidden-words.json`, so updating the list is a one-line edit with no script changes. Each rule has a regex `pattern` and a `message` shown on match. Matching is case-insensitive by default (`caseSensitive: true` per rule to override).
- **Helpful output.** Violations are reported as GitHub error annotations pinned to the exact file and line, plus a console summary.
- **Exclusions.** Global and per-rule `excludePaths` globs let you skip files; lockfiles and the checker's own files are excluded by default.

### Rules shipped

| Phrase | Guidance |
| --- | --- |
| `.NET Aspire` | Use "Aspire" |
| `dotnet aspire` | Use "Aspire" |
| `app host` | Use "AppHost" (word-boundaried, so `AppHost` is allowed) |

## Files

- `.github/workflows/forbidden-words.yml` - runs on `pull_request` (and manual `workflow_dispatch`), resolves base/head SHAs, and invokes the script.
- `.github/scripts/check-forbidden-words.sh` - diff parser and matcher.
- `.github/forbidden-words.json` - the maintainable rule list.

## Validation

Verified end to end in an Ubuntu / bash 5 container: it flags the three phrases with correct line numbers, leaves legitimate `AppHost` untouched, honors the lockfile exclusion, and passes cleanly on diffs with no violations.
