### PR TITLE
Ensure visitors to "Build your first Aspire app" know about prereqs.

### DIFF
--- a/src/frontend/src/content/docs/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/first-app.mdx
@@ -29,7 +29,7 @@ import javascriptDashboardDark from '@assets/get-started/javascript-aspire-dashb
 This quickstart uses the starter template that generates a C# AppHost. You'll create the solution, review the generated AppHost, and run it locally with Aspire.
 
 :::note[Prerequisites]
-Before you run through this quickstart, make sure you've installed the [Prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
+Before you run through this quickstart, make sure you've installed the [prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
 :::
 
 :::tip[Prefer VS Code?]
@@ -58,7 +58,7 @@ architecture-beta
 This quickstart uses the JavaScript starter template, which generates a TypeScript AppHost in `apphost.mts`. You'll create the solution, review the generated TypeScript AppHost, and run it locally with Aspire.
 
 :::note[Prerequisites]
-Before you run through this quickstart, make sure you've installed the [Prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
+Before you run through this quickstart, make sure you've installed the [prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
 :::
 
 :::tip[Prefer VS Code?]

--- a/src/frontend/src/content/docs/get-started/first-app.mdx
+++ b/src/frontend/src/content/docs/get-started/first-app.mdx
@@ -28,6 +28,10 @@ import javascriptDashboardDark from '@assets/get-started/javascript-aspire-dashb
 <Pivot id="csharp">
 This quickstart uses the starter template that generates a C# AppHost. You'll create the solution, review the generated AppHost, and run it locally with Aspire.
 
+:::note[Prerequisites]
+Before you run through this quickstart, make sure you've installed the [Prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
+:::
+
 :::tip[Prefer VS Code?]
 Install the [Aspire VS Code extension](/get-started/aspire-vscode-extension/) if you want the same path in the editor: create or open the app, run **Aspire: Configure launch.json file**, then press <Kbd windows="F5" mac="F5" /> to start the AppHost and open the dashboard.
 :::
@@ -52,6 +56,10 @@ architecture-beta
 </Pivot>
 <Pivot id="typescript">
 This quickstart uses the JavaScript starter template, which generates a TypeScript AppHost in `apphost.mts`. You'll create the solution, review the generated TypeScript AppHost, and run it locally with Aspire.
+
+:::note[Prerequisites]
+Before you run through this quickstart, make sure you've installed the [Prerequisites](/get-started/prerequisites/) and the [Aspire CLI](/get-started/install-cli/).
+:::
 
 :::tip[Prefer VS Code?]
 Install the [Aspire VS Code extension](/get-started/aspire-vscode-extension/) if you want the same path in the editor: create or open the app, run **Aspire: Configure launch.json file**, then press <Kbd windows="F5" mac="F5" /> to start the AppHost and open the dashboard.


### PR DESCRIPTION
Users who enter the site on the [homepage](https://aspire.dev/) and click the prominent "Try Aspire" links may not realize that they must install prerequisites before they run `aspire new`. This PR adds a note to both pivots to make that clear.

Fixes: #1331