### PR TITLE
Update "Get started with the RabbitMQ integrations" docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-get-started.mdx
@@ -16,7 +16,7 @@ import rabbitmqIcon from '@assets/icons/rabbitmq-icon.svg';
   data-zoom-off
 />
 
-[RabbitMQ](https://www.rabbitmq.com/) is a reliable, open-source message broker that supports multiple messaging protocols and is easy to deploy on cloud environments, on-premises, and on your local machine. The Aspire RabbitMQ integration lets you model a RabbitMQ server as a first-class resource in your AppHost, then hand the connection information to any consuming app — regardless of language.
+[RabbitMQ](https://www.rabbitmq.com/) is a reliable, open-source message broker that supports multiple messaging protocols and is easy to deploy in cloud environments, on-premises, and on your local machine. The Aspire RabbitMQ integration lets you model a RabbitMQ server as a first-class resource in your AppHost, then hand the connection information to any consuming app — regardless of language.
 
 ## Why use RabbitMQ with Aspire
 
@@ -82,7 +82,14 @@ Getting there is a two-step process: model the RabbitMQ resource in your AppHost
 
 </Steps>
 
+## Use with messaging frameworks
+
+With Aspire managing the RabbitMQ resource and providing connection information, you can layer a higher-level messaging framework on top. These frameworks build on a raw RabbitMQ connection to add capabilities such as message handlers, recoverability, sagas, and transactional outbox support — while Aspire continues to handle the broker lifecycle and connection wiring underneath.
+
+For example, the [Particular Platform Aspire integration](https://docs.particular.net/platform/aspire/) can orchestrate [NServiceBus](https://particular.net/nservicebus) endpoints and supporting Particular Platform components alongside the RabbitMQ resource.
+
 ## See also
 
 - [RabbitMQ documentation](https://www.rabbitmq.com/docs/)
 - [AMQP 0-9-1 protocol overview](https://www.rabbitmq.com/tutorials/amqp-concepts/)
+- [Particular Platform with RabbitMQ in Aspire (sample)](https://docs.particular.net/samples/aspire/platform-rabbitmq/)


### PR DESCRIPTION
* Clarified that RabbitMQ is easy to deploy "in cloud environments" instead of "on cloud environments" for more accurate language.
* Added a new section explaining how Aspire can be used with messaging frameworks, including an example with the Particular Platform Aspire integration and NServiceBus.
* Added a "See also" link to a sample showing how to use Particular Platform with RabbitMQ in Aspire.