### PR TITLE
Fix mermaid diagram in the "Get started with Blazor hosting" article

### DIFF
--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
@@ -42,7 +42,6 @@ The Blazor hosting integration is a hosting-side API surface. You install it in 
 ```mermaid
 architecture-beta
 
-
   group client(server)[Browser]
   group apphost(server)[AppHost]
 

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
@@ -42,7 +42,7 @@ The Blazor hosting integration is a hosting-side API surface. You install it in 
 ```mermaid
 architecture-beta
 
-  group client(server)[Browser]
+  group client(server)[Client]
   group apphost(server)[AppHost]
 
   service browser(server)[Browser] in client

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-get-started.mdx
@@ -42,9 +42,11 @@ The Blazor hosting integration is a hosting-side API surface. You install it in 
 ```mermaid
 architecture-beta
 
-  group apphost(server)[AppHost]
-  group browser(server)[Browser]
 
+  group client(server)[Browser]
+  group apphost(server)[AppHost]
+
+  service browser(server)[Browser] in client
   service hosting(server)[Blazor hosting integration] in apphost
   service wasm(aspire:blazor)[Blazor WebAssembly app] in apphost
   service gateway(server)[Blazor Gateway] in apphost
@@ -52,7 +54,7 @@ architecture-beta
 
   browser:R --> L:gateway
   hosting:R --> L:wasm
-  hosting:R --> L:gateway
+  hosting:R --> B:gateway
   wasm:B --> T:api
 ```
 


### PR DESCRIPTION
The mermaid diagram in the [How the pieces fit together](https://aspire.dev/integrations/dotnet/blazor-get-started/#how-the-pieces-fit-together) section was giving the error: "Error rendering diagram: can't access property "in", this.nodes[e] is undefined"

This PR includes a mermaid diagram that renders correctly.

Fixes: #1238