### PR TITLE
Correct the 'Reference an existing secret' code in the KeyVault documentation.

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
@@ -168,9 +168,7 @@ await builder.build().run();
 ```
 
 <Aside type="note">
-  The TypeScript AppHost `asExisting` method accepts a vault name or parameter,
-  but does not accept a resource group parameter. Use `runAsExisting` or
-  `publishAsExisting` for mode-specific control.
+  The TypeScript AppHost `asExisting` method accepts a vault name parameter, but does not accept a resource group parameter. Use `runAsExisting` or `publishAsExisting` for mode-specific control.
 </Aside>
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
@@ -274,8 +274,11 @@ To reference an existing secret in the vault and pass it to a consuming resource
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var keyVault = builder.AddAzureKeyVault("key-vault");
-var secretRef = keyVault.GetOutput("vaultUri");
+var existingKeyVaultName = builder.AddParameter("existingKeyVaultName");
+var existingKeyVaultResourceGroup = builder.AddParameter("existingKeyVaultResourceGroup");
+
+var keyVault = builder.AddAzureKeyVault("key-vault")
+    .AsExisting(existingKeyVaultName, existingKeyVaultResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(keyVault)
@@ -293,7 +296,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
+const existingKeyVaultName = await builder.addParameter("existingKeyVaultName");
+
 const keyVault = await builder.addAzureKeyVault("key-vault");
+await keyVault.asExisting(existingKeyVaultName);
+
 const secretRef = await keyVault.getSecret("my-api-key");
 
 await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")


### PR DESCRIPTION
In the [Set up Azure Key Vault in the AppHost](https://aspire.dev/integrations/cloud/azure/azure-key-vault/azure-key-vault-host/) article, in the [Reference an existing secret](https://aspire.dev/integrations/cloud/azure/azure-key-vault/azure-key-vault-host/#reference-an-existing-secret) section, the code creates a variable name `secretRef` and calls `GetOutput()` to store the KeyVault's URI in it. This code is irrelevant to the example and confusing. This PR removes that line.

I've also improved the code by including lines to connect to an existing KeyVault. If the KeyVault is new, there wouldn't be any existing secrets.

Fixes: #1343 