### PR TITLE
Update RavenDB hosting integration docs to reflect TypeScript AppHost support

### DIFF
--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -125,11 +125,11 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 </Steps>
 
 <Aside type="note">
-  The examples on this page don't require a RavenDB license. For production use and
-  more advanced features, a license is required — you can request a free Community
-  license at [ravendb.net/license/request/community](https://ravendb.net/license/request/community)
-  and pass it via the `RAVEN_License` environment variable, or with `RavenDBServerSettings`
-  from a C# AppHost.
+  Depending on your usage, RavenDB may require a license. For development, request a free
+  [Developer license](https://ravendb.net/license/request/dev). For production, see the
+  [available licenses](https://ravendb.net/buy) — including a free Community license that's
+  eligible for commercial use. Pass your license via the `RAVEN_License` environment variable,
+  or with `RavenDBServerSettings` from a C# AppHost.
 </Aside>
 
 <Aside type="note">

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -125,6 +125,14 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 </Steps>
 
 <Aside type="note">
+  The examples on this page don't require a RavenDB license. For production use and
+  more advanced features, a license is required — you can request a free Community
+  license at [ravendb.net/license/request/community](https://ravendb.net/license/request/community)
+  and pass it via the `RAVEN_License` environment variable, or with `RavenDBServerSettings`
+  from a C# AppHost.
+</Aside>
+
+<Aside type="note">
     When you reference a RavenDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as the server URI, hostname, port, and database name. For a complete list of these properties and per-language connection examples, see [Connect to RavenDB](../ravendb-connect/).
 </Aside>
 

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -104,9 +104,9 @@ const builder = await createBuilder();
 const ravenServer = await builder.addRavenDB("ravenServer");
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await apiService.withReference(ravendb);
-await apiService.waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+    .withReference(ravendb)
+    .waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -160,8 +160,8 @@ const ravenServer = await builder.addRavenDB("ravenServer");
 const ravendb = await ravenServer.addDatabase("ravendb", { ensureCreated: true });
 
 const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await apiService.withReference(ravendb);
-await apiService.waitFor(ravendb);
+    .withReference(ravendb)
+    .waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -199,14 +199,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-await ravenServer.withDataVolume();
+const ravenServer = await builder.addRavenDB("ravenServer")
+    .withDataVolume();
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await apiService.withReference(ravendb);
-await apiService.waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+    .withReference(ravendb)
+    .waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -246,14 +246,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-await ravenServer.withDataBindMount("C:\\RavenDb\\Data");
+const ravenServer = await builder.addRavenDB("ravenServer")
+    .withDataBindMount("C:\\RavenDb\\Data");
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await apiService.withReference(ravendb);
-await apiService.waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+    .withReference(ravendb)
+    .waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -298,15 +298,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-await ravenServer.withDataVolume();
-await ravenServer.withLogVolume();
+const ravenServer = await builder.addRavenDB("ravenServer")
+    .withDataVolume()
+    .withLogVolume();
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await apiService.withReference(ravendb);
-await apiService.waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+    .withReference(ravendb)
+    .waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -65,14 +65,10 @@ This updates your `aspire.config.json` with the RavenDB hosting integration pack
 ```json title="aspire.config.json" ins={3}
 {
   "packages": {
-    "CommunityToolkit.Aspire.Hosting.RavenDB": "13.2.1-beta.532"
+    "CommunityToolkit.Aspire.Hosting.RavenDB": "13.4.0"
   }
 }
 ```
-
-<Aside type="caution">
-  The TypeScript AppHost SDK doesn't currently expose `addRavenDB` or related APIs. The hosting integration is only available from C# AppHosts. If you're using a TypeScript AppHost, model the RavenDB server with [`builder.addContainer(...)`](/get-started/app-host/) until TypeScript support is added.
-</Aside>
 
 </TabItem>
 </Tabs>
@@ -80,6 +76,9 @@ This updates your `aspire.config.json` with the RavenDB hosting integration pack
 ## Add RavenDB server resource and database resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a RavenDB server resource and then add a database resource:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -94,6 +93,27 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const ravenServer = await builder.addRavenDB("ravenServer");
+const ravendb = await ravenServer.addDatabase("ravendb");
+
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 <Steps>
 
 1. When Aspire adds a container image to the app host, as shown in the preceding example with the `docker.io/ravendb/ravendb` image, it creates a new RavenDB instance on your local machine.
@@ -104,12 +124,6 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 
 </Steps>
 
-<Aside type="caution">
-  A valid RavenDB license is required. If you don't have one yet, you can request a free Community license at
-  [ravendb.net/license/request/community](https://ravendb.net/license/request/community).
-  Pass the license via the `RAVEN_License` environment variable, or use `RavenDBServerSettings` to configure it.
-</Aside>
-
 <Aside type="note">
     When you reference a RavenDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as the server URI, hostname, port, and database name. For a complete list of these properties and per-language connection examples, see [Connect to RavenDB](../ravendb-connect/).
 </Aside>
@@ -117,6 +131,9 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 ## Add RavenDB database resource with auto-create
 
 By default, `AddDatabase` registers the database in the Aspire model but does not create it in RavenDB automatically. Pass `ensureCreated: true` to have Aspire create the database on startup if it does not already exist:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -131,9 +148,33 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const ravenServer = await builder.addRavenDB("ravenServer");
+const ravendb = await ravenServer.addDatabase("ravendb", { ensureCreated: true });
+
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 ## Add RavenDB server resource with data volume
 
 Add a data volume to the RavenDB server resource to persist data outside the lifecycle of its container:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -150,11 +191,37 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataVolume();
+
+const ravendb = await ravenServer.addDatabase("ravendb");
+
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 The data volume is mounted at the `/var/lib/ravendb/data` path in the RavenDB container. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-ravendb-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 ## Add RavenDB server resource with data bind mount
 
 Add a data bind mount to the RavenDB server resource as an alternative to a named volume:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -171,6 +238,29 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataBindMount("C:\\RavenDb\\Data");
+
+const ravendb = await ravenServer.addDatabase("ravendb");
+
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 Data bind mounts rely on the host machine's filesystem to persist the RavenDB data across container restarts. The data bind mount is mounted at the `C:\RavenDb\Data` on Windows (or the equivalent Unix path) on the host machine in the RavenDB container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
 
 <Aside type="note">
@@ -180,6 +270,9 @@ Data bind mounts rely on the host machine's filesystem to persist the RavenDB da
 ## Add RavenDB server resource with log volume
 
 Add a named volume for the RavenDB logs directory:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -196,6 +289,30 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataVolume();
+await ravenServer.withLogVolume();
+
+const ravendb = await ravenServer.addDatabase("ravendb");
+
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 The log volume is mounted at the `/var/log/ravendb/logs` path in the RavenDB container. You can also use `WithLogBindMount(source: @"C:\RavenDb\Logs")` to bind-mount a host directory for logs.
 

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -159,7 +159,7 @@ const builder = await createBuilder();
 const ravenServer = await builder.addRavenDB("ravenServer");
 const ravendb = await ravenServer.addDatabase("ravendb", { ensureCreated: true });
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
     .withReference(ravendb)
     .waitFor(ravendb);
 


### PR DESCRIPTION
## Update RavenDB hosting docs for TypeScript AppHost support

### What changed

The RavenDB hosting integration page (`/integrations/databases/ravendb/ravendb-host/`) currently states that "The TypeScript AppHost SDK doesn't currently expose `addRavenDB` or related APIs." This is no longer accurate: TypeScript AppHost support for the RavenDB integration shipped in **CommunityToolkit.Aspire v13.4.0**.

- Polyglot exports (`[AspireExport]` on `AddRavenDB`, `AddDatabase`, volume/bind-mount APIs, and both resource types): CommunityToolkit/Aspire#1215
- Working TypeScript example AppHost + integration test: CommunityToolkit/Aspire#1423

This PR:

1. **Removes the stale caution** from the TypeScript installation tab and updates the `aspire.config.json` version example to the stable `13.4.0`.
2. **Adds TypeScript tabs** (`<Tabs syncKey="aspire-lang">`, matching the conventions of `postgres-host.mdx`) to five sections: server + database, auto-create (`ensureCreated`), data volume, data bind mount, and log volume. All TypeScript samples were verified against the actual generated `.aspire/modules` typings from the v13.4.x toolkit package and are modeled on the toolkit's shipped example (`examples/ravendb/CommunityToolkit.Aspire.Hosting.RavenDB.AppHost.TypeScript/apphost.mts`).
3. **Keeps the secured-server section C#-only** — the `RavenDBServerSettings`-based overload is intentionally excluded from polyglot exports (`[AspireExportIgnore]`), so its existing note remains unchanged.

### Also: removed the "A valid RavenDB license is required" caution

This caution is inaccurate for the local-development scenario the page's examples demonstrate:

- The default `AddRavenDB(name)` overload configures the container with `RAVEN_Setup_Mode=None` and passes **no license** unless one is explicitly provided via `RavenDBServerSettings.WithLicense(...)`.
- The toolkit's own C# and TypeScript example AppHosts run entirely license-free, and the toolkit's CI integration tests (which wait for the RavenDB resource's health check to pass) succeed without a license.

### Verification

- Rendered locally with the Astro dev server: tabs display and language-sync correctly on all five sections; no MDX build errors.
- Diff touches only `src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx`.