### PR TITLE
Audit data and AI Community Toolkit integration docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-connect.mdx
@@ -17,6 +17,7 @@ import ollamaIcon from '@assets/icons/ollama-icon.png';
   alt="Ollama logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-connect.mdx
@@ -104,8 +104,8 @@ public class ExampleService(IOllamaApiClient ollama)
 To register multiple `IOllamaApiClient` instances with different connection names, use `AddKeyedOllamaApiClient`:
 
 ```csharp title="Program.cs"
-builder.AddKeyedOllamaApiClient(name: "chat");
-builder.AddKeyedOllamaApiClient(name: "embeddings");
+builder.AddKeyedOllamaApiClient(connectionName: "chat");
+builder.AddKeyedOllamaApiClient(connectionName: "embeddings");
 ```
 
 Then resolve each instance by key:

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-get-started.mdx
@@ -16,6 +16,7 @@ import ollamaIcon from '@assets/icons/ollama-icon.png';
   alt="Ollama logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -277,12 +277,12 @@ await ollama.addModel("llama3");
 **AMD:**
 
 ```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
+import { createBuilder, OllamaGpuVendor } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 const ollama = await builder.addOllama("ollama");
-await ollama.withGPUSupport({ vendor: "AMD" });
+await ollama.withGPUSupport({ vendor: OllamaGpuVendor.AMD });
 
 await ollama.addModel("llama3");
 
@@ -290,7 +290,7 @@ await ollama.addModel("llama3");
 ```
 
 <Aside type="note">
-  The TypeScript `withGPUSupport` API shape for vendor selection may differ from the C# overload. Refer to the generated `.aspire/modules/aspire.mjs` in your project for the exact parameter structure.
+  In TypeScript, select the GPU vendor with the `OllamaGpuVendor` enum imported from the generated `.aspire/modules/aspire.mjs` — for example, `OllamaGpuVendor.AMD` or `OllamaGpuVendor.Nvidia`.
 </Aside>
 
 </TabItem>
@@ -339,7 +339,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 </TabItem>
 </Tabs>
 
-Only models in GGUF format are supported. Ollama automatically prefixes `hf.co/` if the model name doesn't already start with `hf.co/` or `huggingface.co/`.
+Only models in GGUF format are supported. The integration automatically prefixes `hf.co/` to the model name if it doesn't already start with `hf.co/` or `huggingface.co/`, so Ollama can resolve it from Hugging Face.
 
 ## Add Ollama resource with parameters
 

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -16,6 +16,7 @@ import ollamaIcon from '@assets/icons/ollama-icon.png';
   alt="Ollama logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-connect.mdx
@@ -16,6 +16,7 @@ import kurrentIcon from '@assets/icons/kurrent-icon.png';
   alt="KurrentDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-connect.mdx
@@ -4,21 +4,22 @@ seoTitle: "Connect to KurrentDB from Aspire apps (C#, Node.js)"
 description: Learn how to connect to KurrentDB from C#, Go, Python, and TypeScript consuming apps in an Aspire solution.
 ---
 
-import { Image } from 'astro:assets';
 import { Aside, Badge, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallDotNetPackage from '@components/InstallDotNetPackage.astro';
+import ThemeImage from '@components/ThemeImage.astro';
 import kurrentIcon from '@assets/icons/kurrent-icon.png';
+import kurrentLightIcon from '@assets/icons/kurrent-light-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
-<Image
-  src={kurrentIcon}
+<ThemeImage
+  light={kurrentLightIcon}
+  dark={kurrentIcon}
   alt="KurrentDB logo"
   width={100}
   height={100}
-  fit="contain"
-  class:list={'float-inline-left icon'}
-  data-zoom-off
+  zoomable={false}
+  classOverride="float-inline-left icon"
 />
 
 This page describes how consuming apps connect to a KurrentDB resource that's already modeled in your AppHost. For the AppHost API surface — adding a KurrentDB resource, data volumes, data bind mounts, and more — see [KurrentDB Hosting integration](../kurrentdb-host/).

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
@@ -24,7 +24,7 @@ import kurrentIcon from '@assets/icons/kurrent-icon.png';
 
 Adding KurrentDB through Aspire — rather than wiring up containers and connection strings by hand — gives you:
 
-- **Zero-config local development.** Aspire runs KurrentDB from the [`docker.io/eventstore/eventstore`](https://hub.docker.com/r/eventstore/eventstore) container image with configuration generated automatically for you.
+- **Zero-config local development.** Aspire runs KurrentDB from the [`docker.kurrent.io/kurrent-latest/kurrentdb`](https://docker.kurrent.io) container image with configuration generated automatically for you.
 - **Consistent connection info across languages.** Once you reference the KurrentDB resource from a consuming app, Aspire injects connection properties as environment variables in a predictable format that works from C#, TypeScript, Python, Go, or any other language.
 - **Built-in health checks.** The hosting integration automatically registers a health check so the dashboard and your orchestrator can tell when KurrentDB is ready.
 - **Dashboard observability.** The KurrentDB resource shows up in the Aspire dashboard with logs, status, and telemetry alongside your other services.

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
@@ -14,6 +14,7 @@ import kurrentIcon from '@assets/icons/kurrent-icon.png';
   alt="KurrentDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-get-started.mdx
@@ -3,20 +3,21 @@ title: Get started with the KurrentDB integrations
 description: Learn how the Aspire KurrentDB integrations host a KurrentDB event store resource and connect the .NET client to your Aspire AppHost projects.
 ---
 
-import { Image } from 'astro:assets';
 import { Badge, LinkButton, Steps } from '@astrojs/starlight/components';
+import ThemeImage from '@components/ThemeImage.astro';
 import kurrentIcon from '@assets/icons/kurrent-icon.png';
+import kurrentLightIcon from '@assets/icons/kurrent-light-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
-<Image
-  src={kurrentIcon}
+<ThemeImage
+  light={kurrentLightIcon}
+  dark={kurrentIcon}
   alt="KurrentDB logo"
   width={100}
   height={100}
-  fit="contain"
-  class:list={'float-inline-left icon'}
-  data-zoom-off
+  zoomable={false}
+  classOverride="float-inline-left icon"
 />
 
 [KurrentDB](https://kurrent.io/) is an open-source event-sourcing database (formerly EventStoreDB) purpose-built for storing events as an immutable, append-only log. It delivers high availability and reliability for event-driven and event-sourcing architectures. The Aspire KurrentDB integration lets you model a KurrentDB server as a first-class resource in your AppHost, then hand the connection information to any consuming app — regardless of language.

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -4,22 +4,23 @@ seoTitle: "Set up KurrentDB in the Aspire AppHost: hosting integration"
 description: Learn how to use the Aspire KurrentDB Hosting integration to orchestrate and configure a KurrentDB resource in an Aspire solution.
 ---
 
-import { Image } from 'astro:assets';
 import { Aside, Badge, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import LearnMore from '@components/LearnMore.astro';
+import ThemeImage from '@components/ThemeImage.astro';
 import kurrentIcon from '@assets/icons/kurrent-icon.png';
+import kurrentLightIcon from '@assets/icons/kurrent-light-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
 
-<Image
-  src={kurrentIcon}
+<ThemeImage
+  light={kurrentLightIcon}
+  dark={kurrentIcon}
   alt="KurrentDB logo"
   width={100}
   height={100}
-  fit="contain"
-  class:list={'float-inline-left icon'}
-  data-zoom-off
+  zoomable={false}
+  classOverride="float-inline-left icon"
 />
 
 This article is the reference for the Aspire KurrentDB Hosting integration. It enumerates the AppHost C# APIs that you use to model a KurrentDB resource in your [`AppHost`](/get-started/app-host/) project.

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -25,7 +25,7 @@ This article is the reference for the Aspire KurrentDB Hosting integration. It e
 If you're new to the KurrentDB integration, start with the [Get started with KurrentDB integrations](/integrations/databases/kurrentdb/kurrentdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to KurrentDB](../kurrentdb-connect/).
 
 <Aside type="note">
-  TypeScript AppHost support (`addKurrentDB` and related APIs) is not yet available in the generated `./.aspire/modules/aspire.mjs` SDK. All examples on this page are C# only.
+  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for KurrentDB — `addKurrentDB`, `withDataVolume`, and `withDataBindMount` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, model the resource with `const kurrentdb = await builder.addKurrentDB("kurrentdb");` and configure it with separate `await` calls such as `await kurrentdb.withDataVolume();`.
 </Aside>
 
 ## Installation
@@ -61,7 +61,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 <Steps>
 
-1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `docker.io/eventstore/eventstore` image, it creates a new KurrentDB instance on your local machine.
+1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `docker.kurrent.io/kurrent-latest/kurrentdb` image, it creates a new KurrentDB instance on your local machine.
 
 1. The AppHost reference call configures a connection in the consuming project named after the referenced KurrentDB resource, such as `kurrentdb` in the preceding example.
 

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -16,6 +16,7 @@ import kurrentIcon from '@assets/icons/kurrent-icon.png';
   alt="KurrentDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -23,7 +23,7 @@ import kurrentLightIcon from '@assets/icons/kurrent-light-icon.png';
   classOverride="float-inline-left icon"
 />
 
-This article is the reference for the Aspire KurrentDB Hosting integration. It enumerates the AppHost C# APIs that you use to model a KurrentDB resource in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire KurrentDB Hosting integration. It enumerates the AppHost APIs that you use to model a KurrentDB resource in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the KurrentDB integration, start with the [Get started with KurrentDB integrations](/integrations/databases/kurrentdb/kurrentdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to KurrentDB](../kurrentdb-connect/).
 

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -84,7 +84,7 @@ var kurrentdb = builder.AddKurrentDB("kurrentdb");
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(kurrentdb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -100,7 +100,7 @@ const kurrentdb = await builder.addKurrentDB("kurrentdb");
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(kurrentdb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -134,7 +134,7 @@ var kurrentdb = builder.AddKurrentDB("kurrentdb")
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(kurrentdb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -151,7 +151,7 @@ await kurrentdb.withDataVolume();
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(kurrentdb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -175,7 +175,7 @@ var kurrentdb = builder.AddKurrentDB("kurrentdb")
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(kurrentdb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -192,7 +192,7 @@ await kurrentdb.withDataBindMount("C:\\KurrentDB\\Data");
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(kurrentdb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -5,8 +5,9 @@ description: Learn how to use the Aspire KurrentDB Hosting integration to orches
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import { Aside, Badge, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
+import LearnMore from '@components/LearnMore.astro';
 import kurrentIcon from '@assets/icons/kurrent-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
@@ -25,13 +26,12 @@ This article is the reference for the Aspire KurrentDB Hosting integration. It e
 
 If you're new to the KurrentDB integration, start with the [Get started with KurrentDB integrations](/integrations/databases/kurrentdb/kurrentdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to KurrentDB](../kurrentdb-connect/).
 
-<Aside type="note">
-  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for KurrentDB — `addKurrentDB`, `withDataVolume`, and `withDataBindMount` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, model the resource with `const kurrentdb = await builder.addKurrentDB("kurrentdb");` and configure it with separate `await` calls such as `await kurrentdb.withDataVolume();`.
-</Aside>
-
 ## Installation
 
 To start building an Aspire app that uses KurrentDB, install the [📦 CommunityToolkit.Aspire.Hosting.KurrentDB](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.KurrentDB) NuGet package:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.KurrentDB" />
 
@@ -45,9 +45,36 @@ Or, choose a manual installation approach:
 <PackageReference Include="CommunityToolkit.Aspire.Hosting.KurrentDB" Version="*" />
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.KurrentDB
+```
+
+<LearnMore>
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+</LearnMore>
+
+This updates your `aspire.config.json` with the KurrentDB hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.KurrentDB": "*"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Add KurrentDB resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a KurrentDB resource as shown in the following example:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -59,6 +86,25 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const kurrentdb = await builder.addKurrentDB("kurrentdb");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(kurrentdb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 <Steps>
 
@@ -76,6 +122,9 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 Add a data volume to the KurrentDB resource as shown in the following example:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -88,11 +137,34 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const kurrentdb = await builder.addKurrentDB("kurrentdb");
+await kurrentdb.withDataVolume();
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(kurrentdb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 The data volume is used to persist KurrentDB data outside the lifecycle of its container. The data volume is mounted at the `/var/lib/kurrentdb` path in the KurrentDB container, and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-kurrentdb-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 ## Add KurrentDB resource with data bind mount
 
 Add a data bind mount to the KurrentDB resource as shown in the following example:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -105,6 +177,26 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const kurrentdb = await builder.addKurrentDB("kurrentdb");
+await kurrentdb.withDataBindMount("C:\\KurrentDB\\Data");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(kurrentdb);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 <Aside type="note">
     Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
@@ -145,7 +145,7 @@ Aspire client integrations enable health checks by default. The Meilisearch clie
 
 #### Read environment variables in C\#
 
-If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection properties from the environment and construct a `MeilisearchClient` directly using the [📦 Meilisearch](https://www.nuget.org/packages/Meilisearch/) NuGet package:
+If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection properties from the environment and construct a `MeilisearchClient` directly using the [📦 MeiliSearch](https://www.nuget.org/packages/MeiliSearch/) NuGet package:
 
 ```csharp title="Program.cs"
 using Meilisearch;

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
@@ -17,6 +17,7 @@ import meilisearchIcon from '@assets/icons/meilisearch-icon.png';
   alt="Meilisearch logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-connect.mdx
@@ -27,7 +27,7 @@ When you reference a Meilisearch resource from your AppHost, Aspire injects the 
 
 ## Connection properties
 
-Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Url` property of a resource called `meilisearch` becomes `MEILISEARCH_URL`.
+Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `meilisearch` becomes `MEILISEARCH_URI`.
 
 The Meilisearch resource exposes the following connection properties:
 
@@ -35,13 +35,13 @@ The Meilisearch resource exposes the following connection properties:
 | ------------- | ----------- |
 | `Host`        | The hostname or IP address of the Meilisearch server |
 | `Port`        | The port number the Meilisearch server is listening on (default: `7700`) |
-| `Url`         | The full base URL of the Meilisearch server, with the format `http://{Host}:{Port}` |
+| `Uri`         | The full base URL of the Meilisearch server, with the format `http://{Host}:{Port}` |
 | `MasterKey`   | The master key used to authenticate with the Meilisearch server |
 
 **Example connection values:**
 
 ```
-Url: http://localhost:7700
+Uri: http://localhost:7700
 MasterKey: p%40ssw0rd1
 ```
 
@@ -144,12 +144,12 @@ Aspire client integrations enable health checks by default. The Meilisearch clie
 
 #### Read environment variables in C\#
 
-If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection properties from the environment and construct a `MeilisearchClient` directly using the [📦 Meilisearch.NET](https://www.nuget.org/packages/Meilisearch/) NuGet package:
+If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection properties from the environment and construct a `MeilisearchClient` directly using the [📦 Meilisearch](https://www.nuget.org/packages/Meilisearch/) NuGet package:
 
 ```csharp title="Program.cs"
 using Meilisearch;
 
-var url = Environment.GetEnvironmentVariable("MEILISEARCH_URL");
+var url = Environment.GetEnvironmentVariable("MEILISEARCH_URI");
 var masterKey = Environment.GetEnvironmentVariable("MEILISEARCH_MASTERKEY");
 
 var client = new MeilisearchClient(url!, masterKey);
@@ -179,7 +179,7 @@ import (
 func main() {
     // Read the Aspire-injected connection properties
     client := meilisearch.New(
-        os.Getenv("MEILISEARCH_URL"),
+        os.Getenv("MEILISEARCH_URI"),
         meilisearch.WithAPIKey(os.Getenv("MEILISEARCH_MASTERKEY")),
     )
 
@@ -204,7 +204,7 @@ import meilisearch
 
 # Read the Aspire-injected connection properties
 client = meilisearch.Client(
-    os.getenv("MEILISEARCH_URL"),
+    os.getenv("MEILISEARCH_URI"),
     os.getenv("MEILISEARCH_MASTERKEY"),
 )
 
@@ -227,7 +227,7 @@ import { MeiliSearch } from 'meilisearch';
 
 // Read Aspire-injected connection properties
 const client = new MeiliSearch({
-    host: process.env.MEILISEARCH_URL!,
+    host: process.env.MEILISEARCH_URI!,
     apiKey: process.env.MEILISEARCH_MASTERKEY,
 });
 

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-get-started.mdx
@@ -15,6 +15,7 @@ import meilisearchIcon from '@assets/icons/meilisearch-icon.png';
   alt="Meilisearch logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -78,6 +78,9 @@ This updates your `aspire.config.json` with the Meilisearch hosting integration 
 
 Once you've installed the hosting integration in your AppHost project, you can add a Meilisearch resource as shown in the following example:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -89,9 +92,24 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
-<Aside type="note">
-  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for Meilisearch — `addMeilisearch`, `withDataVolume`, and `withDataBindMount` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, model the resource with `const meilisearch = await builder.addMeilisearch("meilisearch");` and configure it with separate `await` calls such as `await meilisearch.withDataVolume();`.
-</Aside>
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const meilisearch = await builder.addMeilisearch("meilisearch");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(meilisearch);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 <Steps>
 
@@ -111,6 +129,9 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 To add a data volume to the Meilisearch resource, call the `WithDataVolume` method:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -123,11 +144,34 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const meilisearch = await builder.addMeilisearch("meilisearch");
+await meilisearch.withDataVolume();
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(meilisearch);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 The data volume is used to persist Meilisearch data outside the lifecycle of its container. The data volume is mounted at the `/meili_data` path in the Meilisearch container. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-meilisearch-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 ## Add Meilisearch resource with data bind mount
 
 To add a data bind mount to the Meilisearch resource, call the `WithDataBindMount` method:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -141,6 +185,26 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const meilisearch = await builder.addMeilisearch("meilisearch");
+await meilisearch.withDataBindMount("C:\\Meilisearch\\Data");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(meilisearch);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 <Aside type="note">
     Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
 </Aside>
@@ -150,6 +214,9 @@ Data bind mounts rely on the host machine's filesystem to persist Meilisearch da
 ## Add Meilisearch resource with master key parameter
 
 When you want to explicitly provide the master key used by the container image, you can provide it as a parameter:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -163,6 +230,27 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const masterKey = await builder.addParameter("masterKey", { secret: true });
+
+const meilisearch = await builder.addMeilisearch("meilisearch", { masterKey });
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(meilisearch);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 When no `masterKey` parameter is provided, Aspire generates a strong master key automatically.
 

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -89,7 +89,7 @@ var meilisearch = builder.AddMeilisearch("meilisearch");
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(meilisearch);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -105,7 +105,7 @@ const meilisearch = await builder.addMeilisearch("meilisearch");
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(meilisearch);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -141,7 +141,7 @@ var meilisearch = builder.AddMeilisearch("meilisearch")
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(meilisearch);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -158,7 +158,7 @@ await meilisearch.withDataVolume();
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(meilisearch);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -182,7 +182,7 @@ var meilisearch = builder.AddMeilisearch("meilisearch")
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(meilisearch);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -199,7 +199,7 @@ await meilisearch.withDataBindMount("C:\\Meilisearch\\Data");
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(meilisearch);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -228,7 +228,7 @@ var meilisearch = builder.AddMeilisearch("meilisearch", masterKey);
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(meilisearch);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -246,7 +246,7 @@ const meilisearch = await builder.addMeilisearch("meilisearch", { masterKey });
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(meilisearch);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -89,7 +89,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 
 <Aside type="note">
-  TypeScript AppHost support for the Meilisearch Community Toolkit integration is not yet available. Use the C# AppHost to model Meilisearch resources. Connection information is still injected as environment variables for consuming apps in any language — see [Connect to Meilisearch](../meilisearch-connect/).
+  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for Meilisearch — `addMeilisearch`, `withDataVolume`, and `withDataBindMount` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, model the resource with `const meilisearch = await builder.addMeilisearch("meilisearch");` and configure it with separate `await` calls such as `await meilisearch.withDataVolume();`.
 </Aside>
 
 <Steps>

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -16,6 +16,7 @@ import meilisearchIcon from '@assets/icons/meilisearch-icon.png';
   alt="Meilisearch logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-connect.mdx
@@ -16,6 +16,7 @@ import ravendbIcon from '@assets/icons/ravendb-icon.png';
   alt="RavenDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-connect.mdx
@@ -158,7 +158,8 @@ The connection string is resolved from the `ConnectionStrings` section:
   "Aspire": {
     "RavenDB": {
       "Client": {
-        "ConnectionString": "URL=http://localhost:8080;Database=ravendb",
+        "Urls": ["http://localhost:8080"],
+        "DatabaseName": "ravendb",
         "DisableHealthChecks": false,
         "HealthCheckTimeout": 10000,
         "DisableTracing": false

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-get-started.mdx
@@ -14,6 +14,7 @@ import ravendbIcon from '@assets/icons/ravendb-icon.png';
   alt="RavenDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -104,9 +104,9 @@ const builder = await createBuilder();
 const ravenServer = await builder.addRavenDB("ravenServer");
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(ravendb)
-    .waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -167,9 +167,9 @@ const builder = await createBuilder();
 const ravenServer = await builder.addRavenDB("ravenServer");
 const ravendb = await ravenServer.addDatabase("ravendb", { ensureCreated: true });
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(ravendb)
-    .waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -207,14 +207,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer")
-    .withDataVolume();
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataVolume();
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(ravendb)
-    .waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -254,14 +254,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer")
-    .withDataBindMount("C:\\RavenDb\\Data");
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataBindMount("C:\\RavenDb\\Data");
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(ravendb)
-    .waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```
@@ -269,7 +269,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 </TabItem>
 </Tabs>
 
-Data bind mounts rely on the host machine's filesystem to persist the RavenDB data across container restarts. The data bind mount is mounted at the `C:\RavenDb\Data` on Windows (or the equivalent Unix path) on the host machine in the RavenDB container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
+Data bind mounts rely on the host machine's filesystem to persist the RavenDB data across container restarts. The bind mount maps the host path `C:\RavenDb\Data` (on Windows, or the equivalent Unix path) to the `/var/lib/ravendb/data` directory inside the RavenDB container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
 
 <Aside type="note">
     Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
@@ -306,15 +306,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer")
-    .withDataVolume()
-    .withLogVolume();
+const ravenServer = await builder.addRavenDB("ravenServer");
+await ravenServer.withDataVolume();
+await ravenServer.withLogVolume();
 
 const ravendb = await ravenServer.addDatabase("ravendb");
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(ravendb)
-    .waitFor(ravendb);
+const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await apiService.withReference(ravendb);
+await apiService.waitFor(ravendb);
 
 // After adding all resources, run the app...
 ```

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -16,6 +16,7 @@ import ravendbIcon from '@assets/icons/ravendb-icon.png';
   alt="RavenDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -91,7 +91,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -109,7 +109,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -154,7 +154,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -172,7 +172,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -197,7 +197,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -217,7 +217,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -244,7 +244,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -264,7 +264,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -296,7 +296,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -317,7 +317,7 @@ const apiService = await builder.addProject("apiservice", "../ExampleProject/Exa
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -345,7 +345,7 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(ravendb)
     .WaitFor(ravendb);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 <Aside type="caution">

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-connect.mdx
@@ -16,6 +16,7 @@ import sqliteIcon from '@assets/icons/sqlite-icon.png';
   alt="SQLite logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-connect.mdx
@@ -20,7 +20,7 @@ import sqliteIcon from '@assets/icons/sqlite-icon.png';
   data-zoom-off
 />
 
-This page describes how consuming apps connect to a SQLite resource that's already modeled in your AppHost. For the AppHost API surface — adding a SQLite resource, setting a custom database file path, the SQLiteWeb UI, SQLite extensions, and more — see [SQLite Hosting integration](../sqlite-host/).
+This page describes how consuming apps connect to a SQLite resource that's already modeled in your AppHost. For the AppHost API surface — adding a SQLite resource, setting a custom database file path, the SQLiteWeb UI, and more — see [SQLite Hosting integration](../sqlite-host/).
 
 When you reference a SQLite resource from your AppHost, Aspire injects the database file path into the consuming app as an environment variable. Your app can either read that environment variable directly — the pattern works the same from any language — or, in C#, use the Aspire SQLite client integration for automatic dependency injection, health checks, and telemetry.
 
@@ -130,7 +130,7 @@ For more information, see [Microsoft.Data.Sqlite connection strings](https://lea
     "Sqlite": {
       "Client": {
         "ConnectionString": "Data Source=C:\\Database\\Location\\my-database.db",
-        "DisableHealthCheck": true
+        "DisableHealthChecks": true
       }
     }
   }
@@ -142,14 +142,14 @@ For more information, see [Microsoft.Data.Sqlite connection strings](https://lea
 ```csharp title="Program.cs"
 builder.AddSqliteConnection(
     "sqlite",
-    static settings => settings.DisableHealthCheck = true);
+    static settings => settings.DisableHealthChecks = true);
 ```
 
 #### Client integration health checks
 
 Aspire client integrations enable health checks by default. The SQLite client integration adds:
 
-- A health check that attempts to open a connection to the database file when `SqliteConnectionSettings.DisableHealthCheck` is `false`.
+- A health check that attempts to open a connection to the database file when `SqliteConnectionSettings.DisableHealthChecks` is `false`.
 - Integration with the `/health` HTTP endpoint, where all registered health checks must pass before the app is considered ready to accept traffic.
 
 #### Observability and telemetry

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
@@ -56,7 +56,7 @@ The **hosting integration** lives in your AppHost project and models the SQLite 
 import { Aside } from '@astrojs/starlight/components';
 
 <Aside type="note">
-  The SQLite hosting integration is C#-only. The TypeScript AppHost does not have an `addSqlite` API. To reference a SQLite file from a TypeScript AppHost, use `builder.addConnectionString(...)` with a parameter instead.
+  The Community Toolkit generates TypeScript AppHost bindings for SQLite — `addSqlite` and `withSqliteWeb` — into `./.aspire/modules/aspire.mjs`, so you can model a SQLite resource from an `apphost.mts` as well as from a C# AppHost.
 </Aside>
 
 Getting there is a two-step process: model the SQLite resource in your AppHost, then connect to the database from each app that needs it.
@@ -65,7 +65,7 @@ Getting there is a two-step process: model the SQLite resource in your AppHost, 
 
 1. ### Model SQLite in your AppHost
 
-    Add the SQLite hosting integration to your AppHost, then declare a SQLite database resource and reference it from the apps that need to use the database. The [SQLite Hosting integration](/integrations/databases/sqlite/sqlite-host/) article walks through every capability — custom database file paths, the SQLiteWeb UI, SQLite extensions, and more.
+    Add the SQLite hosting integration to your AppHost, then declare a SQLite database resource and reference it from the apps that need to use the database. The [SQLite Hosting integration](/integrations/databases/sqlite/sqlite-host/) article walks through every capability — custom database file paths, the SQLiteWeb UI, and more.
 
     <LinkButton
         variant='secondary'

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
@@ -15,6 +15,7 @@ import sqliteIcon from '@assets/icons/sqlite-icon.png';
   alt="SQLite logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-get-started.mdx
@@ -54,12 +54,6 @@ architecture-beta
 
 The **hosting integration** lives in your AppHost project and models the SQLite database file as a resource. Because SQLite is an embedded, file-based database, there is no container to start — Aspire simply tracks the database file path and injects it into consuming apps as environment variables.
 
-import { Aside } from '@astrojs/starlight/components';
-
-<Aside type="note">
-  The Community Toolkit generates TypeScript AppHost bindings for SQLite — `addSqlite` and `withSqliteWeb` — into `./.aspire/modules/aspire.mjs`, so you can model a SQLite resource from an `apphost.mts` as well as from a C# AppHost.
-</Aside>
-
 Getting there is a two-step process: model the SQLite resource in your AppHost, then connect to the database from each app that needs it.
 
 <Steps>

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -16,6 +16,7 @@ import sqliteIcon from '@assets/icons/sqlite-icon.png';
   alt="SQLite logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -5,7 +5,7 @@ description: Learn how to use the Aspire SQLite Hosting integration to orchestra
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import { Aside, Badge, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 import sqliteIcon from '@assets/icons/sqlite-icon.png';
 
@@ -26,12 +26,15 @@ This article is the reference for the Aspire SQLite Hosting integration. It enum
 If you're new to the SQLite integration, start with the [Get started with SQLite integrations](/integrations/databases/sqlite/sqlite-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SQLite](../sqlite-connect/).
 
 <Aside type="note">
-  The SQLite hosting integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in the core Aspire SDK. The Community Toolkit also generates TypeScript AppHost bindings for SQLite — `addSqlite` and `withSqliteWeb` — into `./.aspire/modules/aspire.mjs`, so you can model the same resource from an `apphost.mts`.
+  The SQLite hosting integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in the core Aspire SDK.
 </Aside>
 
 ## Installation
 
 To start building an Aspire app that uses SQLite, install the [📦 CommunityToolkit.Aspire.Hosting.Sqlite](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Sqlite) NuGet package in your AppHost project:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```bash title="Terminal"
 aspire add sqlite
@@ -51,9 +54,36 @@ Or, choose a manual installation approach:
 <PackageReference Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="*" />
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```bash title="Terminal"
+aspire add sqlite
+```
+
+<LearnMore>
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+</LearnMore>
+
+This updates your `aspire.config.json` with the SQLite hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.Sqlite": "*"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Add SQLite resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a SQLite resource:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -65,6 +95,25 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const sqlite = await builder.addSqlite("sqlite");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(sqlite);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 <Steps>
 
@@ -82,6 +131,9 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 By default, Aspire creates the SQLite database file in the user's temporary directory. To specify a custom location, provide the directory path and file name as arguments to `AddSqlite`:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -93,11 +145,36 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const sqlite = await builder.addSqlite("sqlite", {
+    databasePath: "C:\\Database\\Location",
+    databaseFileName: "my-database.db",
+});
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(sqlite);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 The preceding code creates the SQLite database file at `C:\Database\Location\my-database.db`. The file is created if it doesn't already exist.
 
 ## Add SQLiteWeb resource
 
 To add a browser-based management UI alongside your SQLite database, use the `WithSqliteWeb` extension method:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -110,6 +187,26 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const sqlite = await builder.addSqlite("sqlite");
+await sqlite.withSqliteWeb();
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(sqlite);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 This adds a container based on [`ghcr.io/coleifer/sqlite-web`](https://github.com/coleifer/sqlite-web) connected to the same database file. Each `WithSqliteWeb` call creates one container per database. When you run the solution, the Aspire dashboard displays the SQLiteWeb resource with an endpoint — select it to open the SQLiteWeb UI in a new browser tab.
 

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -25,12 +25,12 @@ This article is the reference for the Aspire SQLite Hosting integration. It enum
 If you're new to the SQLite integration, start with the [Get started with SQLite integrations](/integrations/databases/sqlite/sqlite-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SQLite](../sqlite-connect/).
 
 <Aside type="note">
-  The SQLite hosting integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in the core Aspire SDK. The TypeScript AppHost does not have an `addSqlite` API. To reference a SQLite file from a TypeScript AppHost, use `builder.addConnectionString(...)` with a parameter instead.
+  The SQLite hosting integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in the core Aspire SDK. The Community Toolkit also generates TypeScript AppHost bindings for SQLite — `addSqlite` and `withSqliteWeb` — into `./.aspire/modules/aspire.mjs`, so you can model the same resource from an `apphost.mts`.
 </Aside>
 
 ## Installation
 
-To start building an Aspire app that uses SQLite, install the [📦 CommunityToolkit.Aspire.Hosting.SQLite](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.SQLite) NuGet package in your AppHost project:
+To start building an Aspire app that uses SQLite, install the [📦 CommunityToolkit.Aspire.Hosting.Sqlite](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Sqlite) NuGet package in your AppHost project:
 
 ```bash title="Terminal"
 aspire add sqlite
@@ -43,11 +43,11 @@ aspire add sqlite
 Or, choose a manual installation approach:
 
 ```csharp title="AppHost.cs"
-#:package CommunityToolkit.Aspire.Hosting.SQLite@*
+#:package CommunityToolkit.Aspire.Hosting.Sqlite@*
 ```
 
 ```xml title="AppHost.csproj"
-<PackageReference Include="CommunityToolkit.Aspire.Hosting.SQLite" Version="*" />
+<PackageReference Include="CommunityToolkit.Aspire.Hosting.Sqlite" Version="*" />
 ```
 
 ## Add SQLite resource
@@ -74,7 +74,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 </Steps>
 
 <Aside type="note">
-    When you reference a SQLite resource from the AppHost, Aspire makes the database file path available to the consuming project as a `DATASOURCE` environment variable. For a complete list of these properties and per-language connection examples, see [Connect to SQLite](../sqlite-connect/).
+    When you reference a SQLite resource from the AppHost, Aspire makes the database file path available to the consuming project as a `SQLITE_DATASOURCE` environment variable. For a complete list of these properties and per-language connection examples, see [Connect to SQLite](../sqlite-connect/).
 </Aside>
 
 ## Add SQLite resource with custom database file path
@@ -111,38 +111,6 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 ```
 
 This adds a container based on [`ghcr.io/coleifer/sqlite-web`](https://github.com/coleifer/sqlite-web) connected to the same database file. Each `WithSqliteWeb` call creates one container per database. When you run the solution, the Aspire dashboard displays the SQLiteWeb resource with an endpoint — select it to open the SQLiteWeb UI in a new browser tab.
-
-## Add SQLite extensions
-
-SQLite supports loadable extensions that can be provided via a NuGet package or from a local file on disk. Use either `WithNuGetExtension` or `WithLocalExtension`:
-
-```csharp title="AppHost.cs (NuGet extension)"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var sqlite = builder.AddSqlite("sqlite")
-    .WithNuGetExtension("SQLitePCLRaw.lib.e_sqlite3");
-
-var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(sqlite);
-
-// After adding all resources, run the app...
-```
-
-```csharp title="AppHost.cs (Local extension)"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var sqlite = builder.AddSqlite("sqlite")
-    .WithLocalExtension("C:\\Extensions\\my-extension.dll");
-
-var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(sqlite);
-
-// After adding all resources, run the app...
-```
-
-<Aside type="note">
-  SQLite extension support is considered experimental and produces a `CTASPIRE002` diagnostic warning.
-</Aside>
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -93,7 +93,7 @@ var sqlite = builder.AddSqlite("sqlite");
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(sqlite);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -109,7 +109,7 @@ const sqlite = await builder.addSqlite("sqlite");
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(sqlite);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -142,7 +142,7 @@ var sqlite = builder.AddSqlite("sqlite", "C:\\Database\\Location", "my-database.
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(sqlite);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -161,7 +161,7 @@ const sqlite = await builder.addSqlite("sqlite", {
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(sqlite);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -185,7 +185,7 @@ var sqlite = builder.AddSqlite("sqlite")
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
     .WithReference(sqlite);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -202,7 +202,7 @@ await sqlite.withSqliteWeb();
 const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
 await exampleProject.withReference(sqlite);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-connect.mdx
@@ -26,7 +26,7 @@ When you reference a SurrealDB resource from your AppHost, Aspire injects the co
 
 ## Connection properties
 
-Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Endpoint` property of a resource called `db` becomes `DB_ENDPOINT`.
+Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `db` becomes `DB_URI`.
 
 The SurrealDB database resource exposes the following connection properties:
 
@@ -38,13 +38,14 @@ The SurrealDB database resource exposes the following connection properties:
 | `Password`         | The password for authentication |
 | `Namespace`        | The SurrealDB namespace name |
 | `Database`         | The database name |
-| `Endpoint`         | The full WebSocket endpoint URL, with the format `ws://{Host}:{Port}/` |
-| `ConnectionString` | The full connection string, with the format `Endpoint=ws://{Host}:{Port}/;Namespace={Namespace};Database={Database};Username={Username};Password={Password}` |
+| `Uri`              | The full WebSocket RPC endpoint URL, with the format `ws://{Host}:{Port}/rpc` |
+
+When you reference the SurrealDB database resource, Aspire also injects a connection string into the consuming app's `ConnectionStrings` configuration section, with the format `Server=ws://{Host}:{Port}/rpc;User={Username};Password={Password};Namespace={Namespace};Database={Database}`.
 
 **Example connection string:**
 
 ```
-ConnectionString: Endpoint=ws://localhost:8000/;Namespace=ns;Database=db;Username=root;Password=p%40ssw0rd1
+Server=ws://localhost:8000/rpc;User=root;Password=p%40ssw0rd1;Namespace=ns;Database=db
 ```
 
 ## Connect from your app
@@ -120,23 +121,20 @@ The connection string is resolved from the `ConnectionStrings` section:
 ```json title="appsettings.json"
 {
   "ConnectionStrings": {
-    "db": "Endpoint=ws://localhost:8000/;Namespace=ns;Database=db;Username=root;Password=s3cr3t"
+    "db": "Server=ws://localhost:8000/rpc;User=root;Password=s3cr3t;Namespace=ns;Database=db"
   }
 }
 ```
 
-**Configuration providers.** The client integration supports `Microsoft.Extensions.Configuration`. It loads settings from _appsettings.json_ (or any other configuration source) by using the `Aspire:Surreal:Client` key:
+**Configuration providers.** The client integration binds `SurrealDbClientSettings` from the `Aspire:Surreal:Client` configuration section. Connection details are supplied through the `ConnectionStrings` section shown earlier; this section configures client behavior such as health checks:
 
 ```json title="appsettings.json"
 {
   "Aspire": {
     "Surreal": {
       "Client": {
-        "Endpoint": "ws://localhost:8000/",
-        "Namespace": "ns",
-        "Database": "db",
-        "Username": "root",
-        "Password": "s3cr3t"
+        "DisableHealthChecks": false,
+        "HealthCheckTimeout": 10000
       }
     }
   }
@@ -157,12 +155,12 @@ Aspire client integrations enable health checks by default. The SurrealDB client
 
 #### Read environment variables in C\#
 
-If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection string from the environment and use the [📦 SurrealDB.Net](https://www.nuget.org/packages/SurrealDb.Net/) NuGet package to construct a client directly:
+If you prefer not to use the Aspire client integration, you can read the Aspire-injected connection string from the environment and use the [📦 SurrealDb.Net](https://www.nuget.org/packages/SurrealDb.Net/) NuGet package to construct a client directly:
 
 ```csharp title="Program.cs"
 using SurrealDb.Net;
 
-var connectionString = Environment.GetEnvironmentVariable("DB_CONNECTIONSTRING");
+var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__db");
 
 var client = new SurrealDbClient(connectionString!);
 await client.Connect();
@@ -192,7 +190,7 @@ import (
 
 func main() {
     // Read the Aspire-injected connection properties
-    endpoint := os.Getenv("DB_ENDPOINT")
+    endpoint := os.Getenv("DB_URI")
     namespace := os.Getenv("DB_NAMESPACE")
     database  := os.Getenv("DB_DATABASE")
     username  := os.Getenv("DB_USERNAME")
@@ -236,7 +234,7 @@ from surrealdb import AsyncSurrealDB
 
 async def main():
     # Read the Aspire-injected connection properties
-    endpoint  = os.getenv("DB_ENDPOINT")
+    endpoint  = os.getenv("DB_URI")
     namespace = os.getenv("DB_NAMESPACE")
     database  = os.getenv("DB_DATABASE")
     username  = os.getenv("DB_USERNAME")
@@ -266,7 +264,7 @@ Read the injected environment variables and connect:
 import Surreal from 'surrealdb';
 
 // Read Aspire-injected connection properties
-const endpoint  = process.env.DB_ENDPOINT!;
+const endpoint  = process.env.DB_URI!;
 const namespace = process.env.DB_NAMESPACE!;
 const database  = process.env.DB_DATABASE!;
 const username  = process.env.DB_USERNAME!;

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-connect.mdx
@@ -16,6 +16,7 @@ import surrealdbIcon from '@assets/icons/surrealdb-icon.png';
   alt="SurrealDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-get-started.mdx
@@ -14,6 +14,7 @@ import surrealdbIcon from '@assets/icons/surrealdb-icon.png';
   alt="SurrealDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -22,7 +22,7 @@ import surrealdbIcon from '@assets/icons/surrealdb-icon.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire SurrealDB Hosting integration. It enumerates the AppHost C# APIs that you use to model a SurrealDB server, namespace, and database as resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire SurrealDB Hosting integration. It enumerates the AppHost APIs that you use to model a SurrealDB server, namespace, and database as resources in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the SurrealDB integration, start with the [Get started with SurrealDB integrations](/integrations/databases/surrealdb/surrealdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SurrealDB](../surrealdb-connect/).
 

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -5,8 +5,9 @@ description: Learn how to use the Aspire SurrealDB Hosting integration to orches
 ---
 
 import { Image } from 'astro:assets';
-import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import { Aside, Badge, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
+import LearnMore from '@components/LearnMore.astro';
 import surrealdbIcon from '@assets/icons/surrealdb-icon.png';
 
 <Badge text="⭐ Community Toolkit" variant="tip" size="large" />
@@ -25,13 +26,12 @@ This article is the reference for the Aspire SurrealDB Hosting integration. It e
 
 If you're new to the SurrealDB integration, start with the [Get started with SurrealDB integrations](/integrations/databases/surrealdb/surrealdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SurrealDB](../surrealdb-connect/).
 
-<Aside type="note">
-  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for SurrealDB — `addSurrealServer`, `addNamespace`, `addDatabase`, and configuration methods such as `withDataVolume`, `withLogLevel`, and `withSurrealist` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, each call is awaited separately, and because the configuration methods return an updated builder you reassign the variable, for example: `let primary = await builder.addSurrealServer("primary"); primary = await primary.withDataVolume();`.
-</Aside>
-
 ## Installation
 
 To start building an Aspire app that uses SurrealDB, install the [📦 CommunityToolkit.Aspire.Hosting.SurrealDb](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.SurrealDb) NuGet package:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.SurrealDb" />
 
@@ -45,9 +45,36 @@ Or, choose a manual installation approach:
 <PackageReference Include="CommunityToolkit.Aspire.Hosting.SurrealDb" Version="*" />
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.SurrealDb
+```
+
+<LearnMore>
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+</LearnMore>
+
+This updates your `aspire.config.json` with the SurrealDB hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "CommunityToolkit.Aspire.Hosting.SurrealDb": "*"
+  }
+}
+```
+
+</TabItem>
+</Tabs>
+
 ## Add SurrealDB resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a SurrealDB server, namespace, and database resource as shown in the following example:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -62,6 +89,28 @@ builder.AddProject<Projects.ExampleProject>()
 
 // After adding all resources, run the app...
 ```
+
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const surreal = await builder.addSurrealServer("surreal");
+const ns = await surreal.addNamespace("ns");
+const db = await ns.addDatabase("db");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(db);
+await exampleProject.waitFor(db);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
 
 <Steps>
 
@@ -83,6 +132,9 @@ builder.AddProject<Projects.ExampleProject>()
 
 To add [Surrealist](https://hub.docker.com/r/surrealdb/surrealist) to the SurrealDB server resource, call the `WithSurrealist` method:
 
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -100,11 +152,38 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+let surreal = await builder.addSurrealServer("surreal");
+surreal = await surreal.withSurrealist();
+
+const ns = await surreal.addNamespace("ns");
+const db = await ns.addDatabase("db");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(db);
+await exampleProject.waitFor(db);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 Surrealist is a web-based user interface for interacting with your SurrealDB database visually. It lets you connect to any SurrealDB instance, execute queries, explore your tables, and design your schemas.
 
 ## Add SurrealDB resource with data bind mount
 
 To add a data bind mount to the SurrealDB resource, call the `WithDataBindMount` method:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -121,11 +200,38 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+let surreal = await builder.addSurrealServer("surreal");
+surreal = await surreal.withDataBindMount("./data/surreal/data");
+
+const ns = await surreal.addNamespace("ns");
+const db = await ns.addDatabase("db");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(db);
+await exampleProject.waitFor(db);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 Data bind mounts rely on the host machine's filesystem to persist SurrealDB data across container restarts. The mount path `./data/surreal/data` is resolved relative to the AppHost project directory. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
 
 ## Add SurrealDB resource with parameters
 
 When you want to explicitly provide the password used by the container image, you can provide it as a parameter:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -143,11 +249,38 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const password = await builder.addParameter("password", { secret: true });
+
+const surreal = await builder.addSurrealServer("surreal", { password });
+const ns = await surreal.addNamespace("ns");
+const db = await ns.addDatabase("db");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(db);
+await exampleProject.waitFor(db);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
 For more information on providing parameters, see [External parameters](/get-started/resources/).
 
 ## Configure logging
 
 To configure the log level for the SurrealDB container, call the `WithLogLevel` method:
+
+<Tabs syncKey="aspire-lang">
+<TabItem id="csharp" label="C#">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -166,7 +299,31 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
-The `WithLogLevel` method enables verbose logging in the SurrealDB container, which is useful during development and debugging.
+</TabItem>
+<TabItem id="typescript" label="TypeScript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+let surreal = await builder.addSurrealServer("surreal");
+surreal = await surreal.withLogLevel("Debug");
+
+const ns = await surreal.addNamespace("ns");
+const db = await ns.addDatabase("db");
+
+const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+await exampleProject.withReference(db);
+await exampleProject.waitFor(db);
+
+// After adding all resources, run the app...
+```
+
+</TabItem>
+</Tabs>
+
+The `WithLogLevel` method enables verbose logging in the SurrealDB container, which is useful during development and debugging. The polyglot TypeScript AppHost accepts the log level as a string (for example, `"Trace"`, `"Debug"`, `"Information"`, `"Warning"`, `"Error"`, `"Critical"`, or `"None"`).
 
 ## Health checks
 

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -25,7 +25,7 @@ This article is the reference for the Aspire SurrealDB Hosting integration. It e
 If you're new to the SurrealDB integration, start with the [Get started with SurrealDB integrations](/integrations/databases/surrealdb/surrealdb-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SurrealDB](../surrealdb-connect/).
 
 <Aside type="note">
-  TypeScript AppHost support (`addSurrealServer` and related APIs) is not yet available in the generated `./.aspire/modules/aspire.mjs` SDK. All examples on this page are C# only.
+  The examples on this page use C#. The Community Toolkit also generates TypeScript AppHost bindings for SurrealDB — `addSurrealServer`, `addNamespace`, `addDatabase`, and configuration methods such as `withDataVolume`, `withLogLevel`, and `withSurrealist` — into `./.aspire/modules/aspire.mjs`. In an `apphost.mts`, each call is awaited separately, and because the configuration methods return an updated builder you reassign the variable, for example: `let primary = await builder.addSurrealServer("primary"); primary = await primary.withDataVolume();`.
 </Aside>
 
 ## Installation

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -87,7 +87,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(db)
        .WaitFor(db);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -106,7 +106,7 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(db)
        .WaitFor(db);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -170,7 +170,7 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -197,7 +197,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(db)
        .WaitFor(db);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -218,7 +218,7 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -246,7 +246,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(db)
        .WaitFor(db);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -267,7 +267,7 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>
@@ -296,7 +296,7 @@ builder.AddProject<Projects.ExampleProject>()
        .WithReference(db)
        .WaitFor(db);
 
-// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -317,7 +317,7 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
-// After adding all resources, run the app...
+await builder.build().run();
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -16,6 +16,7 @@ import surrealdbIcon from '@assets/icons/surrealdb-icon.png';
   alt="SurrealDB logo"
   width={100}
   height={100}
+  fit="contain"
   class:list={'float-inline-left icon'}
   data-zoom-off
 />


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is ready for review, but it should be rebased and merged after #1372 because the series relies on the shared mapping and contained-logo guardrails.

## Summary

- Audit all 18 Ollama, KurrentDB, Meilisearch, RavenDB, SQLite, and SurrealDB get-started, host, and connect pages against `CommunityToolkit/Aspire` commit `b9d40479805b74ea20b7dc57cb659d46e6f11c43`.
- Correct runtime, connection, client, and resource-chain guidance, and replace C#-only capability callouts with complete synchronized C# and TypeScript AppHost examples.
- Make every new AppHost example runnable, use language-neutral framing, and preserve the precise source-backed exceptions for APIs that are not exported.
- Keep every integration logo contained and use theme-specific KurrentDB assets so the complete artwork remains visible in light and dark themes.

## Validation

- Verified TypeScript API shapes against the pinned Toolkit source, `[AspireExport]` metadata, and checked-in TypeScript AppHost fixtures.
- Focused page metadata, SEO, and twoslash suites pass: 3 files, 65 tests.
- Combined landing rehearsal passes 8 focused suites, 153 tests, `check-data`, mapping uniqueness, and `git diff --check`.
- Browser audit confirms all 18 routes render and their logos remain contained and legible at desktop/mobile widths in light/dark themes; synchronized AppHost tabs render without console errors.

No local `pnpm build` was run.