### PR TITLE
Document dev-tool integration capabilities

### DIFF
--- a/src/frontend/src/components/ThemeImage.astro
+++ b/src/frontend/src/components/ThemeImage.astro
@@ -29,7 +29,7 @@ const {
 const imageWidth = width ?? dark.width;
 const imageHeight = height ?? dark.height;
 const imageClass = [classOverride, 'theme-image'].filter(Boolean).join(' ');
-const imageOptions = { width: imageWidth, height: imageHeight };
+const imageOptions = { width: imageWidth, height: imageHeight, fit: 'contain' as const };
 const optimizedLight = await getImage({ src: light, ...imageOptions });
 const optimizedDark = await getImage({ src: dark, ...imageOptions });
 const themedImageProps = {

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -253,20 +253,50 @@ dotnet add package OpenFeature.Providers.Ofrep
 
 In your AppHost, retrieve the OFREP endpoint from the flagd resource and pass it to your consuming project as an environment variable:
 
-```csharp title="C# — AppHost.cs"
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var flagd = builder.AddFlagd("flagd")
-                   .WithBindFileSync("./flags/");
+    .WithBindFileSync("./flags/");
 
 var ofrepEndpoint = flagd.GetEndpoint("ofrep");
 
-builder.AddProject<Projects.ExampleProject>()
-       .WaitFor(flagd)
-       .WithEnvironment("OFREP_ENDPOINT", ofrepEndpoint);
+builder.AddProject<Projects.ExampleProject>("api")
+    .WaitFor(flagd)
+    .WithEnvironment("OFREP_ENDPOINT", ofrepEndpoint);
 
 // After adding all resources, run the app...
+builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const flagd = await builder.addFlagd('flagd');
+await flagd.withBindFileSync('./flags/');
+
+const ofrepEndpoint = await flagd.ofrepEndpoint();
+
+const api = await builder.addProject(
+  'api',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.waitFor(flagd);
+await api.withEnvironment('OFREP_ENDPOINT', ofrepEndpoint);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 ### Configure the client
 

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect to flagd
-seoTitle: "Connect to flagd from Aspire apps (C# and TypeScript)"
+seoTitle: Connect to flagd from Aspire apps in four languages
 description: Learn how to connect to flagd from C#, Go, Python, and TypeScript consuming apps in an Aspire solution.
 next: false
 ---
@@ -25,7 +25,7 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 
 This page describes how consuming apps connect to a flagd resource that's already modeled in your AppHost. For the AppHost API surface — adding a flagd resource, file sync, port configuration, log levels, and health checks — see [flagd Hosting integration](../flagd-host/).
 
-When you reference a flagd resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. Your app can then configure the appropriate OpenFeature flagd provider using that connection information — the pattern works the same from C#, Go, Python, or TypeScript.
+When you reference a flagd resource from your AppHost, Aspire injects the connection information into the consuming app as environment variables. There isn't a dedicated Aspire client package for flagd, so each app configures a stable OpenFeature SDK and flagd provider directly.
 
 ## Connection properties
 
@@ -33,16 +33,19 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 The flagd resource exposes the following connection properties:
 
-| Property Name | Description |
-| ------------- | ----------- |
-| `Host`        | The hostname or IP address of the flagd server |
-| `Port`        | The port number of the flagd HTTP/gRPC endpoint |
+| Property Name | Description                                              |
+| ------------- | -------------------------------------------------------- |
+| `Host`        | The hostname or IP address of the flagd server           |
+| `Port`        | The port number of the flagd HTTP/gRPC endpoint          |
 | `Uri`         | The endpoint URI, with the format `http://{Host}:{Port}` |
 
-**Example connection string:**
+For a resource named `flagd`, Aspire injects both `ConnectionStrings__flagd` and individual connection properties:
 
 ```
-Uri: http://localhost:8013
+ConnectionStrings__flagd=http://localhost:8013
+FLAGD_HOST=localhost
+FLAGD_PORT=8013
+FLAGD_URI=http://localhost:8013
 ```
 
 ## Connect from your app
@@ -52,15 +55,15 @@ Pick the language your consuming app is written in. Each example assumes your Ap
 <Tabs syncKey="flagd-consuming-lang">
 <TabItem label="C#">
 
-For C# apps, use the OpenFeature SDK with the flagd provider. Install the [📦 OpenFeature.Contrib.Providers.Flagd](https://www.nuget.org/packages/OpenFeature.Contrib.Providers.Flagd) NuGet package in the client-consuming project:
+For C# apps, use the OpenFeature SDK with the flagd provider. Install the [📦 OpenFeature.Providers.Flagd](https://www.nuget.org/packages/OpenFeature.Providers.Flagd) NuGet package in the consuming project:
 
-<InstallDotNetPackage packageName="OpenFeature.Contrib.Providers.Flagd" />
+<InstallDotNetPackage packageName="OpenFeature.Providers.Flagd" />
 
 In _Program.cs_, read the Aspire-injected connection string and register the flagd provider with the OpenFeature SDK:
 
 ```csharp title="Program.cs"
 using OpenFeature;
-using OpenFeature.Contrib.Providers.Flagd;
+using OpenFeature.Providers.Flagd;
 
 var connectionString = builder.Configuration.GetConnectionString("flagd");
 
@@ -69,7 +72,9 @@ await OpenFeature.Api.Instance.SetProviderAsync(
 ```
 
 <Aside type="tip">
-The connection name passed to `GetConnectionString` must match the flagd resource name from the AppHost. For more information, see [Add flagd resource](../flagd-host/#add-flagd-resource).
+  The connection name passed to `GetConnectionString` must match the flagd
+  resource name from the AppHost. For more information, see [Add flagd
+  resource](../flagd-host/#add-flagd-resource).
 </Aside>
 
 Obtain a client and evaluate feature flags:
@@ -92,7 +97,7 @@ If you prefer to read the connection URI from environment variables directly rat
 
 ```csharp title="Program.cs"
 using OpenFeature;
-using OpenFeature.Contrib.Providers.Flagd;
+using OpenFeature.Providers.Flagd;
 
 var uri = Environment.GetEnvironmentVariable("FLAGD_URI");
 
@@ -136,10 +141,15 @@ func main() {
 
     port, _ := strconv.Atoi(uri.Port())
 
-    openfeature.SetProvider(flagd.NewProvider(
+    provider, err := flagd.NewProvider(
         flagd.WithHost(uri.Hostname()),
         flagd.WithPort(uint16(port)),
-    ))
+    )
+    if err != nil {
+        panic(err)
+    }
+
+    openfeature.SetProvider(provider)
 
     client := openfeature.NewClient("app")
 
@@ -170,7 +180,7 @@ Read the injected environment variable, parse the URI, and configure the provide
 import os
 from urllib.parse import urlparse
 from openfeature import api
-from openfeature.contrib.providers.flagd.flagd_provider import FlagdProvider
+from openfeature.contrib.provider.flagd import FlagdProvider
 
 # Read the Aspire-injected connection URI
 uri = urlparse(os.getenv("FLAGD_URI"))
@@ -206,15 +216,20 @@ import { FlagdProvider } from '@openfeature/flagd-provider';
 // Read the Aspire-injected connection URI
 const uri = new URL(process.env.FLAGD_URI!);
 
-OpenFeature.setProvider(new FlagdProvider({
+OpenFeature.setProvider(
+  new FlagdProvider({
     host: uri.hostname,
     port: Number(uri.port),
-}));
+  })
+);
 
 const client = OpenFeature.getClient();
 
 const welcomeBanner = await client.getBooleanValue('welcome-banner', false);
-const backgroundColor = await client.getStringValue('background-color', '#000000');
+const backgroundColor = await client.getStringValue(
+  'background-color',
+  '#000000'
+);
 ```
 
 For more information, see the [OpenFeature JavaScript SDK](https://openfeature.dev/docs/reference/technologies/server/javascript/) and the [flagd Node.js provider](https://flagd.dev/providers/js/).

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -14,8 +14,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdIcon}
-  dark={flagdLightIcon}
+  light={flagdLightIcon}
+  dark={flagdIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -14,8 +14,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdLightIcon}
-  dark={flagdIcon}
+  light={flagdIcon}
+  dark={flagdLightIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -13,8 +13,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdIcon}
-  dark={flagdLightIcon}
+  light={flagdLightIcon}
+  dark={flagdIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -1,11 +1,10 @@
 ---
-title: Get started with the flagd integrations
-seoTitle: Get started with the Aspire flagd integration in .NET
-description: "Use the Aspire flagd hosting and client integrations to run flagd feature-flag servers locally, share configuration, and consume flags from C# and TypeScript apps."
+title: Get started with the flagd integration
+seoTitle: Get started with flagd and Aspire across app languages
+description: 'Use the Aspire flagd hosting integration to run a feature flag server, share its connection details, and connect with OpenFeature clients.'
 prev: false
 ---
 
-import { Image } from 'astro:assets';
 import { Aside, Badge, LinkButton, Steps } from '@astrojs/starlight/components';
 import ThemeImage from '@components/ThemeImage.astro';
 import flagdIcon from '@assets/icons/flagd-icon.svg';
@@ -33,7 +32,7 @@ Adding flagd through Aspire — rather than wiring up containers and connection 
 - **Consistent connection info across languages.** Once you reference the flagd resource from a consuming app, Aspire injects connection properties as environment variables in a predictable format that works from C#, TypeScript, Python, Go, or any other language.
 - **Built-in health checks.** The hosting integration automatically registers a health check against the flagd `/healthz` endpoint so the dashboard and your orchestrator can tell when the server is ready.
 - **Dashboard observability.** The flagd resource shows up in the Aspire dashboard with logs and status alongside your other services.
-- **Multi-language OpenFeature clients.** Any OpenFeature-compatible SDK with a flagd provider — C#, Go, Python, or TypeScript — works with the injected connection information.
+- **Multi-language OpenFeature clients.** There isn't a dedicated Aspire client package for flagd. Use a stable OpenFeature SDK and flagd provider for C#, Go, Python, or TypeScript with the injected connection information.
 
 ## How the pieces fit together
 
@@ -62,33 +61,35 @@ Getting there is a two-step process: model the flagd resource in your AppHost, t
 
 1. ### Model flagd in your AppHost
 
-    Add the flagd hosting integration to your AppHost, then declare a flagd resource and reference it from the apps that need feature flags. The [flagd Hosting integration](/integrations/devtools/flagd/flagd-host/) article walks through every capability — file-based flag sync, port customization, log levels, and health checks.
+   Add the flagd hosting integration to your AppHost, then declare a flagd resource and reference it from the apps that need feature flags. The [flagd Hosting integration](/integrations/devtools/flagd/flagd-host/) article walks through every capability — file-based flag sync, port customization, log levels, and health checks.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/flagd/flagd-host/'>
-        Set up flagd in the AppHost
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/flagd/flagd-host/"
+   >
+     Set up flagd in the AppHost
+   </LinkButton>
 
 2. ### Connect from your consuming app
 
-    When you reference a flagd resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to flagd](/integrations/devtools/flagd/flagd-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — using the OpenFeature SDK and flagd providers.
+   When you reference a flagd resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to flagd](/integrations/devtools/flagd/flagd-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — using the OpenFeature SDK and flagd providers.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/flagd/flagd-connect/'>
-        Connect to flagd
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/flagd/flagd-connect/"
+   >
+     Connect to flagd
+   </LinkButton>
 
 </Steps>
 
 <Aside type="tip">
 
-Flagd also supports the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/), an HTTP/REST-based alternative to the gRPC provider shown above. OFREP is well-suited for polyglot environments since it uses a standardized protocol that works across any language. To learn more, see [Use OFREP provider](/integrations/devtools/flagd/flagd-client/#use-ofrep-provider).
+Flagd also supports the [OFREP (OpenFeature Remote Evaluation Protocol)](https://openfeature.dev/specification/appendix-c/), an HTTP/REST-based alternative to the gRPC provider shown above. OFREP is well-suited for polyglot environments since it uses a standardized protocol that works across any language. To learn more, see [Use OFREP provider](/integrations/devtools/flagd/flagd-connect/#use-ofrep-provider).
 
 </Aside>
 

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-get-started.mdx
@@ -13,8 +13,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdLightIcon}
-  dark={flagdIcon}
+  light={flagdIcon}
+  dark={flagdLightIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
@@ -19,8 +19,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdLightIcon}
-  dark={flagdIcon}
+  light={flagdIcon}
+  dark={flagdLightIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
@@ -1,12 +1,17 @@
 ---
 title: Set up flagd in the AppHost
-seoTitle: "Set up flagd in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up flagd in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire flagd hosting integration to orchestrate and configure a flagd resource in an Aspire solution.
 ---
 
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import {
+  Aside,
+  Badge,
+  Steps,
+  TabItem,
+  Tabs,
+} from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
-import InstallPackage from '@components/InstallPackage.astro';
 import ThemeImage from '@components/ThemeImage.astro';
 import flagdIcon from '@assets/icons/flagd-icon.svg';
 import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
@@ -36,7 +41,8 @@ aspire add flagd
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -49,13 +55,12 @@ Or, choose a manual installation approach:
 <PackageReference Include="CommunityToolkit.Aspire.Hosting.Flagd" Version="*" />
 ```
 
-:::note
-TypeScript AppHost support for the flagd integration is not yet available.
-:::
-
 ## Add flagd resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a flagd resource. The flagd container requires a sync source. Use `WithBindFileSync` to mount a directory of flag-definition files into the container:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -70,6 +75,29 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const flagd = await builder.addFlagd('flagd');
+await flagd.withBindFileSync('./flags/');
+
+const api = await builder.addProject(
+  'api',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(flagd);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 <Steps>
 
 1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `ghcr.io/open-feature/flagd` image, it creates a new flagd server instance on your local machine.
@@ -79,12 +107,18 @@ builder.Build().Run();
 </Steps>
 
 <Aside type="note">
-  When you reference a flagd resource from the AppHost, Aspire makes the server's connection information available to the consuming project as environment variables. For a complete list of these properties and per-language connection examples, see [Connect to flagd](../flagd-connect/).
+  When you reference a flagd resource from the AppHost, Aspire makes the
+  server's connection information available to the consuming project as
+  environment variables. For a complete list of these properties and
+  per-language connection examples, see [Connect to flagd](../flagd-connect/).
 </Aside>
 
 ## Add flagd resource with file sync options
 
 To specify the flag-definition filename explicitly, pass both the `fileSource` directory and the `filename` to `WithBindFileSync`:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -101,6 +135,29 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const flagd = await builder.addFlagd('flagd');
+await flagd.withBindFileSync('./flags/', { filename: 'flagd.json' });
+
+const api = await builder.addProject(
+  'api',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(flagd);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 The `fileSource` parameter is the path on your host machine where flag configuration files are located. The `filename` parameter names the flag configuration file inside that directory. When `filename` is omitted, it defaults to `flagd.json`.
 
 ## Flag configuration format
@@ -109,26 +166,26 @@ flagd uses JSON files for flag definitions. Create a `flags` folder in your proj
 
 ```json title="flags/flagd.json"
 {
-    "$schema": "https://flagd.dev/schema/v0/flags.json",
-    "flags": {
-        "welcome-banner": {
-            "state": "ENABLED",
-            "variants": {
-                "on": true,
-                "off": false
-            },
-            "defaultVariant": "off"
-        },
-        "background-color": {
-            "state": "ENABLED",
-            "variants": {
-                "red": "#FF0000",
-                "blue": "#0000FF",
-                "yellow": "#FFFF00"
-            },
-            "defaultVariant": "red"
-        }
+  "$schema": "https://flagd.dev/schema/v0/flags.json",
+  "flags": {
+    "welcome-banner": {
+      "state": "ENABLED",
+      "variants": {
+        "on": true,
+        "off": false
+      },
+      "defaultVariant": "off"
+    },
+    "background-color": {
+      "state": "ENABLED",
+      "variants": {
+        "red": "#FF0000",
+        "blue": "#0000FF",
+        "yellow": "#FFFF00"
+      },
+      "defaultVariant": "red"
     }
+  }
 }
 ```
 
@@ -154,9 +211,16 @@ builder.Build().Run();
 
 Debug logging provides verbose output for troubleshooting flag evaluation issues. Currently, only the `Debug` log level is supported.
 
+:::note
+`WithLogLevel` isn't exported to TypeScript AppHosts. This limitation applies only to log-level configuration; `addFlagd` and `withBindFileSync` are available in TypeScript.
+:::
+
 ## Customize ports
 
 To use fixed host ports instead of randomly assigned ones, pass the `port` and `ofrepPort` parameters to `AddFlagd`:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -173,6 +237,32 @@ builder.AddProject<Projects.ExampleProject>("api")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const flagd = await builder.addFlagd('flagd', {
+  port: 8013,
+  ofrepPort: 8016,
+});
+await flagd.withBindFileSync('./flags/');
+
+const api = await builder.addProject(
+  'api',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(flagd);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 The `port` parameter sets the host port for the flagd HTTP/gRPC endpoint. The `ofrepPort` parameter sets the host port for the [OFREP](https://github.com/open-feature/protocol) (OpenFeature Remote Evaluation Protocol) endpoint. When these parameters are omitted, Aspire assigns random ports.
 

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
@@ -19,8 +19,8 @@ import flagdLightIcon from '@assets/icons/flagd-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={flagdIcon}
-  dark={flagdLightIcon}
+  light={flagdLightIcon}
+  dark={flagdIcon}
   alt="flagd logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
@@ -212,7 +212,7 @@ builder.Build().Run();
 Debug logging provides verbose output for troubleshooting flag evaluation issues. Currently, only the `Debug` log level is supported.
 
 :::note
-`WithLogLevel` isn't exported to TypeScript AppHosts. This limitation applies only to log-level configuration; `addFlagd` and `withBindFileSync` are available in TypeScript.
+The flagd hosting source explicitly marks `WithLogLevel` with `[AspireExportIgnore]`, so the generated TypeScript API doesn't include `withLogLevel`. In a TypeScript AppHost, set the `FLAGD_DEBUG` environment variable directly instead.
 :::
 
 ## Customize ports

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
@@ -185,7 +185,7 @@ var client = OpenFeature.Api.Instance.GetClient();
 Use the [OpenFeature Go SDK](https://github.com/open-feature/go-sdk) with the [GO Feature Flag relay proxy provider](https://github.com/open-feature/go-sdk-contrib/tree/main/providers/go-feature-flag):
 
 ```bash title="Terminal"
-go get github.com/open-feature/go-sdk/pkg/openfeature
+go get github.com/open-feature/go-sdk/openfeature
 go get github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg
 ```
 
@@ -195,11 +195,10 @@ Read the injected environment variable and connect:
 package main
 
 import (
-    "context"
     "os"
 
     gofeatureflagProvider "github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg"
-    "github.com/open-feature/go-sdk/pkg/openfeature"
+    "github.com/open-feature/go-sdk/openfeature"
 )
 
 func main() {

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
@@ -1,6 +1,6 @@
 ---
 title: Connect to GO Feature Flag
-seoTitle: Connect to GO Feature Flag from your .NET app with Aspire
+seoTitle: Connect Aspire apps to GO Feature Flag relay proxies
 description: Learn how to connect to a GO Feature Flag relay proxy from C#, Go, Python, and TypeScript consuming apps in an Aspire solution.
 ---
 
@@ -22,7 +22,7 @@ import goffIcon from '@assets/icons/go-feature-flag.png';
 
 This page describes how consuming apps connect to a GO Feature Flag relay proxy resource that's already modeled in your AppHost. For the AppHost API surface — adding a relay proxy resource, bind mounts, data volumes, log levels, and more — see [GO Feature Flag Hosting integration](../goff-host/).
 
-When you reference a GO Feature Flag resource from your AppHost, Aspire injects the relay proxy endpoint into the consuming app as environment variables. Your app can either read those environment variables directly — the pattern works the same from any language — or, in C#, use the Aspire GO Feature Flag client integration for automatic dependency injection and health checks.
+When you reference a GO Feature Flag resource from your AppHost, Aspire injects the relay proxy endpoint into the consuming app as environment variables. C# apps can use the dedicated Aspire client integration for dependency injection and health checks. Go, Python, and TypeScript apps use stable OpenFeature providers directly.
 
 ## Connection properties
 
@@ -30,10 +30,10 @@ Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPE
 
 The GO Feature Flag resource exposes the following connection properties:
 
-| Property Name | Description |
-| ------------- | ----------- |
-| `Host`        | The hostname or IP address of the GO Feature Flag relay proxy |
-| `Port`        | The port number the relay proxy is listening on |
+| Property Name | Description                                                                  |
+| ------------- | ---------------------------------------------------------------------------- |
+| `Host`        | The hostname or IP address of the GO Feature Flag relay proxy                |
+| `Port`        | The port number the relay proxy is listening on                              |
 | `Uri`         | The HTTP base URL of the relay proxy, with the format `http://{Host}:{Port}` |
 
 The connection string injected into `ConnectionStrings__goff` uses the format `Endpoint=http://{Host}:{Port}`.
@@ -69,7 +69,9 @@ builder.AddGoFeatureFlagClient(connectionName: "goff");
 ```
 
 <Aside type="tip">
-The `connectionName` must match the GO Feature Flag resource name from the AppHost. For more information, see [Add goff resource](../goff-host/#add-goff-resource).
+  The `connectionName` must match the GO Feature Flag resource name from the
+  AppHost. For more information, see [Add goff
+  resource](../goff-host/#add-goff-resource).
 </Aside>
 
 Resolve the provider through dependency injection:
@@ -183,7 +185,7 @@ Use the [OpenFeature Go SDK](https://github.com/open-feature/go-sdk) with the [G
 
 ```bash title="Terminal"
 go get github.com/open-feature/go-sdk/pkg/openfeature
-go get github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/v2/pkg
+go get github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg
 ```
 
 Read the injected environment variable and connect:
@@ -195,7 +197,7 @@ import (
     "context"
     "os"
 
-    gofeatureflagProvider "github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/v2/pkg"
+    gofeatureflagProvider "github.com/open-feature/go-sdk-contrib/providers/go-feature-flag/pkg"
     "github.com/open-feature/go-sdk/pkg/openfeature"
 )
 
@@ -270,9 +272,7 @@ import { GoFeatureFlagProvider } from '@openfeature/go-feature-flag-provider';
 // Read the Aspire-injected relay proxy URI
 const endpoint = process.env.GOFF_URI + '/';
 
-await OpenFeature.setProviderAndWait(
-    new GoFeatureFlagProvider({ endpoint })
-);
+await OpenFeature.setProviderAndWait(new GoFeatureFlagProvider({ endpoint }));
 
 const client = OpenFeature.getClient();
 // Use client to evaluate feature flags...
@@ -296,7 +296,7 @@ import { GoFeatureFlagWebProvider } from '@openfeature/go-feature-flag-web-provi
 const endpoint = process.env.NEXT_PUBLIC_GOFF_URI + '/';
 
 await OpenFeature.setProviderAndWait(
-    new GoFeatureFlagWebProvider({ endpoint })
+  new GoFeatureFlagWebProvider({ endpoint })
 );
 
 const client = OpenFeature.getClient();
@@ -307,5 +307,8 @@ const client = OpenFeature.getClient();
 </Tabs>
 
 <Aside type="tip">
-    If your app expects a specific environment variable name other than the Aspire defaults, you can pass individual connection properties from the AppHost using `WithEnvironment`. See the Aspire AppHost documentation for more information on [passing environment variables](/get-started/app-host/).
+  If your app expects a specific environment variable name other than the Aspire
+  defaults, you can pass individual connection properties from the AppHost using
+  `WithEnvironment`. See the Aspire AppHost documentation for more information
+  on [passing environment variables](/get-started/app-host/).
 </Aside>

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-connect.mdx
@@ -16,6 +16,7 @@ import goffIcon from '@assets/icons/go-feature-flag.png';
   alt="GO Feature Flag logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-get-started.mdx
@@ -14,6 +14,7 @@ import goffIcon from '@assets/icons/go-feature-flag.png';
   alt="GO Feature Flag logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-get-started.mdx
@@ -1,6 +1,6 @@
 ---
-title: Get started with the GO Feature Flag integrations
-description: Learn how the Aspire GO Feature Flag integrations host a GO Feature Flag relay resource and wire the OpenFeature .NET provider into your AppHost.
+title: Get started with GO Feature Flag integrations
+description: Learn how Aspire hosts a GO Feature Flag relay proxy and connects C#, TypeScript, Python, and Go apps through OpenFeature providers.
 ---
 
 import { Image } from 'astro:assets';
@@ -29,7 +29,7 @@ Adding GO Feature Flag through Aspire — rather than wiring up containers and c
 - **Built-in health checks.** The hosting integration automatically registers a health check against the relay proxy `/health` endpoint so the dashboard can tell when it's ready.
 - **Dashboard observability.** The GO Feature Flag resource shows up in the Aspire dashboard with logs, status, and telemetry alongside your other services.
 - **OpenTelemetry export.** The relay proxy is configured to export traces and metrics through the Aspire OTLP exporter automatically.
-- **A first-class C# client integration.** C# apps can use the `CommunityToolkit.Aspire.GoFeatureFlag` package to register an OpenFeature `GOFeatureFlagProvider` through dependency injection, with health checks included.
+- **Client options for each app.** C# apps can use the dedicated `CommunityToolkit.Aspire.GoFeatureFlag` client integration for dependency injection and health checks. TypeScript, Python, and Go apps use stable OpenFeature providers directly.
 
 ## How the pieces fit together
 
@@ -58,27 +58,29 @@ Getting there is a two-step process: model the GO Feature Flag resource in your 
 
 1. ### Model GO Feature Flag in your AppHost
 
-    Add the GO Feature Flag hosting integration to your AppHost, then declare a relay proxy resource and reference it from the apps that need to evaluate flags. The [GO Feature Flag Hosting integration](/integrations/devtools/goff/goff-host/) article walks through every capability — bind mounts, data volumes, log levels, custom ports, and more.
+   Add the GO Feature Flag hosting integration to your AppHost, then declare a relay proxy resource and reference it from the apps that need to evaluate flags. The [GO Feature Flag Hosting integration](/integrations/devtools/goff/goff-host/) article walks through every capability — bind mounts, data volumes, log levels, custom ports, and more.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/goff/goff-host/'>
-        Set up GO Feature Flag in the AppHost
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/goff/goff-host/"
+   >
+     Set up GO Feature Flag in the AppHost
+   </LinkButton>
 
 2. ### Connect from your consuming app
 
-    When you reference a GO Feature Flag resource from a consuming app, Aspire injects its endpoint as environment variables. See [Connect to GO Feature Flag](/integrations/devtools/goff/goff-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
+   When you reference a GO Feature Flag resource from a consuming app, Aspire injects its endpoint as environment variables. See [Connect to GO Feature Flag](/integrations/devtools/goff/goff-connect/) for the connection properties reference, the dedicated C# client integration, and direct-client examples for Go, Python, and TypeScript.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/goff/goff-connect/'>
-        Connect to GO Feature Flag
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/goff/goff-connect/"
+   >
+     Connect to GO Feature Flag
+   </LinkButton>
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
@@ -4,9 +4,8 @@ description: Learn how to use the Aspire GO Feature Flag Hosting integration to 
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import { Badge, Steps, TabItem, Tabs } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
-import InstallPackage from '@components/InstallPackage.astro';
 import goffIcon from '@assets/icons/go-feature-flag.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
@@ -33,7 +32,8 @@ aspire add CommunityToolkit.Aspire.Hosting.GoFeatureFlag
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -46,13 +46,12 @@ Or, choose a manual installation approach:
 <PackageReference Include="CommunityToolkit.Aspire.Hosting.GoFeatureFlag" Version="*" />
 ```
 
-:::note
-TypeScript AppHost support for this integration is not yet available.
-:::
-
 ## Add goff resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a GO Feature Flag relay proxy resource as shown in the following example:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -66,6 +65,29 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const goff = await builder.addGoFeatureFlag('goff');
+await goff.withGoffBindMount('./goff');
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(goff);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 <Steps>
 
@@ -85,6 +107,9 @@ When you reference a GO Feature Flag resource from the AppHost, Aspire makes sev
 
 To point the relay proxy to a specific configuration file inside the container, pass the `pathToConfigFile` parameter to `AddGoFeatureFlag`:
 
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -98,11 +123,39 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const goff = await builder.addGoFeatureFlag('goff', {
+  pathToConfigFile: '/goff/goff-proxy.yaml',
+});
+await goff.withGoffBindMount('./goff');
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(goff);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 The `pathToConfigFile` parameter sets the `--config` argument passed to the relay proxy entrypoint. If this parameter is omitted, the relay proxy looks for a default configuration file in its working directory.
 
 ## Add goff resource with data volume
 
 To persist relay proxy data (such as cached flag evaluations) across container restarts, add a named data volume:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -117,6 +170,30 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const goff = await builder.addGoFeatureFlag('goff');
+await goff.withGoffBindMount('./goff');
+await goff.withDataVolume();
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(goff);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 The data volume is mounted at the `/goff_data` path in the container. When a `name` parameter isn't provided, a name is generated automatically. For more information on data volumes, see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
@@ -151,6 +228,9 @@ This instructs the relay proxy to load flags from the `flags.yaml` file inside t
 
 To configure the log level for the GO Feature Flag container resource, call `WithLogLevel`:
 
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -165,16 +245,46 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import {
+  createBuilder,
+  GoFeatureFlagLogLevel,
+} from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const goff = await builder.addGoFeatureFlag('goff');
+await goff.withGoffBindMount('./goff');
+await goff.withLogLevel(GoFeatureFlagLogLevel.Debug);
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(goff);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 The `WithLogLevel` method sets the `LOGLEVEL` environment variable on the container. The supported log levels are `Debug`, `Information`, `Warning`, and `Error`.
 
 ## Customize ports
 
 To use a specific host port for the relay proxy HTTP endpoint, pass the `port` parameter to `AddGoFeatureFlag`:
 
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var goff = builder.AddGoFeatureFlag(name: "goff", port: 1031)
+var goff = builder.AddGoFeatureFlag(name: "goff", port: 11031)
     .WithGoffBindMount("./goff");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
@@ -183,6 +293,29 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const goff = await builder.addGoFeatureFlag('goff', { port: 11031 });
+await goff.withGoffBindMount('./goff');
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(goff);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
 
 The `port` parameter specifies the host port bound to the relay proxy's internal port. If not provided, Aspire assigns a random port.
 

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
@@ -15,6 +15,7 @@ import goffIcon from '@assets/icons/go-feature-flag.png';
   alt="GO Feature Flag logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-connect.mdx
@@ -12,8 +12,8 @@ import mailpitLightIcon from '@assets/icons/mailpit-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={mailpitLightIcon}
-  dark={mailpitIcon}
+  light={mailpitIcon}
+  dark={mailpitLightIcon}
   alt="Mailpit logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-connect.mdx
@@ -23,27 +23,30 @@ import mailpitLightIcon from '@assets/icons/mailpit-light-icon.svg';
 
 This page describes how consuming apps connect to a Mailpit resource that's already modeled in your AppHost. For the AppHost API surface — adding a Mailpit resource, the SMTP endpoint, the HTTP UI endpoint, and data volumes — see [Mailpit Hosting integration](../mailpit-host/).
 
-When you reference a Mailpit resource from your AppHost, Aspire injects the SMTP connection information into the consuming app as environment variables. Your app reads those variables and passes them to any standard SMTP library — the pattern works the same from any language.
+When you reference a Mailpit resource from your AppHost, Aspire injects an SMTP connection string and individual connection properties into the consuming app. There isn't a dedicated Aspire client package for Mailpit, so each app passes that information to a stable SMTP library directly.
 
 ## Connection properties
 
-Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `SmtpHost` property of a resource called `mailpit` becomes `MAILPIT_SMTPHOST`.
+Aspire injects the resource connection string as `ConnectionStrings__mailpit`. It also exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Host` property of a resource called `mailpit` becomes `MAILPIT_HOST`.
 
 The Mailpit resource exposes the following connection properties:
 
-| Property Name  | Description |
-| -------------- | ----------- |
-| `Host`     | The hostname or IP address of the Mailpit SMTP server |
-| `Port`     | The port number the Mailpit SMTP server is listening on (default: `1025`) |
-| `Uri` | The base URL of the Mailpit web UI (default: `http://{host}:8025`) |
+| Property Name | Description                                                               |
+| ------------- | ------------------------------------------------------------------------- |
+| `Host`        | The hostname or IP address of the Mailpit SMTP server                     |
+| `Port`        | The port number the Mailpit SMTP server is listening on (default: `1025`) |
+| `Uri`         | The SMTP endpoint URI, with the format `smtp://{Host}:{Port}`             |
 
 **Example environment variable values for a resource named `mailpit`:**
 
 ```
+ConnectionStrings__mailpit=Endpoint=smtp://localhost:1025
 MAILPIT_HOST=localhost
 MAILPIT_PORT=1025
-MAILPIT_URI=http://localhost:8025
+MAILPIT_URI=smtp://localhost:1025
 ```
+
+The Mailpit web UI is a separate `http` endpoint. Open it from the resource's endpoint list in the Aspire dashboard.
 
 ## Connect from your app
 
@@ -52,23 +55,32 @@ Pick the language your consuming app is written in. Each example assumes your Ap
 <Tabs syncKey="mailpit-consuming-lang">
 <TabItem label="C#">
 
-There is no dedicated Aspire client integration package for Mailpit. Instead, read the Aspire-injected environment variables and use `System.Net.Mail.SmtpClient` (or any other SMTP library) to send emails.
+The toolkit's tested C# pattern reads the Aspire connection string and passes its `Endpoint` value to `System.Net.Mail.SmtpClient`.
 
-#### Read the SMTP connection properties
+#### Read the SMTP connection string
 
 ```csharp title="Program.cs"
+using System.Data.Common;
 using System.Net.Mail;
 
-// Read Aspire-injected SMTP connection properties
-var smtpHost = Environment.GetEnvironmentVariable("MAILPIT_HOST") ?? "localhost";
-var smtpPort = int.TryParse(
-    Environment.GetEnvironmentVariable("MAILPIT_PORT"), out var p) ? p : 1025;
+var connectionString =
+    builder.Configuration.GetConnectionString("mailpit")
+    ?? throw new InvalidOperationException("Mailpit connection string is missing.");
+
+var connectionBuilder = new DbConnectionStringBuilder
+{
+    ConnectionString = connectionString,
+};
+
+var smtpEndpoint = new Uri(
+    (string)connectionBuilder["Endpoint"],
+    UriKind.Absolute);
 ```
 
 #### Send an email
 
 ```csharp title="Program.cs"
-using var client = new SmtpClient(smtpHost, smtpPort);
+using var client = new SmtpClient(smtpEndpoint.Host, smtpEndpoint.Port);
 using var message = new MailMessage(
     from: "sender@example.com",
     to: "recipient@example.com",
@@ -78,31 +90,23 @@ using var message = new MailMessage(
 await client.SendMailAsync(message);
 ```
 
-#### Inspect captured emails
-
-Open the Mailpit web UI via the `Uri` property:
-
-```csharp title="Program.cs"
-var mailpitUiUrl = Environment.GetEnvironmentVariable("MAILPIT_URI");
-// Navigate to mailpitUiUrl in a browser to inspect captured emails.
-```
-
 #### Register as a service
 
-For production-style registration, wrap the SMTP configuration in a hosted service or factory:
+Register an SMTP client factory when multiple services need to send email:
 
 ```csharp title="Program.cs"
-builder.Services.AddSingleton<SmtpClient>(_ =>
-    new SmtpClient(
-        host: Environment.GetEnvironmentVariable("MAILPIT_HOST") ?? "localhost",
-        port: int.TryParse(
-            Environment.GetEnvironmentVariable("MAILPIT_PORT"), out var p) ? p : 1025));
+builder.Services.AddTransient(_ =>
+    new SmtpClient(smtpEndpoint.Host, smtpEndpoint.Port));
 ```
+
+:::note
+Microsoft doesn't recommend `SmtpClient` for new development. You can pass the same endpoint to another SMTP library, such as [MailKit](https://github.com/jstedfast/MailKit).
+:::
 
 </TabItem>
 <TabItem label="Go">
 
-Use the standard `net/smtp` package from the Go standard library — no third-party dependency is required:
+The following example uses the Go standard library's `net/smtp` package:
 
 ```go title="main.go"
 package main
@@ -135,6 +139,10 @@ func main() {
     }
 }
 ```
+
+:::note
+The Go team has frozen `net/smtp` and accepts no new features. For new applications, you can pass the same `MAILPIT_HOST` and `MAILPIT_PORT` values to a maintained SMTP package.
+:::
 
 </TabItem>
 <TabItem label="Python">
@@ -177,30 +185,26 @@ import nodemailer from 'nodemailer';
 
 // Read Aspire-injected SMTP connection properties
 const transporter = nodemailer.createTransport({
-    host: process.env.MAILPIT_HOST,
-    port: Number(process.env.MAILPIT_PORT ?? 1025),
-    secure: false,         // Mailpit does not use TLS
-    auth: undefined,       // Mailpit does not require authentication
+  host: process.env.MAILPIT_HOST,
+  port: Number(process.env.MAILPIT_PORT ?? 1025),
+  secure: false, // Mailpit does not use TLS
+  auth: undefined, // Mailpit does not require authentication
 });
 
 await transporter.sendMail({
-    from: 'sender@example.com',
-    to: 'recipient@example.com',
-    subject: 'Hello from Aspire',
-    text: 'This email was captured by Mailpit.',
+  from: 'sender@example.com',
+  to: 'recipient@example.com',
+  subject: 'Hello from Aspire',
+  text: 'This email was captured by Mailpit.',
 });
-```
-
-To open the Mailpit web UI programmatically, read the `Uri`:
-
-```typescript title="Open Mailpit UI"
-const mailpitUiUrl = process.env.MAILPIT_URI;
-// Navigate to mailpitUiUrl in a browser to inspect captured emails.
 ```
 
 </TabItem>
 </Tabs>
 
 <Aside type="tip">
-    If your app expects specific environment variable names different from the Aspire defaults, you can pass individual connection properties from the AppHost using `WithEnvironment`. See [Pass custom environment variables](/get-started/app-host/) in the AppHost reference.
+  If your app expects specific environment variable names different from the
+  Aspire defaults, you can pass individual connection properties from the
+  AppHost using `WithEnvironment`. See [Pass custom environment
+  variables](/get-started/app-host/) in the AppHost reference.
 </Aside>

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-get-started.mdx
@@ -28,6 +28,7 @@ Adding Mailpit through Aspire — rather than wiring up containers and SMTP sett
 
 - **Zero-config local email testing.** Aspire runs Mailpit from the [`docker.io/axllent/mailpit`](https://hub.docker.com/r/axllent/mailpit) container image with endpoints configured automatically.
 - **Consistent connection info across languages.** Once you reference the Mailpit resource from a consuming app, Aspire injects SMTP connection properties as environment variables in a predictable format that works from C#, TypeScript, Python, Go, or any other language.
+- **Built-in health checks.** The hosting integration checks Mailpit's `/livez` and `/readyz` endpoints so the dashboard can report when the resource is ready.
 - **Dashboard observability.** The Mailpit resource shows up in the Aspire dashboard with logs and status alongside your other services.
 - **Built-in web UI.** Mailpit's web interface for inspecting captured emails is automatically accessible through the Aspire dashboard endpoint.
 
@@ -50,7 +51,7 @@ architecture-beta
   mailpit:R --> L:app
 ```
 
-The **hosting integration** lives in your AppHost project and models the Mailpit instance as a resource. Your consuming apps read the SMTP connection properties that Aspire injects and use any standard SMTP library to send emails to Mailpit for inspection.
+The **hosting integration** lives in your AppHost project and models the Mailpit instance as a resource. Your consuming apps read the SMTP connection string or individual connection properties that Aspire injects and use a standard SMTP library to send emails to Mailpit for inspection.
 
 Getting there is a two-step process: model the Mailpit resource in your AppHost, then connect to it from each app that sends emails.
 
@@ -58,27 +59,29 @@ Getting there is a two-step process: model the Mailpit resource in your AppHost,
 
 1. ### Model Mailpit in your AppHost
 
-    Add the Mailpit hosting integration to your AppHost, then declare a Mailpit resource and reference it from the apps that need to send email. The [Mailpit Hosting integration](/integrations/devtools/mailpit/mailpit-host/) article walks through every capability — SMTP endpoint, HTTP UI endpoint, and data volumes.
+   Add the Mailpit hosting integration to your AppHost, then declare a Mailpit resource and reference it from the apps that need to send email. The [Mailpit Hosting integration](/integrations/devtools/mailpit/mailpit-host/) article walks through the SMTP and HTTP endpoints, persistent storage, port configuration, and health checks.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/mailpit/mailpit-host/'>
-        Set up Mailpit in the AppHost
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/mailpit/mailpit-host/"
+   >
+     Set up Mailpit in the AppHost
+   </LinkButton>
 
 2. ### Connect from your consuming app
 
-    When you reference a Mailpit resource from a consuming app, Aspire injects its SMTP connection information as environment variables. See [Connect to Mailpit](/integrations/devtools/mailpit/mailpit-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript.
+   When you reference a Mailpit resource from a consuming app, Aspire injects its SMTP connection information as environment variables. See [Connect to Mailpit](/integrations/devtools/mailpit/mailpit-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/devtools/mailpit/mailpit-connect/'>
-        Connect to Mailpit
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/devtools/mailpit/mailpit-connect/"
+   >
+     Connect to Mailpit
+   </LinkButton>
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-get-started.mdx
@@ -11,8 +11,8 @@ import mailpitLightIcon from '@assets/icons/mailpit-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={mailpitLightIcon}
-  dark={mailpitIcon}
+  light={mailpitIcon}
+  dark={mailpitLightIcon}
   alt="Mailpit logo"
   width={100}
   height={100}

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
@@ -1,11 +1,16 @@
 ---
 title: Set up Mailpit in the AppHost
-seoTitle: "Set up Mailpit in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Mailpit in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Mailpit Hosting integration to orchestrate and configure a Mailpit resource in an Aspire solution.
 ---
 
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
-import InstallPackage from '@components/InstallPackage.astro';
+import {
+  Aside,
+  Badge,
+  Steps,
+  TabItem,
+  Tabs,
+} from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 import ThemeImage from '@components/ThemeImage.astro';
 import mailpitIcon from '@assets/icons/mailpit-icon.svg';
@@ -27,10 +32,6 @@ This article is the reference for the Aspire Mailpit Hosting integration. It enu
 
 If you're new to the Mailpit integration, start with the [Get started with Mailpit integrations](/integrations/devtools/mailpit/mailpit-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Mailpit](../mailpit-connect/).
 
-:::note
-TypeScript AppHost support for the Mailpit integration is not yet available. The examples on this page use the C# AppHost only.
-:::
-
 ## Installation
 
 To start building an Aspire app that uses Mailpit, install the [📦 CommunityToolkit.Aspire.Hosting.MailPit](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.MailPit) NuGet package:
@@ -40,7 +41,8 @@ aspire add mailpit
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -57,6 +59,9 @@ Or, choose a manual installation approach:
 
 Once you've installed the hosting integration in your AppHost project, you can add a Mailpit resource as shown in the following example:
 
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -69,6 +74,28 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 builder.Build().Run();
 ```
 
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const mailpit = await builder.addMailPit('mailpit');
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(mailpit);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
 <Steps>
 
 1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `docker.io/axllent/mailpit` image, it creates a new Mailpit instance on your local machine.
@@ -78,16 +105,19 @@ builder.Build().Run();
 </Steps>
 
 <Aside type="note">
-    When you reference a Mailpit resource from the AppHost, Aspire makes several properties available to the consuming project, such as the SMTP host, SMTP port, and the HTTP UI endpoint URL. For a complete list of these properties and per-language connection examples, see [Connect to Mailpit](../mailpit-connect/).
+  When you reference a Mailpit resource from the AppHost, Aspire makes the SMTP
+  connection string, host, port, and URI available to the consuming project. For
+  the exact formats and per-language examples, see [Connect to
+  Mailpit](../mailpit-connect/).
 </Aside>
 
 ## SMTP endpoint
 
-Mailpit listens for SMTP on port **1025** by default. Aspire exposes this as the `smtp` endpoint on the resource. When you call `WithReference(mailpit)` from a consuming project, Aspire injects the `SmtpHost` and `SmtpPort` connection properties automatically.
+Mailpit listens for SMTP on port **1025** by default. Aspire exposes this as the `smtp` endpoint and uses it for the resource's `Host`, `Port`, `Uri`, and connection string values.
 
 ## HTTP UI endpoint
 
-Mailpit serves its web-based email inspector on port **8025** by default. Aspire exposes this as the `http` endpoint on the resource. The `HttpEndpoint` connection property contains the full URL.
+Mailpit serves its web-based email inspector on port **8025** by default. Aspire exposes this separately as the `http` endpoint on the resource.
 
 You can open the Mailpit web UI from the Aspire dashboard by clicking the HTTP endpoint link next to the Mailpit resource.
 
@@ -95,11 +125,14 @@ You can open the Mailpit web UI from the Aspire dashboard by clicking the HTTP e
 
 Add a data volume to the Mailpit resource to persist captured emails across container restarts:
 
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mailpit = builder.AddMailPit("mailpit")
-    .WithDataVolume();
+    .WithDataVolume("mailpit-data");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(mailpit);
@@ -108,8 +141,109 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 builder.Build().Run();
 ```
 
-The data volume is mounted inside the Mailpit container and persists data outside the lifecycle of the container. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over bind mounts, see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const mailpit = await builder.addMailPit('mailpit');
+await mailpit.withDataVolume('mailpit-data');
+
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(mailpit);
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+The data volume is mounted at `/data` and the integration configures Mailpit to store its database at `/data/mailpit.db`. For more information on data volumes and details on why they're preferred over bind mounts, see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
+
+## Add Mailpit resource with data bind mount
+
+Use a bind mount when you need direct access to Mailpit's database files from the host:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var mailpit = builder.AddMailPit("mailpit")
+    .WithDataBindMount("./mailpit-data");
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const mailpit = await builder.addMailPit('mailpit');
+await mailpit.withDataBindMount('./mailpit-data');
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+The bind mount uses the same `/data` container path and `/data/mailpit.db` database location as a data volume.
+
+## Customize ports
+
+Pass `httpPort` and `smtpPort` to bind Mailpit's endpoints to fixed host ports:
+
+<Tabs syncKey='aspire-lang'>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var mailpit = builder.AddMailPit(
+    name: "mailpit",
+    httpPort: 8025,
+    smtpPort: 1025);
+
+builder.Build().Run();
+```
+
+</TabItem>
+<TabItem id='typescript' label='TypeScript'>
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const mailpit = await builder.addMailPit('mailpit', {
+  httpPort: 8025,
+  smtpPort: 1025,
+});
+
+await builder.build().run();
+```
+
+</TabItem>
+</Tabs>
+
+When these values are omitted, Aspire assigns random host ports while Mailpit continues to listen on ports `8025` and `1025` inside the container.
 
 ## Connection properties
 
 For the full reference of Mailpit connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Mailpit](../mailpit-connect/).
+
+## Hosting integration health checks
+
+The Mailpit hosting integration automatically checks the `/livez` and `/readyz` paths on the HTTP endpoint. The resource becomes healthy after both checks pass.

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
@@ -19,8 +19,8 @@ import mailpitLightIcon from '@assets/icons/mailpit-light-icon.svg';
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
 <ThemeImage
-  light={mailpitLightIcon}
-  dark={mailpitIcon}
+  light={mailpitIcon}
+  dark={mailpitLightIcon}
   alt="Mailpit logo"
   width={100}
   height={100}


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is ready for review, but it should be rebased and merged after #1375 because the series shares mapping, sidebar, and contained-logo behavior.

## Summary

- Audit all nine flagd, GO Feature Flag, and Mailpit get-started, host, and connect pages against `CommunityToolkit/Aspire` commit `b9d40479805b74ea20b7dc57cb659d46e6f11c43`.
- Correct client packages, imports, connection contracts, health behavior, persistence guidance, and dedicated Aspire-client versus direct-client framing.
- Replace flagd's TypeScript capability shortcut with complete synchronized C# and TypeScript OFREP AppHost examples, while precisely scoping the source-marked `WithLogLevel` export exception.
- Preserve complete hero artwork and correct the flagd light/dark asset assignment.

## Validation

- Changed C#, TypeScript, Python, and Go scratch samples compile or type-check successfully.
- Focused metadata, SEO, and twoslash suites pass: 3 files, 65 tests.
- All nine routes pass browser checks; combined landing rehearsal passes 248 logo renders and 199 synchronized AppHost tab groups with zero failures or console errors.

No local `pnpm build` was run.