### PR TITLE
[docs] CLI: mention 'Stopping Aspire...' feedback message on Ctrl+C

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
@@ -35,7 +35,7 @@ The command performs the following steps to run an Aspire AppHost:
 
 ## Stopping the AppHost
 
-To stop the running AppHost and exit, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> (or send `SIGTERM` on Linux/macOS). The CLI requests a graceful shutdown of the AppHost and its resources.
+To stop the running AppHost and exit, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> (or send `SIGTERM` on Linux/macOS). The CLI requests a graceful shutdown of the AppHost and its resources. A `🛑 Stopping Aspire...` message is displayed shortly after you press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> to confirm that shutdown is in progress.
 
 If graceful shutdown is taking too long and you need to exit immediately, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> a second time to terminate the process immediately.
 

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx
@@ -35,7 +35,7 @@ The command performs the following steps to run an Aspire AppHost:
 
 ## Stopping the AppHost
 
-To stop the running AppHost and exit, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> (or send `SIGTERM` on Linux/macOS). The CLI requests a graceful shutdown of the AppHost and its resources. A `🛑 Stopping Aspire...` message is displayed shortly after you press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> to confirm that shutdown is in progress.
+To stop the running AppHost and exit, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> (or send `SIGTERM` on Linux/macOS). The CLI requests a graceful shutdown of the AppHost and its resources. If shutdown takes longer than a moment, a `🛑 Stopping Aspire.` message is displayed shortly after you press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> to confirm that shutdown is in progress.
 
 If graceful shutdown is taking too long and you need to exit immediately, press <Kbd windows="Ctrl+C" mac="⌃+C" linux="Ctrl+C" /> a second time to terminate the process immediately.
 


### PR DESCRIPTION
Supersedes #1201.

This replacement targets elease/13.5 because the original elease/13.4 base branch no longer exists on microsoft/aspire.dev.

Documents changes from microsoft/aspire#17652 by `@JamesNK`.

Targeting `release/13.4` — the latest release branch on `microsoft/aspire.dev` — because `release/13.5` (from the source PR milestone `13.5`) does not exist there.

## Why this PR is needed

PR microsoft/aspire#17652 introduced a user-visible change: when the user presses Ctrl+C, the Aspire CLI now immediately displays a `🛑 Stopping Aspire...` message (after a brief 200 ms delay) to confirm that shutdown is in progress. Previously, no such confirmation message was shown promptly.

The existing `aspire-run.mdx` documented how to stop the AppHost but did not mention this feedback message. This PR adds a short sentence so users know what to expect when they press Ctrl+C.

## Changes

- **Updated** `src/frontend/src/content/docs/reference/cli/commands/aspire-run.mdx`: added a note to the "Stopping the AppHost" section explaining that `🛑 Stopping Aspire...` is displayed shortly after Ctrl+C is pressed.




> Generated by [PR Documentation Check](https://github.com/microsoft/aspire/actions/runs/26876231263) for issue #17652 · sonnet46 3.5M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Faspire.dev+%22gh-aw-workflow-id%3A+pr-docs-check%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Documentation Check, engine: copilot, version: 1.0.55, model: claude-sonnet-4.6, id: 26876231263, workflow_id: pr-docs-check, run: https://github.com/microsoft/aspire/actions/runs/26876231263 -->

<!-- gh-aw-workflow-id: pr-docs-check -->