### PR TITLE
Remove ServiceDefaults project from the aspire init output in "Add Aspire to an existing app"

### DIFF
--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -244,10 +244,7 @@ After setup, a typical solution layout looks like this:
     - MyApp.sln
     - MyApp.AppHost/
         - MyApp.AppHost.csproj
-        - Program.cs
-    - MyApp.ServiceDefaults/
-        - MyApp.ServiceDefaults.csproj
-        - Extensions.cs
+        - AppHost.cs
     - src/
         - Api/
             - MyApp.Api.csproj


### PR DESCRIPTION
In the [Add Aspire to an existing app](https://aspire.dev/get-started/add-aspire-existing-app/) article, in the [Project-based AppHost](https://aspire.dev/get-started/add-aspire-existing-app/#project-based-apphost-with-a-sln) section, the typical solution layout includes a Service Defaults project.

I've just reconstructed the described steps and no ServiceDefaults project was generated. The PR removes that from the typical solution layout and also correct **AppHost/Program.cs** to **AppHost/AppHost.cs**.

Fixes: #1270