### PR TITLE
Post inline PR suggestions for forbidden words

### DIFF
--- a/.github/forbidden-words.json
+++ b/.github/forbidden-words.json
@@ -1,22 +1,26 @@
 {
-  "$comment": "Forbidden words/phrases checked against newly added lines in pull requests by .github/scripts/check-forbidden-words.sh. Each rule has a regex 'pattern' (extended POSIX, evaluated case-insensitively unless 'caseSensitive' is true) and a 'message' shown when matched. Add 'excludePaths' globs to skip files for a specific rule.",
+  "$comment": "Forbidden words/phrases checked against newly added lines in pull requests by .github/scripts/check-forbidden-words.sh. Each rule has a regex 'pattern' (extended POSIX/PCRE, evaluated case-insensitively unless 'caseSensitive' is true), a required 'replacement' string, and a 'message' shown when matched. The check still fails when a forbidden phrase is found; in addition, .github/workflows/forbidden-words-suggest.yml posts an inline PR review 'suggestion' that rewrites the offending line by substituting each matched pattern with its 'replacement'. The 'replacement' value is inserted verbatim (matching honors 'caseSensitive', but the replacement text is never case-adjusted and does not support backreferences). Add 'excludePaths' globs to skip files for a specific rule.",
   "excludePaths": [
     "**/*.lock.yml",
     "pnpm-lock.yaml",
     ".github/forbidden-words.json",
-    ".github/scripts/check-forbidden-words.sh"
+    ".github/scripts/check-forbidden-words.sh",
+    ".github/scripts/post-forbidden-word-suggestions.sh"
   ],
   "rules": [
     {
       "pattern": "\\.NET Aspire",
+      "replacement": "Aspire",
       "message": "Use \"Aspire\" instead of \".NET Aspire\"."
     },
     {
       "pattern": "dotnet aspire",
+      "replacement": "Aspire",
       "message": "Use \"Aspire\" instead of \"dotnet aspire\"."
     },
     {
       "pattern": "\\bapp host\\b",
+      "replacement": "AppHost",
       "message": "Use \"AppHost\" instead of \"app host\"."
     }
   ]

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -6,11 +6,22 @@
 # pre-existing text is never flagged. Rules are defined in
 # .github/forbidden-words.json.
 #
+# In addition to failing when a forbidden phrase is found, this script records
+# a machine-readable list of findings (see FINDINGS_FILE below). Each finding
+# includes the corrected line produced by substituting every matched rule's
+# 'pattern' with its 'replacement'. A companion workflow
+# (.github/workflows/forbidden-words-suggest.yml) turns those findings into
+# inline pull request review suggestions.
+#
 # Usage:
 #   check-forbidden-words.sh <base_sha> <head_sha>
 #
 # Environment overrides:
-#   CONFIG_FILE  Path to the rules file (default: .github/forbidden-words.json)
+#   CONFIG_FILE    Path to the rules file (default: .github/forbidden-words.json)
+#   FINDINGS_FILE  When set, a JSON document of findings is written here (even
+#                  when violations are present). Shape:
+#                    { "findings": [ { "file", "line", "original",
+#                                      "suggestion", "messages", "patterns" } ] }
 #
 # Exits non-zero when at least one forbidden phrase is found.
 
@@ -20,6 +31,7 @@ BASE_SHA="${1:?base SHA required}"
 HEAD_SHA="${2:?head SHA required}"
 MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")" || { echo "::error::Unable to compute merge-base of $BASE_SHA and $HEAD_SHA"; exit 2; }
 CONFIG_FILE="${CONFIG_FILE:-.github/forbidden-words.json}"
+FINDINGS_FILE="${FINDINGS_FILE:-}"
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "::error::Config file not found: $CONFIG_FILE"
@@ -27,15 +39,44 @@ if [[ ! -f "$CONFIG_FILE" ]]; then
 fi
 
 command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
+command -v perl >/dev/null 2>&1 || { echo "::error::perl is required"; exit 2; }
 
 # Read global exclude globs (newline separated).
 mapfile -t GLOBAL_EXCLUDES < <(jq -r '.excludePaths // [] | .[]' "$CONFIG_FILE")
 
 rule_count=$(jq '(.rules // []) | length' "$CONFIG_FILE")
+
+# Emit an empty findings file up front so callers always have a valid document.
+write_findings() {
+  [[ -z "$FINDINGS_FILE" ]] && return 0
+  if [[ -s "$FINDINGS_TMP" ]]; then
+    jq -s '{findings: .}' "$FINDINGS_TMP" > "$FINDINGS_FILE"
+  else
+    printf '{"findings":[]}\n' > "$FINDINGS_FILE"
+  fi
+}
+
+FINDINGS_TMP="$(mktemp)"
+trap 'rm -f "$FINDINGS_TMP"' EXIT
+
 if [[ "$rule_count" -eq 0 ]]; then
   echo "No rules defined in $CONFIG_FILE; nothing to check."
+  write_findings
   exit 0
 fi
+
+# Every rule must define a non-empty replacement so a suggestion can be built.
+missing_replacement=$(jq '[.rules[] | select((.replacement // "") == "")] | length' "$CONFIG_FILE")
+if [[ "$missing_replacement" -ne 0 ]]; then
+  echo "::error::Every rule in $CONFIG_FILE must define a non-empty \"replacement\". Found $missing_replacement rule(s) without one."
+  exit 2
+fi
+
+# Preload rule fields to avoid re-invoking jq for every line.
+mapfile -t PATTERNS       < <(jq -r '.rules[].pattern' "$CONFIG_FILE")
+mapfile -t REPLACEMENTS   < <(jq -r '.rules[].replacement' "$CONFIG_FILE")
+mapfile -t MESSAGES       < <(jq -r '.rules[] | (.message // "")' "$CONFIG_FILE")
+mapfile -t CASE_SENSITIVE < <(jq -r '.rules[] | (.caseSensitive // false)' "$CONFIG_FILE")
 
 # Returns 0 if $1 matches any of the shell globs passed as remaining args.
 matches_any_glob() {
@@ -51,6 +92,20 @@ matches_any_glob() {
   return 1
 }
 
+# Substitutes every occurrence of a pattern with its replacement, inserting the
+# replacement verbatim. Perl inserts the value of $r without reprocessing its
+# contents, so no backreferences ($1) or escape sequences are interpreted.
+# Matching honors the rule's case sensitivity.
+apply_replacement() {
+  CONTENT="$1" PAT="$2" REP="$3" CS="$4" perl -e '
+    my $c = $ENV{CONTENT};
+    my $p = $ENV{PAT};
+    my $r = $ENV{REP};
+    if ($ENV{CS} eq "true") { $c =~ s/$p/$r/g; } else { $c =~ s/$p/$r/gi; }
+    print $c;
+  '
+}
+
 violations=0
 
 # List the files changed between base and head (added/copied/modified/renamed).
@@ -63,6 +118,17 @@ for file in "${CHANGED_FILES[@]}"; do
   if matches_any_glob "$file" "${GLOBAL_EXCLUDES[@]}"; then
     continue
   fi
+
+  # Precompute which rules apply to this file (per-rule excludePaths).
+  rule_applies=()
+  for ((r = 0; r < rule_count; r++)); do
+    mapfile -t RULE_EXCLUDES < <(jq -r ".rules[$r].excludePaths // [] | .[]" "$CONFIG_FILE")
+    if ((${#RULE_EXCLUDES[@]} > 0)) && matches_any_glob "$file" "${RULE_EXCLUDES[@]}"; then
+      rule_applies[$r]=0
+    else
+      rule_applies[$r]=1
+    fi
+  done
 
   # Collect added lines as "<line_number>:<content>". --unified=0 keeps hunks
   # tight so we can track new-file line numbers from the @@ headers.
@@ -91,41 +157,68 @@ for file in "${CHANGED_FILES[@]}"; do
 
   [[ -z "$added_lines" ]] && continue
 
-  for ((r = 0; r < rule_count; r++)); do
-    pattern=$(jq -r ".rules[$r].pattern" "$CONFIG_FILE")
-    message=$(jq -r ".rules[$r].message // \"\"" "$CONFIG_FILE")
-    case_sensitive=$(jq -r ".rules[$r].caseSensitive // false" "$CONFIG_FILE")
+  # Check each added line against every applicable rule, aggregating all matches
+  # on the line into a single corrected line (at most one suggestion per line).
+  while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+    lineno="${entry%%:*}"
+    content="${entry#*:}"
 
-    # Per-rule path excludes.
-    mapfile -t RULE_EXCLUDES < <(jq -r ".rules[$r].excludePaths // [] | .[]" "$CONFIG_FILE")
-    if ((${#RULE_EXCLUDES[@]} > 0)) && matches_any_glob "$file" "${RULE_EXCLUDES[@]}"; then
-      continue
-    fi
+    corrected="$content"
+    line_has_match=0
+    line_messages=()
+    line_patterns=()
 
-    grep_opts=(-P)
-    if [[ "$case_sensitive" != "true" ]]; then
-      grep_opts+=(-i)
-    fi
+    for ((r = 0; r < rule_count; r++)); do
+      [[ "${rule_applies[$r]}" == "1" ]] || continue
 
-    # Check each added line's content (line number stripped) against the rule.
-    while IFS= read -r entry; do
-      [[ -z "$entry" ]] && continue
-      lineno="${entry%%:*}"
-      content="${entry#*:}"
+      pattern="${PATTERNS[$r]}"
+      replacement="${REPLACEMENTS[$r]}"
+      message="${MESSAGES[$r]}"
+      case_sensitive="${CASE_SENSITIVE[$r]}"
+
+      grep_opts=(-P)
+      if [[ "$case_sensitive" != "true" ]]; then
+        grep_opts+=(-i)
+      fi
+
       if printf '%s' "$content" | grep -q "${grep_opts[@]}" -- "$pattern"; then
+        line_has_match=1
+        violations=$((violations + 1))
+        line_messages+=("$message")
+        line_patterns+=("$pattern")
+
         printf '::error file=%s,line=%s::Forbidden phrase (/%s/): %s\n' \
           "$file" "$lineno" "$pattern" "$message"
         printf '    %s:%s: %s\n' "$file" "$lineno" "$content"
-        violations=$((violations + 1))
+
+        corrected="$(apply_replacement "$corrected" "$pattern" "$replacement" "$case_sensitive")"
       fi
-    done <<< "$added_lines"
-  done
+    done
+
+    if [[ "$line_has_match" -eq 1 ]]; then
+      messages_json=$(printf '%s\n' "${line_messages[@]}" | jq -R . | jq -s .)
+      patterns_json=$(printf '%s\n' "${line_patterns[@]}" | jq -R . | jq -s .)
+      jq -cn \
+        --arg file "$file" \
+        --argjson line "$lineno" \
+        --arg original "$content" \
+        --arg suggestion "$corrected" \
+        --argjson messages "$messages_json" \
+        --argjson patterns "$patterns_json" \
+        '{file: $file, line: $line, original: $original, suggestion: $suggestion, messages: $messages, patterns: $patterns}' \
+        >> "$FINDINGS_TMP"
+    fi
+  done <<< "$added_lines"
 done
+
+write_findings
 
 echo
 if [[ "$violations" -gt 0 ]]; then
   echo "Found $violations forbidden phrase occurrence(s) in added lines."
   echo "Update the wording, or adjust .github/forbidden-words.json if a rule is wrong."
+  echo "Inline suggestions will be posted on the pull request where possible."
   exit 1
 fi
 

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -140,6 +140,7 @@ for file in "${CHANGED_FILES[@]}"; do
 
   added_lines=$(awk '
     /^@@/ {
+      in_hunk = 1
       for (i = 1; i <= NF; i++) {
         if (substr($i, 1, 1) == "+") {
           s = substr($i, 2)
@@ -150,8 +151,7 @@ for file in "${CHANGED_FILES[@]}"; do
       }
       next
     }
-    /^\+\+\+/ { next }
-    /^\+/ {
+    in_hunk && /^\+/ {
       content = substr($0, 2)
       printf "%d:%s\n", line, content
       line++

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -69,6 +69,9 @@ fi
 missing_replacement=$(jq '[.rules[] | select((.replacement // "") == "")] | length' "$CONFIG_FILE")
 if [[ "$missing_replacement" -ne 0 ]]; then
   echo "::error::Every rule in $CONFIG_FILE must define a non-empty \"replacement\". Found $missing_replacement rule(s) without one."
+  # Still emit an (empty) findings document so callers that always consume it
+  # see a valid artifact, even though we fail the check.
+  write_findings
   exit 2
 fi
 

--- a/.github/scripts/check-forbidden-words.sh
+++ b/.github/scripts/check-forbidden-words.sh
@@ -169,6 +169,7 @@ for file in "${CHANGED_FILES[@]}"; do
 
     corrected="$content"
     line_has_match=0
+    suggestion_available=1
     line_messages=()
     line_patterns=()
 
@@ -195,11 +196,16 @@ for file in "${CHANGED_FILES[@]}"; do
           "$file" "$lineno" "$pattern" "$message"
         printf '    %s:%s: %s\n' "$file" "$lineno" "$content"
 
-        corrected="$(apply_replacement "$corrected" "$pattern" "$replacement" "$case_sensitive")"
+        if ! updated="$(apply_replacement "$corrected" "$pattern" "$replacement" "$case_sensitive")"; then
+          suggestion_available=0
+          echo "::warning file=$file,line=$lineno::Could not build an inline suggestion for this line because the matched pattern is not supported by the replacement engine."
+        else
+          corrected="$updated"
+        fi
       fi
     done
 
-    if [[ "$line_has_match" -eq 1 ]]; then
+    if [[ "$line_has_match" -eq 1 && "$suggestion_available" -eq 1 ]]; then
       messages_json=$(printf '%s\n' "${line_messages[@]}" | jq -R . | jq -s .)
       patterns_json=$(printf '%s\n' "${line_patterns[@]}" | jq -R . | jq -s .)
       jq -cn \

--- a/.github/scripts/post-forbidden-word-suggestions.sh
+++ b/.github/scripts/post-forbidden-word-suggestions.sh
@@ -35,6 +35,14 @@ if [[ ! -f "$FINDINGS_FILE" ]]; then
   exit 0
 fi
 
+# The findings document originates from a PR-scoped run, so treat it as
+# untrusted input: if it isn't valid JSON with a findings array, skip quietly
+# instead of failing this best-effort workflow.
+if ! jq -e '.findings | type == "array"' "$FINDINGS_FILE" >/dev/null 2>&1; then
+  echo "::warning::Findings file is missing or not a valid findings document ($FINDINGS_FILE); skipping suggestions."
+  exit 0
+fi
+
 total=$(jq '.findings | length' "$FINDINGS_FILE")
 if [[ "$total" -eq 0 ]]; then
   echo "No findings; nothing to suggest."
@@ -43,8 +51,15 @@ fi
 
 # Existing review comments on the PR, as {path, line} objects (line falls back to
 # original_line for outdated comments). Used to avoid duplicate suggestions.
-existing_json=$(gh api --paginate "/repos/$REPO/pulls/$PR_NUMBER/comments" \
-  --jq '.[] | {path: .path, line: (.line // .original_line)}' | jq -s '.')
+# If the listing fails (permissions, rate limiting, transient network), skip
+# rather than risk posting duplicates or failing this best-effort workflow.
+if ! existing_raw=$(gh api --paginate "/repos/$REPO/pulls/$PR_NUMBER/comments" \
+    --jq '.[] | {path: .path, line: (.line // .original_line)}' 2>/tmp/list-comments.err); then
+  echo "::warning::Could not list existing PR comments; skipping suggestions to avoid duplicates."
+  sed 's/^/  gh: /' /tmp/list-comments.err >&2 || true
+  exit 0
+fi
+existing_json=$(printf '%s' "$existing_raw" | jq -s '.')
 
 # Build the list of comments to post: findings that don't already have a comment
 # on the same (path, line), rendered as a suggestion block.

--- a/.github/scripts/post-forbidden-word-suggestions.sh
+++ b/.github/scripts/post-forbidden-word-suggestions.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Posts inline pull request review suggestions for forbidden-word findings.
+#
+# Reads the findings document produced by check-forbidden-words.sh and, for each
+# finding, posts an inline review comment containing a GitHub ```suggestion```
+# block that rewrites the offending line. A suggestion is skipped when a review
+# comment already exists on that (path, line), so re-runs do not pile up
+# duplicates.
+#
+# This script only reads the findings JSON as data and calls the GitHub API; it
+# never checks out or executes pull request code, so it is safe to run from the
+# privileged `workflow_run` context.
+#
+# Required environment:
+#   GH_TOKEN       Token with `pull-requests: write` (the Aspire bot app token).
+#   REPO           "owner/repo".
+#   PR_NUMBER      Pull request number.
+#   HEAD_SHA       Commit SHA the findings were computed against.
+#   FINDINGS_FILE  Path to the findings JSON document.
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN required}"
+: "${REPO:?REPO required}"
+: "${PR_NUMBER:?PR_NUMBER required}"
+: "${HEAD_SHA:?HEAD_SHA required}"
+: "${FINDINGS_FILE:?FINDINGS_FILE required}"
+
+command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
+command -v gh >/dev/null 2>&1 || { echo "::error::gh is required"; exit 2; }
+
+if [[ ! -f "$FINDINGS_FILE" ]]; then
+  echo "Findings file not found ($FINDINGS_FILE); nothing to suggest."
+  exit 0
+fi
+
+total=$(jq '.findings | length' "$FINDINGS_FILE")
+if [[ "$total" -eq 0 ]]; then
+  echo "No findings; nothing to suggest."
+  exit 0
+fi
+
+# Existing review comments on the PR, as {path, line} objects (line falls back to
+# original_line for outdated comments). Used to avoid duplicate suggestions.
+existing_json=$(gh api --paginate "/repos/$REPO/pulls/$PR_NUMBER/comments" \
+  --jq '.[] | {path: .path, line: (.line // .original_line)}' | jq -s '.')
+
+# Build the list of comments to post: findings that don't already have a comment
+# on the same (path, line), rendered as a suggestion block.
+comments_json=$(jq -n \
+  --slurpfile f "$FINDINGS_FILE" \
+  --argjson existing "$existing_json" \
+  '
+  $f[0].findings
+  | map(select(. as $find
+      | ($existing | any(.path == $find.file and .line == $find.line)) | not))
+  | map({
+      path: .file,
+      line: .line,
+      side: "RIGHT",
+      body: ((.messages | join("\n")) + "\n\n```suggestion\n" + .suggestion + "\n```")
+    })
+  ')
+
+count=$(jq 'length' <<< "$comments_json")
+if [[ "$count" -eq 0 ]]; then
+  echo "All $total finding(s) already have a comment on their line; nothing to post."
+  exit 0
+fi
+
+echo "Posting $count new inline suggestion(s) (of $total finding(s))."
+
+# Prefer a single batched review so all suggestions appear together.
+review_payload=$(jq -n \
+  --arg commit "$HEAD_SHA" \
+  --argjson comments "$comments_json" \
+  '{
+     commit_id: $commit,
+     event: "COMMENT",
+     body: "Automated wording suggestions from the forbidden-words check. Apply the suggestions to resolve them.",
+     comments: $comments
+   }')
+
+if printf '%s' "$review_payload" \
+    | gh api --method POST "/repos/$REPO/pulls/$PR_NUMBER/reviews" --input - >/dev/null 2>/tmp/review.err; then
+  echo "Posted a review with $count inline suggestion(s)."
+  exit 0
+fi
+
+echo "::warning::Batched review failed; falling back to individual comments."
+sed 's/^/  gh: /' /tmp/review.err >&2 || true
+
+# Fallback: post each suggestion independently so one bad line can't block the rest.
+ok=0
+fail=0
+while IFS= read -r c; do
+  [[ -z "$c" ]] && continue
+  path=$(jq -r '.path' <<< "$c")
+  line=$(jq -r '.line' <<< "$c")
+  if jq -n \
+      --arg commit "$HEAD_SHA" \
+      --arg path "$path" \
+      --argjson line "$line" \
+      --arg body "$(jq -r '.body' <<< "$c")" \
+      '{commit_id: $commit, path: $path, line: $line, side: "RIGHT", body: $body}' \
+      | gh api --method POST "/repos/$REPO/pulls/$PR_NUMBER/comments" --input - >/dev/null 2>&1; then
+    ok=$((ok + 1))
+  else
+    fail=$((fail + 1))
+    echo "::warning::Could not post suggestion on $path:$line."
+  fi
+done < <(jq -c '.[]' <<< "$comments_json")
+
+echo "Individual fallback: $ok posted, $fail failed."
+# Best-effort: never fail the workflow just because suggestions couldn't post.
+exit 0

--- a/.github/scripts/post-forbidden-word-suggestions.sh
+++ b/.github/scripts/post-forbidden-word-suggestions.sh
@@ -18,6 +18,7 @@
 #   PR_NUMBER      Pull request number.
 #   HEAD_SHA       Commit SHA the findings were computed against.
 #   FINDINGS_FILE  Path to the findings JSON document.
+#   CONFIG_FILE    Path to the trusted forbidden-words rules document.
 
 set -euo pipefail
 
@@ -26,6 +27,7 @@ set -euo pipefail
 : "${PR_NUMBER:?PR_NUMBER required}"
 : "${HEAD_SHA:?HEAD_SHA required}"
 : "${FINDINGS_FILE:?FINDINGS_FILE required}"
+: "${CONFIG_FILE:?CONFIG_FILE required}"
 
 command -v jq >/dev/null 2>&1 || { echo "::error::jq is required"; exit 2; }
 command -v gh >/dev/null 2>&1 || { echo "::error::gh is required"; exit 2; }
@@ -33,6 +35,11 @@ command -v gh >/dev/null 2>&1 || { echo "::error::gh is required"; exit 2; }
 if [[ ! -f "$FINDINGS_FILE" ]]; then
   echo "Findings file not found ($FINDINGS_FILE); nothing to suggest."
   exit 0
+fi
+
+if ! jq -e '.rules | type == "array"' "$CONFIG_FILE" >/dev/null 2>&1; then
+  echo "::error::Trusted rules file is missing or invalid ($CONFIG_FILE)."
+  exit 2
 fi
 
 # The findings document originates from a PR-scoped run, so treat it as
@@ -65,16 +72,33 @@ existing_json=$(printf '%s' "$existing_raw" | jq -s '.')
 # on the same (path, line), rendered as a suggestion block.
 comments_json=$(jq -n \
   --slurpfile f "$FINDINGS_FILE" \
+  --slurpfile config "$CONFIG_FILE" \
   --argjson existing "$existing_json" \
   '
+  ($config[0].rules | map({key: .pattern, value: (.message // "")}) | from_entries) as $messages
+  |
   $f[0].findings
+  | map(select(
+      (.file | type) == "string" and
+      (.file | length > 0) and
+      (.line | type) == "number" and
+      (.line > 0 and .line == (.line | floor)) and
+      (.suggestion | type) == "string" and
+      ((.suggestion | contains("\n")) | not) and
+      ((.suggestion | contains("\r")) | not) and
+      ((.suggestion | contains("```")) | not) and
+      (.patterns | type == "array") and
+      (.patterns | length > 0) and
+      (all(.patterns[]; type == "string")) and
+      (all(.patterns[]; . as $pattern | $messages | has($pattern)))
+    ))
   | map(select(. as $find
       | ($existing | any(.path == $find.file and .line == $find.line)) | not))
   | map({
       path: .file,
       line: .line,
       side: "RIGHT",
-      body: ((.messages | join("\n")) + "\n\n```suggestion\n" + .suggestion + "\n```")
+      body: ((.patterns | map($messages[.]) | join("\n")) + "\n\n```suggestion\n" + .suggestion + "\n```")
     })
   ')
 

--- a/.github/workflows/forbidden-words-suggest.yml
+++ b/.github/workflows/forbidden-words-suggest.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
+            .github/forbidden-words.json
             .github/scripts
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -142,5 +143,6 @@ jobs:
           PR_NUMBER: ${{ steps.source.outputs.pr }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           FINDINGS_FILE: findings/findings.json
+          CONFIG_FILE: .github/forbidden-words.json
         run: |
           .github/scripts/post-forbidden-word-suggestions.sh

--- a/.github/workflows/forbidden-words-suggest.yml
+++ b/.github/workflows/forbidden-words-suggest.yml
@@ -6,12 +6,12 @@ name: Forbidden Words Suggestions
 # Aspire bot credentials even for pull requests from forks.
 #
 # This job only reads the findings artifact as data and posts review comments.
-# It runs the trusted scripts from the default branch (never the pull request's
-# version) and does not check out or execute pull request code.
+# It derives the target pull request from the trusted workflow_run payload and
+# GitHub API, runs scripts from the default branch, and never executes PR code.
 on:
   workflow_run:
-    workflows: [ "Forbidden Words" ]
-    types: [ completed ]
+    workflows: ["Forbidden Words"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -54,7 +54,7 @@ jobs:
         id: check
         shell: bash
         run: |
-          if [[ -f findings/meta.json && -f findings/findings.json ]]; then
+          if [[ -f findings/findings.json ]]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
             count=$(jq '.findings | length' findings/findings.json)
             echo "Findings: $count"
@@ -65,20 +65,49 @@ jobs:
             echo "No findings artifact was produced; nothing to suggest."
           fi
 
-      - name: Read metadata
-        id: meta
+      # Never trust PR coordinates from the artifact. Resolve the source PR from
+      # the workflow_run head identity and require exactly one matching open PR.
+      - name: Resolve source pull request
+        id: source
         if: ${{ steps.check.outputs.has_findings == 'true' }}
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          HEAD_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          echo "repo=$(jq -r '.repo' findings/meta.json)" >> "$GITHUB_OUTPUT"
-          echo "pr=$(jq -r '.pr' findings/meta.json)" >> "$GITHUB_OUTPUT"
-          echo "head=$(jq -r '.head_sha' findings/meta.json)" >> "$GITHUB_OUTPUT"
+          candidates=$(
+            gh api --paginate --slurp "/repos/$REPO/pulls?state=open&per_page=100" |
+              jq -c \
+                --arg repo "$REPO" \
+                --arg head "$HEAD_SHA" \
+                --arg head_repo "$HEAD_REPO" \
+                --arg head_branch "$HEAD_BRANCH" \
+                '[.[][] | select(
+                  .state == "open" and
+                  .base.repo.full_name == $repo and
+                  .head.sha == $head and
+                  .head.repo.full_name == $head_repo and
+                  .head.ref == $head_branch
+                )]'
+          )
+          count=$(jq 'length' <<< "$candidates")
+          if [[ "$count" -ne 1 ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Expected exactly one open pull request for workflow head $HEAD_SHA, found $count; skipping suggestions."
+            exit 0
+          fi
+
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "pr=$(jq -r '.[0].number' <<< "$candidates")" >> "$GITHUB_OUTPUT"
 
       # Skip gracefully when the Aspire bot credentials aren't configured
       # (e.g. on a fork that runs this workflow without the secrets).
       - name: Check Aspire bot credentials
         id: creds
-        if: ${{ steps.check.outputs.has_findings == 'true' }}
+        if: ${{ steps.source.outputs.found == 'true' }}
         shell: bash
         env:
           APP_ID: ${{ secrets.ASPIRE_BOT_APP_ID }}
@@ -109,9 +138,9 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app_token.outputs.token }}
-          REPO: ${{ steps.meta.outputs.repo }}
-          PR_NUMBER: ${{ steps.meta.outputs.pr }}
-          HEAD_SHA: ${{ steps.meta.outputs.head }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ steps.source.outputs.pr }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           FINDINGS_FILE: findings/findings.json
         run: |
           .github/scripts/post-forbidden-word-suggestions.sh

--- a/.github/workflows/forbidden-words-suggest.yml
+++ b/.github/workflows/forbidden-words-suggest.yml
@@ -1,0 +1,114 @@
+name: Forbidden Words Suggestions
+
+# Runs after the "Forbidden Words" check completes. That check runs on
+# `pull_request` (no secrets on fork PRs), so the actual suggestion posting is
+# done here in the privileged `workflow_run` context, which has access to the
+# Aspire bot credentials even for pull requests from forks.
+#
+# This job only reads the findings artifact as data and posts review comments.
+# It runs the trusted scripts from the default branch (never the pull request's
+# version) and does not check out or execute pull request code.
+on:
+  workflow_run:
+    workflows: [ "Forbidden Words" ]
+    types: [ completed ]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  suggest:
+    name: Post inline suggestions
+    runs-on: ubuntu-latest
+    # Only act on runs triggered by pull requests.
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      # Check out the trusted scripts from the default branch (NOT the PR head).
+      - name: Checkout scripts
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Download findings artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        continue-on-error: true
+        with:
+          name: forbidden-words-findings
+          path: findings
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Inspect artifact
+        id: check
+        shell: bash
+        run: |
+          if [[ -f findings/meta.json && -f findings/findings.json ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+            count=$(jq '.findings | length' findings/findings.json)
+            echo "Findings: $count"
+            [[ "$count" -gt 0 ]] && echo "has_findings=true" >> "$GITHUB_OUTPUT" || echo "has_findings=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "has_findings=false" >> "$GITHUB_OUTPUT"
+            echo "No findings artifact was produced; nothing to suggest."
+          fi
+
+      - name: Read metadata
+        id: meta
+        if: ${{ steps.check.outputs.has_findings == 'true' }}
+        shell: bash
+        run: |
+          echo "repo=$(jq -r '.repo' findings/meta.json)" >> "$GITHUB_OUTPUT"
+          echo "pr=$(jq -r '.pr' findings/meta.json)" >> "$GITHUB_OUTPUT"
+          echo "head=$(jq -r '.head_sha' findings/meta.json)" >> "$GITHUB_OUTPUT"
+
+      # Skip gracefully when the Aspire bot credentials aren't configured
+      # (e.g. on a fork that runs this workflow without the secrets).
+      - name: Check Aspire bot credentials
+        id: creds
+        if: ${{ steps.check.outputs.has_findings == 'true' }}
+        shell: bash
+        env:
+          APP_ID: ${{ secrets.ASPIRE_BOT_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+        run: |
+          if [[ -n "$APP_ID" && -n "$PRIVATE_KEY" ]]; then
+            echo "ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Aspire bot credentials unavailable; skipping inline suggestions."
+          fi
+
+      - name: Create Aspire bot token
+        id: app_token
+        if: ${{ steps.creds.outputs.ok == 'true' }}
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.ASPIRE_BOT_APP_ID }}
+          private-key: ${{ secrets.ASPIRE_BOT_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          github-api-url: ${{ github.api_url }}
+          permission-pull-requests: write
+          permission-contents: read
+
+      - name: Post inline suggestions
+        if: ${{ steps.app_token.outputs.token != '' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
+          REPO: ${{ steps.meta.outputs.repo }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr }}
+          HEAD_SHA: ${{ steps.meta.outputs.head }}
+          FINDINGS_FILE: findings/findings.json
+        run: |
+          .github/scripts/post-forbidden-word-suggestions.sh

--- a/.github/workflows/forbidden-words-suggest.yml
+++ b/.github/workflows/forbidden-words-suggest.yml
@@ -19,8 +19,11 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.workflow_run.id }}
-  cancel-in-progress: false
+  # Group by the source pull request (head repo + branch) so rapid pushes don't
+  # run concurrently and race the dedupe check. head_repository.full_name keeps
+  # forks with the same branch name in separate groups.
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
 
 jobs:
   suggest:

--- a/.github/workflows/forbidden-words.yml
+++ b/.github/workflows/forbidden-words.yml
@@ -24,6 +24,10 @@ jobs:
   forbidden-words:
     name: Check forbidden words
     runs-on: ubuntu-latest
+    env:
+      # Directory (relative to the workspace) where findings + PR metadata are
+      # written so the suggestion workflow can pick them up from the artifact.
+      FINDINGS_DIR: forbidden-words-out
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -55,9 +59,56 @@ jobs:
           echo "base=$base" >> "$GITHUB_OUTPUT"
           echo "head=$head" >> "$GITHUB_OUTPUT"
 
+      # Scan runs with continue-on-error so we can still publish findings (for the
+      # suggestion workflow) before the gate step fails the check.
       - name: Scan added lines for forbidden words
+        id: scan
+        continue-on-error: true
         shell: bash
         run: |
-          .github/scripts/check-forbidden-words.sh \
-            "${{ steps.shas.outputs.base }}" \
-            "${{ steps.shas.outputs.head }}"
+          mkdir -p "$FINDINGS_DIR"
+          FINDINGS_FILE="$FINDINGS_DIR/findings.json" \
+            .github/scripts/check-forbidden-words.sh \
+              "${{ steps.shas.outputs.base }}" \
+              "${{ steps.shas.outputs.head }}"
+
+      # Persist the pull request coordinates alongside the findings so the
+      # workflow_run follow-up knows where to post (workflow_run.pull_requests is
+      # unreliable for fork PRs).
+      - name: Write suggestion metadata
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        shell: bash
+        env:
+          META_REPO: ${{ github.repository }}
+          META_PR: ${{ github.event.pull_request.number }}
+          META_HEAD: ${{ steps.shas.outputs.head }}
+          META_BASE: ${{ steps.shas.outputs.base }}
+        run: |
+          mkdir -p "$FINDINGS_DIR"
+          jq -n \
+            --arg repo "$META_REPO" \
+            --argjson pr "$META_PR" \
+            --arg head "$META_HEAD" \
+            --arg base "$META_BASE" \
+            '{repo: $repo, pr: $pr, head_sha: $head, base_sha: $base}' \
+            > "$FINDINGS_DIR/meta.json"
+          cat "$FINDINGS_DIR/meta.json"
+
+      - name: Upload findings
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: forbidden-words-findings
+          path: ${{ env.FINDINGS_DIR }}
+          retention-days: 1
+          if-no-files-found: ignore
+
+      - name: Fail when forbidden words are found
+        if: always()
+        shell: bash
+        run: |
+          if [[ "${{ steps.scan.outcome }}" != "success" ]]; then
+            echo "::error::Forbidden words were found in added lines (or the scan failed). See the annotations above; inline suggestions are posted on the pull request where possible."
+            exit 1
+          fi
+          echo "No forbidden phrases found in added lines."

--- a/.github/workflows/forbidden-words.yml
+++ b/.github/workflows/forbidden-words.yml
@@ -2,14 +2,14 @@ name: Forbidden Words
 
 on:
   pull_request:
-    branches: [ main, release/* ]
+    branches: [main, release/*]
   workflow_dispatch:
     inputs:
       base_sha:
-        description: 'Base SHA to diff from (defaults to origin/<default branch>)'
+        description: "Base SHA to diff from (defaults to origin/<default branch>)"
         required: false
       head_sha:
-        description: 'Head SHA to diff to (defaults to HEAD)'
+        description: "Head SHA to diff to (defaults to HEAD)"
         required: false
 
 # Group by PR so new commits cancel the in-flight run for the same PR.
@@ -25,8 +25,7 @@ jobs:
     name: Check forbidden words
     runs-on: ubuntu-latest
     env:
-      # Directory (relative to the workspace) where findings + PR metadata are
-      # written so the suggestion workflow can pick them up from the artifact.
+      # Directory where findings are written for the suggestion workflow.
       FINDINGS_DIR: forbidden-words-out
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -71,28 +70,6 @@ jobs:
             .github/scripts/check-forbidden-words.sh \
               "${{ steps.shas.outputs.base }}" \
               "${{ steps.shas.outputs.head }}"
-
-      # Persist the pull request coordinates alongside the findings so the
-      # workflow_run follow-up knows where to post (workflow_run.pull_requests is
-      # unreliable for fork PRs).
-      - name: Write suggestion metadata
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        shell: bash
-        env:
-          META_REPO: ${{ github.repository }}
-          META_PR: ${{ github.event.pull_request.number }}
-          META_HEAD: ${{ steps.shas.outputs.head }}
-          META_BASE: ${{ steps.shas.outputs.base }}
-        run: |
-          mkdir -p "$FINDINGS_DIR"
-          jq -n \
-            --arg repo "$META_REPO" \
-            --argjson pr "$META_PR" \
-            --arg head "$META_HEAD" \
-            --arg base "$META_BASE" \
-            '{repo: $repo, pr: $pr, head_sha: $head, base_sha: $base}' \
-            > "$FINDINGS_DIR/meta.json"
-          cat "$FINDINGS_DIR/meta.json"
 
       - name: Upload findings
         if: ${{ always() && github.event_name == 'pull_request' }}


### PR DESCRIPTION
## Summary

Extends the **Forbidden Words** check so that, in addition to failing a PR when a forbidden phrase is found, it now posts **inline PR review `suggestion` blocks** that rewrite each offending line using the rule''s replacement. Suggestions are posted by the **Aspire bot GitHub App** (the same app used elsewhere in this repo), and are skipped when a comment already exists on that line, so re-runs don''t pile up duplicates.

The blocking gate is preserved: the check still fails when forbidden words are present.

## How it works

A secure two-workflow split (so it works for fork PRs, which can''t see secrets on `pull_request`):

1. **`Forbidden Words`** (`pull_request`) — scans added lines, writes a `findings.json` + `meta.json`, uploads them as an artifact, and fails the check when violations exist. Read-only token, no secrets.
2. **`Forbidden Words Suggestions`** (`workflow_run`) — runs in the privileged base-repo context, mints the Aspire bot token, and posts the inline suggestions. It only reads the artifact JSON as data and runs **trusted scripts from the default branch** — it never checks out or executes PR code.

> [!NOTE]
> Because the suggestion workflow runs trusted scripts from the default branch, inline suggestions only start appearing on PRs **after this change merges to `main`**.

## Changes

- **`.github/forbidden-words.json`** — every rule now requires a `replacement`; updated `$comment` docs; excluded the new posting script.
- **`.github/scripts/check-forbidden-words.sh`** — validates replacements (fails if any rule lacks one), aggregates all matches on a line into a single corrected line, and writes a findings document. The replacement is inserted **verbatim** (matching still honors `caseSensitive`, but replacement text is never case-adjusted and does not support backreferences).
- **`.github/scripts/post-forbidden-word-suggestions.sh`** (new) — turns findings into a single batched PR review of `suggestion` blocks, deduped against existing comments, with a per-comment fallback.
- **`.github/workflows/forbidden-words.yml`** — scan (continue-on-error) → upload findings + PR metadata → gate/fail on violations.
- **`.github/workflows/forbidden-words-suggest.yml`** (new) — `workflow_run` follow-up that posts the suggestions.

## Validation

- Both scripts `bash -n` clean; both workflows pass `actionlint`.
- Scan logic tested locally against crafted diffs: detection, single aggregated suggestion per line, missing-`replacement` failure (exit 2), and verbatim replacement (incl. `$`/`@`/`\` edge cases).
- `pnpm build` not run (no frontend changes).
