### PR TITLE
Pin compromised Keyv ecosystem releases

### DIFF
--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -6,16 +6,27 @@ settings:
 
 overrides:
   '@anthropic-ai/claude-code@<2.0.31': '>=2.0.31'
+  '@cacheable/memory@2.2.1': 2.2.0
+  '@cacheable/net@2.1.1': 2.1.0
+  '@cacheable/node-cache@3.1.2': 3.1.1
+  '@cacheable/utils@2.5.1': 2.5.0
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: 8.18.0
   brace-expansion@<5.0.8: '>=5.0.8'
+  cache-manager@7.2.10: 7.2.9
+  cacheable-request@13.0.20: 13.0.19
+  cacheable@2.5.1: 2.5.0
   devalue@<5.6.4: '>=5.6.4'
   dompurify@<3.4.12: '>=3.4.12'
+  ecto@5.0.1: 5.0.0
   esbuild@<0.28.1: '>=0.28.1'
   fast-xml-builder@<1.1.7: '>=1.1.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
+  file-entry-cache@11.1.6: 11.1.5
+  flat-cache@6.1.24: 6.1.23
   flatted@<3.4.2: '>=3.4.2'
   h3@<1.15.9: '>=1.15.9'
+  keyv@6.0.0: 5.6.0
   lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
   minimatch@<10.2.3: '>=10.2.3'

--- a/src/frontend/pnpm-workspace.yaml
+++ b/src/frontend/pnpm-workspace.yaml
@@ -25,16 +25,27 @@ peerDependencyRules:
 
 overrides:
   '@anthropic-ai/claude-code@<2.0.31': '>=2.0.31'
+  '@cacheable/memory@2.2.1': 2.2.0
+  '@cacheable/net@2.1.1': 2.1.0
+  '@cacheable/node-cache@3.1.2': 3.1.1
+  '@cacheable/utils@2.5.1': 2.5.0
   ajv@<6.14.0: 6.14.0
   ajv@>=7.0.0-alpha.0 <8.18.0: 8.18.0
   brace-expansion@<5.0.8: '>=5.0.8'
+  cache-manager@7.2.10: 7.2.9
+  cacheable-request@13.0.20: 13.0.19
+  cacheable@2.5.1: 2.5.0
   devalue@<5.6.4: '>=5.6.4'
   dompurify@<3.4.12: '>=3.4.12'
+  ecto@5.0.1: 5.0.0
   esbuild@<0.28.1: '>=0.28.1'
   fast-xml-builder@<1.1.7: '>=1.1.7'
   fast-xml-parser@<5.7.0: '>=5.7.0'
+  file-entry-cache@11.1.6: 11.1.5
+  flat-cache@6.1.24: 6.1.23
   flatted@<3.4.2: '>=3.4.2'
   h3@<1.15.9: '>=1.15.9'
+  keyv@6.0.0: 5.6.0
   lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
   lodash@>=4.0.0 <=4.17.22: '>=4.17.23'
   minimatch@<10.2.3: '>=10.2.3'


### PR DESCRIPTION
## Summary

Snyk reported an active npm supply-chain compromise affecting 11 releases in the Keyv/Cacheable ecosystem. Aspire.dev does not currently resolve any affected version: its dependency tree remains on `file-entry-cache@8.0.0`, `flat-cache@4.0.1`, and `keyv@4.5.4`.

This adds exact, version-scoped pnpm overrides for each malicious release. The selectors only replace the compromised versions with Snyk's last-known-good versions, so they do not force incompatible upgrades of the existing dependency tree.

The exposure check found 0 malicious resolutions in the tracked lockfiles, 0 malicious versions or install hooks in the checked installs, and 0 payload or persistence indicators at Snyk's documented locations.

## Third-party links and affiliations

- [Snyk's investigation of the Keyv npm compromise](https://snyk.io/blog/inside-keyv-npm-compromise-preinstall-malware-trusted-provenance-ide-hooks/)

No material affiliation.

## Validation

- Ran pnpm 11.9.0 with `install --frozen-lockfile --ignore-scripts --offline`
- Verified all 11 overrides are present in the workspace and lockfile
- Verified no malicious release is resolved
- Verified the installed tree remains `file-entry-cache@8.0.0` -> `flat-cache@4.0.1` -> `keyv@4.5.4`, with no `preinstall` hooks
- Verified `allowBuilds` remains restricted to `esbuild` and `sharp`
