### PR TITLE
Add Aspire version placeholders to release docs

### DIFF
--- a/.agents/skills/doc-pr-reviewer/SKILL.md
+++ b/.agents/skills/doc-pr-reviewer/SKILL.md
@@ -80,6 +80,40 @@ For each non-`narrative` claim:
    - `contradicted` — the source code says something different than the PR claims; include both texts
 4. Do not infer from documentation, blog posts, or other branches. The branch you actually checked out and recorded for that repo (per the **Source of truth** section — the PR's matching branch, or the documented fallback when none matches) is the only source of truth.
 
+## Current-version placeholder review
+
+When a docs PR adds or edits Aspire version strings, check whether the version
+is intended to represent the current release or an intentionally fixed version.
+The docs site provides placeholders for current-version values:
+
+| Placeholder | Use for |
+|-------------|---------|
+| `%ASPIRE_VERSION%` | Full current Aspire version, including patch (for example, `13.5.0`) |
+| `%ASPIRE_VERSION_MAJOR_MINOR%` | Current Aspire major/minor display version (for example, `13.5`) |
+
+Flag hard-coded Aspire versions as a review finding when they appear in current
+copy/paste guidance that should track the active release, including:
+
+- `Aspire.AppHost.Sdk` declarations in project files or file-based apps.
+- `#:package Aspire.*@...` file-based app package directives.
+- Aspire CLI or AppHost sample output that reports the current CLI/AppHost
+  version.
+- Getting started, installation, or "use this today" examples that should move
+  with the release branch.
+
+Do **not** require placeholders for intentionally fixed versions, including:
+
+- What's-new or release-note pages that describe a specific historical release.
+- Upgrade examples that deliberately compare old and new versions.
+- CLI examples where the point is pinning a specific version with `--version`,
+  `-Version`, or `Aspire.ProjectTemplates::...`.
+- Versioned schema URLs, package compatibility notes, minimum-version
+  requirements, third-party dependency versions, container image tags, or issue
+  reproduction snippets.
+
+If the intent is ambiguous, leave a `COMMENT` asking whether the version should
+track the current release instead of requesting changes outright.
+
 ## Phase A artifact
 
 When Phase A finishes, write down (in memory) a frozen Phase A result containing:

--- a/.github/agents/release-verifier.agent.md
+++ b/.github/agents/release-verifier.agent.md
@@ -121,7 +121,22 @@ Scan the documentation for version strings that should have been updated for thi
 
 Determine the immediately prior version. For `13.2` the prior is `13.1`; for `13.0` the prior is `9.5` (or whatever the last release of the previous major is). Use the existing what's-new files to determine this.
 
-#### 4b. Scan for stale version references
+#### 4b. Verify shared version placeholders
+
+Read `src/frontend/config/aspire-versions.mjs` and verify the exported current
+version constants match the release being verified:
+
+| Export | Expected value |
+|--------|----------------|
+| `currentAspireMajorMinorVersion` | `{VERSION}` (for example, `13.2`) |
+| `currentAspireVersion` | `{NUGET_VERSION}` (for example, `13.2.0`) |
+
+These constants drive the `%ASPIRE_VERSION_MAJOR_MINOR%` and
+`%ASPIRE_VERSION%` documentation placeholders. If either value is stale, flag it
+as a **critical** failure because generated docs can show the wrong current
+release version.
+
+#### 4c. Scan for stale version references
 
 Search the docs content tree for references to the prior NuGet version that appear **outside** of intentional historical context (e.g., upgrade-from examples that deliberately show the old version).
 
@@ -139,7 +154,7 @@ grep -rn 'Aspire.AppHost.Sdk.*Version="{PRIOR_NUGET_VERSION}"' src/frontend/src/
   --include="*.mdx"
 ```
 
-#### 4c. Evaluate each match
+#### 4d. Evaluate each match
 
 For every match found:
 
@@ -149,7 +164,7 @@ For every match found:
    - **Stale (should be updated)**: The reference is in current guidance, installation instructions, or sample code that a user would copy today. Flag these for update.
 3. Log each stale reference with file path, line number, and surrounding context.
 
-#### 4d. Verify new version references
+#### 4e. Verify new version references
 
 Spot-check that key documentation pages reference the release version:
 

--- a/src/frontend/.starlight-icons/safelist.json
+++ b/src/frontend/.starlight-icons/safelist.json
@@ -51,7 +51,6 @@
   "i-material-icon-theme:markdown",
   "i-material-icon-theme:mdx",
   "i-material-icon-theme:next",
-  "i-material-icon-theme:nix",
   "i-material-icon-theme:nodejs",
   "i-material-icon-theme:nuget",
   "i-material-icon-theme:perl",

--- a/src/frontend/.starlight-icons/safelist.json
+++ b/src/frontend/.starlight-icons/safelist.json
@@ -51,6 +51,7 @@
   "i-material-icon-theme:markdown",
   "i-material-icon-theme:mdx",
   "i-material-icon-theme:next",
+  "i-material-icon-theme:nix",
   "i-material-icon-theme:nodejs",
   "i-material-icon-theme:nuget",
   "i-material-icon-theme:perl",

--- a/src/frontend/astro.config.mjs
+++ b/src/frontend/astro.config.mjs
@@ -8,6 +8,8 @@ import { cookieConfig } from './config/cookie.config';
 import { locales } from './config/locales.ts';
 import { headAttrs } from './config/head.attrs.ts';
 import { socialConfig } from './config/socials.config.ts';
+import { aspireVersionPlaceholdersIntegration } from './config/aspire-version-placeholders-integration.mjs';
+import { remarkAspireVersionPlaceholders } from './config/remark-aspire-version-placeholders.mjs';
 import catppuccin from '@catppuccin/starlight';
 import lunaria from './config/lunaria-starlight.mjs';
 import mermaid from 'astro-mermaid';
@@ -48,7 +50,9 @@ export default defineConfig({
   site: 'https://aspire.dev',
   trailingSlash: 'always',
   markdown: {
-    processor: unified(),
+    processor: unified({
+      remarkPlugins: [remarkAspireVersionPlaceholders],
+    }),
   },
   redirects: redirects,
   integrations: [
@@ -238,6 +242,7 @@ export default defineConfig({
     }),
     jopSoftwarecookieconsent(cookieConfig),
     ...(isBuildTimingEnabled ? [buildTiming()] : []),
+    aspireVersionPlaceholdersIntegration(),
   ],
   build: {
     concurrency: buildConcurrency,

--- a/src/frontend/config/aspire-version-placeholders-integration.mjs
+++ b/src/frontend/config/aspire-version-placeholders-integration.mjs
@@ -1,0 +1,43 @@
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { replaceAspireVersionPlaceholders } from './remark-aspire-version-placeholders.mjs';
+
+const generatedAssetExtensions = new Set(['.html', '.md', '.txt']);
+
+export function aspireVersionPlaceholdersIntegration() {
+  return {
+    name: 'aspire-version-placeholders',
+    hooks: {
+      'astro:build:done': async ({ dir }) => {
+        await replaceAspireVersionPlaceholdersInDirectory(fileURLToPath(dir));
+      },
+    },
+  };
+}
+
+export async function replaceAspireVersionPlaceholdersInDirectory(directory) {
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  await Promise.all(
+    entries.map(async (entry) => {
+      const resolvedPath = path.join(directory, entry.name);
+
+      if (entry.isDirectory()) {
+        await replaceAspireVersionPlaceholdersInDirectory(resolvedPath);
+        return;
+      }
+
+      if (!entry.isFile() || !generatedAssetExtensions.has(path.extname(entry.name))) {
+        return;
+      }
+
+      const content = await readFile(resolvedPath, 'utf8');
+      const updated = replaceAspireVersionPlaceholders(content);
+
+      if (updated !== content) {
+        await writeFile(resolvedPath, updated);
+      }
+    })
+  );
+}

--- a/src/frontend/config/aspire-versions.mjs
+++ b/src/frontend/config/aspire-versions.mjs
@@ -1,0 +1,7 @@
+export const currentAspireMajorMinorVersion = '13.5';
+export const currentAspireVersion = '13.5.0';
+
+export const aspireVersionPlaceholders = Object.freeze({
+  '%ASPIRE_VERSION_MAJOR_MINOR%': currentAspireMajorMinorVersion,
+  '%ASPIRE_VERSION%': currentAspireVersion,
+});

--- a/src/frontend/config/remark-aspire-version-placeholders.mjs
+++ b/src/frontend/config/remark-aspire-version-placeholders.mjs
@@ -1,0 +1,40 @@
+import { aspireVersionPlaceholders } from './aspire-versions.mjs';
+
+const placeholderEntries = Object.entries(aspireVersionPlaceholders);
+
+export function replaceAspireVersionPlaceholders(value) {
+  return placeholderEntries.reduce(
+    (current, [placeholder, version]) => current.replaceAll(placeholder, version),
+    value
+  );
+}
+
+export function remarkAspireVersionPlaceholders() {
+  return (tree) => {
+    replaceNodeValues(tree);
+  };
+}
+
+function replaceNodeValues(node) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  if (typeof node.value === 'string') {
+    node.value = replaceAspireVersionPlaceholders(node.value);
+  }
+
+  if (Array.isArray(node.attributes)) {
+    for (const attribute of node.attributes) {
+      if (attribute && typeof attribute.value === 'string') {
+        attribute.value = replaceAspireVersionPlaceholders(attribute.value);
+      }
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      replaceNodeValues(child);
+    }
+  }
+}

--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -144,8 +144,8 @@ Use a file-based AppHost when you want a lightweight single-file orchestrator wi
 3. Wire the resources in `apphost.cs`:
 
    ```csharp title="apphost.cs"
-   #:sdk Aspire.AppHost.Sdk@13.2.0
-   #:package Aspire.Hosting.Redis@13.2.0
+   #:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
+   #:package Aspire.Hosting.Redis@%ASPIRE_VERSION%
 
    #pragma warning disable ASPIRECSHARPAPPS001
 
@@ -401,10 +401,10 @@ Common examples include Node.js apps, Vite frontends, Python workers, and Uvicor
 <TabItem id='csharp' label='C#'>
 
 ```csharp title="apphost.cs — Existing services with hosting integrations"
-#:sdk Aspire.AppHost.Sdk@13.3.0
-#:package Aspire.Hosting.Redis@13.3.0
-#:package Aspire.Hosting.Python@13.3.0
-#:package Aspire.Hosting.JavaScript@13.3.0
+#:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
+#:package Aspire.Hosting.Redis@%ASPIRE_VERSION%
+#:package Aspire.Hosting.Python@%ASPIRE_VERSION%
+#:package Aspire.Hosting.JavaScript@%ASPIRE_VERSION%
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -481,9 +481,9 @@ aspire add redis
 <TabItem id='csharp' label='C#'>
 
 ```csharp title="apphost.cs — Existing containers and shared infrastructure"
-#:sdk Aspire.AppHost.Sdk@13.3.0
-#:package Aspire.Hosting.PostgreSQL@13.3.0
-#:package Aspire.Hosting.Redis@13.3.0
+#:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
+#:package Aspire.Hosting.PostgreSQL@%ASPIRE_VERSION%
+#:package Aspire.Hosting.Redis@%ASPIRE_VERSION%
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -572,8 +572,8 @@ services:
 <TabItem label='C#'>
 
 ```csharp title="apphost.cs" showLineNumbers
-#:sdk Aspire.AppHost.Sdk@13.3.0
-#:package Aspire.Hosting.PostgreSQL@13.3.0
+#:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
+#:package Aspire.Hosting.PostgreSQL@%ASPIRE_VERSION%
 
 var builder = DistributedApplication.CreateBuilder(args);
 

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -16,8 +16,9 @@ The [📦 Aspire.AppHost.Sdk](https://www.nuget.org/packages/Aspire.AppHost.Sdk)
 
 The `Aspire.AppHost.Sdk` is defined in the top-level `Project` node's `Sdk` attribute:
 
-```xml title='*.csproj file' {1}
-<Project Sdk="Aspire.AppHost.Sdk/13.1">
+```xml
+title='*.csproj file' {1}
+<Project Sdk="Aspire.AppHost.Sdk/%ASPIRE_VERSION%">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -34,8 +35,9 @@ The `Aspire.AppHost.Sdk` is defined in the top-level `Project` node's `Sdk` attr
 
 The `Aspire.AppHost.Sdk` is defined in a file-based app's source file using the `#:sdk` directive:
 
-```csharp title='file-based app' {1}
-#:sdk Aspire.AppHost.Sdk@13.3.0
+```csharp
+title='file-based app' {1}
+#:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -87,7 +89,8 @@ For example, if you have two microservices with the same project name (like `Pre
 
 This generates `Projects.MicroService1` and `Projects.MicroService2` classes, allowing you to reference each project distinctly in your AppHost:
 
-```csharp title="AppHost.cs"
+```csharp
+title="AppHost.cs"
 var microservice1 = builder.AddProject<Projects.MicroService1>("micro1");
 var microservice2 = builder.AddProject<Projects.MicroService2>("micro2");
 ```
@@ -115,15 +118,16 @@ When `AspireUseCliBundle` is `true`:
 - `Aspire.AppHost.Sdk` still sets AppHost properties and adds the implicit `Aspire.Hosting.AppHost` package.
 - Your AppHost uses the DCP and Dashboard versions installed with the Aspire CLI.
 - At build time, the SDK resolves the DCP and Dashboard executables in this priority order:
-  1. Explicit `AspireCliBundlePath` / `AspireCliPath` properties in the project file.
-  2. The `aspire` executable on `PATH`.
+    1. Explicit `AspireCliBundlePath` / `AspireCliPath` properties in the project file.
+    2. The `aspire` executable on `PATH`.
 - If the bundle cannot be found, the build emits error `ASPIRE009` with a message directing you to [get.aspire.dev](https://get.aspire.dev) to install the Aspire CLI.
 
 #### Enable the opt-in
 
 Set `AspireUseCliBundle` in your AppHost `.csproj`:
 
-```xml title="MyApp.AppHost.csproj"
+```xml
+title="MyApp.AppHost.csproj"
 <PropertyGroup>
   <AspireUseCliBundle>true</AspireUseCliBundle>
 </PropertyGroup>
@@ -132,7 +136,8 @@ Set `AspireUseCliBundle` in your AppHost `.csproj`:
 :::note[Advanced scenario: Override the bundle path]
 Most apps don't need to set the CLI bundle path. If the Aspire CLI isn't on `PATH`, provide an explicit path using `AspireCliBundlePath` (path to the CLI bundle directory) or `AspireCliPath` (path to the `aspire` executable):
 
-```xml title="MyApp.AppHost.csproj"
+```xml
+title="MyApp.AppHost.csproj"
 <PropertyGroup>
   <AspireUseCliBundle>true</AspireUseCliBundle>
   <!-- Either set the path to the aspire executable: -->

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -87,8 +87,7 @@ For example, if you have two microservices with the same project name (like `Pre
 
 This generates `Projects.MicroService1` and `Projects.MicroService2` classes, allowing you to reference each project distinctly in your AppHost:
 
-```csharp
-title="AppHost.cs"
+```csharp title="AppHost.cs"
 var microservice1 = builder.AddProject<Projects.MicroService1>("micro1");
 var microservice2 = builder.AddProject<Projects.MicroService2>("micro2");
 ```

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -34,8 +34,7 @@ The `Aspire.AppHost.Sdk` is defined in the top-level `Project` node's `Sdk` attr
 
 The `Aspire.AppHost.Sdk` is defined in a file-based app's source file using the `#:sdk` directive:
 
-```csharp
-title='file-based app' {1}
+```csharp title='file-based app' {1}
 #:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
 
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -132,8 +132,7 @@ Set `AspireUseCliBundle` in your AppHost `.csproj`:
 :::note[Advanced scenario: Override the bundle path]
 Most apps don't need to set the CLI bundle path. If the Aspire CLI isn't on `PATH`, provide an explicit path using `AspireCliBundlePath` (path to the CLI bundle directory) or `AspireCliPath` (path to the `aspire` executable):
 
-```xml
-title="MyApp.AppHost.csproj"
+```xml title="MyApp.AppHost.csproj"
 <PropertyGroup>
   <AspireUseCliBundle>true</AspireUseCliBundle>
   <!-- Either set the path to the aspire executable: -->

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -16,8 +16,7 @@ The [📦 Aspire.AppHost.Sdk](https://www.nuget.org/packages/Aspire.AppHost.Sdk)
 
 The `Aspire.AppHost.Sdk` is defined in the top-level `Project` node's `Sdk` attribute:
 
-```xml
-title='*.csproj file' {1}
+```xml title='*.csproj file' {1}
 <Project Sdk="Aspire.AppHost.Sdk/%ASPIRE_VERSION%">
 
     <PropertyGroup>

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -123,8 +123,7 @@ When `AspireUseCliBundle` is `true`:
 
 Set `AspireUseCliBundle` in your AppHost `.csproj`:
 
-```xml
-title="MyApp.AppHost.csproj"
+```xml title="MyApp.AppHost.csproj"
 <PropertyGroup>
   <AspireUseCliBundle>true</AspireUseCliBundle>
 </PropertyGroup>

--- a/src/frontend/src/content/docs/get-started/install-cli.mdx
+++ b/src/frontend/src/content/docs/get-started/install-cli.mdx
@@ -198,7 +198,7 @@ aspire --version
 If that command works, you're presented with the version of the Aspire CLI tool:
 
 ```bash title="Aspire CLI — Output" data-disable-copy
-13.4.0+{commitSHA}
+%ASPIRE_VERSION%+{commitSHA}
 ```
 
 The `+{commitSHA}` suffix indicates the specific commit from which the Aspire CLI was built.

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -129,9 +129,9 @@ You must ensure that this script is copied to the AppHost's output directory, so
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.MySql" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.1.0" />
-    <PackageReference Include="Aspire.Hosting.SqlServer" Version="13.1.0" />
+    <PackageReference Include="Aspire.Hosting.MySql" Version="%ASPIRE_VERSION%" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="%ASPIRE_VERSION%" />
+    <PackageReference Include="Aspire.Hosting.SqlServer" Version="%ASPIRE_VERSION%" />
   </ItemGroup>
 
 </Project>

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -108,7 +108,7 @@ GO
 You must ensure that this script is copied to the AppHost's output directory, so that Aspire can execute it. Add the following XML to your *.csproj* file:
 
 ```xml title="DatabaseContainers.AppHost.csproj" {11-15}
-<Project Sdk="Aspire.AppHost.Sdk/13.1.0">
+<Project Sdk="Aspire.AppHost.Sdk/%ASPIRE_VERSION%">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
@@ -212,8 +212,8 @@ The available options are the same as those used with `AddProject<T>`:
 You can also write the AppHost itself as a file-based C# app using the `#:sdk` directive:
 
 ```csharp title="apphost.cs"
-#:sdk Aspire.AppHost.Sdk@13.1.0
-#:package Aspire.Hosting.Redis@13.1.0
+#:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
+#:package Aspire.Hosting.Redis@%ASPIRE_VERSION%
 
 #pragma warning disable ASPIRECSHARPAPPS001
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-doctor.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-doctor.mdx
@@ -88,10 +88,10 @@ Aspire Environment Check
 ========================
 
 Aspire
-  ✅ Aspire CLI version 13.4.0
+  ✅ Aspire CLI version %ASPIRE_VERSION%
 
 AppHost
-  ✅ AppHost version 13.4.0 (MyApp.AppHost.csproj)
+  ✅ AppHost version %ASPIRE_VERSION% (MyApp.AppHost.csproj)
 
 .NET SDK
   ✅ .NET 10.0.203 installed (arm64)
@@ -113,11 +113,11 @@ When the CLI is out of date, the Aspire section shows a warning with the latest 
 
 ```bash title="Aspire CLI"
 Aspire
-  ⚠️ Aspire CLI version 13.4.0-dev is out of date. Latest version is 13.4.0-preview.1.26262.10
+  ⚠️ Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION%-preview.1.26262.10
        Run 'aspire update' to update Aspire CLI.
 
 AppHost
-  ✅ AppHost version 13.4.0 (MyApp.AppHost.csproj)
+  ✅ AppHost version %ASPIRE_VERSION% (MyApp.AppHost.csproj)
 ```
 
 This warning snippet is abbreviated. In complete table output, a summary follows
@@ -167,19 +167,19 @@ When using the `--format Json` option, the output includes a structured response
       "category": "aspire",
       "name": "cli-version",
       "status": "pass",
-      "message": "Aspire CLI version 13.4.0",
+      "message": "Aspire CLI version %ASPIRE_VERSION%",
       "metadata": {
-        "currentVersion": "13.4.0"
+        "currentVersion": "%ASPIRE_VERSION%"
       }
     },
     {
       "category": "apphost",
       "name": "apphost-version",
       "status": "pass",
-      "message": "AppHost version 13.4.0 (MyApp.AppHost.csproj)",
+      "message": "AppHost version %ASPIRE_VERSION% (MyApp.AppHost.csproj)",
       "metadata": {
         "appHostPath": "MyApp.AppHost.csproj",
-        "version": "13.4.0"
+        "version": "%ASPIRE_VERSION%"
       }
     },
     {
@@ -204,11 +204,11 @@ When the CLI is out of date, the `cli-version` check has `"status": "warning"` a
   "category": "aspire",
   "name": "cli-version",
   "status": "warning",
-  "message": "Aspire CLI version 13.4.0-dev is out of date. Latest version is 13.4.0-preview.1.26262.10",
+  "message": "Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION%-preview.1.26262.10",
   "fix": "Run 'aspire update' to update Aspire CLI.",
   "metadata": {
-    "currentVersion": "13.4.0-dev",
-    "latestVersion": "13.4.0-preview.1.26262.10"
+    "currentVersion": "%ASPIRE_VERSION%-dev",
+    "latestVersion": "%ASPIRE_VERSION%-preview.1.26262.10"
   }
 }
 ```

--- a/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
+++ b/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+import { replaceAspireVersionPlaceholdersInDirectory } from '../../config/aspire-version-placeholders-integration.mjs';
+import {
+  currentAspireMajorMinorVersion,
+  currentAspireVersion,
+} from '../../config/aspire-versions.mjs';
+import {
+  remarkAspireVersionPlaceholders,
+  replaceAspireVersionPlaceholders,
+} from '../../config/remark-aspire-version-placeholders.mjs';
+
+describe('Aspire version placeholders', () => {
+  test('replaces current Aspire major.minor and patch placeholders', () => {
+    expect(
+      replaceAspireVersionPlaceholders(
+        'Aspire %ASPIRE_VERSION_MAJOR_MINOR% ships as %ASPIRE_VERSION%.'
+      )
+    ).toBe(`Aspire ${currentAspireMajorMinorVersion} ships as ${currentAspireVersion}.`);
+  });
+
+  test('replaces placeholders in markdown text, code fences, and MDX attributes', () => {
+    const tree = {
+      type: 'root',
+      children: [
+        {
+          type: 'paragraph',
+          children: [{ type: 'text', value: 'Aspire %ASPIRE_VERSION_MAJOR_MINOR%' }],
+        },
+        { type: 'code', lang: 'bash', value: 'aspire %ASPIRE_VERSION%' },
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'Code',
+          attributes: [{ type: 'mdxJsxAttribute', name: 'code', value: '%ASPIRE_VERSION%' }],
+          children: [],
+        },
+      ],
+    };
+
+    remarkAspireVersionPlaceholders()(tree);
+
+    expect(tree.children[0].children[0].value).toBe(
+      `Aspire ${currentAspireMajorMinorVersion}`
+    );
+    expect(tree.children[1].value).toBe(`aspire ${currentAspireVersion}`);
+    expect(tree.children[2].attributes[0].value).toBe(currentAspireVersion);
+  });
+
+  test('replaces placeholders in generated markdown assets', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'aspire-version-placeholders-'));
+
+    try {
+      const markdownPath = path.join(tempDir, 'example.md');
+      const jsonPath = path.join(tempDir, 'example.json');
+
+      await Promise.all([
+        writeFile(markdownPath, 'Aspire %ASPIRE_VERSION_MAJOR_MINOR%: %ASPIRE_VERSION%'),
+        writeFile(jsonPath, '{"version":"%ASPIRE_VERSION%"}'),
+      ]);
+
+      await replaceAspireVersionPlaceholdersInDirectory(tempDir);
+
+      await expect(readFile(markdownPath, 'utf8')).resolves.toBe(
+        `Aspire ${currentAspireMajorMinorVersion}: ${currentAspireVersion}`
+      );
+      await expect(readFile(jsonPath, 'utf8')).resolves.toBe('{"version":"%ASPIRE_VERSION%"}');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Hard-coded current Aspire versions in generated CLI output and SDK examples need to stay aligned with the active release branch. This adds a shared version placeholder pipeline so docs can use stable tokens and have them resolved during Markdown rendering and generated asset post-processing.

## Summary

- Add shared Aspire version constants and placeholder replacement helpers for `%ASPIRE_VERSION%` and `%ASPIRE_VERSION_MAJOR_MINOR%`.
- Wire the placeholder replacement into Astro Markdown processing and generated HTML/Markdown/text assets.
- Replace current-version examples in CLI and SDK docs with placeholders, including release/13.5 examples.
- Add targeted Vitest coverage for direct replacement, Markdown AST replacement, and generated asset replacement.

## Validation

- `pnpm --dir ./src/frontend exec vitest run --config vitest.config.ts tests/unit/aspire-version-placeholders.vitest.test.ts`