### PR TITLE
Document Go polyglot options flattening breaking change

### DIFF
--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -440,7 +440,7 @@ DTOs are input objects, not live resource handles. Keep `[AspireDto]` types JSON
 
 For an API with one optional options DTO, prefer a flat generated call shape such as `addMyResource('name', { port: 5432 })` instead of requiring `{ options: { port: 5432 } }`. If an existing C# API uses a rich model type that doesn't serialize cleanly, add a small DTO or options type for the exported API.
 
-Both the TypeScript and Go code generators automatically flatten the call shape when a method has exactly one optional parameter that is a DTO named `options` (with no coexisting cancellation token or callback). The Go generator applies this flattening as of Aspire 13.5; TypeScript has done so since Aspire 13.4.
+Both generators flatten the call shape when a method's optional parameters reduce to a single DTO named options. The Go generator applies this as of Aspire 13.5 and only when there's no coexisting cancellation token or callback. TypeScript has flattened single options DTOs since Aspire 13.3; it additionally still flattens when a trailing cancellation token is present, rendering the token as its own parameter.
 
 ```csharp title="Flat options DTO"
 [AspireDto]

--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -440,6 +440,8 @@ DTOs are input objects, not live resource handles. Keep `[AspireDto]` types JSON
 
 For an API with one optional options DTO, prefer a flat generated call shape such as `addMyResource('name', { port: 5432 })` instead of requiring `{ options: { port: 5432 } }`. If an existing C# API uses a rich model type that doesn't serialize cleanly, add a small DTO or options type for the exported API.
 
+Both the TypeScript and Go code generators automatically flatten the call shape when a method has exactly one optional parameter that is a DTO named `options` (with no coexisting cancellation token or callback). The Go generator applies this flattening as of Aspire 13.5; TypeScript has done so since Aspire 13.4.
+
 ```csharp title="Flat options DTO"
 [AspireDto]
 public sealed class AddMyWorkerOptions
@@ -463,11 +465,18 @@ public static IResourceBuilder<MyWorkerResource> AddMyWorker(
 }
 ```
 
-```typescript title="Flat generated call shape"
+```typescript title="Flat generated call shape (TypeScript)"
 const worker = await builder.addMyWorker('worker', {
   imageTag: '1.2.3',
   args: ['--verbose'],
 });
+```
+
+```go title="Flat generated call shape (Go)"
+worker, err := builder.AddMyWorker("worker", &aspire.AddMyWorkerOptions{
+    ImageTag: aspire.StringPtr("1.2.3"),
+    Args:     []string{"--verbose"},
+})
 ```
 
 Collection-valued DTO inputs should also feel like plain JSON in the generated SDK:

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -204,6 +204,8 @@ The following breaking changes are included in Aspire 13.5:
 
 5. **Proxyless endpoint port allocation timing changed**: Proxyless endpoints without an explicit public `port` now receive one during service preparation, before workload resources are created. Executable proxyless endpoints that previously failed without a public port, and container proxyless endpoints that expected the public port to be assigned later during container startup, should expect Aspire to assign the port earlier. The default allocation range is `10000-32767` and can be overridden with `ASPIRE_PROXYLESS_ENDPOINT_PORT_RANGE=start-end`. Persistent resources reuse allocated ports from user secrets when available.
 
+6. **Go polyglot SDK: single optional `options` DTO is now passed directly**: When a C# exported API has exactly one optional parameter that is a DTO named `options` (with no coexisting cancellation token or callback), the Go polyglot code generator now passes the DTO type directly as a variadic parameter instead of wrapping it in a generated method-options struct. Go AppHosts that used the wrapper-struct form must update their call sites after regenerating the SDK.
+
 <Aside type="caution" title="Review deprecated APIs">
   Review your code for uses of `ServiceProvider` on hosting context types and `PublishAsConnectionString` extension methods. These will generate compiler warnings in Aspire 13.5 and may become harder errors in future releases. If you use the `Aspire.Hosting.GitHub.Models` integration, plan to migrate off it before the package is removed.
 </Aside>


### PR DESCRIPTION
Documents the breaking change from microsoft/aspire#18698 where the Go polyglot code generator now passes a single optional options DTO directly instead of wrapping it in a generated method-options struct.

- whats-new/aspire-13-5.mdx: add breaking change entry
- extensibility/multi-language-integration-authoring.mdx: note Go parity (as of 13.5) and add a Go flat-options example alongside the TypeScript one.