### PR TITLE
[docs] Document aspire render debug command and links scenario

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-render.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-render.mdx
@@ -1,0 +1,81 @@
+---
+title: aspire render command
+description: Learn about the hidden aspire render command, a debug-only tool for CLI contributors to smoke test terminal rendering in the Aspire CLI.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+## Name
+
+`aspire render` - Smoke test terminal rendering in the Aspire CLI (debug builds only).
+
+## Synopsis
+
+```bash title="Aspire CLI"
+aspire render [--scenario <scenario>] [--console-width <width>]
+```
+
+## Description
+
+The `aspire render` command is a **hidden, debug-only** command used by CLI contributors to smoke test
+the Aspire CLI's terminal rendering helpers — such as `MarkupHelpers`, `MarkdownHelpers`, and
+`InteractionService` — without needing a full AppHost or project. It is not surfaced in
+`aspire --help` output and is only available in debug builds of the CLI.
+
+<Aside type="caution">
+  The `aspire render` command is intended for CLI contributors and maintainers only.
+  It is a debug tool and is not part of the stable Aspire CLI API. Its behavior,
+  scenarios, and options may change without notice.
+</Aside>
+
+When run without `--scenario`, the command enters an interactive loop that prompts you
+to select a scenario from the available list. After each scenario completes, a blank
+separator line is inserted before the prompt reappears, making repeated passes easier
+to scan.
+
+## Options
+
+- **`--scenario <scenario>`**
+
+  Run a specific rendering scenario non-interactively and exit. If omitted, the command
+  enters the interactive scenario selector.
+
+- **`--console-width <width>`**
+
+  Override the detected console width used when rendering. Useful for testing how output
+  wraps at specific widths.
+
+## Scenarios
+
+The following rendering scenarios are available in debug builds:
+
+| Scenario | Description |
+|---|---|
+| `links` | Render terminal hyperlinks with `SafeLink` and `SafeFileLink`. Creates a temporary file named `safe file link sample.txt` and renders it as a clickable file link alongside a URL link to Aspire documentation. |
+| `markdown-interactive` | Render Markdown with `DisplayMarkdown` (interactive mode). |
+| `markdown-plain` | Render Markdown as plain text with `DisplayRawText` (non-interactive mode). |
+| `markdown-renderable` | Render Markdown via `ConvertToRenderable` with ANSI disabled. |
+| `debug-activities` | Debug pipeline activities by calling `ProcessPublishingActivitiesDebugAsync`. |
+| `pipeline-activities` | Pipeline activities with a spinner via `ProcessAndDisplayPublishingActivitiesAsync`. |
+| `publish-summary-all` | Publish summary timeline stress scenarios. |
+
+### Example: smoke test terminal hyperlink rendering
+
+The `links` scenario exercises both `MarkupHelpers.SafeLink` (for clickable URLs) and
+`MarkupHelpers.SafeFileLink` (for clickable file-system paths, including paths with
+spaces). It creates a real temporary file so that the file link points to a valid path
+on disk:
+
+```bash title="Aspire CLI (debug build)"
+aspire render --scenario links
+```
+
+Example output (terminals that support OSC 8 hyperlinks will render the link text as
+a clickable hyperlink; others show the raw URL or path):
+
+```text
+Temporary file created at /tmp/aspire-render-links-XXXX/safe file link sample.txt
+Supports links: True
+SafeLink: Aspire documentation
+SafeFileLink: /tmp/aspire-render-links-XXXX/safe file link sample.txt
+```

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -32,6 +32,7 @@ This release introduces:
 - **AI agent readiness** with Aspire workflow skills moving into the new [`microsoft/aspire-skills`](https://github.com/microsoft/aspire-skills) bundle, clearer separation between first-run setup, lifecycle orchestration, monitoring, AppHost wiring, and deployment guidance, and eval-driven iteration on agent routing.
 - **Richer resource commands** with typed arguments, visibility controls, immediate result display, named CLI options, resource-scoped help, built-in parameter command options, and the experimental `WithProcessCommand` API.
 - **CLI discoverability and diagnostics** with `aspire integration list`, `aspire integration search`, `--search` for logs and telemetry, version checks in `aspire doctor`, better logs output, and more consistent command error handling.
+- A new **`links` scenario** for the hidden `aspire render` debug command, allowing CLI contributors to smoke test terminal hyperlink rendering (`SafeLink` and `SafeFileLink`) without a full AppHost.
 - **Dashboard and editor updates** including the AI Agents dialog, resource state fixes, CodeLens actions that appear without opening the Aspire panel, and improved VS Code terminal/debug output integration.
 - **Integration updates** for NATS, Azure Front Door, Foundry hosted agents, and more.
 - …and much more.


### PR DESCRIPTION
Supersedes #970.

This replacement targets elease/13.5 because the original elease/13.4 base branch no longer exists on microsoft/aspire.dev.

Documents changes from microsoft/aspire#17106

Author: `@JamesNK`

## Target branch

Targeting `release/13.4` based on the source PR milestone `13.4` (exact match on `microsoft/aspire.dev`).

## Why this PR is needed

microsoft/aspire#17106 modified `src/Aspire.Cli/Commands/RenderCommand.cs` (triggering `cli_command_file_changed`) and includes a `### User-facing usage` section and `--scenario links` flag mention (`pr_body_has_user_facing_section`, `pr_body_has_cli_flag_mention`). The `aspire render` command had no prior documentation on `aspire.dev`.

The change adds a `links` scenario to the hidden, debug-only `aspire render` command. This scenario allows CLI contributors to smoke test terminal hyperlink rendering — both `MarkupHelpers.SafeLink` (clickable URLs) and `MarkupHelpers.SafeFileLink` (clickable file-system paths, including paths with spaces).

## Documentation changes

- **New page**: `src/frontend/src/content/docs/reference/cli/commands/aspire-render.mdx`
  - Documents the hidden `aspire render` debug command with a prominent caution note that it is for CLI contributors/maintainers only
  - Lists all available scenarios including the new `links` scenario
  - Shows example output for the `links` scenario
- **Updated**: `src/frontend/src/content/docs/whats-new/aspire-13-4.mdx`
  - Adds a bullet noting the new `links` scenario for the `aspire render` debug command

> [!NOTE]
> The `aspire render` command is hidden from end users and only available in debug builds. The SME reviewer should confirm whether this reference page is appropriate for the public docs site, or whether it should be closed as an internal-only change.




> Generated by [PR Documentation Check](https://github.com/microsoft/aspire/actions/runs/25898795122/agentic_workflow) for issue #17106 · ● 19.9M · [◷](https://github.com/search?q=repo%3Amicrosoft%2Faspire.dev+%22gh-aw-workflow-id%3A+pr-docs-check%22&type=pullrequests)

<!-- gh-aw-agentic-workflow: PR Documentation Check, engine: copilot, version: 1.0.40, model: claude-sonnet-4.6, id: 25898795122, workflow_id: pr-docs-check, run: https://github.com/microsoft/aspire/actions/runs/25898795122 -->

<!-- gh-aw-workflow-id: pr-docs-check -->