### PR TITLE
Add Particular Service Platform integration and fix Official/Community filter

### DIFF
--- a/src/frontend/config/sidebar/integrations.topics.ts
+++ b/src/frontend/config/sidebar/integrations.topics.ts
@@ -1454,6 +1454,10 @@ export const integrationTopics: StarlightSidebarTopicsUserConfig = {
           ],
         },
         {
+          label: 'Particular Service Platform',
+          link: 'https://docs.particular.net/platform/aspire/',
+        },
+        {
           label: 'RabbitMQ',
           collapsed: true,
           items: [

--- a/src/frontend/src/components/Integrations.astro
+++ b/src/frontend/src/components/Integrations.astro
@@ -594,8 +594,8 @@ const sortedIntegrations = visibleIntegrations.sort((a, b) => {
         );
 
       // Official/Community filter
-      const isCommunity = cardTitle.startsWith('communitytoolkit.');
-      const isOfficial = !isCommunity;
+      const isOfficial = cardTitle.startsWith('aspire.');
+      const isCommunity = !isOfficial;
       const matchesSource = (showOfficial || !isOfficial) && (showCommunity || !isCommunity);
 
       // Type filters: hide cards with hosting/client tags when toggled off

--- a/src/frontend/src/data/aspire-integration-names.json
+++ b/src/frontend/src/data/aspire-integration-names.json
@@ -137,5 +137,6 @@
   "CommunityToolkit.Aspire.Minio.Client",
   "CommunityToolkit.Aspire.OllamaSharp",
   "CommunityToolkit.Aspire.RavenDB.Client",
-  "CommunityToolkit.Aspire.SurrealDb"
+  "CommunityToolkit.Aspire.SurrealDb",
+  "Particular.Aspire.Hosting.ServicePlatform"
 ]

--- a/src/frontend/src/data/aspire-integrations.json
+++ b/src/frontend/src/data/aspire-integrations.json
@@ -2859,5 +2859,22 @@
     ],
     "downloads": 18433,
     "version": "13.4.0"
+  },
+  {
+    "title": "Particular.Aspire.Hosting.ServicePlatform",
+    "description": "Particular Service Platform hosting support for Aspire, including ServiceControl, ServicePulse, the ServiceControl database, and message transport.",
+    "icon": "https://api.nuget.org/v3-flatcontainer/particular.aspire.hosting.serviceplatform/1.1.0/icon",
+    "href": "https://www.nuget.org/packages/Particular.Aspire.Hosting.ServicePlatform",
+    "tags": [
+      "aspire",
+      "integration",
+      "hosting",
+      "particular",
+      "nservicebus",
+      "messaging",
+      "eventing"
+    ],
+    "downloads": 420,
+    "version": "1.1.0"
   }
 ]

--- a/src/frontend/src/data/integration-docs.json
+++ b/src/frontend/src/data/integration-docs.json
@@ -550,5 +550,9 @@
   {
     "match": "CommunityToolkit.Aspire.SurrealDb",
     "href": "/integrations/databases/surrealdb/surrealdb-get-started/"
+  },
+  {
+    "match": "Particular.Aspire.Hosting.ServicePlatform",
+    "href": "https://docs.particular.net/platform/aspire/"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds `Particular.Aspire.Hosting.ServicePlatform` to the integrations gallery, sidebar, and doc links
- Fixes the **Official/Community** filter, which only recognized `CommunityToolkit.*` as **Community** and defaulted everything else (including the new `Particular` package) to **Official**. It now classifies by the `Aspire.*` prefix instead, matching the `isOfficialAspirePackage` convention already used elsewhere in the codebase.