### PR TITLE
[docs] Document automatic HTTPS certificate generation for non-.NET AppHosts

### DIFF
--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -38,7 +38,7 @@ Many of the certificate features in Aspire rely on a development certificate. Be
 
 The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run`, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
 
-For non-.NET AppHosts (such as [TypeScript AppHosts](/app-host/typescript-apphost/)), the `dotnet` first-run experience that normally creates the HTTPS development certificate does not run. The Aspire CLI handles this automatically: when `aspire run` starts a non-.NET AppHost in non-interactive mode and no HTTPS development certificate exists, the CLI generates one. If generation fails, a warning is displayed but the run continues.
+For non-C# AppHosts (such as [TypeScript AppHosts](/app-host/typescript-apphost/)), the `dotnet` first-run experience that normally creates the HTTPS development certificate doesn't run. The Aspire CLI handles this automatically: when `aspire run` starts a non-C# AppHost in non-interactive mode and no HTTPS development certificate exists, the CLI generates one. If generation fails, a warning is displayed but the run continues.
 
 To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`:
 

--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -39,9 +39,9 @@ Many of the certificate features in Aspire rely on a development certificate. Be
 
 The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run` in an interactive session, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
 
-For non-.NET AppHosts (such as [TypeScript](/app-host/typescript-apphost/) or Python AppHosts), the `dotnet` first-run experience that normally creates the HTTPS development certificate never runs, because these AppHosts launch a prebuilt native binary instead of invoking `dotnet`. The Aspire CLI fills this gap when `aspire run` starts and no development certificate exists:
+For non-C# AppHosts (such as [TypeScript](/app-host/typescript-apphost/) or Python AppHosts), the `dotnet` first-run experience that normally creates the HTTPS development certificate never runs, because these AppHosts launch a prebuilt native binary instead of invoking `dotnet`. The Aspire CLI fills this gap when `aspire run` starts and no development certificate exists:
 
-- In an interactive session—and on Linux, where establishing trust doesn't require a prompt—the CLI creates *and* trusts the certificate, just as it does for .NET AppHosts.
+- In an interactive session—and on Linux, where establishing trust doesn't require a prompt—the CLI creates *and* trusts the certificate, just as it does for C# AppHosts.
 - In a non-interactive session on macOS or Windows (for example, in CI), the CLI can't show the macOS Keychain password prompt or the Windows trust dialog, so it *generates* the certificate without trusting it. This lets servers such as Kestrel load the certificate from the personal store, even though it isn't trusted. If the certificate can't be generated, a warning is displayed and the run continues.
 
 To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`. This mirrors the .NET SDK's `DOTNET_GENERATE_ASPNET_CERTIFICATE` opt-out:

--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -5,6 +5,7 @@ description: Configure HTTPS endpoints and certificate trust for Aspire resource
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
 
 Aspire provides two complementary sets of certificate APIs:
 
@@ -36,19 +37,31 @@ Many of the certificate features in Aspire rely on a development certificate. Be
 
 ### Using the Aspire CLI (recommended)
 
-The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run`, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
+The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run` in an interactive session, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
 
-For non-C# AppHosts (such as [TypeScript AppHosts](/app-host/typescript-apphost/)), the `dotnet` first-run experience that normally creates the HTTPS development certificate doesn't run. The Aspire CLI handles this automatically: when `aspire run` starts a non-C# AppHost in non-interactive mode and no HTTPS development certificate exists, the CLI generates one. If generation fails, a warning is displayed but the run continues.
+For non-.NET AppHosts (such as [TypeScript](/app-host/typescript-apphost/) or Python AppHosts), the `dotnet` first-run experience that normally creates the HTTPS development certificate never runs, because these AppHosts launch a prebuilt native binary instead of invoking `dotnet`. The Aspire CLI fills this gap when `aspire run` starts and no development certificate exists:
 
-To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`:
+- In an interactive session—and on Linux, where establishing trust doesn't require a prompt—the CLI creates *and* trusts the certificate, just as it does for .NET AppHosts.
+- In a non-interactive session on macOS or Windows (for example, in CI), the CLI can't show the macOS Keychain password prompt or the Windows trust dialog, so it *generates* the certificate without trusting it. This lets servers such as Kestrel load the certificate from the personal store, even though it isn't trusted. If the certificate can't be generated, a warning is displayed and the run continues.
+
+To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`. This mirrors the .NET SDK's `DOTNET_GENERATE_ASPNET_CERTIFICATE` opt-out:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
 
 ```bash title="Disable automatic HTTPS certificate generation"
 ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE=false aspire run
 ```
 
-```powershell title="Disable automatic HTTPS certificate generation (PowerShell)"
+</div>
+<div slot="windows">
+
+```powershell title="Disable automatic HTTPS certificate generation"
 $env:ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE="false"; aspire run
 ```
+
+</div>
+</OsAwareTabs>
 
 You can also manage certificates explicitly with the Aspire CLI:
 

--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -38,6 +38,18 @@ Many of the certificate features in Aspire rely on a development certificate. Be
 
 The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run`, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
 
+For non-.NET AppHosts (such as [TypeScript AppHosts](/app-host/typescript-apphost/)), the `dotnet` first-run experience that normally creates the HTTPS development certificate does not run. The Aspire CLI handles this automatically: when `aspire run` starts a non-.NET AppHost in non-interactive mode and no HTTPS development certificate exists, the CLI generates one. If generation fails, a warning is displayed but the run continues.
+
+To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`:
+
+```bash title="Disable automatic HTTPS certificate generation"
+ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE=false aspire run
+```
+
+```powershell title="Disable automatic HTTPS certificate generation (PowerShell)"
+$env:ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE="false"; aspire run
+```
+
 You can also manage certificates explicitly with the Aspire CLI:
 
 ```bash title="Trust the development certificate"


### PR DESCRIPTION
Supersedes #1063.

This replacement targets elease/13.5 because the original elease/13.4 base branch no longer exists on microsoft/aspire.dev.

Documents changes from microsoft/aspire#17454 (`@JamesNK`).

Targeting `release/13.4` based on the source PR milestone `13.4`.

## Why this PR is needed

PR microsoft/aspire#17454 fixes a failure for non-.NET AppHosts (such as TypeScript AppHosts) where the dashboard resource service defaults to HTTPS but no HTTPS development certificate exists. Unlike .NET projects, TypeScript AppHosts don't trigger the `dotnet` first-run experience that normally generates the dev cert.

The fix adds automatic HTTPS development certificate generation in the Aspire CLI when running a non-.NET AppHost in non-interactive mode, with an opt-out via `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE=false`.

## What was changed

Updated `src/frontend/src/content/docs/app-host/certificate-configuration.mdx` to document:
- The automatic HTTPS certificate generation behavior for non-.NET AppHosts when running `aspire run`
- The `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable opt-out with example commands for bash and PowerShell

## Files modified

- `src/frontend/src/content/docs/app-host/certificate-configuration.mdx` — updated existing page




> Generated by [PR Documentation Check](https://github.com/microsoft/aspire/actions/runs/26385649728/agentic_workflow) for issue #17454 · ● 65.2M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Faspire.dev+%22gh-aw-workflow-id%3A+pr-docs-check%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Documentation Check, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 26385649728, workflow_id: pr-docs-check, run: https://github.com/microsoft/aspire/actions/runs/26385649728 -->

<!-- gh-aw-workflow-id: pr-docs-check -->