### PR TITLE
Fix forbidden phrases flagged by CI

### DIFF
--- a/src/frontend/src/content/docs/dashboard/troubleshooting.mdx
+++ b/src/frontend/src/content/docs/dashboard/troubleshooting.mdx
@@ -1,15 +1,15 @@
 ---
 title: Troubleshoot the Aspire dashboard
-description: Diagnose and resolve common Aspire dashboard issues including connection errors between the dashboard and the app host resource service.
+description: Diagnose and resolve common Aspire dashboard issues including connection errors between the dashboard and the AppHost resource service.
 ---
 
 import LearnMore from '@components/LearnMore.astro';
 
 This article helps you diagnose and resolve common issues with the Aspire dashboard.
 
-## Connection errors between the dashboard and app host
+## Connection errors between the dashboard and AppHost
 
-The dashboard displays resource information by connecting to a gRPC resource service hosted by the app host. When this connection fails, the dashboard may show an error message or display telemetry data without any resource list or console logs.
+The dashboard displays resource information by connecting to a gRPC resource service hosted by the AppHost. When this connection fails, the dashboard may show an error message or display telemetry data without any resource list or console logs.
 
 ### Symptoms
 
@@ -20,7 +20,7 @@ The dashboard displays resource information by connecting to a gRPC resource ser
 
 ### Viewing dashboard logs
 
-Enable verbose logging to get more detail about connection failures. Run the app host with debug-level output:
+Enable verbose logging to get more detail about connection failures. Run the AppHost with debug-level output:
 
 ```bash title="Run with debug output"
 aspire run --log-level Debug
@@ -30,7 +30,7 @@ Review the console output for messages related to the resource service connectio
 
 ### Certificate and TLS errors
 
-When running with HTTPS, the dashboard and app host use certificates to secure the gRPC connection. Certificate issues are a common source of connection failures.
+When running with HTTPS, the dashboard and AppHost use certificates to secure the gRPC connection. Certificate issues are a common source of connection failures.
 
 **Common causes:**
 
@@ -41,9 +41,9 @@ When running with HTTPS, the dashboard and app host use certificates to secure t
 ### Firewall and network issues
 
 - Confirm that a firewall or security software isn't blocking the connection between the dashboard and the resource service endpoint.
-- The resource service uses gRPC, which requires HTTP/2. Some firewalls, proxies, or network appliances don't support HTTP/2 traffic and may silently drop or downgrade the connection. Ensure that any intermediary between the dashboard and the app host allows HTTP/2.
+- The resource service uses gRPC, which requires HTTP/2. Some firewalls, proxies, or network appliances don't support HTTP/2 traffic and may silently drop or downgrade the connection. Ensure that any intermediary between the dashboard and the AppHost allows HTTP/2.
 
-### Ping timeout errors when debugging the app host
+### Ping timeout errors when debugging the AppHost
 
 You may see the following error in the dashboard:
 
@@ -53,11 +53,11 @@ HttpRequestException: The HTTP/2 server didn't respond to a ping request
 within the configured KeepAlivePingDelay. (HttpProtocolError)")
 ```
 
-This means the dashboard's gRPC client sent an HTTP/2 PING frame to the app host's resource service, but didn't receive a response in time.
+This means the dashboard's gRPC client sent an HTTP/2 PING frame to the AppHost's resource service, but didn't receive a response in time.
 
-The most likely cause is that a debugger is paused on the app host — when you hit a breakpoint, the process can't respond to HTTP/2 PING frames, triggering the timeout. This error resolves once execution resumes.
+The most likely cause is that a debugger is paused on the AppHost — when you hit a breakpoint, the process can't respond to HTTP/2 PING frames, triggering the timeout. This error resolves once execution resumes.
 
-If you see this error and you're running without a debugger attached, verify the app host process is still alive and responsive.
+If you see this error and you're running without a debugger attached, verify the AppHost process is still alive and responsive.
 
 <LearnMore>
 For the full list of configuration options, see [Aspire dashboard configuration](/dashboard/configuration/).

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -178,7 +178,7 @@ The Aspire CLI is now available as an npm package (`@microsoft/aspire-cli`), pro
 - **Show discovered AppHosts in Aspire pane**: Idle AppHosts discovered via `aspire ls` now display in the VS Code Aspire pane with context menu actions.
 - **Security hardening**: Terminal commands now use structured shell arguments to prevent command injection via malicious paths or resource names.
 - **Parameter display improvements**: Consistent display across panels with secret masks, missing value warnings, and 80-character truncation for non-secrets.
-- **VS Code extension branding**: Renamed from ".NET Aspire" to "Aspire" with updated icon and display name.
+- **VS Code extension branding**: Rebranded to "Aspire" with an updated icon and display name.
 - **AppHost discovery efficiency**: Respects workspace exclusion settings, debounces file changes, and avoids overlapping discovery runs.
 
 ## 🔌 Integration improvements


### PR DESCRIPTION
Addresses the forbidden-words CI check failures on #1233.

- **`dashboard/troubleshooting.mdx`**: Replace all 10 occurrences of "app host" with "AppHost".
- **`whats-new/aspire-13-5.mdx`**: Reword the VS Code extension branding note to avoid the literal ".NET Aspire" phrase (a direct substitution would have produced the nonsensical "Renamed from \"Aspire\" to \"Aspire\"").

Targets `release/13.5`.