### PR TITLE
Fix topic sidebar toggle styling

### DIFF
--- a/src/frontend/src/components/starlight/Sidebar.astro
+++ b/src/frontend/src/components/starlight/Sidebar.astro
@@ -1267,12 +1267,13 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
      Collapse/expand stays available across all widths where the
      sidebar itself is visible.
 
-     Sample detail pages (`.sample-detail`) opt out of this treatment —
-     they removed the mobile TOC bar but the flat in-bar styling reads
-     as a stray bar fragment next to the hero. They use the base
-     floating-tab style instead (rounded right edge, drop shadow,
-     page background) so the toggle reads as a tab projecting from the
-     sidebar rather than a leftover bar.
+     Topic landing pages keep the positioning but omit the synthetic
+     bar's background and borders because no TOC bar is present.
+
+     Sample detail pages (`.sample-detail`) opt out of this treatment
+     entirely. They use the base floating-tab style instead (rounded
+     right edge, drop shadow, page background) so the toggle reads as
+     a tab projecting from the sidebar.
 
      Use a literal 3rem instead of var(--sl-mobile-toc-height, 3rem)
      because the variable is explicitly set to 0rem outside of the
@@ -1283,18 +1284,36 @@ const hasTopicsList = Boolean(currentTopic && effectiveTopics.length > 0);
     :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-expand-btn {
       top: calc(var(--sl-nav-height, 4rem) + var(--aspire-banner-height, 0px) - 1px);
       height: 3rem;
+      z-index: calc(var(--sl-z-index-toc, 10) + 1);
+    }
+
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #sidebar-collapse-btn,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #sidebar-expand-btn {
       border-radius: 0;
       box-shadow: none;
       border-inline-end: 1px solid var(--sl-color-gray-5);
       border-block-end: 1px solid var(--sl-color-hairline-shade);
       background: var(--sl-color-bg-nav);
-      z-index: calc(var(--sl-z-index-toc, 10) + 1);
     }
 
-    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-collapse-btn:hover,
-    :global(html:not([data-has-toc]):not(:has(.sample-detail))) .sidebar-expand-btn:hover {
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #topic-sidebar-collapse-btn,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #topic-sidebar-expand-btn {
+      border: none;
+      border-radius: 0;
+      box-shadow: none;
+      background: transparent;
+    }
+
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #sidebar-collapse-btn:hover,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #sidebar-expand-btn:hover {
       box-shadow: none;
       background: var(--sl-color-bg);
+    }
+
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #topic-sidebar-collapse-btn:hover,
+    :global(html:not([data-has-toc]):not(:has(.sample-detail))) #topic-sidebar-expand-btn:hover {
+      box-shadow: none;
+      background: transparent;
     }
   }
 


### PR DESCRIPTION
## Summary
- keep topic landing-page collapse and expand icons transparent and borderless when no On this page bar is present
- preserve the existing bar styling on API reference and topic pages that render the mobile TOC

## Validation
- verified the landing page and regular topic page at affected viewport widths using the local dev server and playwright-cli