### PR TITLE
Clarify trusted repository guidance for Aspire CLI

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/overview.mdx
+++ b/src/frontend/src/content/docs/reference/cli/overview.mdx
@@ -9,6 +9,10 @@ import LearnMore from '@components/LearnMore.astro';
 
 The Aspire CLI (`aspire` command) is a cross-platform tool that provides command-line functionality to create, manage, run, and publish multi-language Aspire projects. Use the Aspire CLI to streamline development workflows and coordinate services for distributed applications.
 
+:::caution[Use trusted repositories]
+Only run Aspire CLI commands from repositories and directories that you trust.
+:::
+
 <Aside type="note">
   Starting with Aspire 13.0, the Aspire CLI requires .NET SDK version 10.0.100
   or later. Ensure that you have the appropriate .NET SDK installed to use the


### PR DESCRIPTION
## Summary

Clarifies general Aspire CLI usage guidance with a prominent caution to run commands only from trusted repositories and directories.

## Third-party links and affiliations

None.

## Validation

- Repository Prettier check for `src/content/docs/reference/cli/overview.mdx`
- `tests/unit/filetree-format.vitest.test.ts` (2 tests passed)