### PR TITLE
Document Aspire VS Code AppHost polling setting

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-vscode-extension.mdx
@@ -71,7 +71,7 @@ The Command Palette has commands for the most common tasks:
 
 When an AppHost is running, the extension paints live state directly into your editor.
 
-**CodeLens** appears above each resource definition in C# and TypeScript AppHosts. It shows the current state and health and exposes one-click `Start`, `Stop`, `Restart`, and `View Logs` actions in addition to any custom commands the resource publishes. 
+**CodeLens** appears above each resource definition in C# and TypeScript AppHosts. It shows the current state and health and exposes one-click `Start`, `Stop`, `Restart`, and `View Logs` actions in addition to any custom commands the resource publishes.
 
 **Editor title bar buttons** add **Run Aspire AppHost** and **Debug Aspire AppHost** actions next to the standard Run/Debug buttons whenever you have an AppHost file open.
 
@@ -89,13 +89,17 @@ Aspire registers an AppHost view to VS Code. **Workspace** mode shows the AppHos
 
 Each resource shows its type, state, health summary, and exit code, plus a health-aware icon and a markdown tooltip listing endpoint URLs. Resources with health checks expose an expandable **Health Checks** group; use **Expand all** on the AppHost item to open everything at once. You can right-click a resource to start, stop, or restart it, view its logs, run resource-specific commands, or open the dashboard.
 
+:::note[Renamed polling setting]
+`aspire.globalAppHostsPollingInterval` is deprecated. Use `aspire.appHostsPollingInterval` to configure how often the Aspire view polls for running AppHosts.
+:::
+
 ## Run, debug, and deploy
 
 :::note[Debugging]
 The Aspire Dashboard is no longer opened by default when the AppHost starts, as most operations can be performed using the Aspire view inside VS Code. To launch the dashboard, use the **Open Dashboard** CodeLens, the **Aspire: Open Dashboard** command, or open it from the Aspire view.
 :::
 
-**Aspire: Configure launch.json file** adds a minimal launch configuration `.vscode/launch.json` that supports AppHosts written in any language. AppHosts are discovered automatically in the workspace. 
+**Aspire: Configure launch.json file** adds a minimal launch configuration `.vscode/launch.json` that supports AppHosts written in any language. AppHosts are discovered automatically in the workspace.
 
 <LearnMore>
 To launch a specific AppHost, configure an [aspire.config.json](/reference/cli/configuration/) with an `appHost.path` property.


### PR DESCRIPTION
## Summary

- Document that `aspire.globalAppHostsPollingInterval` is deprecated in favor of `aspire.appHostsPollingInterval`.

## Related

- Follows up on microsoft/aspire#18527.
- Addresses failed docs automation from https://github.com/microsoft/aspire/pull/18527#issuecomment-5027815747.