### PR TITLE
Document --skills and --skill-locations flags for init and new commands

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-init.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-init.mdx
@@ -102,6 +102,14 @@ The following options are available:
 
   The AppHost language to scaffold (`csharp`, `typescript`).
 
+- **`--skill-locations <skill-locations>`**
+
+  Comma-separated list of skill locations to configure. Use `all` to configure all supported locations or `none` to skip skill location configuration. When not specified, the command prompts interactively. Useful for non-interactive mode in scripts and CI environments. For the list of available locations, see the [`aspire agent init` command reference](../aspire-agent-init/#options).
+
+- **`--skills <skills>`**
+
+  Comma-separated list of skills to install. Use `all` to install all available skills or `none` to skip skill installation. When not specified, the command prompts interactively. Useful for non-interactive mode in scripts and CI environments. For the list of available skills, see the [`aspire agent init` command reference](../aspire-agent-init/#options).
+
 - <Include relativePath="reference/cli/includes/option-help.md" />
 
 - <Include relativePath="reference/cli/includes/option-log-level.md" />
@@ -132,4 +140,16 @@ The following options are available:
 
   ```bash title="Aspire CLI"
   aspire init --channel daily
+  ```
+
+- Initialize Aspire support non-interactively without installing any agent skills:
+
+  ```bash title="Aspire CLI"
+  aspire init --non-interactive --skills none
+  ```
+
+- Initialize Aspire support non-interactively, installing all skills in the standard location:
+
+  ```bash title="Aspire CLI"
+  aspire init --non-interactive --language csharp --skill-locations standard --skills all
   ```

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
@@ -122,6 +122,14 @@ The following options are available:
 
   Suppress the prompt to initialize MCP server configuration for agent environments after project creation.
 
+- **`--skill-locations <skill-locations>`**
+
+  Comma-separated list of skill locations to configure. Use `all` to configure all supported locations or `none` to skip skill location configuration. When not specified, the command prompts interactively. Useful for non-interactive mode in scripts and CI environments. For the list of available locations, see the [`aspire agent init` command reference](../aspire-agent-init/#options).
+
+- **`--skills <skills>`**
+
+  Comma-separated list of skills to install. Use `all` to install all available skills or `none` to skip skill installation. When not specified, the command prompts interactively. Useful for non-interactive mode in scripts and CI environments. For the list of available skills, see the [`aspire agent init` command reference](../aspire-agent-init/#options).
+
 - <Include relativePath="reference/cli/includes/option-help.md" />
 
 - <Include relativePath="reference/cli/includes/option-log-level.md" />
@@ -177,6 +185,18 @@ The `aspire-py-starter` template accepts the following additional options:
 
   ```bash title="Aspire CLI"
   aspire new aspire-starter --channel daily
+  ```
+
+- Create a new project non-interactively without installing any agent skills:
+
+  ```bash title="Aspire CLI"
+  aspire new aspire-starter --name myapp --skills none --non-interactive
+  ```
+
+- Create a new project non-interactively and install all skills in all supported locations:
+
+  ```bash title="Aspire CLI"
+  aspire new aspire-starter --name myapp --skill-locations all --skills all --non-interactive
   ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Documents the `--skills` and `--skill-locations` flags that were added to `aspire init`, `aspire new`, and `aspire agent init` commands in the Aspire CLI. These flags support non-interactive mode, allowing use in scripts and CI environments without interactive prompts.

## Changes

- **`aspire init` command reference** — added `--skill-locations` and `--skills` options with descriptions and cross-references to `aspire agent init` for the full list of values. Added non-interactive usage examples.
- **`aspire new` command reference** — added `--skill-locations` and `--skills` options with descriptions and cross-references to `aspire agent init` for the full list of values. Added non-interactive usage examples.
- **`aspire agent init` command reference** — already had both options documented; no changes needed.

## Related PRs

- microsoft/aspire#18191 — Add `--skills` flag to `aspire init`
- microsoft/aspire#18192 — Thread `--skill-locations` and `--skills` through `AgentInitCommand`, `InitCommand`, and `NewCommand`

Community contribution by @nanookclaw.