### PR TITLE
[auto-sec] Fix brace-expansion GHSA-mh99-v99m-4gvg in aspire.dev frontend

### DIFF
--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   '@anthropic-ai/claude-code@<2.0.31': '>=2.0.31'
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: 8.18.0
-  brace-expansion@<5.0.7: '>=5.0.7'
+  brace-expansion@<5.0.8: '>=5.0.8'
   devalue@<5.6.4: '>=5.6.4'
   dompurify@<3.4.12: '>=3.4.12'
   esbuild@<0.28.1: '>=0.28.1'
@@ -1969,8 +1969,8 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -6057,7 +6057,7 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7704,7 +7704,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 

--- a/src/frontend/pnpm-workspace.yaml
+++ b/src/frontend/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ overrides:
   '@anthropic-ai/claude-code@<2.0.31': '>=2.0.31'
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: 8.18.0
-  brace-expansion@<5.0.7: '>=5.0.7'
+  brace-expansion@<5.0.8: '>=5.0.8'
   devalue@<5.6.4: '>=5.6.4'
   dompurify@<3.4.12: '>=3.4.12'
   esbuild@<0.28.1: '>=0.28.1'


### PR DESCRIPTION
## [auto-sec] Fix brace-expansion GHSA-mh99-v99m-4gvg in aspire.dev frontend

**Last refreshed:** 2026-07-31
**Branch rebased on:** upstream `microsoft/aspire.dev` `main` (2026-07-31)
**Canonical PR for cluster:** `aspire-dev-lowrisk-batch`

---

### Alerts addressed

| Package | Advisory | Severity | Status | Fix |
|---------|----------|----------|--------|-----|
| `brace-expansion` | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) · [alert #106](https://github.com/microsoft/aspire.dev/security/dependabot/106) | High | ✅ Fixed | Pinned to `5.0.8` in `pnpm-lock.yaml` |

**Advisory:** brace-expansion DoS — unbounded expansion length causes an out-of-memory process crash.

---

### Changes

- `src/frontend/pnpm-workspace.yaml`: override `brace-expansion@<5.0.8: '>=5.0.8'`.
- `src/frontend/pnpm-lock.yaml`: `brace-expansion` pinned `5.0.7 → 5.0.8` (integrity `sha512-JZyDyq3D4A…`); `balanced-match` unchanged (`4.0.4`).

Surgical 4-line lockfile change — no other transitive versions touched.

---

### Verification

- ✅ `brace-expansion@5.0.8` is now published to the configured feed; the lockfile pins it, so the alert clears on merge.
- ✅ Integrity hash validated via `npm pack brace-expansion@5.0.8` (matches the lock).
- ✅ Lockfile remains `--frozen-lockfile` consistent — only a transitive version bump forced by the pre-existing override; no importer/manifest changes.
- ✅ Rebased cleanly on latest upstream `main`.

---

### Related / non-overlapping PRs

- Dependabot **#1414** (`Bump the npm-all group … 11 updates`) is a **routine, non-security** batch (astro, eslint, typescript, prettier, …). It does **not** include `brace-expansion`, so there is **no security overlap** with this canonical PR and it is intentionally left independent.

---

### Canonical PR identity

- Branch: `dapire/security-deps/aspire-dev-lowrisk-batch`
- Label: `automated-security`
- Cluster: `aspire-dev-lowrisk-batch`
- Exactly one `[auto-sec]` PR for this cluster.
