### PR TITLE
Update "Get started with the Azure Service Bus integrations" docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-get-started.mdx
@@ -84,7 +84,14 @@ Getting there is a two-step process: model the Service Bus resources in your App
 
 </Steps>
 
+## Use with messaging frameworks
+
+With Aspire managing the Azure Service Bus resource and providing connection information, you can layer a higher-level messaging framework on top. These frameworks build on a raw Service Bus connection to add capabilities such as message handlers, recoverability, sagas, and transactional outbox support — while Aspire continues to handle the resource lifecycle and connection wiring underneath.
+
+For example, the [Particular Platform Aspire integration](https://docs.particular.net/platform/aspire/) can orchestrate [NServiceBus](https://particular.net/nservicebus) endpoints and supporting Particular Platform components alongside the Azure Service Bus resource.
+
 ## See also
 
 - [Azure Service Bus documentation](https://learn.microsoft.com/azure/service-bus-messaging/)
 - [Azure Service Bus Emulator overview](https://learn.microsoft.com/azure/service-bus-messaging/overview-emulator)
+- [Particular Platform with ASB in Aspire (sample)](https://docs.particular.net/samples/aspire/platform-asb/)


### PR DESCRIPTION
* Added a new section explaining how Aspire can be used with messaging frameworks, including an example with the Particular Platform Aspire integration and NServiceBus.
* Added a "See also" link to a sample showing how to use Particular Platform with Azure Service bus in Aspire.