### PR TITLE
Revert "Adopt `PublishWithContainerFiles` for frontend assets and remove `esproj` coupling"

### DIFF
--- a/Aspire.Dev.slnx
+++ b/Aspire.Dev.slnx
@@ -10,4 +10,8 @@
     <Project Path="tests/PackageJsonGenerator.Tests/PackageJsonGenerator.Tests.csproj" />
     <Project Path="tests/StaticHost.Tests/StaticHost.Tests.csproj" />
   </Folder>
+  <Project Path="src/frontend/frontend.esproj">
+    <Build />
+    <Deploy />
+  </Project>
 </Solution>

--- a/src/apphost/Aspire.Dev.AppHost/AppHost.cs
+++ b/src/apphost/Aspire.Dev.AppHost/AppHost.cs
@@ -3,21 +3,18 @@ var builder = DistributedApplication.CreateBuilder(args);
 // For deployment: We want to pick AppService as the environment to publish to.
 builder.AddAzureAppServiceEnvironment("production");
 
-var frontend = builder.AddViteApp("frontend", "../../frontend")
-    .WithPnpm();
-
 var staticHostWebsite = builder.AddProject<Projects.StaticHost>("aspiredev")
     .WithExternalHttpEndpoints();
-
-staticHostWebsite.PublishWithContainerFiles(frontend, "./wwwroot");
 
 builder.AddAzureFrontDoor(staticHostWebsite);
 
 if (builder.ExecutionContext.IsRunMode)
 {
     // For local development: Use ViteApp for hot reload and development experience
-    frontend.WithUrlForEndpoint("http", static url => url.DisplayText = "aspire.dev (Local)")
-            .WithExternalHttpEndpoints();
+    builder.AddViteApp("frontend", "../../frontend")
+           .WithPnpm()
+           .WithUrlForEndpoint("http", static url => url.DisplayText = "aspire.dev (Local)")
+           .WithExternalHttpEndpoints();
 }
 
 builder.Build().Run();

--- a/src/statichost/StaticHost/StaticHost.csproj
+++ b/src/statichost/StaticHost/StaticHost.csproj
@@ -26,5 +26,18 @@
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      The frontend ESProj produces wwwroot static assets at build time.
+      PrivateAssets="all" prevents MSBuild from propagating its output (the
+      `dist/` directory, which appears as a directory-shaped metadata
+      reference) to downstream consumers like test projects. Without this,
+      `dotnet build` of any project that transitively references StaticHost
+      fails with `error CS0006: Metadata file '.../frontend/dist' could not
+      be found` unless the frontend has already been built.
+    -->
+    <ProjectReference Include="../../frontend/frontend.esproj" PrivateAssets="all" />
+  </ItemGroup>
+
   <Import Project="Caching.targets" />
 </Project>


### PR DESCRIPTION
Reverts microsoft/aspire.dev#1171