### PR TITLE
[docs] Add CLI startup profiling reference page

### DIFF
--- a/src/frontend/config/sidebar/reference.topics.ts
+++ b/src/frontend/config/sidebar/reference.topics.ts
@@ -256,6 +256,27 @@ export const referenceTopics: StarlightSidebarTopicsUserConfig[number] = {
           slug: 'reference/cli/microsoft-collected-cli-telemetry',
         },
         {
+          label: 'Startup profiling',
+          translations: {
+            da: 'Opstartsprofilering',
+            de: 'Startprofilerstellung',
+            en: 'Startup profiling',
+            es: 'Creación de perfiles de inicio',
+            fr: 'Profilage au démarrage',
+            hi: 'स्टार्टअप प्रोफाइलिंग',
+            id: 'Pembuatan profil startup',
+            it: 'Profilatura all\'avvio',
+            ja: 'スタートアップ プロファイリング',
+            ko: '시작 프로파일링',
+            'pt-BR': 'Criação de perfil de inicialização',
+            ru: 'Профилирование запуска',
+            tr: 'Başlangıç profili oluşturma',
+            uk: 'Профілювання запуску',
+            'zh-CN': '启动分析',
+          },
+          slug: 'reference/cli/startup-profiling',
+        },
+        {
           label: 'Commands',
           translations: {
             da: 'Kommandoer',

--- a/src/frontend/src/content/docs/reference/cli/startup-profiling.mdx
+++ b/src/frontend/src/content/docs/reference/cli/startup-profiling.mdx
@@ -1,0 +1,84 @@
+---
+title: CLI startup profiling
+description: Learn how to capture an end-to-end OpenTelemetry startup trace from the Aspire CLI using the ASPIRE_PROFILING_ENABLED environment variable.
+---
+
+import OsAwareTabs from '@components/OsAwareTabs.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+The Aspire CLI can export an end-to-end OpenTelemetry trace of its startup sequence to any OTLP-compatible backend. This lets you identify which phase of startup — TypeScript guest compilation, `npm install`, AppHost server startup, or DCP initialization — is taking the most wall-clock time.
+
+Startup profiling works in release CLI builds. It uses a dedicated OTLP exporter that is separate from the [Microsoft-collected CLI telemetry](/reference/cli/microsoft-collected-cli-telemetry/), so enabling profiling does not affect the reported telemetry stream and does not send data to Microsoft.
+
+## How to enable
+
+Set `ASPIRE_PROFILING_ENABLED=true` together with `OTEL_EXPORTER_OTLP_ENDPOINT` pointing at a running OTLP collector:
+
+<OsAwareTabs syncKey="terminal">
+<div slot="unix">
+
+```bash
+export ASPIRE_PROFILING_ENABLED=true
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+aspire start
+```
+
+</div>
+<div slot="windows">
+
+```powershell
+$env:ASPIRE_PROFILING_ENABLED = "true"
+$env:OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4317"
+$env:OTEL_EXPORTER_OTLP_PROTOCOL = "grpc"
+aspire start
+```
+
+</div>
+</OsAwareTabs>
+
+:::note
+`ASPIRE_STARTUP_PROFILING_ENABLED` is a legacy alias for `ASPIRE_PROFILING_ENABLED` and remains supported for existing scripts.
+:::
+
+## What is captured
+
+The profiling trace spans the full `aspire start` lifetime and includes spans for each subprocess the CLI launches:
+
+| Span | Description |
+|------|-------------|
+| `aspire/cli/run` | Child CLI `run` command lifetime during `aspire start`. |
+| `aspire/cli/start_apphost.wait_for_backchannel` | Parent `start` command waiting for the child CLI and AppHost backchannel metadata. |
+| `aspire/cli/run_apphost.wait_for_backchannel` | Child CLI waiting for the AppHost server backchannel connection. |
+| `aspire/cli/run_apphost.get_dashboard_urls` | Child CLI retrieving dashboard URLs. |
+| `aspire.hosting.dcp.run_application` | Hosting DCP startup work. |
+| `process aspire.exe` | Parent CLI spawning the detached child `run` process. |
+| `process aspire-managed.exe` | AppHost server process. |
+| `process npm.CMD` | `npm install` runs (restore and start-time). |
+| `process npx.CMD` | TypeScript guest execution phases (pre-execute type check and execute). |
+
+Process spans include the following OpenTelemetry tags:
+
+| Tag | Description |
+|-----|-------------|
+| `process.executable.name` | The short executable name (for example, `npm.CMD`). |
+| `process.executable.path` | The resolved executable path. |
+| `process.command_args` | The command-line arguments passed to the process. |
+| `process.command_args.count` | The number of command-line arguments. |
+
+## Telemetry stream separation
+
+The CLI maintains three separate OpenTelemetry `TracerProvider` pipelines:
+
+| Stream | Activity source | Exporter | Enabled by |
+|--------|----------------|----------|------------|
+| Reported telemetry | `Aspire.Cli.Reported` | Azure Monitor | On by default; disable with `ASPIRE_CLI_TELEMETRY_OPTOUT=true`. |
+| Startup profiling | `Aspire.Cli.Profiling` | OTLP | `ASPIRE_PROFILING_ENABLED=true` plus `OTEL_EXPORTER_OTLP_ENDPOINT`. |
+| DEBUG diagnostics | `Aspire.Cli.Diagnostics` | OTLP or console | `ASPIRE_CLI_CONSOLE_EXPORTER_LEVEL=Diagnostic`, or `OTEL_EXPORTER_OTLP_ENDPOINT` without profiling enabled (DEBUG builds only). |
+
+When `ASPIRE_PROFILING_ENABLED=true` and `OTEL_EXPORTER_OTLP_ENDPOINT` are both set, the OTLP endpoint is reserved exclusively for the profiling provider. The reported and diagnostic streams are kept separate so that startup profiling exports contain only profiling spans.
+
+## See also
+
+- [Microsoft-collected CLI telemetry](/reference/cli/microsoft-collected-cli-telemetry/)
+- [Aspire CLI overview](/reference/cli/overview/)


### PR DESCRIPTION
Supersedes #984.

This replacement targets elease/13.5 because the original elease/13.4 base branch no longer exists on microsoft/aspire.dev.

Documents changes from microsoft/aspire#17099 — `@davidfowl`

Targeting `release/13.4` based on the source PR milestone `13.4`.

## Why this PR is needed

microsoft/aspire#17099 separated the Aspire CLI's OpenTelemetry telemetry streams into three distinct `TracerProvider` pipelines: reported telemetry (Azure Monitor), startup profiling (OTLP), and DEBUG diagnostics. As a result, startup profiling now works in **release** CLI builds — users set `ASPIRE_PROFILING_ENABLED=true` plus `OTEL_EXPORTER_OTLP_ENDPOINT` to get an end-to-end OTLP trace of the CLI startup sequence. This user-facing capability was previously undocumented.

The PR body included an explicit **User-facing usage** section demonstrating the environment variables, and the `TelemetryManager.cs` diff showed the three-provider model and the `ASPIRE_STARTUP_PROFILING_ENABLED` legacy alias.

## Changes

- **New page** `src/frontend/src/content/docs/reference/cli/startup-profiling.mdx` — covers how to enable startup profiling, what spans and process tags are captured, and the three-stream separation model.
- **Updated sidebar** `src/frontend/config/sidebar/reference.topics.ts` — adds the new page after the Microsoft telemetry entry in the CLI section, with translations for all supported locales.

## Files modified or created

| File | Action |
|------|--------|
| `src/frontend/src/content/docs/reference/cli/startup-profiling.mdx` | Created |
| `src/frontend/config/sidebar/reference.topics.ts` | Updated |




> Generated by [PR Documentation Check](https://github.com/microsoft/aspire/actions/runs/25929143917/agentic_workflow) for issue #17099 · ● 20M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Faspire.dev+%22gh-aw-workflow-id%3A+pr-docs-check%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Documentation Check, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25929143917, workflow_id: pr-docs-check, run: https://github.com/microsoft/aspire/actions/runs/25929143917 -->

<!-- gh-aw-workflow-id: pr-docs-check -->