### PR TITLE
Clarify third-party link guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## Summary
+
+<!-- Describe what this pull request changes and why. -->
+
+## Third-party links and affiliations
+
+<!--
+List any third-party links added or changed by this pull request and disclose any
+material affiliation with the linked organizations, such as employment,
+sponsorship, or ownership. Write "None" if this pull request doesn't add or
+change third-party links.
+-->
+
+## Validation
+
+<!-- List the checks you ran or explain why validation isn't needed. -->

--- a/src/frontend/src/content/docs/community/contributor-guide.mdx
+++ b/src/frontend/src/content/docs/community/contributor-guide.mdx
@@ -235,6 +235,16 @@ When contributing to `aspire.dev`, follow these writing guidelines to ensure con
 - **Follow formatting conventions** - Use consistent formatting for code snippets, commands, and technical terms. Refer to the examples in this guide for guidance.
 - **Review existing content** - Before adding new content, review existing documentation to avoid duplication and ensure coherence.
 
+### Third-party links
+
+Third-party links can provide useful context, but they must serve the reader rather than the linked organization:
+
+- Include third-party links only when they are directly relevant, and use them sparingly. Prefer Aspire documentation when it covers the same information.
+- Describe third-party resources factually and neutrally. Avoid endorsements, marketing language, promotional comparisons, and calls to purchase or sign up.
+- Link to technical documentation or other substantive resources, not exclusively to a paid product, pricing, lead-generation, or sales page.
+- Do not add content whose purpose is to promote a product or service that competes with Aspire.
+- Disclose any material affiliation with the linked organization, such as employment, sponsorship, or ownership, in the pull request. An affiliation does not automatically disqualify a link, but the link and surrounding content must meet the same relevance and editorial standards as any other contribution.
+
 ### AppHost-specific C# and TypeScript content
 
 When you are documenting AppHost-specific content that changes between C# and TypeScript, use synced `Tabs` and `TabItem` blocks with `syncKey='aspire-lang'`. Each code snippet should have its own C# and TypeScript selector, and the shared sync key keeps the selected language consistent across the page.

--- a/src/frontend/src/content/docs/community/contributor-guide.mdx
+++ b/src/frontend/src/content/docs/community/contributor-guide.mdx
@@ -237,13 +237,15 @@ When contributing to `aspire.dev`, follow these writing guidelines to ensure con
 
 ### Third-party links
 
-Third-party links can provide useful context, but they must serve the reader rather than the linked organization:
+Third-party links are appropriate when they help readers complete a task or understand a topic. Apply these standards to both authored and generated content:
 
-- Include third-party links only when they are directly relevant, and use them sparingly. Prefer Aspire documentation when it covers the same information.
-- Describe third-party resources factually and neutrally. Avoid endorsements, marketing language, promotional comparisons, and calls to purchase or sign up.
-- Link to technical documentation or other substantive resources, not to paid product marketing, pricing, lead-generation, or other sales-focused pages.
-- Do not add content whose primary purpose is to market or promote a third-party product or service (for example, promotional comparisons positioned against Aspire).
-- Disclose any material affiliation with the linked organization, such as employment, sponsorship, or ownership, in the pull request description (or in a top-level comment). An affiliation does not automatically disqualify a link, but the link and surrounding content must meet the same relevance and editorial standards as any other contribution.
+- **Use links sparingly** - Include third-party links only when they're directly relevant. Prefer Aspire documentation when it covers the same information.
+- **Present resources neutrally** - Describe third-party resources factually. Avoid endorsements, marketing claims, promotional comparisons, and calls to purchase or sign up.
+- **Avoid promotion** - Don't add links or surrounding content whose primary purpose is to market a third-party offering or position it as a preferred replacement for Aspire.
+- **Choose substantive destinations** - Link to technical documentation or other substantive resources. Don't link to product, pricing, lead-generation, or sales pages except as described in the following exceptions.
+- **Allow necessary exceptions** - Prerequisite download or account sign-up pages, pricing or billing references needed for cost planning, and project descriptions or links on attribution and acknowledgment pages are allowed. Keep each exception limited to the context that makes it necessary.
+- **Disclose affiliations** - In the **Third-party links and affiliations** section of the pull request description, disclose any material affiliation with a linked organization, such as employment, sponsorship, or ownership. An affiliation doesn't automatically disqualify a link, but the link and surrounding content must meet the same editorial standards as any other contribution.
+- **Review generated content** - Automated updates and generated catalogs aren't exempt. They may reproduce upstream metadata when that's the catalog's explicit purpose, but the reviewing maintainer must apply the same editorial standards to the surrounding content and linked destinations.
 
 ### AppHost-specific C# and TypeScript content
 

--- a/src/frontend/src/content/docs/community/contributor-guide.mdx
+++ b/src/frontend/src/content/docs/community/contributor-guide.mdx
@@ -241,9 +241,9 @@ Third-party links can provide useful context, but they must serve the reader rat
 
 - Include third-party links only when they are directly relevant, and use them sparingly. Prefer Aspire documentation when it covers the same information.
 - Describe third-party resources factually and neutrally. Avoid endorsements, marketing language, promotional comparisons, and calls to purchase or sign up.
-- Link to technical documentation or other substantive resources, not exclusively to a paid product, pricing, lead-generation, or sales page.
-- Do not add content whose purpose is to promote a product or service that competes with Aspire.
-- Disclose any material affiliation with the linked organization, such as employment, sponsorship, or ownership, in the pull request. An affiliation does not automatically disqualify a link, but the link and surrounding content must meet the same relevance and editorial standards as any other contribution.
+- Link to technical documentation or other substantive resources, not to paid product marketing, pricing, lead-generation, or other sales-focused pages.
+- Do not add content whose primary purpose is to market or promote a third-party product or service (for example, promotional comparisons positioned against Aspire).
+- Disclose any material affiliation with the linked organization, such as employment, sponsorship, or ownership, in the pull request description (or in a top-level comment). An affiliation does not automatically disqualify a link, but the link and surrounding content must meet the same relevance and editorial standards as any other contribution.
 
 ### AppHost-specific C# and TypeScript content
 


### PR DESCRIPTION
## Summary

- Establish clear relevance, neutrality, and non-promotion standards for third-party links.
- Allow necessary prerequisite, cost-planning, attribution, acknowledgment, and generated-catalog uses.
- Require affiliation disclosure and add a pull request template section where contributors can provide it.

## Third-party links and affiliations

None. This pull request doesn't add or change third-party links.

## Validation

- `pnpm --dir ./src/frontend run test:unit:docs`
- Prettier check for `.github/PULL_REQUEST_TEMPLATE.md`
- `git diff --check`