### PR TITLE
Update Aspire VS Code dashboard docs

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
@@ -75,16 +75,7 @@ When an AppHost is running, the extension paints live state directly into your e
 
 **Editor title bar buttons** add **Run Aspire AppHost** and **Debug Aspire AppHost** actions next to the standard Run/Debug buttons whenever you have an AppHost file open.
 
-**Health-aware gutter decorations** provide an at-a-glance view of resource health and state without cluttering the editor with text using the following shapes and colors:
-
-| Icon | Meaning |
-|------|---------|
-| ✓ (green checkmark) | Running and healthy |
-| ⊙ (grey circle with check) | Completed — exited cleanly (exit code 0) |
-| ⚠ (yellow triangle with `!`) | Running but unhealthy (health checks failing) |
-| ✕ (red X) | Failed to start, exited with a non-zero exit code, or runtime unhealthy |
-| ⌛ (blue hourglass) | Starting, stopping, building, or waiting |
-| ○ (grey hollow circle) | Not yet started |
+**Health-aware gutter decorations** provide an at-a-glance view of resource health and state without cluttering the editor with text.
 
 <ThemeImage
   dark={sidebarTree}
@@ -99,6 +90,10 @@ Aspire registers an AppHost view to VS Code. **Workspace** mode shows the AppHos
 Each resource shows its type, state, health summary, and exit code, plus a health-aware icon and a markdown tooltip listing endpoint URLs. Resources with health checks expose an expandable **Health Checks** group; use **Expand all** on the AppHost item to open everything at once. You can right-click a resource to start, stop, or restart it, view its logs, run resource-specific commands, or open the dashboard.
 
 ## Run, debug, and deploy
+
+:::note[Debugging]
+The Aspire Dashboard is no longer opened by default when the AppHost starts, as most operations can be performed using the Aspire view inside VS Code. To launch the dashboard, open the AppHost editor in VS Code then use the **Open Dashboard** CodeLens or the `Aspire: Open Dashboard` command.
+:::
 
 **Aspire: Configure launch.json file** adds a minimal launch configuration `.vscode/launch.json` that supports AppHosts written in any language. AppHosts are discovered automatically in the workspace. 
 
@@ -159,10 +154,6 @@ Finally, you can specify `env` and `args` to set environment variables and comma
 <LearnMore>
 For more information, see [Aspire publishing and deployment overview](/deployment/deploy-with-aspire/).
 </LearnMore>
-
-## Dashboard from VS Code
-
-By default, the dashboard opens automatically when the AppHost starts. You can also open it from the Aspire view if you closed the browser tab and want it back.
 
 ## Language coverage
 

--- a/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
@@ -92,7 +92,7 @@ Each resource shows its type, state, health summary, and exit code, plus a healt
 ## Run, debug, and deploy
 
 :::note[Debugging]
-The Aspire Dashboard is no longer opened by default when the AppHost starts, as most operations can be performed using the Aspire view inside VS Code. To launch the dashboard, open the AppHost editor in VS Code then use the **Open Dashboard** CodeLens or the `Aspire: Open Dashboard` command.
+The Aspire Dashboard is no longer opened by default when the AppHost starts, as most operations can be performed using the Aspire view inside VS Code. To launch the dashboard, use the **Open Dashboard** CodeLens, the **Aspire: Open Dashboard** command, or open it from the Aspire view.
 :::
 
 **Aspire: Configure launch.json file** adds a minimal launch configuration `.vscode/launch.json` that supports AppHosts written in any language. AppHosts are discovered automatically in the workspace. 


### PR DESCRIPTION
The Aspire Dashboard no longer opens by default when starting an AppHost from VS Code, so update the extension docs to point users at the Open Dashboard CodeLens/command instead.

Also removes the old dashboard section and trims the gutter decoration details now that the screenshot covers the visual state.

Tested with `pnpm --dir src/frontend test:unit:docs`.