### PR TITLE
Harden API data generation and fix C# deep links

### DIFF
--- a/.github/forbidden-words.json
+++ b/.github/forbidden-words.json
@@ -19,9 +19,9 @@
       "message": "Use \"Aspire\" instead of \"dotnet aspire\"."
     },
     {
-      "pattern": "\\bapp hosts\\b",
+      "pattern": "(?<=polyglot )\\bapp hosts\\b",
       "replacement": "AppHosts",
-      "message": "Use \"AppHosts\" instead of \"app hosts\"."
+      "message": "Use \"polyglot AppHosts\" instead of \"polyglot app hosts\"."
     },
     {
       "pattern": "\\bapp host\\b",

--- a/.github/forbidden-words.json
+++ b/.github/forbidden-words.json
@@ -19,6 +19,11 @@
       "message": "Use \"Aspire\" instead of \"dotnet aspire\"."
     },
     {
+      "pattern": "\\bapp hosts\\b",
+      "replacement": "AppHosts",
+      "message": "Use \"AppHosts\" instead of \"app hosts\"."
+    },
+    {
       "pattern": "\\bapp host\\b",
       "replacement": "AppHost",
       "message": "Use \"AppHost\" instead of \"app host\"."

--- a/.github/workflows/update-integration-data.yml
+++ b/.github/workflows/update-integration-data.yml
@@ -211,6 +211,7 @@ jobs:
             echo "- Changed: \`${{ steps.update.outputs.changed || 'unknown' }}\`"
             echo "- Versions changed: \`${{ steps.update.outputs.versions_changed || 'n/a' }}\`"
             echo "- API regen ran: \`${{ steps.update.outputs.regen_ran || 'n/a' }}\`"
+            echo "- Semantic validation: \`${{ steps.update.outputs.semantic_validation || 'not run' }}\`"
             if [ -n "${{ steps.update.outputs.icon_warnings }}" ]; then
               echo "- Icon warnings: \`${{ steps.update.outputs.icon_warnings }}\`"
             fi

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -55,7 +55,8 @@
     "update:ts-api": "tsx ./scripts/update-ts-api.ts",
     "update:github-stats": "tsx ./scripts/update-github-stats.ts",
     "update:samples": "tsx ./scripts/update-samples.ts",
-    "normalize:api-data": "tsx ./scripts/normalize-generated-api-data.ts"
+    "normalize:api-data": "tsx ./scripts/normalize-generated-api-data.ts",
+    "validate:api-data": "tsx ./scripts/validate-generated-api-data.ts"
   },
   "dependencies": {
     "@astro-community/astro-embed-vimeo": "^0.3.12",

--- a/src/frontend/scripts/aspire-terminology.ts
+++ b/src/frontend/scripts/aspire-terminology.ts
@@ -54,7 +54,7 @@ const terminologyRules: readonly TerminologyRule[] = [
     article: 'an',
   },
   {
-    term: String.raw`app${horizontalWhitespace}hosts`,
+    term: String.raw`(?<=polyglot${horizontalWhitespace})app${horizontalWhitespace}hosts`,
     replacement: 'AppHosts',
   },
   {

--- a/src/frontend/scripts/aspire-terminology.ts
+++ b/src/frontend/scripts/aspire-terminology.ts
@@ -54,6 +54,10 @@ const terminologyRules: readonly TerminologyRule[] = [
     article: 'an',
   },
   {
+    term: String.raw`app${horizontalWhitespace}hosts`,
+    replacement: 'AppHosts',
+  },
+  {
     term: String.raw`app${horizontalWhitespace}host`,
     replacement: 'AppHost',
   },

--- a/src/frontend/scripts/generate-twoslash-types.ts
+++ b/src/frontend/scripts/generate-twoslash-types.ts
@@ -8,15 +8,21 @@
  * after regenerating).
  */
 
-import { readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const MODULES_DIR = resolve(__dirname, '..', 'src', 'data', 'ts-modules');
-const PKGS_DIR = resolve(__dirname, '..', 'src', 'data', 'pkgs');
-const OUTPUT_DIR = resolve(__dirname, '..', 'src', 'data', 'twoslash');
-const OUTPUT_FILE = resolve(OUTPUT_DIR, 'aspire.d.ts');
+const MODULES_DIR = process.env.ASPIRE_API_TS_MODULES_DIR
+  ? resolve(process.env.ASPIRE_API_TS_MODULES_DIR)
+  : resolve(__dirname, '..', 'src', 'data', 'ts-modules');
+const PKGS_DIR = process.env.ASPIRE_API_PKGS_DIR
+  ? resolve(process.env.ASPIRE_API_PKGS_DIR)
+  : resolve(__dirname, '..', 'src', 'data', 'pkgs');
+const OUTPUT_FILE = process.env.ASPIRE_API_TWOSLASH_FILE
+  ? resolve(process.env.ASPIRE_API_TWOSLASH_FILE)
+  : resolve(__dirname, '..', 'src', 'data', 'twoslash', 'aspire.d.ts');
+const OUTPUT_DIR = dirname(OUTPUT_FILE);
 
 interface Parameter {
   name: string;
@@ -43,6 +49,7 @@ interface FunctionEntry {
 interface DtoField {
   name: string;
   type: string;
+  isOptional?: boolean;
 }
 
 interface DtoType {
@@ -65,6 +72,7 @@ interface HandleType {
   kind: 'handle';
   exposeProperties?: boolean;
   implementedInterfaces?: string[];
+  baseTypeHierarchy?: string[];
   capabilities?: FunctionEntry[];
 }
 
@@ -78,6 +86,7 @@ interface ModuleJson {
 
 interface PkgTypeEntry {
   name: string;
+  fullName: string;
   kind: string;
   baseType?: string;
 }
@@ -96,6 +105,10 @@ function lastDotted(id: string): string {
   const afterSlash = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
   const parts = afterSlash.split('.');
   return parts[parts.length - 1];
+}
+
+function withoutAssemblyPrefix(id: string): string {
+  return id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
 }
 
 function cleanType(raw: string | undefined): string {
@@ -282,6 +295,7 @@ function optionsOverloadSplit(fnName: string, params: Parameter[]): number {
   }
   if (firstOpt < 0) return -1;
   const tail = params.slice(firstOpt);
+  if (tail.length === 1 && tail[0].name === 'options') return -1;
   const minTail = /^(add|with|publish)[A-Z0-9]/.test(fnName) ? 1 : 2;
   if (tail.length < minTail) return -1;
   // `with*` methods that take a callback (e.g. `withPgAdmin(configureContainer?)`)
@@ -324,25 +338,26 @@ const modules: ModuleJson[] = files.map(
 
 console.log(`📚 Loaded ${modules.length} module JSON files`);
 
-// Load class-inheritance metadata from the richer pkgs/*.json dumps. The
-// ts-modules JSON captures implemented interfaces but not class-level `extends`,
-// so resource types like ViteAppResource lose inherited methods such as
-// publishAsDockerFile. Map each class short-name to its base class short-name.
-const classBaseByName = new Map<string, string>();
-try {
+// Load class-inheritance metadata from the richer pkgs/*.json dumps. Older
+// ts-modules snapshots omitted BaseTypeHierarchy, so this remains the fallback.
+// Key by full type name: short names are not unique across integration packages.
+const classBaseByFullName = new Map<string, string>();
+if (existsSync(PKGS_DIR)) {
   const pkgFiles = readdirSync(PKGS_DIR).filter((f) => f.endsWith('.json'));
   for (const f of pkgFiles) {
     const pkg = JSON.parse(readFileSync(resolve(PKGS_DIR, f), 'utf8')) as PkgJson;
     for (const t of pkg.types ?? []) {
       if (t.kind !== 'class' || !t.baseType) continue;
-      const base = lastDotted(t.baseType).split('<')[0];
-      if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(base)) continue;
-      if (!classBaseByName.has(t.name)) classBaseByName.set(t.name, base);
+      const existing = classBaseByFullName.get(t.fullName);
+      if (existing && existing !== t.baseType) {
+        throw new Error(
+          `Conflicting base types for ${t.fullName}: ${existing} and ${t.baseType}`
+        );
+      }
+      classBaseByFullName.set(t.fullName, t.baseType);
     }
   }
-  console.log(`   + ${classBaseByName.size} class-inheritance links from pkgs/`);
-} catch {
-  // pkgs directory is optional — older snapshots may not include it.
+  console.log(`   + ${classBaseByFullName.size} class-inheritance links from pkgs/`);
 }
 
 // ---------- collect ----------
@@ -354,11 +369,6 @@ const handleTypes: HandleType[] = [];
 const handleByName = new Map<string, HandleType>();
 const dtoByName = new Map<string, DtoType>();
 const enumByName = new Map<string, EnumType>();
-// Track which package each handle originates from, so we can decide whether
-// to inject a ContainerResource base (integration packages ship container-backed
-// resources whose .NET class extends ContainerResource, but the JSON dump only
-// lists implemented interfaces — no class inheritance).
-const handlePackage = new Map<string, string>();
 
 // target short name -> methods
 const methodsByTarget = new Map<string, FunctionEntry[]>();
@@ -383,7 +393,9 @@ export declare function refExpr(strings: TemplateStringsArray, ...values: unknow
 ];
 
 const POST_SNAPSHOT_DECLARATIONS = [
-  `/**
+  {
+    name: 'InputType',
+    declaration: `/**
  * Enum Aspire.Hosting.ApplicationModel.InputType
  */
 export type InputType = "Text" | "Number" | "Choice" | "SecretText";
@@ -393,28 +405,35 @@ export declare const InputType: {
   readonly Choice: "Choice";
   readonly SecretText: "SecretText";
 };`,
-  `export interface ParameterCustomInputOptions {
+  },
+  {
+    name: 'ParameterCustomInputOptions',
+    declaration: `export interface ParameterCustomInputOptions {
   inputType?: InputType;
   label?: string;
   placeholder?: string;
   options?: Record<string, string>;
 }`,
-  `export interface BeforePublishEvent extends IDistributedApplicationEvent {
+  },
+  {
+    name: 'BeforePublishEvent',
+    declaration: `export interface BeforePublishEvent extends IDistributedApplicationEvent {
   model: PropertyAccessor<DistributedApplicationModel>;
   services: PropertyAccessor<IServiceProvider>;
 }`,
-  `export interface AfterPublishEvent extends IDistributedApplicationEvent {
+  },
+  {
+    name: 'AfterPublishEvent',
+    declaration: `export interface AfterPublishEvent extends IDistributedApplicationEvent {
   model: PropertyAccessor<DistributedApplicationModel>;
   services: PropertyAccessor<IServiceProvider>;
 }`,
+  },
 ];
 
-const POST_SNAPSHOT_DECLARATION_TYPE_NAMES = new Set([
-  'BeforePublishEvent',
-  'AfterPublishEvent',
-  'InputType',
-  'ParameterCustomInputOptions',
-]);
+const POST_SNAPSHOT_DECLARATION_TYPE_NAMES = new Set(
+  POST_SNAPSHOT_DECLARATIONS.map(({ name }) => name)
+);
 
 const POST_SNAPSHOT_AUGMENTATIONS = [
   `export interface IDistributedApplicationBuilder {
@@ -508,7 +527,6 @@ for (const mod of modules) {
     if (!handleByName.has(h.name)) {
       handleByName.set(h.name, h);
       handleTypes.push(h);
-      handlePackage.set(h.name, mod.package.name);
     }
   }
 
@@ -633,12 +651,8 @@ const BUILT_IN = new Set([
 ]);
 
 const declaredTypes = new Set<string>([
-  ...dtoTypes
-    .filter((d) => !POST_SNAPSHOT_DECLARATION_TYPE_NAMES.has(d.name))
-    .map((d) => d.name),
-  ...enumTypes
-    .filter((e) => !POST_SNAPSHOT_DECLARATION_TYPE_NAMES.has(e.name))
-    .map((e) => e.name),
+  ...dtoTypes.map((d) => d.name),
+  ...enumTypes.map((e) => e.name),
   ...handleTypes.map((h) => h.name),
   ...methodsByTarget.keys(),
   ...POST_SNAPSHOT_DECLARATION_TYPE_NAMES,
@@ -672,12 +686,17 @@ parts.push(`  set(key: string, value: unknown): Promise<void>;`);
 parts.push(`};`);
 parts.push(``);
 parts.push(`// ---- enums ----`);
-for (const declaration of POST_SNAPSHOT_DECLARATIONS) {
+const generatedDeclarationTypeNames = new Set([
+  ...dtoTypes.map((dto) => dto.name),
+  ...enumTypes.map((enumType) => enumType.name),
+  ...handleTypes.map((handle) => handle.name),
+]);
+for (const { name, declaration } of POST_SNAPSHOT_DECLARATIONS) {
+  if (generatedDeclarationTypeNames.has(name)) continue;
   parts.push(declaration);
   parts.push('');
 }
 for (const en of enumTypes) {
-  if (POST_SNAPSHOT_DECLARATION_TYPE_NAMES.has(en.name)) continue;
   parts.push(jsdoc([`Enum ${en.fullName}`]));
   const members = en.members.map((m) => JSON.stringify(m)).join(' | ') || 'string';
   parts.push(`export type ${en.name} = ${members};`);
@@ -694,40 +713,20 @@ for (const en of enumTypes) {
 
 parts.push(`// ---- DTOs ----`);
 for (const dto of dtoTypes) {
-  if (POST_SNAPSHOT_DECLARATION_TYPE_NAMES.has(dto.name)) continue;
   parts.push(jsdoc([`DTO ${dto.fullName}`]));
   parts.push(`export interface ${dto.name} {`);
   for (const f of dto.fields) {
     const t = cleanType(f.type);
     extractTypeIdentifiers(t, referencedTypes);
     scanExprForGenerics(t);
-    parts.push(`  ${camelCase(f.name)}: ${t};`);
+    const optional = f.isOptional ? '?' : '';
+    parts.push(`  ${camelCase(f.name)}${optional}: ${t};`);
   }
   parts.push(`}`);
   parts.push('');
 }
 
 parts.push(`// ---- handle types ----`);
-// Integration packages whose resources are NOT container-backed. Resources
-// from these packages implement the same IComputeResource/IResourceWithArgs/
-// IResourceWithEndpoints trio that container-backed resources do, but their
-// .NET class does not derive from ContainerResource — so we must not inject
-// it into the TS extends clause.
-const NON_CONTAINER_PACKAGES = new Set([
-  'Aspire.Hosting', // core primitives (ProjectResource, ExecutableResource, ...)
-  'Aspire.Hosting.JavaScript',
-  'Aspire.Hosting.Python',
-  'Aspire.Hosting.DevTunnels',
-  'Aspire.Hosting.Maui',
-]);
-// Specific handles to exclude even if their package is container-friendly.
-// AzureFunctionsProjectResource is a project handle that lives in the Functions
-// package alongside the Storage emulator (which IS container-backed).
-const NON_CONTAINER_HANDLES = new Set([
-  'AzureFunctionsProjectResource',
-  'AzurePromptAgentResource',
-]);
-
 const EXTRA_HANDLE_MEMBERS: Record<string, string[]> = {
   AzureResourceInfrastructure: [
     '  /** Gets the provisionable Azure resources produced by the infrastructure callback. */',
@@ -739,17 +738,22 @@ const EXTRA_HANDLE_MEMBERS: Record<string, string[]> = {
   ],
 };
 
-function isContainerBacked(h: HandleType): boolean {
-  if (h.name === 'ContainerResource') return false;
-  if (NON_CONTAINER_HANDLES.has(h.name)) return false;
-  const pkg = handlePackage.get(h.name);
-  if (pkg && NON_CONTAINER_PACKAGES.has(pkg)) return false;
-  const ifaces = new Set((h.implementedInterfaces ?? []).map((i) => lastDotted(i).split('<')[0]));
-  return (
-    ifaces.has('IComputeResource') &&
-    ifaces.has('IResourceWithArgs') &&
-    ifaces.has('IResourceWithEndpoints')
-  );
+function getBaseTypeHierarchy(h: HandleType): string[] {
+  if ((h.baseTypeHierarchy?.length ?? 0) > 0) {
+    return h.baseTypeHierarchy!;
+  }
+
+  const hierarchy: string[] = [];
+  const seen = new Set<string>([h.fullName]);
+  let ancestor = classBaseByFullName.get(h.fullName);
+  while (ancestor) {
+    const identity = withoutAssemblyPrefix(ancestor);
+    if (seen.has(identity)) break;
+    seen.add(identity);
+    hierarchy.push(identity);
+    ancestor = classBaseByFullName.get(identity);
+  }
+  return hierarchy;
 }
 
 for (const h of handleTypes) {
@@ -758,23 +762,16 @@ for (const h of handleTypes) {
     .map((i) => i.split('<')[0])
     .filter((i) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(i) && i !== h.name);
   const uniqueParents = [...new Set(parents)];
-  if (isContainerBacked(h) && !uniqueParents.includes('ContainerResource')) {
-    // Put ContainerResource first so chains like `.withImageTag(...).withLifetime(...)`
-    // resolve to inherited members before the marker interfaces contribute noise.
-    uniqueParents.unshift('ContainerResource');
-  }
-  // Chase the class-inheritance chain so methods defined on a parent class
-  // (e.g. publishAsDockerFile on ExecutableResource) are visible on subclasses
-  // (e.g. ViteAppResource). The ts-modules dump only lists implemented
-  // interfaces, so without this step subclasses lose inherited members.
-  let ancestor = classBaseByName.get(h.name);
-  const seen = new Set<string>([h.name]);
-  while (ancestor && !seen.has(ancestor)) {
-    seen.add(ancestor);
-    if (handleByName.has(ancestor) && !uniqueParents.includes(ancestor)) {
-      uniqueParents.unshift(ancestor);
+
+  for (const ancestor of getBaseTypeHierarchy(h)) {
+    const ancestorName = cleanType(ancestor).split('<')[0];
+    if (
+      ancestorName !== h.name &&
+      handleByName.has(ancestorName) &&
+      !uniqueParents.includes(ancestorName)
+    ) {
+      uniqueParents.unshift(ancestorName);
     }
-    ancestor = classBaseByName.get(ancestor);
   }
   const implementsClause = uniqueParents.length > 0 ? ` extends ${uniqueParents.join(', ')}` : '';
   for (const i of uniqueParents) referencedTypes.add(i);

--- a/src/frontend/scripts/normalize-generated-api-data.ts
+++ b/src/frontend/scripts/normalize-generated-api-data.ts
@@ -48,9 +48,10 @@ export const TS_MODULES_DIR = path.join(DATA_DIR, 'ts-modules');
 // left intact, hence the kind gating below. `description`/`returns`/`remarks`
 // are always prose (and appear as string values only in the TS API + member
 // summaries; the C# doc arrays open with `[` and are skipped, their inner text
-// nodes handled by the `text` rule).
+// nodes handled by the `text` rule). `Reason` is the prose payload of
+// `AspireExportIgnoreAttribute`.
 const nodeLine =
-  /^[ \t]*"kind"[ \t]*:[ \t]*"([^"]*)"|^([ \t]*")(text|description|returns|remarks)("[ \t]*:[ \t]*")((?:[^"\\]|\\.)*)(")/gm;
+  /^[ \t]*"kind"[ \t]*:[ \t]*"([^"]*)"|^([ \t]*")(text|description|returns|remarks|Reason)("[ \t]*:[ \t]*")((?:[^"\\]|\\.)*)(")/gm;
 
 /**
  * Rewrite deprecated Aspire terminology in the prose fields of a generated API

--- a/src/frontend/scripts/normalize-generated-api-data.ts
+++ b/src/frontend/scripts/normalize-generated-api-data.ts
@@ -135,10 +135,20 @@ function main(): void {
   const explicit = args.includes('--pkgs') || args.includes('--ts-modules');
   const targets: Array<{ label: string; dir: string }> = [];
   if (!explicit || args.includes('--pkgs')) {
-    targets.push({ label: 'pkgs', dir: PKGS_DIR });
+    targets.push({
+      label: 'pkgs',
+      dir: process.env.ASPIRE_API_PKGS_DIR
+        ? path.resolve(process.env.ASPIRE_API_PKGS_DIR)
+        : PKGS_DIR,
+    });
   }
   if (!explicit || args.includes('--ts-modules')) {
-    targets.push({ label: 'ts-modules', dir: TS_MODULES_DIR });
+    targets.push({
+      label: 'ts-modules',
+      dir: process.env.ASPIRE_API_TS_MODULES_DIR
+        ? path.resolve(process.env.ASPIRE_API_TS_MODULES_DIR)
+        : TS_MODULES_DIR,
+    });
   }
 
   let total = 0;

--- a/src/frontend/scripts/update-integration-data.ps1
+++ b/src/frontend/scripts/update-integration-data.ps1
@@ -19,8 +19,10 @@
            a. generate-package-json.ps1  -> src/data/pkgs/*.json (C# API)
            b. pnpm update:ts-api         -> src/data/ts-modules/*.json (TS API)
                                             + chains twoslash aspire.d.ts bundle
-      4. Scope check — the working tree must only contain allowed data files.
-      5. Emits a summary + PR title/body. In CI, writes step outputs to
+      4. Semantic validation — cross-checks generated identities, provenance,
+         DTO optionality, inheritance, options shapes, and attribute payloads.
+      5. Scope check — the working tree must only contain allowed data files.
+      6. Emits a summary + PR title/body. In CI, writes step outputs to
          $GITHUB_OUTPUT and the PR body to a file; locally prints a summary.
 
     Exit codes:
@@ -28,9 +30,8 @@
       1  a required phase failed (update:all, TS API regen, out-of-scope diff).
          The caller must NOT open a PR on a non-zero exit.
 
-    Per-package failures inside generate-package-json.ps1 are tolerated (they
-    are common for meta-packages without a public API surface); their counts are
-    reported in the PR body but do not fail the run.
+    Packages without a public API surface are reported as explicit skips. Any
+    generation failure or semantic validation error fails the run.
 
 .PARAMETER SkipRegen
     Skip the API-reference regeneration phase even when versions changed. Useful
@@ -79,6 +80,9 @@ $AllowedPaths = @(
 )
 
 $IsCI = [bool]$env:GITHUB_ACTIONS
+$script:ApiStageRoot = $null
+$script:PreserveApiStage = $false
+$script:PreviousApiEnvironment = @{}
 
 function Write-Section([string]$Text) {
     Write-Host ""
@@ -124,6 +128,128 @@ function Test-PathAllowed {
     return $false
 }
 
+function Restore-ApiEnvironment {
+    foreach ($name in @(
+        'ASPIRE_API_PKGS_DIR',
+        'ASPIRE_API_TS_MODULES_DIR',
+        'ASPIRE_API_TWOSLASH_FILE'
+    )) {
+        $previousValue = $script:PreviousApiEnvironment[$name]
+        if ($null -eq $previousValue) {
+            Remove-Item "Env:$name" -ErrorAction SilentlyContinue
+        }
+        else {
+            Set-Item "Env:$name" $previousValue
+        }
+    }
+}
+
+function Remove-ApiStage {
+    Restore-ApiEnvironment
+    if ($script:ApiStageRoot -and (Test-Path $script:ApiStageRoot)) {
+        if ($script:PreserveApiStage) {
+            Write-Warning "Preserving API generation recovery data at $($script:ApiStageRoot)."
+        }
+        else {
+            Remove-Item -Path $script:ApiStageRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+    $script:ApiStageRoot = $null
+    $script:PreserveApiStage = $false
+}
+
+function Stop-ApiRegeneration {
+    param([Parameter(Mandatory)][string]$Message)
+
+    Remove-ApiStage
+    Write-Host $Message -ForegroundColor Red
+    exit 1
+}
+
+function Publish-GeneratedApiData {
+    param(
+        [Parameter(Mandatory)][string]$PackageSource,
+        [Parameter(Mandatory)][string]$ModuleSource,
+        [Parameter(Mandatory)][string]$TwoslashSource
+    )
+
+    $moves = @(
+        [PSCustomObject]@{
+            Source = $PackageSource
+            Destination = Join-Path $DataDir 'pkgs'
+            Backup = Join-Path $script:ApiStageRoot 'backup-pkgs'
+        },
+        [PSCustomObject]@{
+            Source = $ModuleSource
+            Destination = Join-Path $DataDir 'ts-modules'
+            Backup = Join-Path $script:ApiStageRoot 'backup-ts-modules'
+        },
+        [PSCustomObject]@{
+            Source = $TwoslashSource
+            Destination = Join-Path $DataDir 'twoslash' 'aspire.d.ts'
+            Backup = Join-Path $script:ApiStageRoot 'backup-aspire.d.ts'
+        }
+    )
+    $completed = [System.Collections.Generic.List[object]]::new()
+
+    try {
+        foreach ($move in $moves) {
+            if (-not (Test-Path $move.Source)) {
+                throw "Staged API artifact is missing: $($move.Source)"
+            }
+            if (-not (Test-Path $move.Destination)) {
+                throw "Published API artifact is missing: $($move.Destination)"
+            }
+            if (Test-Path $move.Backup) {
+                throw "API recovery path already exists: $($move.Backup)"
+            }
+        }
+
+        foreach ($move in $moves) {
+            Move-Item -LiteralPath $move.Destination -Destination $move.Backup
+            $completed.Add($move)
+            Move-Item -LiteralPath $move.Source -Destination $move.Destination
+        }
+    }
+    catch {
+        $publishError = $_
+        $rollbackErrors = [System.Collections.Generic.List[string]]::new()
+        for ($index = $completed.Count - 1; $index -ge 0; $index--) {
+            $move = $completed[$index]
+            try {
+                if (Test-Path $move.Destination) {
+                    if (Test-Path $move.Source) {
+                        throw "Staged path already exists: $($move.Source)"
+                    }
+                    Move-Item -LiteralPath $move.Destination -Destination $move.Source
+                }
+            }
+            catch {
+                $rollbackErrors.Add("$($move.Destination) -> $($move.Source): $_")
+            }
+
+            try {
+                if (Test-Path $move.Backup) {
+                    if (Test-Path $move.Destination) {
+                        throw "Destination is still occupied: $($move.Destination)"
+                    }
+                    Move-Item -LiteralPath $move.Backup -Destination $move.Destination
+                }
+            }
+            catch {
+                $rollbackErrors.Add("$($move.Backup) -> $($move.Destination): $_")
+            }
+        }
+
+        if ($rollbackErrors.Count -gt 0) {
+            $script:PreserveApiStage = $true
+            throw "Publishing failed: $publishError Rollback was incomplete: $($rollbackErrors -join '; '). Recovery data remains under $($script:ApiStageRoot)."
+        }
+
+        throw "Publishing failed: $publishError The original generated data was restored."
+    }
+}
+
 # ── Phase 1: data update ────────────────────────────────────────────────────
 Write-Section 'Phase 1 — pnpm update:all'
 Push-Location $FrontendDir
@@ -166,6 +292,7 @@ if (-not $anyChanges) {
     Set-Output 'changed' 'false'
     Set-Output 'versions_changed' 'false'
     Set-Output 'regen_ran' 'false'
+    Set-Output 'semantic_validation' 'not run'
     exit 0
 }
 
@@ -229,23 +356,59 @@ else {
 # ── Phase 3: conditional API-reference regeneration ─────────────────────────
 $regenRan = $false
 $pkgSummary = ''
+$pkgSkippedPackages = ''
 $tsApiSummary = ''
+$tsSkippedPackages = ''
 $twoslashSummary = ''
+$semanticSummary = ''
 
 if ($versionsChanged -and -not $SkipRegen) {
     Write-Section 'Phase 3 — API reference regeneration'
 
-    # 3a. C# API JSON. Per-package failures are tolerated (meta-packages).
+    $script:ApiStageRoot = Join-Path $DataDir ".api-generation-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $script:ApiStageRoot -Force | Out-Null
+    $pkgStageDir = Join-Path $script:ApiStageRoot 'pkgs'
+    $tsStageDir = Join-Path $script:ApiStageRoot 'ts-modules'
+    $twoslashStageFile = Join-Path $script:ApiStageRoot 'twoslash' 'aspire.d.ts'
+    foreach ($name in @(
+        'ASPIRE_API_PKGS_DIR',
+        'ASPIRE_API_TS_MODULES_DIR',
+        'ASPIRE_API_TWOSLASH_FILE'
+    )) {
+        $script:PreviousApiEnvironment[$name] = [Environment]::GetEnvironmentVariable($name, 'Process')
+    }
+    $env:ASPIRE_API_PKGS_DIR = $pkgStageDir
+    $env:ASPIRE_API_TS_MODULES_DIR = $tsStageDir
+    $env:ASPIRE_API_TWOSLASH_FILE = $twoslashStageFile
+
+    # 3a. C# API JSON.
     Write-Host "→ generate-package-json.ps1 (C# API → pkgs/)" -ForegroundColor Cyan
-    $pkgArgs = @('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PkgGenScript)
+    $pkgArgs = @(
+        '-NoProfile', '-ExecutionPolicy', 'Bypass',
+        '-File', $PkgGenScript,
+        '-OutputDir', $pkgStageDir
+    )
     if ($Framework) { $pkgArgs += @('-Framework', $Framework) }
     $pkgLog = & pwsh @pkgArgs 2>&1 | Tee-Object -Variable pkgTeed | Out-String
     if ($LASTEXITCODE -ne 0) {
-        Write-Error "generate-package-json.ps1 failed hard (exit $LASTEXITCODE). Aborting; no PR will be opened."
-        exit 1
+        Stop-ApiRegeneration "generate-package-json.ps1 failed (exit $LASTEXITCODE).`n$pkgLog`nAborting; no PR will be opened."
     }
     $pkgDone = ($pkgLog -split "`n" | Where-Object { $_ -match 'Done!\s+Success:' } | Select-Object -First 1)
-    $pkgSummary = if ($pkgDone) { ($pkgDone -replace '.*Done!\s+', '').Trim() } else { 'summary unavailable' }
+    if (-not $pkgDone -or
+        $pkgDone -notmatch 'Done!\s+Success:\s+(?<Succeeded>\d+)\s+\|\s+Failed:\s+(?<Failed>\d+)\s+\|\s+Skipped:\s+(?<Skipped>\d+)') {
+        Stop-ApiRegeneration "C# API generation did not emit a valid completion summary. Aborting; no PR will be opened."
+    }
+    $pkgSummary = "Success: $($Matches.Succeeded) | Failed: $($Matches.Failed) | Skipped: $($Matches.Skipped)"
+    if ([int]$Matches.Failed -gt 0) {
+        Stop-ApiRegeneration "C# API generation reported $($Matches.Failed) package failure(s). Aborting; no PR will be opened."
+    }
+    $pkgSkippedLine = ($pkgLog -split "`n" |
+        Where-Object { $_ -match '^\s*Skipped packages:' } |
+        Select-Object -First 1)
+    $pkgSkippedPackages = if ($pkgSkippedLine) {
+        ($pkgSkippedLine -replace '^\s*Skipped packages:\s*', '').Trim()
+    }
+    else { '' }
     Write-Host "  C# API: $pkgSummary"
 
     # 3a-normalize. Enforce Aspire terminology in the freshly generated C# API
@@ -262,8 +425,7 @@ if ($versionsChanged -and -not $SkipRegen) {
         Pop-Location
     }
     if ($pkgNormExit -ne 0) {
-        Write-Error "normalize:api-data (pkgs) failed (exit $pkgNormExit).`n$pkgNormLog`nAborting; no PR will be opened."
-        exit 1
+        Stop-ApiRegeneration "normalize:api-data (pkgs) failed (exit $pkgNormExit).`n$pkgNormLog`nAborting; no PR will be opened."
     }
 
     # 3b. TS API JSON (+ chained twoslash bundle). Requires the Aspire CLI; the
@@ -281,12 +443,11 @@ if ($versionsChanged -and -not $SkipRegen) {
     if ($tsExit -ne 0) {
         # Distinguish phase-2 vs phase-3 failure using the script's log markers.
         if ($tsLog -match 'Twoslash type generation failed') {
-            Write-Error "Twoslash bundle generation failed. Aborting; no PR will be opened."
+            Stop-ApiRegeneration "Twoslash bundle generation failed.`n$tsLog`nAborting; no PR will be opened."
         }
         else {
-            Write-Error "TypeScript API generation failed. Aborting; no PR will be opened."
+            Stop-ApiRegeneration "TypeScript API generation failed.`n$tsLog`nAborting; no PR will be opened."
         }
-        exit 1
     }
 
     $tsApiDone = ($tsLog -split "`n" |
@@ -294,24 +455,56 @@ if ($versionsChanged -and -not $SkipRegen) {
         Select-Object -First 1)
     if (-not $tsApiDone -or
         $tsApiDone -notmatch 'Complete:\s+(?<Succeeded>\d+)\s+succeeded,\s+(?<Failed>\d+)\s+failed,\s+(?<Skipped>\d+)\s+skipped') {
-        Write-Error "TypeScript API generation did not emit a valid completion summary. Aborting; no PR will be opened."
-        exit 1
+        Stop-ApiRegeneration "TypeScript API generation did not emit a valid completion summary. Aborting; no PR will be opened."
     }
     $tsApiSummary = "$($Matches.Succeeded) succeeded, $($Matches.Failed) failed, $($Matches.Skipped) skipped"
     if ([int]$Matches.Failed -gt 0) {
-        Write-Error "TypeScript API generation reported $($Matches.Failed) package failure(s). Aborting; no PR will be opened."
-        exit 1
+        Stop-ApiRegeneration "TypeScript API generation reported $($Matches.Failed) package failure(s). Aborting; no PR will be opened."
     }
+    $tsSkippedLine = ($tsLog -split "`n" |
+        Where-Object { $_ -match '^\s*Skipped packages:' } |
+        Select-Object -First 1)
+    $tsSkippedPackages = if ($tsSkippedLine) {
+        ($tsSkippedLine -replace '^\s*Skipped packages:\s*', '').Trim()
+    }
+    else { '' }
 
     $twoslashSummary = 'succeeded'
+
+    # 3c. Cross-artifact semantic validation. This runs only after every
+    # generator has completed and must pass before the workflow can publish.
+    Write-Host "→ pnpm validate:api-data (semantic regression gate)" -ForegroundColor Cyan
+    Push-Location $FrontendDir
+    try {
+        $validationLog = & pnpm run validate:api-data 2>&1 | Tee-Object -Variable validationTeed | Out-String
+        $validationExit = $LASTEXITCODE
+    }
+    finally {
+        Pop-Location
+    }
+    if ($validationExit -ne 0) {
+        Stop-ApiRegeneration "Generated API semantic validation failed.`n$validationLog`nAborting; no PR will be opened."
+    }
+    $semanticSummary = 'passed'
+
+    try {
+        Publish-GeneratedApiData `
+            -PackageSource $pkgStageDir `
+            -ModuleSource $tsStageDir `
+            -TwoslashSource $twoslashStageFile
+    }
+    catch {
+        Stop-ApiRegeneration "Publishing validated API data failed: $_"
+    }
+    Remove-ApiStage
     $regenRan = $true
 }
 elseif ($versionsChanged -and $SkipRegen) {
     Write-Warning "Versions changed but -SkipRegen was set; regeneration skipped (local/dev use only)."
 }
 
-# ── Phase 4: scope check ────────────────────────────────────────────────────
-Write-Section 'Phase 4 — scope check'
+# ── Phase 5: scope check ────────────────────────────────────────────────────
+Write-Section 'Phase 5 — scope check'
 $allStatus = @(Invoke-Git @('status', '--porcelain') | Where-Object { $_ -and $_.Trim().Length -gt 0 })
 $outOfScope = [System.Collections.Generic.List[string]]::new()
 foreach ($line in $allStatus) {
@@ -396,6 +589,13 @@ if ($regenRan) {
     [void]$sb.AppendLine("- C# API JSON (``generate-package-json.ps1`` → ``pkgs/``): $pkgSummary")
     [void]$sb.AppendLine("- TS API JSON (``update:ts-api`` → ``ts-modules/``): $tsApiSummary")
     [void]$sb.AppendLine("- Twoslash bundle (``twoslash/aspire.d.ts``): $twoslashSummary")
+    [void]$sb.AppendLine("- Semantic generated-data validation: $semanticSummary")
+    if ($pkgSkippedPackages) {
+        [void]$sb.AppendLine("- C# packages skipped because they have no public API: ``$pkgSkippedPackages``")
+    }
+    if ($tsSkippedPackages) {
+        [void]$sb.AppendLine("- TypeScript packages skipped because they export no ATS functions: ``$tsSkippedPackages``")
+    }
 }
 else {
     [void]$sb.AppendLine("_No integration package versions changed in this run — API reference regeneration was skipped._")
@@ -429,6 +629,7 @@ Set-Content -Path $prBodyFile -Value $prBody -Encoding utf8
 Set-Output 'changed' 'true'
 Set-Output 'versions_changed' ($versionsChanged.ToString().ToLowerInvariant())
 Set-Output 'regen_ran' ($regenRan.ToString().ToLowerInvariant())
+Set-Output 'semantic_validation' $(if ($regenRan) { $semanticSummary } else { 'not run' })
 Set-Output 'pr_title' $prTitle
 Set-Output 'pr_body_file' $prBodyFile
 Set-Output 'icon_warnings' $iconWarnings

--- a/src/frontend/scripts/update-ts-api.ts
+++ b/src/frontend/scripts/update-ts-api.ts
@@ -18,7 +18,7 @@
  *   tsx ./scripts/update-ts-api.ts /path/aspire  # from repo clone
  */
 
-import { execSync, execFileSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { existsSync } from 'fs';
 import { dirname, resolve } from 'path';
 import { fileURLToPath } from 'url';
@@ -60,7 +60,7 @@ function main(): void {
     process.exit(1);
   }
 
-  let psArgs: string;
+  const psArgs = ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', SCRIPT_PATH];
   if (aspireRepoPath) {
     const resolvedPath = resolve(aspireRepoPath);
     if (!existsSync(resolvedPath)) {
@@ -68,17 +68,20 @@ function main(): void {
       process.exit(1);
     }
     console.log(`🔄 Generating TypeScript API reference data from ${resolvedPath}...`);
-    psArgs = `-AspireRepoPath "${resolvedPath}"`;
+    psArgs.push('-AspireRepoPath', resolvedPath);
   } else {
     console.log('🔄 Generating TypeScript API reference data from installed Aspire CLI...');
-    psArgs = '';
+  }
+
+  const outputDir = process.env.ASPIRE_API_TS_MODULES_DIR
+    ? resolve(process.env.ASPIRE_API_TS_MODULES_DIR)
+    : TS_MODULES_DIR;
+  if (process.env.ASPIRE_API_TS_MODULES_DIR) {
+    psArgs.push('-OutputDir', outputDir);
   }
 
   try {
-    execSync(
-      `pwsh -NoProfile -ExecutionPolicy Bypass -File "${SCRIPT_PATH}" ${psArgs}`.trim(),
-      { stdio: 'inherit', cwd: resolve(__dirname, '..') }
-    );
+    execFileSync('pwsh', psArgs, { stdio: 'inherit', cwd: resolve(__dirname, '..') });
     console.log('✅ TypeScript API reference data updated.');
   } catch (error: unknown) {
     console.error('❌ Generation failed:', getErrorMessage(error));
@@ -91,7 +94,7 @@ function main(): void {
   // JSDoc/XML docs may carry. Reuses the single source of truth in
   // aspire-terminology.ts.
   console.log('🔄 Normalizing Aspire terminology in ts-modules JSON...');
-  const { changes: tsModuleChanges } = normalizeApiDir(TS_MODULES_DIR);
+  const { changes: tsModuleChanges } = normalizeApiDir(outputDir);
   console.log(`✅ Normalized ${tsModuleChanges} occurrence(s) in ts-modules JSON.`);
 
   // Refresh the twoslash .d.ts bundle so docs hover tooltips stay in sync

--- a/src/frontend/scripts/validate-generated-api-data.ts
+++ b/src/frontend/scripts/validate-generated-api-data.ts
@@ -97,7 +97,7 @@ export interface ValidationResult {
 
 interface ParsedInterface {
   parents: string[];
-  properties: Map<string, boolean>;
+  properties: Map<string, { optional: boolean; type: string }>;
 }
 
 interface AttributePayloadShape {
@@ -138,6 +138,28 @@ function shortTypeName(typeId: string): string {
 
 function camelCase(name: string): string {
   return name.length === 0 ? name : name[0].toLowerCase() + name.slice(1);
+}
+
+function normalizeTypeScriptType(typeName: string): string {
+  return typeName
+    .trim()
+    .replace(/[A-Za-z_][A-Za-z0-9_]*(?:[./][A-Za-z_][A-Za-z0-9_]*)+/g, (value) => {
+      const withoutAssembly = value.includes('/')
+        ? value.slice(value.lastIndexOf('/') + 1)
+        : value;
+      const parts = withoutAssembly.split('.');
+      return parts[parts.length - 1];
+    })
+    .replace(/\s+/g, '');
+}
+
+function normalizeClrType(typeName: string): string {
+  const slashIndex = typeName.indexOf('/');
+  return (slashIndex >= 0 ? typeName.slice(slashIndex + 1) : typeName)
+    .replace(/\s+/g, '')
+    .replace(/`\d+\[\[/g, '<')
+    .replace(/\],\[/g, ',')
+    .replace(/\]\]/g, '>');
 }
 
 function addUnique<T>(
@@ -289,8 +311,13 @@ function parseInterfaces(declarations: string): Map<string, ParsedInterface> {
     }
     const properties = new Map(previous?.properties ?? []);
     const body = declarations.slice(bodyStart, bodyEnd);
-    for (const property of body.matchAll(/^\s{2}([A-Za-z_][A-Za-z0-9_]*)(\?)?:/gm)) {
-      properties.set(property[1], property[2] === '?');
+    for (const property of body.matchAll(
+      /^\s{2}([A-Za-z_][A-Za-z0-9_]*)(\?)?:\s*(.+);$/gm
+    )) {
+      properties.set(property[1], {
+        optional: property[2] === '?',
+        type: property[3].trim(),
+      });
     }
 
     result.set(match[1], {
@@ -450,16 +477,24 @@ export function validateGeneratedApiData(input: ValidationInput): ValidationResu
     }
     for (const field of dto.fields ?? []) {
       const propertyName = camelCase(field.name);
-      const actualOptionality = declaration.properties.get(propertyName);
+      const property = declaration.properties.get(propertyName);
       if (!field.isOptional) {
         errors.push(
           `TypeScript DTO ${dto.name}.${propertyName} is required, but the SDK emits every DTO field as optional.`
         );
-      } else if (actualOptionality === undefined) {
+      } else if (!property) {
         errors.push(`Twoslash DTO ${dto.name} is missing property ${propertyName}.`);
-      } else if (!actualOptionality) {
+      } else if (!property.optional) {
         errors.push(
           `Twoslash DTO ${dto.name}.${propertyName} optionality does not match ts-modules metadata.`
+        );
+      }
+      if (
+        property &&
+        normalizeTypeScriptType(property.type) !== normalizeTypeScriptType(field.type)
+      ) {
+        errors.push(
+          `Twoslash DTO ${dto.name}.${propertyName} type ${property.type} does not match ts-modules metadata ${field.type}.`
         );
       }
     }
@@ -471,6 +506,24 @@ export function validateGeneratedApiData(input: ValidationInput): ValidationResu
     if (!declaration) {
       errors.push(`Twoslash handle ${handle.name} is missing its declaration.`);
       continue;
+    }
+    const matchingPackage = packageByIdentity.get(identity(module.package))?.data;
+    const packageType = (matchingPackage?.types ?? []).find(
+      (type) => type.fullName === handle.fullName
+    );
+    const generatedDirectBase = handle.baseTypeHierarchy?.[0];
+    if (packageType?.baseType) {
+      if (!generatedDirectBase) {
+        errors.push(
+          `TypeScript handle ${handle.name} is missing base hierarchy metadata for C# base type ${packageType.baseType}.`
+        );
+      } else if (
+        normalizeClrType(generatedDirectBase) !== normalizeClrType(packageType.baseType)
+      ) {
+        errors.push(
+          `TypeScript handle ${handle.name} base type ${generatedDirectBase} does not match C# metadata ${packageType.baseType}.`
+        );
+      }
     }
     const expectedParents = new Set(
       (handle.implementedInterfaces ?? [])
@@ -517,6 +570,58 @@ const repoRoot = path.resolve(frontendDir, '..', '..');
 const dataDir = path.join(frontendDir, 'src', 'data');
 const canonicalPackageDir = path.join(dataDir, 'pkgs');
 
+export interface GitCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: Error;
+}
+
+export type GitCommandRunner = (arguments_: string[]) => GitCommandResult;
+
+function runGit(arguments_: string[]): GitCommandResult {
+  const result = spawnSync('git', arguments_, {
+    encoding: 'utf8',
+    maxBuffer: 128 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+    error: result.error,
+  };
+}
+
+function assertGitSucceeded(
+  command: string,
+  relativePath: string,
+  result: GitCommandResult
+): void {
+  if (result.status === 0) return;
+
+  const detail = result.error?.message ?? result.stderr.trim() ?? '';
+  throw new Error(
+    `Unable to read HEAD baseline for ${relativePath}: git ${command} failed${detail ? `: ${detail}` : '.'}`
+  );
+}
+
+export function loadJsonFromHead<T>(
+  root: string,
+  relativePath: string,
+  git: GitCommandRunner = runGit
+): T | undefined {
+  const treeArguments = ['-C', root, 'ls-tree', '--name-only', 'HEAD', '--', relativePath];
+  const treeResult = git(treeArguments);
+  assertGitSucceeded('ls-tree', relativePath, treeResult);
+  if (treeResult.stdout.trim().length === 0) {
+    return undefined;
+  }
+
+  const showResult = git(['-C', root, 'show', `HEAD:${relativePath}`]);
+  assertGitSucceeded('show', relativePath, showResult);
+  return JSON.parse(showResult.stdout) as T;
+}
+
 function loadJsonFiles<T>(directory: string, baselineDirectory?: string): GeneratedFile<T>[] {
   return fs
     .readdirSync(directory)
@@ -529,12 +634,7 @@ function loadJsonFiles<T>(directory: string, baselineDirectory?: string): Genera
         const relativePath = path
           .relative(repoRoot, path.join(baselineDirectory, fileName))
           .replaceAll(path.sep, '/');
-        const result = spawnSync('git', ['-C', repoRoot, 'show', `HEAD:${relativePath}`], {
-          encoding: 'utf8',
-        });
-        if (result.status === 0) {
-          baseline = JSON.parse(result.stdout) as T;
-        }
+        baseline = loadJsonFromHead<T>(repoRoot, relativePath);
       }
       return { fileName, data, baseline };
     });

--- a/src/frontend/scripts/validate-generated-api-data.ts
+++ b/src/frontend/scripts/validate-generated-api-data.ts
@@ -1,0 +1,577 @@
+import { spawnSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+interface CatalogEntry {
+  title: string;
+  version: string;
+}
+
+interface PackageMetadata {
+  name: string;
+  version: string;
+  sourceRepository?: string;
+  sourceCommit?: string;
+}
+
+interface ApiAttribute {
+  name: string;
+  constructorArguments?: unknown[];
+  arguments?: Record<string, unknown>;
+  namedArguments?: Record<string, unknown>;
+}
+
+interface ApiParameter {
+  name: string;
+  type?: string;
+  modifier?: string;
+  attributes?: ApiAttribute[];
+}
+
+interface ApiMember {
+  name: string;
+  kind?: string;
+  signature?: string;
+  genericParameters?: unknown[];
+  attributes?: ApiAttribute[];
+  parameters?: ApiParameter[];
+}
+
+interface ApiType {
+  name: string;
+  fullName: string;
+  kind: string;
+  baseType?: string;
+  attributes?: ApiAttribute[];
+  members?: ApiMember[];
+}
+
+interface PackageJson {
+  package: PackageMetadata;
+  types?: ApiType[];
+}
+
+interface DtoField {
+  name: string;
+  type: string;
+  isOptional?: boolean;
+}
+
+interface DtoType {
+  name: string;
+  fields?: DtoField[];
+}
+
+interface HandleType {
+  name: string;
+  fullName: string;
+  implementedInterfaces?: string[];
+  baseTypeHierarchy?: string[];
+}
+
+interface TsModuleJson {
+  package: PackageMetadata;
+  functions?: unknown[];
+  dtoTypes?: DtoType[];
+  handleTypes?: HandleType[];
+}
+
+export interface GeneratedFile<T> {
+  fileName: string;
+  data: T;
+  baseline?: T;
+}
+
+export interface ValidationInput {
+  catalog: CatalogEntry[];
+  packages: GeneratedFile<PackageJson>[];
+  modules: GeneratedFile<TsModuleJson>[];
+  declarations: string;
+}
+
+export interface ValidationResult {
+  errors: string[];
+  checks: string[];
+}
+
+interface ParsedInterface {
+  parents: string[];
+  properties: Map<string, boolean>;
+}
+
+interface AttributePayloadShape {
+  constructorArgumentCount: number;
+  namedArgumentNames: string[];
+}
+
+const relevantAttribute = /(?:^|\.)Aspire(?:Export(?:Ignore)?|Dto|Union)Attribute$/;
+
+function identity(metadata: PackageMetadata): string {
+  return `${metadata.name}@${metadata.version}`;
+}
+
+function expectedFileName(metadata: PackageMetadata): string {
+  return `${metadata.name}.${metadata.version}.json`;
+}
+
+function shortTypeName(typeId: string): string {
+  let normalized = typeId.trim();
+  normalized = normalized.replace(
+    /[A-Za-z_][A-Za-z0-9_]*(?:[./][A-Za-z_][A-Za-z0-9_]*)+/g,
+    (value) => {
+      const withoutAssembly = value.includes('/')
+        ? value.slice(value.lastIndexOf('/') + 1)
+        : value;
+      const parts = withoutAssembly.split('.');
+      return parts[parts.length - 1];
+    }
+  );
+  normalized = normalized.replace(/\]\]+/g, '');
+  const withoutAssembly = normalized.includes('/')
+    ? normalized.slice(normalized.lastIndexOf('/') + 1)
+    : normalized;
+  const withoutGeneric = withoutAssembly.split('<')[0];
+  const parts = withoutGeneric.split('.');
+  return parts[parts.length - 1];
+}
+
+function camelCase(name: string): string {
+  return name.length === 0 ? name : name[0].toLowerCase() + name.slice(1);
+}
+
+function addUnique<T>(
+  files: GeneratedFile<T>[],
+  metadata: (data: T) => PackageMetadata,
+  label: string,
+  errors: string[]
+): Map<string, GeneratedFile<T>> {
+  const byIdentity = new Map<string, GeneratedFile<T>>();
+  for (const file of files) {
+    const packageMetadata = metadata(file.data);
+    const key = identity(packageMetadata);
+    if (byIdentity.has(key)) {
+      errors.push(`${label} contains duplicate package identity ${key}.`);
+      continue;
+    }
+    byIdentity.set(key, file);
+    if (file.fileName !== expectedFileName(packageMetadata)) {
+      errors.push(
+        `${label} file ${file.fileName} does not match its package identity; expected ${expectedFileName(packageMetadata)}.`
+      );
+    }
+  }
+  return byIdentity;
+}
+
+function isPackageOutputExpected(name: string): boolean {
+  return (
+    !name.startsWith('Aspire.Hosting.CodeGeneration.') &&
+    name !== 'Aspire.Hosting.Integration.Analyzers'
+  );
+}
+
+function attributesForOwner(
+  result: Map<string, AttributePayloadShape>,
+  owner: string,
+  attributes: ApiAttribute[] | undefined
+): void {
+  const indexes = new Map<string, number>();
+  for (const attribute of attributes ?? []) {
+    if (!relevantAttribute.test(attribute.name)) continue;
+    const index = indexes.get(attribute.name) ?? 0;
+    indexes.set(attribute.name, index + 1);
+    result.set(`${owner}|${attribute.name}|${index}`, {
+      constructorArgumentCount: attribute.constructorArguments?.length ?? 0,
+      namedArgumentNames: [
+        ...new Set([
+          ...Object.keys(attribute.arguments ?? {}),
+          ...Object.keys(attribute.namedArguments ?? {}),
+        ]),
+      ].sort(),
+    });
+  }
+}
+
+function memberOwnerKey(typeOwner: string, member: ApiMember): string {
+  const genericArity = member.genericParameters?.length ?? 0;
+  const parameterTypes = (member.parameters ?? [])
+    .map((parameter) =>
+      `${parameter.modifier ? `${parameter.modifier} ` : ''}${parameter.type ?? '?'}`
+    )
+    .join(',');
+  return `${typeOwner}/member:${member.kind ?? 'member'}:${member.name}${genericArity > 0 ? `\`${genericArity}` : ''}(${parameterTypes})`;
+}
+
+function collectAttributePayloads(pkg: PackageJson): Map<string, AttributePayloadShape> {
+  const result = new Map<string, AttributePayloadShape>();
+  for (const type of pkg.types ?? []) {
+    const typeOwner = `type:${type.fullName}`;
+    attributesForOwner(result, typeOwner, type.attributes);
+    for (const member of type.members ?? []) {
+      const memberOwner = memberOwnerKey(typeOwner, member);
+      attributesForOwner(result, memberOwner, member.attributes);
+      for (const [index, parameter] of (member.parameters ?? []).entries()) {
+        attributesForOwner(
+          result,
+          `${memberOwner}/parameter:${index}:${parameter.name}`,
+          parameter.attributes
+        );
+      }
+    }
+  }
+  return result;
+}
+
+function hasExportedApi(pkg: PackageJson): boolean {
+  const visit = (attributes: ApiAttribute[] | undefined): boolean =>
+    (attributes ?? []).some((attribute) => /(?:^|\.)AspireExportAttribute$/.test(attribute.name));
+
+  return (pkg.types ?? []).some(
+    (type) =>
+      visit(type.attributes) ||
+      (type.members ?? []).some(
+        (member) =>
+          visit(member.attributes) ||
+          (member.parameters ?? []).some((parameter) => visit(parameter.attributes))
+      )
+  );
+}
+
+function splitTopLevel(value: string): string[] {
+  const result: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let index = 0; index < value.length; index++) {
+    if (value[index] === '<') depth++;
+    if (value[index] === '>') depth--;
+    if (value[index] === ',' && depth === 0) {
+      result.push(value.slice(start, index).trim());
+      start = index + 1;
+    }
+  }
+  const tail = value.slice(start).trim();
+  if (tail) result.push(tail);
+  return result;
+}
+
+function parseInterfaces(declarations: string): Map<string, ParsedInterface> {
+  const header = /^export interface ([A-Za-z_][A-Za-z0-9_]*)/gm;
+  const matches = [...declarations.matchAll(header)];
+  const result = new Map<string, ParsedInterface>();
+
+  for (const [index, match] of matches.entries()) {
+    const lineStart = match.index ?? 0;
+    const lineEnd = declarations.indexOf('\n', lineStart);
+    const headerLine = declarations.slice(
+      lineStart,
+      lineEnd === -1 ? declarations.length : lineEnd
+    );
+    let cursor = match[0].length;
+    if (headerLine[cursor] === '<') {
+      let depth = 0;
+      do {
+        if (headerLine[cursor] === '<') depth++;
+        if (headerLine[cursor] === '>') depth--;
+        cursor++;
+      } while (cursor < headerLine.length && depth > 0);
+    }
+    const remainder = headerLine.slice(cursor).trim();
+    const extendsText = remainder.startsWith('extends ')
+      ? remainder.slice('extends '.length, remainder.lastIndexOf('{')).trim()
+      : '';
+    const bodyStart = lineEnd === -1 ? declarations.length : lineEnd + 1;
+    const bodyEnd = matches[index + 1]?.index ?? declarations.length;
+    const previous = result.get(match[1]);
+    const parents = new Set(previous?.parents ?? []);
+    for (const parent of splitTopLevel(extendsText).map(shortTypeName)) {
+      parents.add(parent);
+    }
+    const properties = new Map(previous?.properties ?? []);
+    const body = declarations.slice(bodyStart, bodyEnd);
+    for (const property of body.matchAll(/^\s{2}([A-Za-z_][A-Za-z0-9_]*)(\?)?:/gm)) {
+      properties.set(property[1], property[2] === '?');
+    }
+
+    result.set(match[1], {
+      parents: [...parents],
+      properties,
+    });
+  }
+  return result;
+}
+
+function setDifference(left: Set<string>, right: Set<string>): string[] {
+  return [...left].filter((value) => !right.has(value)).sort();
+}
+
+function resolveBaseHierarchy(
+  module: TsModuleJson,
+  handle: HandleType,
+  packageByIdentity: Map<string, GeneratedFile<PackageJson>>
+): string[] {
+  if ((handle.baseTypeHierarchy?.length ?? 0) > 0) {
+    return handle.baseTypeHierarchy!;
+  }
+
+  const pkg = packageByIdentity.get(identity(module.package))?.data;
+  const baseByFullName = new Map(
+    (pkg?.types ?? [])
+      .filter((type) => type.kind === 'class' && type.baseType)
+      .map((type) => [type.fullName, type.baseType!] as const)
+  );
+  const hierarchy: string[] = [];
+  const seen = new Set<string>([handle.fullName]);
+  let ancestor = baseByFullName.get(handle.fullName);
+  while (ancestor && !seen.has(ancestor)) {
+    hierarchy.push(ancestor);
+    seen.add(ancestor);
+    ancestor = baseByFullName.get(ancestor);
+  }
+  return hierarchy;
+}
+
+export function validateGeneratedApiData(input: ValidationInput): ValidationResult {
+  const errors: string[] = [];
+  const catalogByName = new Map<string, CatalogEntry>();
+  for (const entry of input.catalog) {
+    if (catalogByName.has(entry.title)) {
+      errors.push(`Integration catalog contains duplicate package ${entry.title}.`);
+    } else {
+      catalogByName.set(entry.title, entry);
+    }
+  }
+
+  const packageByIdentity = addUnique(input.packages, (pkg) => pkg.package, 'pkgs', errors);
+  const moduleByIdentity = addUnique(input.modules, (module) => module.package, 'ts-modules', errors);
+
+  for (const entry of input.catalog) {
+    if (!isPackageOutputExpected(entry.title)) continue;
+    const key = `${entry.title}@${entry.version}`;
+    if (!packageByIdentity.has(key)) {
+      errors.push(`Missing C# API output for catalog package ${key}.`);
+    }
+  }
+
+  for (const file of input.packages) {
+    const metadata = file.data.package;
+    const catalogEntry = catalogByName.get(metadata.name);
+    if (!catalogEntry) {
+      errors.push(`C# API output ${identity(metadata)} is not present in the integration catalog.`);
+    } else if (catalogEntry.version !== metadata.version) {
+      errors.push(
+        `Stale C# API output ${identity(metadata)}; catalog version is ${catalogEntry.version}.`
+      );
+    }
+    if (!metadata.sourceRepository) {
+      errors.push(`C# API output ${identity(metadata)} is missing its source repository.`);
+    }
+
+    if (file.baseline && identity(file.baseline.package) === identity(metadata)) {
+      const before = collectAttributePayloads(file.baseline);
+      const after = collectAttributePayloads(file.data);
+      for (const [attributeKey, payload] of before) {
+        const generatedPayload = after.get(attributeKey);
+        const lostConstructorArguments =
+          !generatedPayload ||
+          generatedPayload.constructorArgumentCount < payload.constructorArgumentCount;
+        const lostNamedArguments =
+          !generatedPayload ||
+          payload.namedArgumentNames.some(
+            (name) => !generatedPayload.namedArgumentNames.includes(name)
+          );
+        if (lostConstructorArguments || lostNamedArguments) {
+          errors.push(
+            `Attribute payload changed or disappeared for ${identity(metadata)} at ${attributeKey}.`
+          );
+        }
+      }
+    }
+  }
+
+  for (const file of input.modules) {
+    const metadata = file.data.package;
+    const catalogEntry = catalogByName.get(metadata.name);
+    if (!catalogEntry) {
+      errors.push(`TypeScript API output ${identity(metadata)} is not present in the integration catalog.`);
+    } else if (catalogEntry.version !== metadata.version) {
+      errors.push(
+        `Stale TypeScript API output ${identity(metadata)}; catalog version is ${catalogEntry.version}.`
+      );
+    }
+    if ((file.data.functions?.length ?? 0) === 0) {
+      errors.push(`TypeScript API output ${identity(metadata)} contains no exported functions.`);
+    }
+
+    const matchingPackage = packageByIdentity.get(identity(metadata))?.data;
+    if (!matchingPackage) {
+      errors.push(`TypeScript API output ${identity(metadata)} has no exact C# API output.`);
+      continue;
+    }
+    if (metadata.sourceRepository !== matchingPackage.package.sourceRepository) {
+      errors.push(
+        `Source repository mismatch for ${identity(metadata)}: C# has ${matchingPackage.package.sourceRepository ?? '(missing)'}, TypeScript has ${metadata.sourceRepository ?? '(missing)'}.`
+      );
+    }
+    if (metadata.sourceCommit !== matchingPackage.package.sourceCommit) {
+      errors.push(
+        `Source commit mismatch for ${identity(metadata)}: C# has ${matchingPackage.package.sourceCommit ?? '(missing)'}, TypeScript has ${metadata.sourceCommit ?? '(missing)'}.`
+      );
+    }
+  }
+
+  for (const file of input.packages) {
+    if (hasExportedApi(file.data) && !moduleByIdentity.has(identity(file.data.package))) {
+      errors.push(`Missing TypeScript API output for exported package ${identity(file.data.package)}.`);
+    }
+  }
+
+  const parsedInterfaces = parseInterfaces(input.declarations);
+  const selectedDtos = new Map<string, DtoType>();
+  const selectedHandles = new Map<string, { handle: HandleType; module: TsModuleJson }>();
+  for (const file of [...input.modules].sort((left, right) =>
+    left.fileName.localeCompare(right.fileName)
+  )) {
+    for (const dto of file.data.dtoTypes ?? []) {
+      if (!selectedDtos.has(dto.name)) selectedDtos.set(dto.name, dto);
+    }
+    for (const handle of file.data.handleTypes ?? []) {
+      if (!selectedHandles.has(handle.name)) {
+        selectedHandles.set(handle.name, { handle, module: file.data });
+      }
+    }
+  }
+
+  for (const dto of selectedDtos.values()) {
+    const declaration = parsedInterfaces.get(dto.name);
+    if (!declaration) {
+      errors.push(`Twoslash DTO ${dto.name} is missing its declaration.`);
+      continue;
+    }
+    for (const field of dto.fields ?? []) {
+      const propertyName = camelCase(field.name);
+      const actualOptionality = declaration.properties.get(propertyName);
+      if (!field.isOptional) {
+        errors.push(
+          `TypeScript DTO ${dto.name}.${propertyName} is required, but the SDK emits every DTO field as optional.`
+        );
+      } else if (actualOptionality === undefined) {
+        errors.push(`Twoslash DTO ${dto.name} is missing property ${propertyName}.`);
+      } else if (!actualOptionality) {
+        errors.push(
+          `Twoslash DTO ${dto.name}.${propertyName} optionality does not match ts-modules metadata.`
+        );
+      }
+    }
+  }
+
+  const knownHandles = new Set(selectedHandles.keys());
+  for (const { handle, module } of selectedHandles.values()) {
+    const declaration = parsedInterfaces.get(handle.name);
+    if (!declaration) {
+      errors.push(`Twoslash handle ${handle.name} is missing its declaration.`);
+      continue;
+    }
+    const expectedParents = new Set(
+      (handle.implementedInterfaces ?? [])
+        .map(shortTypeName)
+        .filter(
+          (name) =>
+            /^[A-Za-z_][A-Za-z0-9_]*$/.test(name) &&
+            name !== handle.name
+        )
+    );
+    for (const ancestor of resolveBaseHierarchy(module, handle, packageByIdentity)) {
+      const name = shortTypeName(ancestor);
+      if (name !== handle.name && knownHandles.has(name)) expectedParents.add(name);
+    }
+    const actualParents = new Set(declaration.parents);
+    const missing = setDifference(expectedParents, actualParents);
+    const unexpected = setDifference(actualParents, expectedParents);
+    if (missing.length > 0 || unexpected.length > 0) {
+      errors.push(
+        `Twoslash handle ${handle.name} has incorrect inheritance (missing: ${missing.join(', ') || 'none'}; unexpected: ${unexpected.join(', ') || 'none'}).`
+      );
+    }
+  }
+
+  if (/options\?:\s*\{\s*options\?:/s.test(input.declarations)) {
+    errors.push('Twoslash declarations contain a nested single-DTO options wrapper.');
+  }
+
+  return {
+    errors,
+    checks: [
+      `${catalogByName.size} catalog package identities reconciled`,
+      `${moduleByIdentity.size} TypeScript modules matched to C# provenance`,
+      `${selectedDtos.size} DTO shapes checked`,
+      `${selectedHandles.size} handle inheritance chains checked`,
+      'attribute payload regressions checked against HEAD',
+    ],
+  };
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendDir = path.resolve(scriptDir, '..');
+const repoRoot = path.resolve(frontendDir, '..', '..');
+const dataDir = path.join(frontendDir, 'src', 'data');
+const canonicalPackageDir = path.join(dataDir, 'pkgs');
+
+function loadJsonFiles<T>(directory: string, baselineDirectory?: string): GeneratedFile<T>[] {
+  return fs
+    .readdirSync(directory)
+    .filter((fileName) => fileName.endsWith('.json'))
+    .sort()
+    .map((fileName) => {
+      const data = JSON.parse(fs.readFileSync(path.join(directory, fileName), 'utf8')) as T;
+      let baseline: T | undefined;
+      if (baselineDirectory) {
+        const relativePath = path
+          .relative(repoRoot, path.join(baselineDirectory, fileName))
+          .replaceAll(path.sep, '/');
+        const result = spawnSync('git', ['-C', repoRoot, 'show', `HEAD:${relativePath}`], {
+          encoding: 'utf8',
+        });
+        if (result.status === 0) {
+          baseline = JSON.parse(result.stdout) as T;
+        }
+      }
+      return { fileName, data, baseline };
+    });
+}
+
+function main(): void {
+  const packageDir = process.env.ASPIRE_API_PKGS_DIR
+    ? path.resolve(process.env.ASPIRE_API_PKGS_DIR)
+    : canonicalPackageDir;
+  const moduleDir = process.env.ASPIRE_API_TS_MODULES_DIR
+    ? path.resolve(process.env.ASPIRE_API_TS_MODULES_DIR)
+    : path.join(dataDir, 'ts-modules');
+  const declarationsFile = process.env.ASPIRE_API_TWOSLASH_FILE
+    ? path.resolve(process.env.ASPIRE_API_TWOSLASH_FILE)
+    : path.join(dataDir, 'twoslash', 'aspire.d.ts');
+  const result = validateGeneratedApiData({
+    catalog: JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'aspire-integrations.json'), 'utf8')
+    ) as CatalogEntry[],
+    packages: loadJsonFiles<PackageJson>(packageDir, canonicalPackageDir),
+    modules: loadJsonFiles<TsModuleJson>(moduleDir),
+    declarations: fs.readFileSync(declarationsFile, 'utf8'),
+  });
+
+  if (result.errors.length > 0) {
+    console.error(`Generated API validation failed with ${result.errors.length} error(s):`);
+    for (const error of result.errors) console.error(`  - ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log('Generated API semantic validation passed:');
+  for (const check of result.checks) console.log(`  - ${check}`);
+}
+
+const isMainModule = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isMainModule) main();

--- a/src/frontend/src/components/api-reference/MemberCard.astro
+++ b/src/frontend/src/components/api-reference/MemberCard.astro
@@ -31,6 +31,8 @@ interface Props {
   parentType?: ParentTypeInfo;
   sourceBaseUrl?: string;
   diagnosticSlugs?: Set<string>;
+  anchorAlias?: string;
+  exactAnchor?: string;
 }
 
 const {
@@ -40,6 +42,8 @@ const {
   parentType,
   sourceBaseUrl,
   diagnosticSlugs,
+  anchorAlias,
+  exactAnchor,
 } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 
@@ -95,7 +99,8 @@ const returnLink = member.returnType
 const rawDisplayName = memberDisplayName(member);
 const displayName =
   member.name === '.ctor' ? rawDisplayName.replace('.ctor', 'Constructor') : rawDisplayName;
-const anchorSlug = memberSlug(member);
+const anchorSlug = exactAnchor ?? memberSlug(member);
+const primaryAnchorSlug = anchorAlias ?? anchorSlug;
 const isCtor = member.name === '.ctor';
 const returnShort = member.returnType ? shortTypeName(member.returnType) : member.returnType;
 const returnColorClass = returnShort ? `mc-param-type-${typeColorIndex(returnShort)}` : '';
@@ -152,7 +157,8 @@ if (formattedSigRaw && (member.kind === 'property' || member.kind === 'indexer')
 }
 ---
 
-<div class={`mc not-content${isObsolete ? ' mc-obsolete' : ''}`} id={anchorSlug}>
+<div class={`mc not-content${isObsolete ? ' mc-obsolete' : ''}`} id={primaryAnchorSlug}>
+  {anchorAlias && <span id={anchorSlug} class="mc-exact-anchor" aria-hidden="true"></span>}
   {/* Obsolete aside */}
   {
     isObsolete && (
@@ -446,6 +452,12 @@ if (formattedSigRaw && (member.kind === 'property' || member.kind === 'indexer')
       border-color 0.18s ease,
       background 0.18s ease,
       box-shadow 0.18s ease;
+  }
+  .mc-exact-anchor {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline-start: 0;
+    scroll-margin-top: calc(var(--sl-nav-height, 0px) + var(--sl-mobile-toc-height, 0px) + 1rem);
   }
   .mc:hover {
     border-color: var(--api-border-hover);

--- a/src/frontend/src/components/api-reference/MemberCard.astro
+++ b/src/frontend/src/components/api-reference/MemberCard.astro
@@ -31,7 +31,7 @@ interface Props {
   parentType?: ParentTypeInfo;
   sourceBaseUrl?: string;
   diagnosticSlugs?: Set<string>;
-  anchorAlias?: string;
+  anchorAliases?: string[];
   exactAnchor?: string;
 }
 
@@ -42,7 +42,7 @@ const {
   parentType,
   sourceBaseUrl,
   diagnosticSlugs,
-  anchorAlias,
+  anchorAliases = [],
   exactAnchor,
 } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
@@ -100,7 +100,11 @@ const rawDisplayName = memberDisplayName(member);
 const displayName =
   member.name === '.ctor' ? rawDisplayName.replace('.ctor', 'Constructor') : rawDisplayName;
 const anchorSlug = exactAnchor ?? memberSlug(member);
-const primaryAnchorSlug = anchorAlias ?? anchorSlug;
+const aliases = anchorAliases.filter((alias) => alias !== anchorSlug);
+const primaryAnchorSlug = aliases[0] ?? anchorSlug;
+const hiddenAnchorSlugs = primaryAnchorSlug === anchorSlug
+  ? []
+  : [anchorSlug, ...aliases.slice(1)];
 const isCtor = member.name === '.ctor';
 const returnShort = member.returnType ? shortTypeName(member.returnType) : member.returnType;
 const returnColorClass = returnShort ? `mc-param-type-${typeColorIndex(returnShort)}` : '';
@@ -158,7 +162,9 @@ if (formattedSigRaw && (member.kind === 'property' || member.kind === 'indexer')
 ---
 
 <div class={`mc not-content${isObsolete ? ' mc-obsolete' : ''}`} id={primaryAnchorSlug}>
-  {anchorAlias && <span id={anchorSlug} class="mc-exact-anchor" aria-hidden="true" />}
+  {hiddenAnchorSlugs.map((slug) => (
+    <span id={slug} class="mc-exact-anchor" aria-hidden="true" />
+  ))}
   {/* Obsolete aside */}
   {
     isObsolete && (

--- a/src/frontend/src/components/api-reference/MemberCard.astro
+++ b/src/frontend/src/components/api-reference/MemberCard.astro
@@ -158,7 +158,7 @@ if (formattedSigRaw && (member.kind === 'property' || member.kind === 'indexer')
 ---
 
 <div class={`mc not-content${isObsolete ? ' mc-obsolete' : ''}`} id={primaryAnchorSlug}>
-  {anchorAlias && <span id={anchorSlug} class="mc-exact-anchor" aria-hidden="true"></span>}
+  {anchorAlias && <span id={anchorSlug} class="mc-exact-anchor" aria-hidden="true" />}
   {/* Obsolete aside */}
   {
     isObsolete && (
@@ -463,7 +463,8 @@ if (formattedSigRaw && (member.kind === 'property' || member.kind === 'indexer')
     border-color: var(--api-border-hover);
     box-shadow: 0 12px 28px color-mix(in srgb, var(--sl-color-black) 14%, transparent);
   }
-  .mc:target {
+  .mc:target,
+  .mc:has(> .mc-exact-anchor:target) {
     border-color: color-mix(in srgb, var(--sl-color-accent-high) 40%, var(--api-border));
     background: color-mix(in srgb, var(--sl-color-accent) 4%, var(--api-surface));
     box-shadow: 0 12px 28px color-mix(in srgb, var(--sl-color-black) 14%, transparent);

--- a/src/frontend/src/components/api-reference/MemberList.astro
+++ b/src/frontend/src/components/api-reference/MemberList.astro
@@ -6,7 +6,7 @@
  */
 import MemberCard from './MemberCard.astro';
 import AnchorHeading from './AnchorHeading.astro';
-import { groupMembersByKind, memberKindLabels, resolveMemberAnchors } from '@utils/packages';
+import { groupMembersByKind, memberKindLabels, resolveMemberAnchorMap } from '@utils/packages';
 import type { ParentTypeInfo } from '@utils/packages';
 
 interface Props {
@@ -20,10 +20,7 @@ interface Props {
 
 const { members = [], allTypes = [], packageName = '', parentType, sourceBaseUrl, diagnosticSlugs } = Astro.props;
 const groups = groupMembersByKind(members);
-const resolvedAnchors = resolveMemberAnchors(members);
-const anchorByMember = new Map(
-  members.map((member, index) => [member, resolvedAnchors[index]] as const),
-);
+const anchorByMember = resolveMemberAnchorMap(members);
 ---
 
 {groups.size > 0 && (
@@ -38,7 +35,7 @@ const anchorByMember = new Map(
             <MemberCard
               member={m}
               exactAnchor={anchorByMember.get(m)?.exact}
-              anchorAlias={anchorByMember.get(m)?.alias}
+              anchorAliases={anchorByMember.get(m)?.aliases}
               allTypes={allTypes}
               packageName={packageName}
               parentType={parentType}

--- a/src/frontend/src/components/api-reference/MemberList.astro
+++ b/src/frontend/src/components/api-reference/MemberList.astro
@@ -6,7 +6,7 @@
  */
 import MemberCard from './MemberCard.astro';
 import AnchorHeading from './AnchorHeading.astro';
-import { groupMembersByKind, memberKindLabels } from '@utils/packages';
+import { groupMembersByKind, memberKindLabels, resolveMemberAnchors } from '@utils/packages';
 import type { ParentTypeInfo } from '@utils/packages';
 
 interface Props {
@@ -20,6 +20,10 @@ interface Props {
 
 const { members = [], allTypes = [], packageName = '', parentType, sourceBaseUrl, diagnosticSlugs } = Astro.props;
 const groups = groupMembersByKind(members);
+const resolvedAnchors = resolveMemberAnchors(members);
+const anchorByMember = new Map(
+  members.map((member, index) => [member, resolvedAnchors[index]] as const),
+);
 ---
 
 {groups.size > 0 && (
@@ -33,6 +37,8 @@ const groups = groupMembersByKind(members);
           {items.map((m: any) => (
             <MemberCard
               member={m}
+              exactAnchor={anchorByMember.get(m)?.exact}
+              anchorAlias={anchorByMember.get(m)?.alias}
               allTypes={allTypes}
               packageName={packageName}
               parentType={parentType}

--- a/src/frontend/src/components/api-reference/MemberOverviewList.astro
+++ b/src/frontend/src/components/api-reference/MemberOverviewList.astro
@@ -16,7 +16,7 @@ import {
   typeHref,
   resolveTypeLink,
   shortTypeName,
-  memberSlug,
+  resolveMemberAnchorMap,
   memberDisplayName,
 } from '@utils/packages';
 
@@ -31,6 +31,7 @@ interface Props {
 const { members = [], typeName, typeArity = 0, allTypes = [], packageName = '' } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const groups = groupMembersByKind(members);
+const anchorByMember = resolveMemberAnchorMap(members);
 
 /** Build the href for a member-kind detail page. */
 function kindPageHref(kind: string): string {
@@ -54,7 +55,7 @@ function kindPageHref(kind: string): string {
             {items.map((m: any) => {
               const rawDisplayName = memberDisplayName(m);
               const displayName = m.name === '.ctor' ? rawDisplayName.replace('.ctor', typeName) : rawDisplayName;
-              const memberAnchor = memberSlug(m);
+              const memberAnchor = anchorByMember.get(m)!.exact;
               const memberHref = kindHref !== '#' ? `${kindHref}#${memberAnchor}` : undefined;
               const returnShort = m.returnType && m.returnType !== 'void'
                 ? shortTypeName(m.returnType)

--- a/src/frontend/src/data/pkgs/Aspire.Azure.Storage.Files.DataLake.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Azure.Storage.Files.DataLake.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Azure.Storage.Files.DataLake",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Elastic.Clients.Elasticsearch.13.3.0.json
+++ b/src/frontend/src/data/pkgs/Aspire.Elastic.Clients.Elasticsearch.13.3.0.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Elastic.Clients.Elasticsearch",
     "version": "13.3.0",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/elastic/elastic-aspire-dotnet",
     "sourceCommit": "cb75438c68bc9385b00564d69ba8f537c26a696d"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
@@ -1360,7 +1360,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addConnectionString dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addConnectionString dispatcher export."
               }
             }
           ],
@@ -1447,7 +1447,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts should build a ReferenceExpression explicitly and use the canonical addConnectionString export."
+                "Reason": "Polyglot AppHosts should build a ReferenceExpression explicitly and use the canonical addConnectionString export."
               }
             }
           ],
@@ -1673,7 +1673,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addContainerRegistry dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addContainerRegistry dispatcher export."
               }
             }
           ],
@@ -1803,7 +1803,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addContainerRegistry dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addContainerRegistry dispatcher export."
               }
             }
           ],
@@ -2800,7 +2800,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the async callback overload."
+                "Reason": "Polyglot AppHosts use the async callback overload."
               }
             }
           ],
@@ -3481,7 +3481,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withBuildArg dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withBuildArg dispatcher export."
               }
             }
           ],
@@ -5697,7 +5697,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the async callback overload."
+                "Reason": "Polyglot AppHosts use the async callback overload."
               }
             }
           ],
@@ -7642,7 +7642,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal createBuilder dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal createBuilder dispatcher export."
               }
             }
           ],
@@ -13177,7 +13177,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the overload with the optional configure callback."
+                "Reason": "Polyglot AppHosts use the overload with the optional configure callback."
               }
             }
           ],
@@ -13742,7 +13742,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13818,7 +13818,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13894,7 +13894,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13974,7 +13974,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withHttpHealthCheck export wrapper."
+                "Reason": "Polyglot AppHosts use the internal withHttpHealthCheck export wrapper."
               }
             }
           ],
@@ -19790,7 +19790,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -19904,7 +19904,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -20357,7 +20357,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addConnectionString dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addConnectionString dispatcher export."
               }
             }
           ],
@@ -20436,7 +20436,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addParameter dispatcher export."
               }
             }
           ],
@@ -20521,7 +20521,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addParameter dispatcher export."
               }
             }
           ],
@@ -21678,7 +21678,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addCSharpApp dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addCSharpApp dispatcher export."
               }
             }
           ],
@@ -21803,7 +21803,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addCSharpApp dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addCSharpApp dispatcher export."
               }
             }
           ],
@@ -22135,7 +22135,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -22468,7 +22468,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -22805,7 +22805,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -24513,7 +24513,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal waitFor dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal waitFor dispatcher export."
               }
             }
           ],
@@ -24661,7 +24661,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal waitFor dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal waitFor dispatcher export."
               }
             }
           ],
@@ -24995,7 +24995,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal waitForStart dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal waitForStart dispatcher export."
               }
             }
           ],
@@ -25118,7 +25118,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal waitForStart dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal waitForStart dispatcher export."
               }
             }
           ],
@@ -25565,7 +25565,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withArgsCallback."
+                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withArgsCallback."
               }
             }
           ],
@@ -26733,7 +26733,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withConnectionProperty dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withConnectionProperty dispatcher export."
               }
             }
           ],
@@ -26822,7 +26822,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withConnectionProperty dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withConnectionProperty dispatcher export."
               }
             }
           ],
@@ -27264,7 +27264,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEndpointCallback export, which exposes EndpointUpdateContext instead of EndpointAnnotation."
+                "Reason": "Polyglot AppHosts use the internal withEndpointCallback export, which exposes EndpointUpdateContext instead of EndpointAnnotation."
               }
             }
           ],
@@ -28322,7 +28322,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28511,7 +28511,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28721,7 +28721,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the async callback overload."
+                "Reason": "Polyglot AppHosts use the async callback overload."
               }
             }
           ],
@@ -28887,7 +28887,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28987,7 +28987,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29093,7 +29093,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29193,7 +29193,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29285,7 +29285,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -32839,7 +32839,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the async callback overload."
+                "Reason": "Polyglot AppHosts use the async callback overload."
               }
             }
           ],
@@ -34073,7 +34073,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot app hosts."
+                "Reason": "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot AppHosts."
               }
             }
           ],
@@ -34236,7 +34236,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot app hosts."
+                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot AppHosts."
               }
             }
           ],
@@ -34457,7 +34457,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot app hosts."
+                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot AppHosts."
               }
             }
           ],
@@ -34667,7 +34667,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withReference dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withReference dispatcher export."
               }
             }
           ],
@@ -34810,7 +34810,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the generic withReference export."
+                "Reason": "Polyglot AppHosts use the generic withReference export."
               }
             }
           ],
@@ -34971,7 +34971,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the generic withReference export."
+                "Reason": "Polyglot AppHosts use the generic withReference export."
               }
             }
           ],
@@ -35138,7 +35138,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the generic withReference dispatcher export."
+                "Reason": "Polyglot AppHosts use the generic withReference dispatcher export."
               }
             }
           ],
@@ -35226,7 +35226,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts can use the generic withReference dispatcher with an ExternalServiceResource builder."
+                "Reason": "Polyglot AppHosts can use the generic withReference dispatcher with an ExternalServiceResource builder."
               }
             }
           ],
@@ -35308,7 +35308,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the generic withReference dispatcher export."
+                "Reason": "Polyglot AppHosts use the generic withReference dispatcher export."
               }
             }
           ],
@@ -36394,7 +36394,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withUrl dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withUrl dispatcher export."
               }
             }
           ],
@@ -36648,7 +36648,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withUrl dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withUrl dispatcher export."
               }
             }
           ],
@@ -36925,7 +36925,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the Action<ResourceUrlAnnotation> overload for withUrlForEndpoint."
+                "Reason": "Polyglot AppHosts use the Action<ResourceUrlAnnotation> overload for withUrlForEndpoint."
               }
             }
           ],
@@ -37177,7 +37177,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withUrlsCallback."
+                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withUrlsCallback."
               }
             }
           ],
@@ -86698,7 +86698,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withPipelineConfiguration."
+                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withPipelineConfiguration."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
@@ -884,7 +884,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " Use this property to document why an API cannot be exported to polyglot app hosts, distinguishing reviewed-but-incompatible members from those not yet reviewed. "
+                "text": " Use this property to document why an API cannot be exported to polyglot AppHosts, distinguishing reviewed-but-incompatible members from those not yet reviewed. "
               }
             ]
           },
@@ -3849,7 +3849,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the ATS wrapper overload instead."
+                "text": "This method is not available in polyglot AppHosts. Use the ATS wrapper overload instead."
               }
             ],
             "returns": [
@@ -4371,7 +4371,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -7253,7 +7253,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -10001,7 +10001,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               },
@@ -10143,7 +10143,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               },
@@ -10507,7 +10507,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -10707,7 +10707,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -10811,7 +10811,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -10915,7 +10915,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -11019,7 +11019,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -11123,7 +11123,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -12016,7 +12016,7 @@
             "summary": [
               {
                 "kind": "text",
-                "text": " The application name to display in the dashboard. For source-file app hosts, this defaults to the AppHost directory name. For other apps, it falls back to the environment's application name. "
+                "text": " The application name to display in the dashboard. For source-file AppHosts, this defaults to the AppHost directory name. For other apps, it falls back to the environment's application name. "
               }
             ]
           },
@@ -12280,7 +12280,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload with name and packageId instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload with name and packageId instead."
               }
             ],
             "returns": [
@@ -13090,7 +13090,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the string[] overload instead."
+                "text": "This method is not available in polyglot AppHosts. Use the string[] overload instead."
               }
             ],
             "returns": [
@@ -20640,7 +20640,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the overload with a string value instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the overload with a string value instead."
                   }
                 ]
               }
@@ -20748,7 +20748,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload with a string value instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload with a string value instead."
               }
             ],
             "returns": [
@@ -21510,7 +21510,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -22057,7 +22057,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -22371,7 +22371,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -22717,7 +22717,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -23149,7 +23149,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -23557,7 +23557,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the overload without validation callback instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the overload without validation callback instead."
                   }
                 ]
               },
@@ -24064,7 +24064,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the overload without NetworkIdentifier instead."
+                "text": "This method is not available in polyglot AppHosts. Use the overload without NetworkIdentifier instead."
               }
             ],
             "returns": [
@@ -24437,7 +24437,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -25403,7 +25403,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the string[] overload instead."
+                "text": "This method is not available in polyglot AppHosts. Use the string[] overload instead."
               }
             ],
             "returns": [
@@ -25689,7 +25689,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -25808,7 +25808,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -26174,7 +26174,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the IResourceBuilder overload instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the IResourceBuilder overload instead."
                   }
                 ]
               }
@@ -26915,7 +26915,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -27323,7 +27323,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the callback-based endpoint mutation export instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the callback-based endpoint mutation export instead."
                   }
                 ]
               }
@@ -27893,7 +27893,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the overload with ProtocolType parameter instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the overload with ProtocolType parameter instead."
                   }
                 ]
               },
@@ -28428,7 +28428,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the ReferenceExpression overload instead."
+                "text": "This method is not available in polyglot AppHosts. Use the ReferenceExpression overload instead."
               }
             ],
             "returns": [
@@ -28641,7 +28641,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -29009,7 +29009,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "text": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             ],
             "returns": [
@@ -29299,7 +29299,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the unified "
+                "text": "This method is not available in polyglot AppHosts. Use the unified "
               },
               {
                 "kind": "code",
@@ -29427,7 +29427,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -30430,7 +30430,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -30777,7 +30777,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -31380,7 +31380,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the endpointName-based overload instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the endpointName-based overload instead."
                   }
                 ]
               }
@@ -31566,7 +31566,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. The parameter name 'type' is a reserved keyword in Go and Rust."
+                    "text": "This method is not available in polyglot AppHosts. The parameter name 'type' is a reserved keyword in Go and Rust."
                   }
                 ]
               }
@@ -31779,7 +31779,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the endpointName-based overload instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the endpointName-based overload instead."
                   }
                 ]
               }
@@ -31947,7 +31947,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use "
+                    "text": "This method is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -32081,7 +32081,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -33284,7 +33284,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -33379,7 +33379,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -33869,7 +33869,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the IResourceBuilder overload instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the IResourceBuilder overload instead."
                   }
                 ]
               }
@@ -34107,7 +34107,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# overload is not exported to polyglot app hosts. Use the language-specific static process command API instead."
+                    "text": "This C# overload is not exported to polyglot AppHosts. Use the language-specific static process command API instead."
                   }
                 ]
               }
@@ -34335,7 +34335,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# callback overload is not available in polyglot app hosts."
+                    "text": "This C# callback overload is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -34556,7 +34556,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# callback overload is not available in polyglot app hosts."
+                    "text": "This C# callback overload is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -35412,7 +35412,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -35508,7 +35508,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -35596,7 +35596,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -35684,7 +35684,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -35813,7 +35813,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               }
@@ -36561,7 +36561,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts. Use the ReferenceExpression overload instead."
+                    "text": "This method is not available in polyglot AppHosts. Use the ReferenceExpression overload instead."
                   }
                 ]
               }
@@ -39378,7 +39378,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -39466,7 +39466,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -39554,7 +39554,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -39641,7 +39641,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -39737,7 +39737,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               },
@@ -39864,7 +39864,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot app hosts."
+                    "text": "This method is not available in polyglot AppHosts."
                   }
                 ]
               },
@@ -73169,7 +73169,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -73266,7 +73266,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -84850,7 +84850,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -84913,7 +84913,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -86855,7 +86855,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead."
               }
             ],
             "returns": [
@@ -86934,7 +86934,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead."
               }
             ],
             "returns": [
@@ -87013,7 +87013,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead, and call it multiple times."
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead, and call it multiple times."
               }
             ],
             "returns": [
@@ -87092,7 +87092,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead, and call it multiple times."
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead, and call it multiple times."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -884,7 +884,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " Use this property to document why an API cannot be exported to polyglot AppHosts, distinguishing reviewed-but-incompatible members from those not yet reviewed. "
+                "text": " Use this property to document why an API cannot be exported to polyglot app hosts, distinguishing reviewed-but-incompatible members from those not yet reviewed. "
               }
             ]
           },
@@ -1360,7 +1360,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addConnectionString dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addConnectionString dispatcher export."
               }
             }
           ],
@@ -1447,7 +1447,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts should build a ReferenceExpression explicitly and use the canonical addConnectionString export."
+                "Reason": "Polyglot app hosts should build a ReferenceExpression explicitly and use the canonical addConnectionString export."
               }
             }
           ],
@@ -1673,7 +1673,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addContainerRegistry dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addContainerRegistry dispatcher export."
               }
             }
           ],
@@ -1803,7 +1803,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addContainerRegistry dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addContainerRegistry dispatcher export."
               }
             }
           ],
@@ -2800,7 +2800,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the async callback overload."
+                "Reason": "Polyglot app hosts use the async callback overload."
               }
             }
           ],
@@ -3481,7 +3481,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withBuildArg dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withBuildArg dispatcher export."
               }
             }
           ],
@@ -3849,7 +3849,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the ATS wrapper overload instead."
+                "text": "This method is not available in polyglot app hosts. Use the ATS wrapper overload instead."
               }
             ],
             "returns": [
@@ -4371,7 +4371,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -5697,7 +5697,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the async callback overload."
+                "Reason": "Polyglot app hosts use the async callback overload."
               }
             }
           ],
@@ -7253,7 +7253,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -7642,7 +7642,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal createBuilder dispatcher export."
+                "Reason": "Polyglot app hosts use the internal createBuilder dispatcher export."
               }
             }
           ],
@@ -8452,7 +8452,7 @@
               },
               {
                 "kind": "cref",
-                "value": "M:IHostApplicationLifetime.StopApplication()"
+                "value": "M:Microsoft.Extensions.Hosting.IHostApplicationLifetime.StopApplication"
               },
               {
                 "kind": "text",
@@ -10001,7 +10001,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               },
@@ -10143,7 +10143,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               },
@@ -10507,7 +10507,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -10707,7 +10707,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -10811,7 +10811,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -10915,7 +10915,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -11019,7 +11019,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -11123,7 +11123,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -12016,7 +12016,7 @@
             "summary": [
               {
                 "kind": "text",
-                "text": " The application name to display in the dashboard. For source-file AppHosts, this defaults to the AppHost directory name. For other apps, it falls back to the environment's application name. "
+                "text": " The application name to display in the dashboard. For source-file app hosts, this defaults to the AppHost directory name. For other apps, it falls back to the environment's application name. "
               }
             ]
           },
@@ -12280,7 +12280,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload with name and packageId instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload with name and packageId instead."
               }
             ],
             "returns": [
@@ -13090,7 +13090,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the string[] overload instead."
+                "text": "This method is not available in polyglot app hosts. Use the string[] overload instead."
               }
             ],
             "returns": [
@@ -13177,7 +13177,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the overload with the optional configure callback."
+                "Reason": "Polyglot app hosts use the overload with the optional configure callback."
               }
             }
           ],
@@ -13742,7 +13742,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13818,7 +13818,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13894,7 +13894,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addExternalService dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addExternalService dispatcher export."
               }
             }
           ],
@@ -13974,7 +13974,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withHttpHealthCheck export wrapper."
+                "Reason": "Polyglot app hosts use the internal withHttpHealthCheck export wrapper."
               }
             }
           ],
@@ -19790,7 +19790,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -19904,7 +19904,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -20357,7 +20357,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addConnectionString dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addConnectionString dispatcher export."
               }
             }
           ],
@@ -20436,7 +20436,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addParameter dispatcher export."
               }
             }
           ],
@@ -20521,7 +20521,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addParameter dispatcher export."
               }
             }
           ],
@@ -20640,7 +20640,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the overload with a string value instead."
+                    "text": "This method is not available in polyglot app hosts. Use the overload with a string value instead."
                   }
                 ]
               }
@@ -20748,7 +20748,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload with a string value instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload with a string value instead."
               }
             ],
             "returns": [
@@ -21510,7 +21510,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -21678,7 +21678,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addCSharpApp dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addCSharpApp dispatcher export."
               }
             }
           ],
@@ -21803,7 +21803,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addCSharpApp dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addCSharpApp dispatcher export."
               }
             }
           ],
@@ -22057,7 +22057,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -22135,7 +22135,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -22371,7 +22371,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -22468,7 +22468,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -22717,7 +22717,7 @@
               },
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload with projectPath instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload with projectPath instead."
               }
             ],
             "returns": [
@@ -22805,7 +22805,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addProject dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addProject dispatcher export."
               }
             }
           ],
@@ -23149,7 +23149,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -23557,7 +23557,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the overload without validation callback instead."
+                    "text": "This method is not available in polyglot app hosts. Use the overload without validation callback instead."
                   }
                 ]
               },
@@ -24064,7 +24064,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the overload without NetworkIdentifier instead."
+                "text": "This method is not available in polyglot app hosts. Use the overload without NetworkIdentifier instead."
               }
             ],
             "returns": [
@@ -24437,7 +24437,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -24513,7 +24513,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal waitFor dispatcher export."
+                "Reason": "Polyglot app hosts use the internal waitFor dispatcher export."
               }
             }
           ],
@@ -24661,7 +24661,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal waitFor dispatcher export."
+                "Reason": "Polyglot app hosts use the internal waitFor dispatcher export."
               }
             }
           ],
@@ -24995,7 +24995,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal waitForStart dispatcher export."
+                "Reason": "Polyglot app hosts use the internal waitForStart dispatcher export."
               }
             }
           ],
@@ -25118,7 +25118,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal waitForStart dispatcher export."
+                "Reason": "Polyglot app hosts use the internal waitForStart dispatcher export."
               }
             }
           ],
@@ -25403,7 +25403,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the string[] overload instead."
+                "text": "This method is not available in polyglot app hosts. Use the string[] overload instead."
               }
             ],
             "returns": [
@@ -25565,7 +25565,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withArgsCallback."
+                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withArgsCallback."
               }
             }
           ],
@@ -25689,7 +25689,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -25808,7 +25808,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -26174,7 +26174,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the IResourceBuilder overload instead."
+                    "text": "This method is not available in polyglot app hosts. Use the IResourceBuilder overload instead."
                   }
                 ]
               }
@@ -26733,7 +26733,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withConnectionProperty dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withConnectionProperty dispatcher export."
               }
             }
           ],
@@ -26822,7 +26822,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withConnectionProperty dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withConnectionProperty dispatcher export."
               }
             }
           ],
@@ -26915,7 +26915,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -27264,7 +27264,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEndpointCallback export, which exposes EndpointUpdateContext instead of EndpointAnnotation."
+                "Reason": "Polyglot app hosts use the internal withEndpointCallback export, which exposes EndpointUpdateContext instead of EndpointAnnotation."
               }
             }
           ],
@@ -27323,7 +27323,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the callback-based endpoint mutation export instead."
+                    "text": "This method is not available in polyglot app hosts. Use the callback-based endpoint mutation export instead."
                   }
                 ]
               }
@@ -27893,7 +27893,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the overload with ProtocolType parameter instead."
+                    "text": "This method is not available in polyglot app hosts. Use the overload with ProtocolType parameter instead."
                   }
                 ]
               },
@@ -28322,7 +28322,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28428,7 +28428,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the ReferenceExpression overload instead."
+                "text": "This method is not available in polyglot app hosts. Use the ReferenceExpression overload instead."
               }
             ],
             "returns": [
@@ -28511,7 +28511,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28641,7 +28641,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -28721,7 +28721,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the async callback overload."
+                "Reason": "Polyglot app hosts use the async callback overload."
               }
             }
           ],
@@ -28887,7 +28887,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -28987,7 +28987,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29009,7 +29009,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "text": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             ],
             "returns": [
@@ -29093,7 +29093,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29193,7 +29193,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29285,7 +29285,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -29299,7 +29299,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the unified "
+                "text": "This method is not available in polyglot app hosts. Use the unified "
               },
               {
                 "kind": "code",
@@ -29427,7 +29427,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -30430,7 +30430,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -30777,7 +30777,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -31380,7 +31380,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the endpointName-based overload instead."
+                    "text": "This method is not available in polyglot app hosts. Use the endpointName-based overload instead."
                   }
                 ]
               }
@@ -31566,7 +31566,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. The parameter name 'type' is a reserved keyword in Go and Rust."
+                    "text": "This method is not available in polyglot app hosts. The parameter name 'type' is a reserved keyword in Go and Rust."
                   }
                 ]
               }
@@ -31779,7 +31779,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the endpointName-based overload instead."
+                    "text": "This method is not available in polyglot app hosts. Use the endpointName-based overload instead."
                   }
                 ]
               }
@@ -31947,7 +31947,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use "
+                    "text": "This method is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -32081,7 +32081,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -32839,7 +32839,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the async callback overload."
+                "Reason": "Polyglot app hosts use the async callback overload."
               }
             }
           ],
@@ -33284,7 +33284,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -33379,7 +33379,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -33869,7 +33869,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the IResourceBuilder overload instead."
+                    "text": "This method is not available in polyglot app hosts. Use the IResourceBuilder overload instead."
                   }
                 ]
               }
@@ -34073,7 +34073,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot AppHosts."
+                "Reason": "Process commands start local processes from AppHost callbacks and cannot be represented in polyglot app hosts."
               }
             }
           ],
@@ -34107,7 +34107,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# overload is not exported to polyglot AppHosts. Use the language-specific static process command API instead."
+                    "text": "This C# overload is not exported to polyglot app hosts. Use the language-specific static process command API instead."
                   }
                 ]
               }
@@ -34236,7 +34236,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot AppHosts."
+                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot app hosts."
               }
             }
           ],
@@ -34335,7 +34335,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# callback overload is not available in polyglot AppHosts."
+                    "text": "This C# callback overload is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -34457,7 +34457,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot AppHosts."
+                "Reason": "Process command factories are C# callbacks and cannot be represented in polyglot app hosts."
               }
             }
           ],
@@ -34556,7 +34556,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This C# callback overload is not available in polyglot AppHosts."
+                    "text": "This C# callback overload is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -34667,7 +34667,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withReference dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withReference dispatcher export."
               }
             }
           ],
@@ -34810,7 +34810,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the generic withReference export."
+                "Reason": "Polyglot app hosts use the generic withReference export."
               }
             }
           ],
@@ -34971,7 +34971,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the generic withReference export."
+                "Reason": "Polyglot app hosts use the generic withReference export."
               }
             }
           ],
@@ -35138,7 +35138,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the generic withReference dispatcher export."
+                "Reason": "Polyglot app hosts use the generic withReference dispatcher export."
               }
             }
           ],
@@ -35226,7 +35226,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts can use the generic withReference dispatcher with an ExternalServiceResource builder."
+                "Reason": "Polyglot app hosts can use the generic withReference dispatcher with an ExternalServiceResource builder."
               }
             }
           ],
@@ -35308,7 +35308,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the generic withReference dispatcher export."
+                "Reason": "Polyglot app hosts use the generic withReference dispatcher export."
               }
             }
           ],
@@ -35412,7 +35412,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -35508,7 +35508,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -35596,7 +35596,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -35684,7 +35684,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -35813,7 +35813,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               }
@@ -36394,7 +36394,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withUrl dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withUrl dispatcher export."
               }
             }
           ],
@@ -36561,7 +36561,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts. Use the ReferenceExpression overload instead."
+                    "text": "This method is not available in polyglot app hosts. Use the ReferenceExpression overload instead."
                   }
                 ]
               }
@@ -36648,7 +36648,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withUrl dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withUrl dispatcher export."
               }
             }
           ],
@@ -36925,7 +36925,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the Action<ResourceUrlAnnotation> overload for withUrlForEndpoint."
+                "Reason": "Polyglot app hosts use the Action<ResourceUrlAnnotation> overload for withUrlForEndpoint."
               }
             }
           ],
@@ -37177,7 +37177,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withUrlsCallback."
+                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withUrlsCallback."
               }
             }
           ],
@@ -39378,7 +39378,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -39466,7 +39466,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -39554,7 +39554,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -39641,7 +39641,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -39737,7 +39737,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               },
@@ -39864,7 +39864,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This method is not available in polyglot AppHosts."
+                    "text": "This method is not available in polyglot app hosts."
                   }
                 ]
               },
@@ -46639,8 +46639,8 @@
           "name": "HealthStatus",
           "kind": "property",
           "accessibility": "public",
-          "signature": "public HealthStatus?? CustomResourceSnapshot.HealthStatus",
-          "returnType": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus??",
+          "signature": "public HealthStatus? CustomResourceSnapshot.HealthStatus",
+          "returnType": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?",
           "isReturnNullable": true,
           "hasGet": true,
           "docs": {
@@ -55305,7 +55305,7 @@
           "name": ".ctor",
           "kind": "constructor",
           "accessibility": "public",
-          "signature": "public HealthReportSnapshot.HealthReportSnapshot(string Name, HealthStatus?? Status, string? Description, string? ExceptionText)",
+          "signature": "public HealthReportSnapshot.HealthReportSnapshot(string Name, HealthStatus? Status, string? Description, string? ExceptionText)",
           "returnType": "void",
           "parameters": [
             {
@@ -55314,7 +55314,7 @@
             },
             {
               "name": "Status",
-              "type": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus??",
+              "type": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?",
               "isNullable": true
             },
             {
@@ -55384,7 +55384,7 @@
           "name": "Deconstruct",
           "kind": "method",
           "accessibility": "public",
-          "signature": "public void HealthReportSnapshot.Deconstruct(out string Name, out HealthStatus?? Status, out string? Description, out string? ExceptionText)",
+          "signature": "public void HealthReportSnapshot.Deconstruct(out string Name, out HealthStatus? Status, out string? Description, out string? ExceptionText)",
           "returnType": "void",
           "parameters": [
             {
@@ -55394,7 +55394,7 @@
             },
             {
               "name": "Status",
-              "type": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus??",
+              "type": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?",
               "isNullable": true,
               "modifier": "out"
             },
@@ -55692,8 +55692,8 @@
           "name": "Status",
           "kind": "property",
           "accessibility": "public",
-          "signature": "public HealthStatus?? HealthReportSnapshot.Status",
-          "returnType": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus??",
+          "signature": "public HealthStatus? HealthReportSnapshot.Status",
+          "returnType": "Microsoft.Extensions.Diagnostics.HealthChecks.HealthStatus?",
           "isReturnNullable": true,
           "hasGet": true,
           "hasSet": true,
@@ -73169,7 +73169,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -73266,7 +73266,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -84850,7 +84850,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use "
+                "text": "This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -84913,7 +84913,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use "
+                "text": "This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -86698,7 +86698,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the synchronous Action<> overload via withPipelineConfiguration."
+                "Reason": "Polyglot app hosts use the synchronous Action<> overload via withPipelineConfiguration."
               }
             }
           ],
@@ -86855,7 +86855,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead."
+                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead."
               }
             ],
             "returns": [
@@ -86934,7 +86934,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead."
+                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead."
               }
             ],
             "returns": [
@@ -87013,7 +87013,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead, and call it multiple times."
+                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead, and call it multiple times."
               }
             ],
             "returns": [
@@ -87092,7 +87092,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the overload that takes a step name and callback instead, and call it multiple times."
+                "text": "This overload is not available in polyglot app hosts. Use the overload that takes a step name and callback instead, and call it multiple times."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
@@ -351,7 +351,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -533,7 +533,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -621,7 +621,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -715,7 +715,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -810,7 +810,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1108,7 +1108,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1312,7 +1312,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1407,7 +1407,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1502,7 +1502,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1597,7 +1597,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -351,7 +351,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -533,7 +533,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withEnvironment dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withEnvironment dispatcher export."
               }
             }
           ],
@@ -621,7 +621,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -715,7 +715,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -810,7 +810,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -919,7 +919,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -1020,7 +1020,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -1108,7 +1108,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1217,7 +1217,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "cref",
@@ -1312,7 +1312,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1407,7 +1407,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1502,7 +1502,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1597,7 +1597,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withParameter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withParameter dispatcher export."
               }
             }
           ],
@@ -1893,7 +1893,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -2019,7 +2019,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. "
+                "text": " This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [
@@ -2173,7 +2173,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -2319,7 +2319,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. "
+                "text": " This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [
@@ -2467,7 +2467,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. "
+                "text": " This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [
@@ -2605,7 +2605,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. "
+                "text": " This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [
@@ -2743,7 +2743,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. "
+                "text": " This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [
@@ -3271,7 +3271,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the Azure resource-specific polyglot surface instead."
+                "text": "This method is not available in polyglot app hosts. Use the Azure resource-specific polyglot surface instead."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.13.4.6.json
@@ -919,7 +919,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1020,7 +1020,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1217,7 +1217,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "cref",
@@ -1893,7 +1893,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -2019,7 +2019,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. "
+                "text": " This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [
@@ -2173,7 +2173,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -2319,7 +2319,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. "
+                "text": " This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [
@@ -2467,7 +2467,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. "
+                "text": " This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [
@@ -2605,7 +2605,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. "
+                "text": " This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [
@@ -2743,7 +2743,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. "
+                "text": " This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [
@@ -3271,7 +3271,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the Azure resource-specific polyglot surface instead."
+                "text": "This method is not available in polyglot AppHosts. Use the Azure resource-specific polyglot surface instead."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
@@ -480,7 +480,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.AppConfiguration",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -141,7 +141,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -461,7 +464,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "AppConfigurationBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureAppConfigurationRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -474,7 +480,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -617,7 +623,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.AppConfiguration/AzureAppConfigurationEmulatorResource.cs",
           "sourceLines": "17-17"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppContainers.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppContainers.13.4.6.json
@@ -1401,7 +1401,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal publishAsAzureContainerAppJob dispatcher export."
               }
             }
           ],
@@ -1491,7 +1491,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal publishAsAzureContainerAppJob dispatcher export."
               }
             }
           ],
@@ -1576,7 +1576,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal publishAsScheduledAzureContainerAppJob dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal publishAsScheduledAzureContainerAppJob dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppContainers.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppContainers.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.AppContainers",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -54,7 +54,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "publishContainerAsAzureContainerApp"
+              ],
+              "arguments": {
+                "MethodName": "publishAsAzureContainerApp"
+              }
             }
           ],
           "docs": {
@@ -156,7 +162,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "publishExecutableAsAzureContainerApp"
+              ],
+              "arguments": {
+                "MethodName": "publishAsAzureContainerApp"
+              }
             }
           ],
           "docs": {
@@ -1056,7 +1068,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "publishProjectAsAzureContainerApp"
+              ],
+              "arguments": {
+                "MethodName": "publishAsAzureContainerApp"
+              }
             }
           ],
           "docs": {
@@ -1381,7 +1399,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1468,7 +1489,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal publishAsAzureContainerAppJob dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1550,7 +1574,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal publishAsScheduledAzureContainerAppJob dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1940,7 +1967,110 @@
               }
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets a "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing a deployed endpoint property for the specified "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.EndpointReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": ". "
+              }
+            ],
+            "remarks": [
+              {
+                "kind": "text",
+                "text": " Use this method when an endpoint property should be represented as a compute-environment-specific "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " instead of being resolved from a local endpoint allocation. The default implementation composes values from "
+              },
+              {
+                "kind": "cref",
+                "value": "M:Aspire.Hosting.ApplicationModel.IComputeEnvironmentResource.GetHostAddressExpression(Aspire.Hosting.ApplicationModel.EndpointReference)"
+              },
+              {
+                "kind": "text",
+                "text": ", the endpoint scheme, and endpoint ports. HTTP and HTTPS endpoints use ports 80 and 443 respectively when no explicit port is configured. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the deployed endpoint property."
+              }
+            ],
+            "parameters": {
+              "endpointReferenceExpression": [
+                {
+                  "kind": "text",
+                  "text": "The endpoint reference expression for which to retrieve a deployed endpoint property."
+                }
+              ]
+            },
+            "exceptions": [
+              {
+                "type": "T:System.ArgumentNullException",
+                "description": [
+                  {
+                    "kind": "text",
+                    "text": "Thrown when "
+                  },
+                  {
+                    "kind": "paramref",
+                    "value": "endpointReferenceExpression"
+                  },
+                  {
+                    "kind": "text",
+                    "text": " is "
+                  },
+                  {
+                    "kind": "langword",
+                    "value": "null"
+                  },
+                  {
+                    "kind": "text",
+                    "text": "."
+                  }
+                ]
+              },
+              {
+                "type": "T:System.InvalidOperationException",
+                "description": [
+                  {
+                    "kind": "text",
+                    "text": "Thrown when the requested endpoint property is unsupported, or when a non-HTTP/HTTPS endpoint does not specify a port."
+                  }
+                ]
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs",
           "sourceLines": "349-371"
         },
@@ -1967,7 +2097,58 @@
               }
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets a "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the host address or host name for the specified "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.EndpointReference"
+              },
+              {
+                "kind": "text",
+                "text": ". "
+              }
+            ],
+            "remarks": [
+              {
+                "kind": "text",
+                "text": " The returned value typically contains only the host name or address, without scheme, port, or path information. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the host address or host name (not a full URL)."
+              }
+            ],
+            "parameters": {
+              "endpointReference": [
+                {
+                  "kind": "text",
+                  "text": "The endpoint reference for which to retrieve the host address or host name."
+                }
+              ]
+            }
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.AppContainers/AzureContainerAppEnvironmentResource.cs",
           "sourceLines": "332-342"
         },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppService.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppService.13.4.6.json
@@ -592,7 +592,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAzureApplicationInsights dispatcher export."
               }
             }
           ],
@@ -644,7 +644,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAzureApplicationInsights dispatcher export."
               }
             }
           ],
@@ -701,7 +701,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAzureApplicationInsights dispatcher export."
               }
             }
           ],
@@ -758,7 +758,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAzureApplicationInsights dispatcher export."
               }
             }
           ],
@@ -889,7 +889,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withDeploymentSlot dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withDeploymentSlot dispatcher export."
               }
             }
           ],
@@ -946,7 +946,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withDeploymentSlot dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withDeploymentSlot dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppService.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.AppService.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.AppService",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -590,7 +590,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -639,7 +642,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -693,7 +699,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -747,7 +756,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAzureApplicationInsights dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -875,7 +887,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withDeploymentSlot dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -929,7 +944,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withDeploymentSlot dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1246,7 +1264,110 @@
               }
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets a "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing a deployed endpoint property for the specified "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.EndpointReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": ". "
+              }
+            ],
+            "remarks": [
+              {
+                "kind": "text",
+                "text": " Use this method when an endpoint property should be represented as a compute-environment-specific "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " instead of being resolved from a local endpoint allocation. The default implementation composes values from "
+              },
+              {
+                "kind": "cref",
+                "value": "M:Aspire.Hosting.ApplicationModel.IComputeEnvironmentResource.GetHostAddressExpression(Aspire.Hosting.ApplicationModel.EndpointReference)"
+              },
+              {
+                "kind": "text",
+                "text": ", the endpoint scheme, and endpoint ports. HTTP and HTTPS endpoints use ports 80 and 443 respectively when no explicit port is configured. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the deployed endpoint property."
+              }
+            ],
+            "parameters": {
+              "endpointReferenceExpression": [
+                {
+                  "kind": "text",
+                  "text": "The endpoint reference expression for which to retrieve a deployed endpoint property."
+                }
+              ]
+            },
+            "exceptions": [
+              {
+                "type": "T:System.ArgumentNullException",
+                "description": [
+                  {
+                    "kind": "text",
+                    "text": "Thrown when "
+                  },
+                  {
+                    "kind": "paramref",
+                    "value": "endpointReferenceExpression"
+                  },
+                  {
+                    "kind": "text",
+                    "text": " is "
+                  },
+                  {
+                    "kind": "langword",
+                    "value": "null"
+                  },
+                  {
+                    "kind": "text",
+                    "text": "."
+                  }
+                ]
+              },
+              {
+                "type": "T:System.InvalidOperationException",
+                "description": [
+                  {
+                    "kind": "text",
+                    "text": "Thrown when the requested endpoint property is unsupported, or when a non-HTTP/HTTPS endpoint does not specify a port."
+                  }
+                ]
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs",
           "sourceLines": "496-518"
         },
@@ -1273,7 +1394,58 @@
               }
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets a "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the host address or host name for the specified "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.EndpointReference"
+              },
+              {
+                "kind": "text",
+                "text": ". "
+              }
+            ],
+            "remarks": [
+              {
+                "kind": "text",
+                "text": " The returned value typically contains only the host name or address, without scheme, port, or path information. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.ReferenceExpression"
+              },
+              {
+                "kind": "text",
+                "text": " representing the host address or host name (not a full URL)."
+              }
+            ],
+            "parameters": {
+              "endpointReference": [
+                {
+                  "kind": "text",
+                  "text": "The endpoint reference for which to retrieve the host address or host name."
+                }
+              ]
+            }
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.AppService/AzureAppServiceEnvironmentResource.cs",
           "sourceLines": "488-489"
         },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
@@ -138,7 +138,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -248,7 +248,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that accepts an "
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that accepts an "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.ApplicationInsights",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -122,7 +122,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "logAnalyticsWorkspace parameter cannot be made optional in ATS. Use the single-parameter overload with WithLogAnalyticsWorkspace instead."
+              }
             }
           ],
           "docs": {
@@ -135,7 +138,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use "
+                "text": "This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -221,7 +224,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "BicepOutputReference is not ATS-compatible. Use the IResourceBuilder<AzureLogAnalyticsWorkspaceResource> overload instead."
+              }
             }
           ],
           "docs": {
@@ -242,7 +248,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the overload that accepts an "
+                "text": "This overload is not available in polyglot app hosts. Use the overload that accepts an "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
@@ -177,7 +177,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -435,7 +435,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use the enum-based overload instead. "
+                "text": " This overload is not available in polyglot AppHosts. Use the enum-based overload instead. "
               },
               {
                 "kind": "text",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.CognitiveServices",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -139,7 +139,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API that accepts AzureOpenAIDeployment which is not ATS-compatible."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -174,7 +177,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -329,7 +332,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -413,7 +419,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "CognitiveServicesBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the enum-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -426,7 +435,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use the enum-based overload instead. "
+                "text": " This overload is not available in polyglot app hosts. Use the enum-based overload instead. "
               },
               {
                 "kind": "text",
@@ -745,7 +754,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.CognitiveServices/AzureOpenAIDeploymentResource.cs",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
@@ -737,7 +737,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.ContainerRegistry",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -284,7 +284,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withContainerRegistryAzureContainerRegistry"
+              ],
+              "arguments": {
+                "MethodName": "withAzureContainerRegistry"
+              }
             }
           ],
           "docs": {
@@ -715,7 +721,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "ContainerRegistryBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureContainerRegistryRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -728,7 +737,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.CosmosDB",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -501,7 +501,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addContainer dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -594,7 +597,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addContainer dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -760,7 +766,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API with incorrect return type. Use AddCosmosDatabase instead."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -779,7 +788,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -845,7 +854,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -952,7 +964,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1054,7 +1069,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1122,7 +1140,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -2056,7 +2077,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.CosmosDB/AzureCosmosDBEmulatorResource.cs",
           "sourceLines": "18-18"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
@@ -788,7 +788,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
@@ -503,7 +503,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addContainer dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addContainer dispatcher export."
               }
             }
           ],
@@ -599,7 +599,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addContainer dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addContainer dispatcher export."
               }
             }
           ],
@@ -1071,7 +1071,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAccessKeyAuthentication dispatcher export."
               }
             }
           ],
@@ -1142,7 +1142,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAccessKeyAuthentication dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.EventHubs.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.EventHubs.13.4.6.json
@@ -493,7 +493,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1022,7 +1022,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.EventHubs.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.EventHubs.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.EventHubs",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -373,7 +373,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -474,7 +477,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<JsonNode> callbacks are not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -487,7 +493,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -913,7 +919,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -997,7 +1006,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "EventHubsBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureEventHubsRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -1010,7 +1022,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1306,7 +1318,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.EventHubs/AzureEventHubResource.cs",
@@ -1532,7 +1547,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsEmulatorResource.cs",
           "sourceLines": "27-27"
         },
@@ -1544,7 +1566,14 @@
           "returnType": "string",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the name of the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.EventHubs/AzureEventHubsEmulatorResource.cs",
           "sourceLines": "24-24"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.FrontDoor.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.FrontDoor.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.FrontDoor",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Functions.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Functions.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Functions",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -63,7 +63,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "TProject : IProjectMetadata is a .NET-specific generic constraint not compatible with ATS. Use the project path overload instead."
+              }
             }
           ],
           "docs": {
@@ -79,7 +82,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -552,7 +555,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IResourceWithAzureFunctionsConfig is an internal interface constraint not compatible with ATS."
+              }
             }
           ],
           "docs": {
@@ -565,7 +571,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use the standard "
+                "text": "This method is not available in polyglot app hosts. Use the standard "
               },
               {
                 "kind": "code",
@@ -827,7 +833,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -911,7 +920,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot export is via RunAsExistingCore which accepts both string and parameter resource inputs."
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1000,7 +1012,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot export is via RunAsExistingCore which accepts both string and parameter resource inputs."
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1089,7 +1104,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot export is via WithTaskHubNameCore which accepts both string and parameter resource inputs."
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1172,7 +1190,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot export is via WithTaskHubNameCore which accepts both string and parameter resource inputs."
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1338,7 +1359,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         },
         {
           "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -1555,7 +1579,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Functions/DurableTask/DurableTaskSchedulerEmulatorResource.cs",
           "sourceLines": "22-22"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Functions.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Functions.13.4.6.json
@@ -82,7 +82,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -571,7 +571,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use the standard "
+                "text": "This method is not available in polyglot AppHosts. Use the standard "
               },
               {
                 "kind": "code",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.KeyVault.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.KeyVault.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.KeyVault",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -193,7 +193,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -265,7 +268,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw ParameterResource overload; use the IResourceBuilder<ParameterResource> variant instead."
+              }
             }
           ],
           "docs": {
@@ -337,7 +343,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -414,7 +423,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -496,7 +508,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw ParameterResource overload; use the IResourceBuilder<ParameterResource> variant instead."
+              }
             }
           ],
           "docs": {
@@ -578,7 +593,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -721,7 +739,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "KeyVaultBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureKeyVaultRole-based overload instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.KeyVault.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.KeyVault.13.4.6.json
@@ -195,7 +195,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSecret dispatcher export."
               }
             }
           ],
@@ -345,7 +345,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSecret dispatcher export."
               }
             }
           ],
@@ -425,7 +425,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSecret dispatcher export."
               }
             }
           ],
@@ -595,7 +595,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSecret dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSecret dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Kubernetes",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -810,7 +810,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withNodePoolSubnet"
+              ],
+              "arguments": {
+                "MethodName": "withSubnet"
+              }
             }
           ],
           "docs": {
@@ -1614,7 +1620,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withLoadBalancerOnIngress"
+              ],
+              "arguments": {
+                "MethodName": "withLoadBalancer"
+              }
             }
           ],
           "docs": {
@@ -2862,7 +2874,22 @@
           "signature": "public AzureKubernetesEnvironmentResource AzureKubernetesLoadBalancerResource.Parent",
           "returnType": "Aspire.Hosting.Azure.Kubernetes.AzureKubernetesEnvironmentResource",
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the parent resource of type "
+              },
+              {
+                "kind": "typeparamref",
+                "value": "T"
+              },
+              {
+                "kind": "text",
+                "text": ". "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Kubernetes/AzureKubernetesLoadBalancerResource.cs",
           "sourceLines": "100-100"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -2881,8 +2881,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.Azure.Kubernetes.AzureKubernetesEnvironmentResource"
               },
               {
                 "kind": "text",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kusto.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Kusto.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Kusto",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -242,7 +242,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -454,7 +457,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.Kusto/AzureKustoClusterResource.cs",
@@ -652,7 +658,14 @@
           "signature": "public ReferenceExpression AzureKustoClusterResource.ConnectionStringExpression",
           "returnType": "Aspire.Hosting.ApplicationModel.ReferenceExpression",
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Describes the connection string format string used for this resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Kusto/AzureKustoClusterResource.cs",
           "sourceLines": "64-73"
         },
@@ -783,7 +796,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Kusto/AzureKustoEmulatorResource.cs",
           "sourceLines": "24-24"
         }
@@ -824,7 +844,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.Kusto/AzureKustoReadWriteDatabaseResource.cs",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Network.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Network.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Network",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -577,7 +577,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "associateWithNetworkSecurityPerimeter"
+              ],
+              "arguments": {
+                "MethodName": "withNetworkSecurityPerimeter"
+              }
             }
           ],
           "docs": {
@@ -974,7 +980,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addAzureVirtualNetwork dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1058,7 +1067,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addAzureVirtualNetwork dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1148,7 +1160,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSubnet dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1244,7 +1259,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addSubnet dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1906,7 +1924,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withSubnetDelegatedSubnet"
+              ],
+              "arguments": {
+                "MethodName": "withDelegatedSubnet"
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Network.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Network.13.4.6.json
@@ -982,7 +982,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addAzureVirtualNetwork dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addAzureVirtualNetwork dispatcher export."
               }
             }
           ],
@@ -1069,7 +1069,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addAzureVirtualNetwork dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addAzureVirtualNetwork dispatcher export."
               }
             }
           ],
@@ -1162,7 +1162,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSubnet dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSubnet dispatcher export."
               }
             }
           ],
@@ -1261,7 +1261,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addSubnet dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addSubnet dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.OperationalInsights.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.OperationalInsights.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.OperationalInsights",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.PostgreSQL",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -345,7 +345,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -427,7 +430,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withPasswordAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -535,7 +541,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withPasswordAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -634,7 +643,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -860,7 +872,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerDatabaseResource.cs",
           "sourceLines": "72-72"
         },
@@ -1211,7 +1230,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresFlexibleServerResource.cs",
           "sourceLines": "69-69"
         },
@@ -1616,7 +1642,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs",
           "sourceLines": "34-34"
         },
@@ -1664,7 +1697,14 @@
           "returnType": "string",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the name of the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.PostgreSQL/AzurePostgresResource.cs",
           "sourceLines": "31-31"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
@@ -432,7 +432,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withPasswordAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withPasswordAuthentication dispatcher export."
               }
             }
           ],
@@ -543,7 +543,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withPasswordAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withPasswordAuthentication dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
@@ -201,7 +201,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAccessKeyAuthentication dispatcher export."
               }
             }
           ],
@@ -272,7 +272,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withAccessKeyAuthentication dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
@@ -997,7 +997,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot app hosts."
+                "text": "This property is not available in polyglot AppHosts."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Redis.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Redis",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -126,7 +126,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -196,7 +199,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -264,7 +270,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal withAccessKeyAuthentication dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -797,7 +806,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.Redis/AzureManagedRedisResource.cs",
@@ -976,10 +988,16 @@
             }
           ],
           "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ],
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot AppHosts."
+                "text": "This property is not available in polyglot app hosts."
               }
             ]
           },
@@ -1407,7 +1425,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Redis/AzureRedisCacheResource.cs",
           "sourceLines": "59-59"
         },
@@ -1613,7 +1638,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Redis/AzureRedisResource.cs",
           "sourceLines": "34-34"
         },
@@ -1661,7 +1693,14 @@
           "returnType": "string",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the name of the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Redis/AzureRedisResource.cs",
           "sourceLines": "31-31"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Search.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Search.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Search",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -152,7 +152,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "SearchBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureSearchRole-based overload instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.ServiceBus",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -131,7 +131,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API with incorrect return type. Use AddServiceBusQueue instead."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -150,7 +153,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -467,7 +470,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API. Use AddServiceBusSubscription instead."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -486,7 +492,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -556,7 +562,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API with incorrect return type. Use AddServiceBusTopic instead."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -575,7 +584,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -629,7 +638,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Obsolete API. Use AddServiceBusTopic and AddServiceBusSubscription instead."
+              }
             },
             {
               "name": "System.ObsoleteAttribute",
@@ -648,7 +660,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -714,7 +726,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -808,7 +823,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<JsonNode> callbacks are not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -821,7 +839,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. Use "
+                "text": " This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1045,7 +1063,14 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withQueueProperties"
+              ],
+              "arguments": {
+                "MethodName": "withProperties",
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -1115,7 +1140,14 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withTopicProperties"
+              ],
+              "arguments": {
+                "MethodName": "withProperties",
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -1185,7 +1217,14 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withSubscriptionProperties"
+              ],
+              "arguments": {
+                "MethodName": "withProperties",
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -1268,7 +1307,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "ServiceBusBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureServiceBusRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -1281,7 +1323,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1650,7 +1692,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusEmulatorResource.cs",
           "sourceLines": "22-22"
         }
@@ -1744,7 +1793,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusQueueResource.cs",
@@ -2600,7 +2652,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusSubscriptionResource.cs",
@@ -2932,7 +2987,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.ServiceBus/AzureServiceBusTopicResource.cs",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
@@ -153,7 +153,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -492,7 +492,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -584,7 +584,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -660,7 +660,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -839,7 +839,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. Use "
+                "text": " This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1323,7 +1323,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.SignalR.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.SignalR.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.SignalR",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -46,7 +46,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Use the dedicated polyglot overload instead."
+              }
             }
           ],
           "docs": {
@@ -143,7 +146,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Use the dedicated polyglot overload instead."
+              }
             }
           ],
           "docs": {
@@ -260,7 +266,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -370,7 +379,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "SignalRBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureSignalRRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -807,7 +819,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.SignalR/AzureSignalREmulatorResource.cs",
           "sourceLines": "17-17"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Sql.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Sql.13.4.6.json
@@ -306,7 +306,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -701,7 +704,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.Sql/AzureSqlDatabaseResource.cs",
@@ -780,10 +786,16 @@
             }
           ],
           "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ],
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot AppHosts."
+                "text": "This property is not available in polyglot app hosts."
               }
             ]
           },
@@ -956,7 +968,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Azure.Sql/AzureSqlServerResource.cs",
@@ -1208,10 +1223,16 @@
             }
           ],
           "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ],
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot AppHosts."
+                "text": "This property is not available in polyglot app hosts."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Sql.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Sql.13.4.6.json
@@ -795,7 +795,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot app hosts."
+                "text": "This property is not available in polyglot AppHosts."
               }
             ]
           },
@@ -1232,7 +1232,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot app hosts."
+                "text": "This property is not available in polyglot AppHosts."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Storage.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.Storage.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.Storage",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -944,7 +944,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -1395,7 +1398,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "StorageBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureStorageRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -2656,7 +2662,14 @@
           "returnType": "Aspire.Hosting.ApplicationModel.ResourceAnnotationCollection",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the annotations associated with the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorResource.cs",
           "sourceLines": "20-20"
         },
@@ -2668,7 +2681,14 @@
           "returnType": "string",
           "isOverride": true,
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the name of the resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Azure.Storage/AzureStorageEmulatorResource.cs",
           "sourceLines": "17-17"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Azure.WebPubSub",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -157,7 +157,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "ExpressionInterpolatedStringHandler and UpstreamAuthSettings are not ATS-compatible. Use the polyglot overload without auth settings instead."
+              }
             }
           ],
           "docs": {
@@ -170,7 +173,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Configure Web PubSub event handlers without auth settings in polyglot AppHosts."
+                "text": "This overload is not available in polyglot app hosts. Configure Web PubSub event handlers without auth settings in polyglot app hosts."
               }
             ],
             "parameters": {
@@ -248,7 +251,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "UpstreamAuthSettings is not ATS-compatible. Use the polyglot overload without auth settings instead."
+              }
             }
           ],
           "docs": {
@@ -261,7 +267,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Configure Web PubSub event handlers without auth settings in polyglot AppHosts."
+                "text": "This overload is not available in polyglot app hosts. Configure Web PubSub event handlers without auth settings in polyglot app hosts."
               }
             ],
             "parameters": {
@@ -321,7 +327,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Use the AddHub overload with the optional hubName parameter instead."
+              }
             }
           ],
           "docs": {
@@ -334,7 +343,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the named hub overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the named hub overload instead."
               }
             ],
             "parameters": {
@@ -472,7 +481,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "WebPubSubBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the AzureWebPubSubRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -485,7 +497,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
@@ -173,7 +173,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Configure Web PubSub event handlers without auth settings in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts. Configure Web PubSub event handlers without auth settings in polyglot AppHosts."
               }
             ],
             "parameters": {
@@ -267,7 +267,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Configure Web PubSub event handlers without auth settings in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts. Configure Web PubSub event handlers without auth settings in polyglot AppHosts."
               }
             ],
             "parameters": {
@@ -343,7 +343,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the named hub overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the named hub overload instead."
               }
             ],
             "parameters": {
@@ -497,7 +497,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Blazor.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Blazor.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Blazor",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Browsers.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Browsers.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Browsers",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.ClickHouse.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.ClickHouse.13.4.6.json
@@ -177,7 +177,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.ClickHouse.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.ClickHouse.13.4.6.json
@@ -177,7 +177,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use "
+                "text": "This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.DevTunnels.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.DevTunnels.13.4.6.json
@@ -90,7 +90,7 @@
               },
               {
                 "kind": "text",
-                "text": ". This overload is not available in polyglot app hosts. Use "
+                "text": ". This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -166,7 +166,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. Use "
+                "text": " This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -275,7 +275,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot app hosts. Use "
+                "text": " This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -598,7 +598,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use the overload that accepts a "
+                "text": " This overload is not available in polyglot AppHosts. Use the overload that accepts a "
               },
               {
                 "kind": "langword",
@@ -825,7 +825,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -931,7 +931,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " Referencing a dev tunnel will delay the start of the resource until the referenced dev tunnel's endpoint is allocated. This method is not available in polyglot app hosts. "
+                "text": " Referencing a dev tunnel will delay the start of the resource until the referenced dev tunnel's endpoint is allocated. This method is not available in polyglot AppHosts. "
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.DevTunnels.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.DevTunnels.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.DevTunnels",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -90,7 +90,7 @@
               },
               {
                 "kind": "text",
-                "text": ". This overload is not available in polyglot AppHosts. Use "
+                "text": ". This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -166,7 +166,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. Use "
+                "text": " This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -275,7 +275,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This method is not available in polyglot AppHosts. Use "
+                "text": " This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -598,7 +598,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use the overload that accepts a "
+                "text": " This overload is not available in polyglot app hosts. Use the overload that accepts a "
               },
               {
                 "kind": "langword",
@@ -825,7 +825,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use "
+                "text": " This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -931,7 +931,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " Referencing a dev tunnel will delay the start of the resource until the referenced dev tunnel's endpoint is allocated. This method is not available in polyglot AppHosts. "
+                "text": " Referencing a dev tunnel will delay the start of the resource until the referenced dev tunnel's endpoint is allocated. This method is not available in polyglot app hosts. "
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
@@ -1732,8 +1732,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.Docker.DockerComposeEnvironmentResource"
               },
               {
                 "kind": "text",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Docker",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -735,7 +735,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot AppHosts."
+                "Reason": "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot app hosts."
               }
             }
           ],
@@ -749,7 +749,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts because "
+                "text": "This overload is not available in polyglot app hosts because "
               },
               {
                 "kind": "cref",
@@ -900,7 +900,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Prefer the builder or IManifestExpressionProvider overloads in polyglot AppHosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource."
+                "Reason": "Prefer the builder or IManifestExpressionProvider overloads in polyglot app hosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource."
               }
             }
           ],
@@ -922,7 +922,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the builder or manifest-expression overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the builder or manifest-expression overload instead."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
@@ -749,7 +749,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts because "
+                "text": "This overload is not available in polyglot AppHosts because "
               },
               {
                 "kind": "cref",
@@ -922,7 +922,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the builder or manifest-expression overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the builder or manifest-expression overload instead."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Docker.13.4.6.json
@@ -735,7 +735,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot app hosts."
+                "Reason": "IManifestExpressionProvider parameters are not ATS-compatible. Use the parameter-builder overload in polyglot AppHosts."
               }
             }
           ],
@@ -900,7 +900,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Prefer the builder or IManifestExpressionProvider overloads in polyglot app hosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource."
+                "Reason": "Prefer the builder or IManifestExpressionProvider overloads in polyglot AppHosts to avoid duplicate asEnvironmentPlaceholder projections on ParameterResource."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Elasticsearch.13.3.0.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Elasticsearch.13.3.0.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Elasticsearch",
     "version": "13.3.0",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/elastic/elastic-aspire-dotnet",
     "sourceCommit": "cb75438c68bc9385b00564d69ba8f537c26a696d"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
@@ -791,7 +791,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withMigrationsProject dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withMigrationsProject dispatcher export."
               }
             }
           ],
@@ -865,7 +865,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Uses IProjectMetadata generic constraint which is a .NET-specific type. Polyglot app hosts use the internal withMigrationsProject dispatcher export."
+                "Reason": "Uses IProjectMetadata generic constraint which is a .NET-specific type. Polyglot AppHosts use the internal withMigrationsProject dispatcher export."
               }
             }
           ],
@@ -960,7 +960,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addEFMigrations dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addEFMigrations dispatcher export."
               }
             }
           ],
@@ -1137,7 +1137,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addEFMigrations dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addEFMigrations dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.EntityFrameworkCore",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -791,7 +791,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withMigrationsProject dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withMigrationsProject dispatcher export."
               }
             }
           ],
@@ -865,7 +865,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Uses IProjectMetadata generic constraint which is a .NET-specific type. Polyglot AppHosts use the internal withMigrationsProject dispatcher export."
+                "Reason": "Uses IProjectMetadata generic constraint which is a .NET-specific type. Polyglot app hosts use the internal withMigrationsProject dispatcher export."
               }
             }
           ],
@@ -960,7 +960,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addEFMigrations dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addEFMigrations dispatcher export."
               }
             }
           ],
@@ -1137,7 +1137,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal addEFMigrations dispatcher export."
+                "Reason": "Polyglot app hosts use the internal addEFMigrations dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Foundry",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -191,7 +191,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addBingGroundingConnectionFromParameter"
+              ]
             }
           ],
           "docs": {
@@ -282,7 +285,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "The configureProperties callback returns Azure provisioning types that are not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -295,7 +301,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -365,7 +371,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw AzureCosmosDBResource parameters are not ATS-compatible. Use the resource-builder overload instead."
+              }
             }
           ],
           "docs": {
@@ -399,7 +408,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addCosmosConnection"
+              ]
             }
           ],
           "docs": {
@@ -433,7 +445,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw AzureStorageResource parameters are not ATS-compatible. Use the resource-builder overload instead."
+              }
             }
           ],
           "docs": {
@@ -467,7 +482,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addStorageConnection"
+              ]
             }
           ],
           "docs": {
@@ -501,7 +519,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw AzureContainerRegistryResource parameters are not ATS-compatible. Use the resource-builder overload instead."
+              }
             }
           ],
           "docs": {
@@ -535,7 +556,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addContainerRegistryConnection"
+              ]
             }
           ],
           "docs": {
@@ -569,7 +593,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Raw AzureSearchResource parameters are not ATS-compatible. Use the resource-builder overload instead."
+              }
             }
           ],
           "docs": {
@@ -603,7 +630,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addSearchConnection"
+              ]
             }
           ],
           "docs": {
@@ -637,7 +667,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addKeyVaultConnection"
+              ]
             }
           ],
           "docs": {
@@ -698,7 +731,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "CapabilityHostBuilder is not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -711,7 +747,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts."
+                "text": "This method is not available in polyglot app hosts."
               }
             ],
             "returns": [
@@ -777,7 +813,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addModelDeployment dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -866,7 +905,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addModelDeployment dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1117,7 +1159,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "The standard WithReference export already covers this polyglot scenario."
+              }
             }
           ],
           "docs": {
@@ -1130,7 +1175,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the standard "
+                "text": "This overload is not available in polyglot app hosts. Use the standard "
               },
               {
                 "kind": "code",
@@ -1198,7 +1243,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addDeployment dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1283,7 +1331,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts use the internal addDeployment dispatcher export."
+              }
             }
           ],
           "docs": {
@@ -1500,7 +1551,14 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withFoundryDeploymentProperties"
+              ],
+              "arguments": {
+                "MethodName": "withProperties",
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -1584,7 +1642,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "CognitiveServicesBuiltInRole is an Azure.Provisioning type not compatible with ATS. Use the FoundryRole-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -1689,7 +1750,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Subset of the full AsHostedAgent(project) overload which is exported."
+              }
             }
           ],
           "docs": {
@@ -1783,7 +1847,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action callback shape is awkward for polyglot hosts; the HostedAgentOptions DTO shape is exported instead."
+              }
             }
           ],
           "docs": {
@@ -1900,7 +1967,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Subset of the full AsHostedAgent overload."
+              }
             }
           ],
           "docs": {
@@ -2124,7 +2194,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "BinaryData parameter is not ATS-compatible. Use the string overload instead."
+              }
             }
           ],
           "docs": {
@@ -2825,7 +2898,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "BinaryData parameter is not ATS-compatible. Use the string overload instead."
+              }
             }
           ],
           "docs": {
@@ -3279,7 +3355,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IFoundryTool is not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -3451,7 +3530,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Covered by the internal AspireUnion overload."
+              }
             }
           ],
           "docs": {
@@ -3530,7 +3612,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Covered by the internal AspireUnion overload."
+              }
             }
           ],
           "docs": {
@@ -3600,7 +3685,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Covered by the internal AspireUnion overload."
+              }
             }
           ],
           "docs": {
@@ -5015,7 +5103,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs",
@@ -5099,7 +5190,14 @@
           "signature": "public ReferenceExpression AzurePromptAgentResource.ConnectionStringExpression",
           "returnType": "Aspire.Hosting.ApplicationModel.ReferenceExpression",
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Describes the connection string format string used for this resource. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Foundry/PromptAgent/AzurePromptAgentResource.cs",
           "sourceLines": "165-165"
         },
@@ -5204,7 +5302,10 @@
           "hasGet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IFoundryTool is a .NET extensibility point and is not ATS-compatible."
+              }
             }
           ],
           "docs": {
@@ -7486,7 +7587,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Foundry/FoundryDeploymentResource.cs",
@@ -8634,13 +8738,16 @@
           },
           {
             "kind": "text",
-            "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot AppHosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
+            "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot app hosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
           }
         ]
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/Aspire.Hosting.Foundry/HostedAgent/HostedAgentConfiguration.cs",
@@ -8676,7 +8783,7 @@
               },
               {
                 "kind": "text",
-                "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot AppHosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
+                "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot app hosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
               }
             ]
           },
@@ -8694,7 +8801,10 @@
           "isInitOnly": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Azure SDK-specific type not usable from polyglot hosts."
+              }
             }
           ],
           "docs": {
@@ -8718,7 +8828,10 @@
           "hasSet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Azure SDK-specific type not usable from polyglot hosts."
+              }
             }
           ],
           "docs": {
@@ -8758,7 +8871,10 @@
           "hasGet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Derived formatting property used internally by Azure provisioning."
+              }
             }
           ],
           "docs": {
@@ -8819,7 +8935,10 @@
           "hasSet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Image comes from the executable resource and is not configured from polyglot hosted agent callbacks."
+              }
             }
           ],
           "docs": {
@@ -8859,7 +8978,10 @@
           "hasGet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Derived formatting property used internally by Azure provisioning."
+              }
             }
           ],
           "docs": {
@@ -8903,7 +9025,10 @@
           "isInitOnly": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Azure SDK-specific type not usable from polyglot hosts."
+              }
             }
           ],
           "docs": {
@@ -31872,7 +31997,30 @@
               "isOptional": true
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the value for use as an environment variable. "
+              }
+            ],
+            "parameters": {
+              "cancellationToken": [
+                {
+                  "kind": "text",
+                  "text": "A "
+                },
+                {
+                  "kind": "cref",
+                  "value": "T:System.Threading.CancellationToken"
+                },
+                {
+                  "kind": "text",
+                  "text": "."
+                }
+              ]
+            }
+          },
           "sourceFile": "src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs",
           "sourceLines": "513-519"
         },
@@ -31906,7 +32054,14 @@
           "signature": "public string StaticValueProvider<T>.ValueExpression",
           "returnType": "string",
           "hasGet": true,
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Gets the expression that represents a value in manifest. "
+              }
+            ]
+          },
           "sourceFile": "src/Aspire.Hosting.Foundry/HostedAgent/AzureHostedAgentResource.cs",
           "sourceLines": "478-478"
         }

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -301,7 +301,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -747,7 +747,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1175,7 +1175,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the standard "
+                "text": "This overload is not available in polyglot AppHosts. Use the standard "
               },
               {
                 "kind": "code",
@@ -8738,7 +8738,7 @@
           },
           {
             "kind": "text",
-            "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot app hosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
+            "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot AppHosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
           }
         ]
       },
@@ -8783,7 +8783,7 @@
               },
               {
                 "kind": "text",
-                "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot app hosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
+                "text": " to provide a strongly typed configuration surface for hosted agent definitions. When used from polyglot AppHosts, only the ATS-compatible properties are exported; Azure SDK-specific members remain .NET-only. "
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -815,7 +815,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addModelDeployment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addModelDeployment dispatcher export."
               }
             }
           ],
@@ -907,7 +907,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addModelDeployment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addModelDeployment dispatcher export."
               }
             }
           ],
@@ -1245,7 +1245,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addDeployment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addDeployment dispatcher export."
               }
             }
           ],
@@ -1333,7 +1333,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal addDeployment dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal addDeployment dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Garnet.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Garnet.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Garnet",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.GitHub.Models.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.GitHub.Models.13.4.6.json
@@ -178,7 +178,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                    "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
                   }
                 ]
               },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.GitHub.Models.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.GitHub.Models.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.GitHub.Models",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -178,7 +178,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
+                    "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
                   }
                 ]
               },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Go.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Go.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Go",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.JavaScript.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.JavaScript.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.JavaScript",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Kafka.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Kafka.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Kafka",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
@@ -488,7 +488,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -594,7 +594,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Keycloak",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -488,7 +488,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],
@@ -594,7 +594,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withOtlpExporter dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withOtlpExporter dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -5800,7 +5800,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartDescription dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartDescription dispatcher export."
               }
             }
           ],
@@ -5860,7 +5860,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartDescription dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartDescription dispatcher export."
               }
             }
           ],
@@ -5920,7 +5920,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartName dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartName dispatcher export."
               }
             }
           ],
@@ -6004,7 +6004,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartName dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartName dispatcher export."
               }
             }
           ],
@@ -6064,7 +6064,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartVersion dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartVersion dispatcher export."
               }
             }
           ],
@@ -6164,7 +6164,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withChartVersion dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withChartVersion dispatcher export."
               }
             }
           ],
@@ -6216,7 +6216,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withNamespace dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withNamespace dispatcher export."
               }
             }
           ],
@@ -6268,7 +6268,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withNamespace dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withNamespace dispatcher export."
               }
             }
           ],
@@ -6320,7 +6320,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withReleaseName dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withReleaseName dispatcher export."
               }
             }
           ],
@@ -6372,7 +6372,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the union-based withReleaseName dispatcher export."
+                "Reason": "Polyglot AppHosts use the union-based withReleaseName dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Kubernetes",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -5800,7 +5800,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartDescription dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartDescription dispatcher export."
               }
             }
           ],
@@ -5860,7 +5860,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartDescription dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartDescription dispatcher export."
               }
             }
           ],
@@ -5920,7 +5920,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartName dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartName dispatcher export."
               }
             }
           ],
@@ -6004,7 +6004,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartName dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartName dispatcher export."
               }
             }
           ],
@@ -6064,7 +6064,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartVersion dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartVersion dispatcher export."
               }
             }
           ],
@@ -6164,7 +6164,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withChartVersion dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withChartVersion dispatcher export."
               }
             }
           ],
@@ -6216,7 +6216,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withNamespace dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withNamespace dispatcher export."
               }
             }
           ],
@@ -6268,7 +6268,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withNamespace dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withNamespace dispatcher export."
               }
             }
           ],
@@ -6320,7 +6320,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withReleaseName dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withReleaseName dispatcher export."
               }
             }
           ],
@@ -6372,7 +6372,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the union-based withReleaseName dispatcher export."
+                "Reason": "Polyglot app hosts use the union-based withReleaseName dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -8408,8 +8408,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource"
               },
               {
                 "kind": "text",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
@@ -99,7 +99,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -228,7 +228,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -520,7 +520,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -666,7 +666,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -970,7 +970,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1100,7 +1100,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1351,7 +1351,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1472,7 +1472,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1725,7 +1725,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -2223,7 +2223,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot app hosts. Use "
+                    "text": " This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Maui",
     "version": "13.4.6-preview.1.26319.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -99,7 +99,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -228,7 +228,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -520,7 +520,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -666,7 +666,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -970,7 +970,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1100,7 +1100,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1351,7 +1351,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1472,7 +1472,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -1725,7 +1725,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -2223,7 +2223,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": " This overload is not available in polyglot AppHosts. Use "
+                    "text": " This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Milvus.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Milvus.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Milvus",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.MongoDB.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.MongoDB.13.4.6.json
@@ -178,7 +178,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot app hosts. Use "
+                    "text": "This overload is not available in polyglot AppHosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -627,7 +627,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.MongoDB.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.MongoDB.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.MongoDB",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -178,7 +178,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot AppHosts. Use "
+                    "text": "This overload is not available in polyglot app hosts. Use "
                   },
                   {
                     "kind": "cref",
@@ -627,7 +627,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.MySql.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.MySql.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.MySql",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Nats.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Nats.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Nats",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.OpenAI.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.OpenAI.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.OpenAI",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Oracle.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Oracle.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Oracle",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Orleans.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Orleans.13.4.6.json
@@ -280,7 +280,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -467,7 +467,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -592,7 +592,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -708,7 +708,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -848,7 +848,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -925,7 +925,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1065,7 +1065,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1429,7 +1429,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1554,7 +1554,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1625,7 +1625,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1765,7 +1765,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Orleans.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Orleans.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Orleans",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -280,7 +280,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -467,7 +467,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -592,7 +592,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -708,7 +708,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -848,7 +848,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -925,7 +925,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1065,7 +1065,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1429,7 +1429,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1554,7 +1554,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1625,7 +1625,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot AppHosts. Use "
+                "text": "This resource name is the name the application will use to resolve the provider. This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -1765,7 +1765,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.PostgreSQL.13.4.6.json
@@ -908,7 +908,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.PostgreSQL.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.PostgreSQL",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -908,7 +908,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Python.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Python.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Python",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Qdrant",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -337,7 +337,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Use the overload that accepts an explicit connection name when calling this API from polyglot AppHosts."
+                "Reason": "Use the overload that accepts an explicit connection name when calling this API from polyglot app hosts."
               }
             }
           ],
@@ -351,7 +351,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot AppHosts. Use the overload that accepts an explicit connection name instead. "
+                "text": " This overload is not available in polyglot app hosts. Use the overload that accepts an explicit connection name instead. "
               }
             ],
             "returns": [
@@ -423,7 +423,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the generic withReference export."
+                "Reason": "Polyglot app hosts use the generic withReference export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
@@ -351,7 +351,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use the overload that accepts an explicit connection name instead. "
+                "text": " This overload is not available in polyglot AppHosts. Use the overload that accepts an explicit connection name instead. "
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Qdrant.13.4.6.json
@@ -337,7 +337,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Use the overload that accepts an explicit connection name when calling this API from polyglot app hosts."
+                "Reason": "Use the overload that accepts an explicit connection name when calling this API from polyglot AppHosts."
               }
             }
           ],
@@ -423,7 +423,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the generic withReference export."
+                "Reason": "Polyglot AppHosts use the generic withReference export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.RabbitMQ.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.RabbitMQ.13.4.6.json
@@ -341,7 +341,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withManagementPlugin dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withManagementPlugin dispatcher export."
               }
             }
           ],
@@ -471,7 +471,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the internal withManagementPlugin dispatcher export."
+                "Reason": "Polyglot AppHosts use the internal withManagementPlugin dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.RabbitMQ.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.RabbitMQ.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.RabbitMQ",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -341,7 +341,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withManagementPlugin dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withManagementPlugin dispatcher export."
               }
             }
           ],
@@ -471,7 +471,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the internal withManagementPlugin dispatcher export."
+                "Reason": "Polyglot app hosts use the internal withManagementPlugin dispatcher export."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Redis.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Redis.13.4.6.json
@@ -53,7 +53,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the canonical addRedis export with options."
+                "Reason": "Polyglot AppHosts use the canonical addRedis export with options."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Redis.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Redis.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Redis",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -53,7 +53,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the canonical addRedis export with options."
+                "Reason": "Polyglot app hosts use the canonical addRedis export with options."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Seq.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Seq.13.4.6.json
@@ -76,7 +76,7 @@
               },
               {
                 "kind": "text",
-                "text": " container image. This overload is not available in polyglot app hosts. Use "
+                "text": " container image. This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Seq.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Seq.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Seq",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -76,7 +76,7 @@
               },
               {
                 "kind": "text",
-                "text": " container image. This overload is not available in polyglot AppHosts. Use "
+                "text": " container image. This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Valkey.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Valkey.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Valkey",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
@@ -63,7 +63,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "code",
@@ -123,7 +123,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "code",
@@ -183,7 +183,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "code",
@@ -247,7 +247,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "code",
@@ -317,7 +317,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the "
+                "text": "This overload is not available in polyglot AppHosts. Use the "
               },
               {
                 "kind": "code",
@@ -1488,7 +1488,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1531,7 +1531,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1574,7 +1574,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1693,7 +1693,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1830,7 +1830,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload or the specific match helper methods instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload or the specific match helper methods instead."
               }
             ]
           },
@@ -1874,7 +1874,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -2025,7 +2025,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -2181,7 +2181,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -2531,7 +2531,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2574,7 +2574,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2617,7 +2617,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2660,7 +2660,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
@@ -511,7 +511,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],
@@ -569,7 +569,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],
@@ -631,7 +631,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -699,7 +699,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -767,7 +767,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -831,7 +831,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Hosting.Yarp.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Hosting.Yarp",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
@@ -63,7 +63,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "code",
@@ -123,7 +123,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "code",
@@ -183,7 +183,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "code",
@@ -247,7 +247,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "code",
@@ -317,7 +317,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the "
+                "text": "This overload is not available in polyglot app hosts. Use the "
               },
               {
                 "kind": "code",
@@ -511,7 +511,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],
@@ -569,7 +569,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],
@@ -631,7 +631,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -699,7 +699,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -767,7 +767,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addRoute dispatcher."
               }
             }
           ],
@@ -831,7 +831,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot AppHosts use the exported addCatchAllRoute dispatcher."
+                "Reason": "Polyglot app hosts use the exported addCatchAllRoute dispatcher."
               }
             }
           ],
@@ -1488,7 +1488,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1531,7 +1531,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1574,7 +1574,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1693,7 +1693,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -1830,7 +1830,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload or the specific match helper methods instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload or the specific match helper methods instead."
               }
             ]
           },
@@ -1874,7 +1874,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -2025,7 +2025,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the DTO-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the DTO-based overload instead."
               }
             ]
           },
@@ -2181,7 +2181,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot AppHosts. Use "
+                "text": "This method is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -2531,7 +2531,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2574,7 +2574,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2617,7 +2617,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
               }
             ]
           },
@@ -2660,7 +2660,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/Aspire.MongoDB.EntityFrameworkCore.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.MongoDB.EntityFrameworkCore.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.MongoDB.EntityFrameworkCore",
     "version": "13.4.6",
-    "targetFramework": "net9.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.Pomelo.EntityFrameworkCore.MySql.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.Pomelo.EntityFrameworkCore.MySql.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.Pomelo.EntityFrameworkCore.MySql",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/Aspire.TypeSystem.13.4.6.json
+++ b/src/frontend/src/data/pkgs/Aspire.TypeSystem.13.4.6.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "Aspire.TypeSystem",
     "version": "13.4.6",
-    "targetFramework": "net8.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/microsoft/aspire",
     "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.ActiveMQ.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.ActiveMQ.13.4.0.json
@@ -1026,7 +1026,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This property is not available in polyglot app hosts."
+                "text": "This property is not available in polyglot AppHosts."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
@@ -75,7 +75,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -180,7 +180,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
@@ -61,7 +61,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the overload that makes both configFilePaths and httpPort optional."
+                "Reason": "Polyglot AppHosts use the overload that makes both configFilePaths and httpPort optional."
               }
             }
           ],
@@ -166,7 +166,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts use the overload that makes both configFilePaths and httpPort optional to avoid optional parameter ordering issues."
+                "Reason": "Polyglot AppHosts use the overload that makes both configFilePaths and httpPort optional to avoid optional parameter ordering issues."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
@@ -185,7 +185,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
@@ -1,10 +1,10 @@
 {
   "package": {
     "name": "CommunityToolkit.Aspire.Hosting.Bun",
-    "version": "13.4.0",
+    "version": "13.3.0",
     "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
-    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
+    "sourceCommit": "0a6068734d939cdf93e8a6a0cab67cf1e5c76953"
   },
   "types": [
     {
@@ -72,13 +72,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
-            },
-            {
-              "name": "System.ObsoleteAttribute",
+              "name": "Aspire.Hosting.AspireExportAttribute",
               "constructorArguments": [
-                "CommunityToolkit.Aspire.Hosting.Bun is deprecated. Use Aspire.Hosting.JavaScript and builder.AddBunApp(...) instead. This package will be removed in a future release."
-              ]
+                "addBunApp"
+              ],
+              "arguments": {
+                "Description": "Adds a Bun app"
+              }
             }
           ],
           "docs": {
@@ -144,7 +144,7 @@
             }
           },
           "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Bun/BunAppExtensions.cs",
-          "sourceLines": "34-46"
+          "sourceLines": "31-43"
         },
         {
           "name": "WithBunPackageInstallation",
@@ -173,12 +173,6 @@
               "arguments": {
                 "Reason": "Action<IResourceBuilder<BunInstallerResource>> is not ATS-compatible. Use the overload without configureInstaller instead."
               }
-            },
-            {
-              "name": "System.ObsoleteAttribute",
-              "constructorArguments": [
-                "CommunityToolkit.Aspire.Hosting.Bun is deprecated. Use Aspire.Hosting.JavaScript and builder.AddBunApp(...) instead. This package will be removed in a future release."
-              ]
             }
           ],
           "docs": {
@@ -191,7 +185,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot AppHosts. Use "
+                "text": "This overload is not available in polyglot app hosts. Use "
               },
               {
                 "kind": "cref",
@@ -232,7 +226,7 @@
             }
           },
           "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Bun/BunAppExtensions.cs",
-          "sourceLines": "59-59"
+          "sourceLines": "55-55"
         }
       ]
     },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Dapr.AzureRedis.9.1.1-beta.197.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Dapr.AzureRedis.9.1.1-beta.197.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "CommunityToolkit.Aspire.Hosting.Dapr.AzureRedis",
     "version": "9.1.1-beta.197",
-    "targetFramework": "net9.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
     "sourceCommit": "3cda8176ea0f2026494df22514906dd4079880d7"
   },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Deno.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Deno.13.4.0.json
@@ -296,7 +296,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
@@ -246,7 +246,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": " Currently only debug is supported. This method is not available in polyglot app hosts. Configure the "
+                "text": " Currently only debug is supported. This method is not available in polyglot AppHosts. Configure the "
               },
               {
                 "kind": "code",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
@@ -230,7 +230,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Microsoft.Extensions.Logging.LogLevel is defined in an external assembly and is not compatible with ATS."
+              }
             }
           ],
           "docs": {
@@ -346,7 +349,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Flagd/FlagdResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.13.4.0.json
@@ -366,7 +366,7 @@
               },
               {
                 "kind": "text",
-                "text": ". This overload is not available in polyglot app hosts. Use the enum-based overload instead. "
+                "text": ". This overload is not available in polyglot AppHosts. Use the enum-based overload instead. "
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.13.4.0.json
@@ -74,7 +74,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -186,7 +186,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -476,7 +476,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -569,7 +569,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -743,7 +743,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -836,7 +836,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1091,7 +1091,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1184,7 +1184,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1277,7 +1277,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -1370,7 +1370,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
@@ -3259,8 +3259,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.K3sClusterResource"
               },
               {
                 "kind": "text",
@@ -3564,8 +3564,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.K3sClusterResource"
               },
               {
                 "kind": "text",
@@ -4308,8 +4308,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.K3sClusterResource"
               },
               {
                 "kind": "text",
@@ -4551,8 +4551,8 @@
                 "text": " Gets the parent resource of type "
               },
               {
-                "kind": "typeparamref",
-                "value": "T"
+                "kind": "cref",
+                "value": "T:Aspire.Hosting.ApplicationModel.K3sClusterResource"
               },
               {
                 "kind": "text",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
@@ -3119,7 +3119,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.K3s/HelmReleaseResource.cs",
@@ -3663,7 +3666,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.K3s/K3sClusterResource.cs",
@@ -3858,7 +3864,10 @@
           "hasGet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Internal tracking collection; not needed by guest SDK consumers."
+              }
             }
           ],
           "docs": {
@@ -3881,7 +3890,10 @@
           "hasGet": true,
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Internal tracking collection; not needed by guest SDK consumers."
+              }
             }
           ],
           "docs": {
@@ -3998,7 +4010,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.K3s/K3sServiceEndpointResource.cs",
@@ -4424,7 +4439,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.K3s/K8sManifestResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Kind.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Kind.13.4.1-beta.701.json
@@ -250,7 +250,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<KindConfigModel> is not ATS-compatible. Configure Kind config through ATS-supported APIs."
+              }
             }
           ],
           "docs": {
@@ -422,7 +425,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withKindClusterReference"
+              ]
             }
           ],
           "docs": {
@@ -768,7 +774,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withKindContainerReference"
+              ]
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.KurrentDB.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.KurrentDB.13.4.0.json
@@ -312,7 +312,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.KurrentDB/KurrentDBResource.cs",
@@ -509,7 +512,50 @@
               "isOptional": true
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Runs the health check, returning the status of the component being checked. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:System.Threading.Tasks.Task`1"
+              },
+              {
+                "kind": "text",
+                "text": " that completes when the health check has finished, yielding the status of the component being checked."
+              }
+            ],
+            "parameters": {
+              "cancellationToken": [
+                {
+                  "kind": "text",
+                  "text": "A "
+                },
+                {
+                  "kind": "cref",
+                  "value": "T:System.Threading.CancellationToken"
+                },
+                {
+                  "kind": "text",
+                  "text": " that can be used to cancel the health check."
+                }
+              ],
+              "context": [
+                {
+                  "kind": "text",
+                  "text": "A context object associated with the current execution."
+                }
+              ]
+            }
+          },
           "sourceFile": "src/CommunityToolkit.Aspire.Hosting.KurrentDB/KurrentDBHealthCheck.cs",
           "sourceLines": "26-45"
         },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.LavinMQ.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.LavinMQ.13.4.0.json
@@ -295,7 +295,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.LavinMQ/LavinMQContainerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Listmonk.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Listmonk.13.4.1-beta.701.json
@@ -1257,7 +1257,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Listmonk/ListmonkResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Logto.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Logto.13.4.1-beta.701.json
@@ -921,7 +921,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Logto/LogtoResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MailPit.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MailPit.13.4.0.json
@@ -337,7 +337,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.MailPit/MailPitContainerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
@@ -514,7 +514,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Use the parameter-based overload so polyglot app hosts expose a single addMcpInspector capability."
+                "Reason": "Use the parameter-based overload so polyglot AppHosts expose a single addMcpInspector capability."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
@@ -279,7 +279,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "McpInspectorOptions is not ATS-compatible. Use the parameter-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -399,7 +402,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<McpInspectorOptions> is not ATS-compatible. Use the parameter-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -506,7 +512,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Use the parameter-based overload so polyglot app hosts expose a single addMcpInspector capability."
+              }
             }
           ],
           "docs": {
@@ -678,7 +687,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withInspectedMcpServer"
+              ],
+              "arguments": {
+                "MethodName": "withInspectedMcpServer"
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
@@ -312,7 +312,7 @@
               },
               {
                 "kind": "text",
-                "text": " This overload is not available in polyglot app hosts. Use "
+                "text": " This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -426,7 +426,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -536,7 +536,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Meilisearch.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Meilisearch.13.4.0.json
@@ -324,7 +324,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Meilisearch/MeilisearchResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Minio.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Minio.13.4.0.json
@@ -558,7 +558,10 @@
           ]
         },
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Minio/MinioContainerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
@@ -62,7 +62,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "The configuration callback depends on DbGate container APIs that are not exported to polyglot app hosts. Use the overload without a configuration callback instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
@@ -86,7 +86,7 @@
               },
               {
                 "kind": "text",
-                "text": " container image. This overload is not available in polyglot app hosts. Use the overload without the configuration callback instead. "
+                "text": " container image. This overload is not available in polyglot AppHosts. Use the overload without the configuration callback instead. "
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
@@ -64,7 +64,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "The configuration callback depends on DbGate container APIs that are not exported to polyglot app hosts. Use the overload without a configuration callback instead."
+                "Reason": "The configuration callback depends on DbGate container APIs that are not exported to polyglot AppHosts. Use the overload without a configuration callback instead."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MySql.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.MySql.Extensions.13.4.0.json
@@ -62,7 +62,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -154,7 +157,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
@@ -165,7 +165,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withAuthTokenValue"
+              ],
+              "arguments": {
+                "MethodName": "withAuthTokenValue"
+              }
             }
           ],
           "docs": {
@@ -297,7 +303,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IDictionary<string, string> is not ATS-compatible. Use the IReadOnlyDictionary<string, string> overload instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
@@ -319,7 +319,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the overload that accepts "
+                "text": "This overload is not available in polyglot AppHosts. Use the overload that accepts "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ollama.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Ollama.13.4.0.json
@@ -245,7 +245,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addNamedModel"
+              ]
             }
           ],
           "docs": {
@@ -514,7 +517,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withOllamaDataVolume"
+              ],
+              "arguments": {
+                "MethodName": "withDataVolume"
+              }
             }
           ],
           "docs": {
@@ -598,7 +607,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withOpenWebUIDataVolume"
+              ],
+              "arguments": {
+                "MethodName": "withDataVolume"
+              }
             }
           ],
           "docs": {
@@ -861,7 +876,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -954,7 +972,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Ollama/IOllamaResource.cs",
@@ -1140,7 +1161,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaExecutableResource.cs",
@@ -1401,7 +1425,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaModelResource.cs",
@@ -1571,7 +1598,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Ollama/OllamaResource.cs",
@@ -1802,7 +1832,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Ollama/OpenWebUIResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.13.4.0.json
@@ -52,7 +52,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {
@@ -219,7 +222,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorResource.cs",
@@ -341,7 +347,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withOpenTelemetryCollectorRouting"
+              ]
             }
           ],
           "docs": {
@@ -401,7 +410,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector/OpenTelemetryCollectorSettings.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PapercutSmtp.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PapercutSmtp.13.4.0.json
@@ -163,7 +163,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.PapercutSmtp/PapercutSmtpContainerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
@@ -93,7 +93,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot app hosts. Use the overload without the configuration callback instead."
+                    "text": "This overload is not available in polyglot AppHosts. Use the overload without the configuration callback instead."
                   }
                 ]
               }
@@ -208,7 +208,7 @@
                 "children": [
                   {
                     "kind": "text",
-                    "text": "This overload is not available in polyglot app hosts. Use the overload without the configuration callback instead."
+                    "text": "This overload is not available in polyglot AppHosts. Use the overload without the configuration callback instead."
                   }
                 ]
               }

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
@@ -62,7 +62,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<IResourceBuilder<AdminerContainerResource>> is not ATS-compatible. Use the callback-free overload instead."
+              }
             }
           ],
           "docs": {
@@ -174,7 +177,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<IResourceBuilder<DbGateContainerResource>> is not ATS-compatible. Use the callback-free overload instead."
+              }
             }
           ],
           "docs": {
@@ -298,7 +304,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot app hosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
+              }
             }
           ],
           "docs": {},
@@ -326,7 +335,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot app hosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
+              }
             }
           ],
           "docs": {},

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
@@ -306,7 +306,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot app hosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
+                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot AppHosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
               }
             }
           ],
@@ -337,7 +337,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot app hosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
+                "Reason": "IResourceBuilder<FlywayResource> cannot be created from polyglot AppHosts. Use the overload that creates the Flyway resource from a name and migration scripts path instead."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
@@ -378,7 +378,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ]
           },
@@ -996,7 +996,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the string-based overload instead."
               }
             ]
           },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
@@ -37,7 +37,7 @@
           "name": "AddPowerShell",
           "kind": "method",
           "accessibility": "public",
-          "signature": "public static IResourceBuilder<PowerShellRunspacePoolResource> DistributedApplicationBuilderExtensions.AddPowerShell(this IDistributedApplicationBuilder builder, string name, PSLanguageMode languageMode = 3, int minRunspaces = 1, int maxRunspaces = 5)",
+          "signature": "public static IResourceBuilder<PowerShellRunspacePoolResource> DistributedApplicationBuilderExtensions.AddPowerShell(this IDistributedApplicationBuilder builder, string name, PSLanguageMode languageMode = PSLanguageMode.ConstrainedLanguage, int minRunspaces = 1, int maxRunspaces = 5)",
           "returnType": "Aspire.Hosting.ApplicationModel.IResourceBuilder<CommunityToolkit.Aspire.Hosting.PowerShell.PowerShellRunspacePoolResource>",
           "isStatic": true,
           "isExtension": true,
@@ -72,7 +72,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "PSLanguageMode is not ATS-compatible. Use the string-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -158,7 +161,7 @@
           "name": ".ctor",
           "kind": "constructor",
           "accessibility": "public",
-          "signature": "public PowerShellRunspacePoolResource.PowerShellRunspacePoolResource(string name, PSLanguageMode languageMode = 3, int minRunspaces = 1, int maxRunspaces = 5)",
+          "signature": "public PowerShellRunspacePoolResource.PowerShellRunspacePoolResource(string name, PSLanguageMode languageMode = PSLanguageMode.ConstrainedLanguage, int minRunspaces = 1, int maxRunspaces = 5)",
           "returnType": "void",
           "parameters": [
             {
@@ -359,7 +362,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "IResourceBuilder<IResourceWithConnectionString> is not currently validated for ATS export in this integration."
+              }
             }
           ],
           "docs": {
@@ -974,7 +980,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "object[] is not ATS-compatible. Use the string-based overload instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
@@ -307,7 +307,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -431,7 +431,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
@@ -275,7 +275,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "RavenDBServerSettings includes secured certificate and licensing configuration that is not fully compatible with ATS."
+              }
             }
           ],
           "docs": {
@@ -404,7 +407,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Dictionary<string, object> environment variables and manual secured configuration are not supported by ATS for this overload."
+              }
             }
           ],
           "docs": {
@@ -835,7 +841,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBDatabaseResource.cs",
@@ -961,7 +970,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.RavenDB/RavenDBServerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Redis.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Redis.Extensions.13.4.0.json
@@ -62,7 +62,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "arguments": {
+                "RunSyncOnBackgroundThread": "True"
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RustFs.13.4.1-beta.701.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.RustFs.13.4.1-beta.701.json
@@ -125,7 +125,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "addBuckets"
+              ]
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sftp.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sftp.13.4.0.json
@@ -444,7 +444,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Sftp/SftpContainerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Solr.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Solr.13.4.0.json
@@ -502,7 +502,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Solr/SolrResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
@@ -130,7 +130,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot supply IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot supply IPackageMetadata types."
               }
             }
           ],
@@ -227,7 +227,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot supply IProjectMetadata types."
+                "Reason": "Polyglot AppHosts cannot supply IProjectMetadata types."
               }
             }
           ],
@@ -503,7 +503,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Action<DacDeployOptions> is not ATS-compatible, and polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Action<DacDeployOptions> is not ATS-compatible, and polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],
@@ -676,7 +676,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],
@@ -841,7 +841,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],
@@ -1128,7 +1128,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],
@@ -1239,7 +1239,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],
@@ -1406,7 +1406,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+                "Reason": "Polyglot AppHosts cannot create SQL package resources that require IPackageMetadata types."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
@@ -144,7 +144,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -241,7 +241,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -422,7 +422,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts. Use "
+                "text": "This method is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -525,7 +525,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This method is not available in polyglot app hosts."
+                "text": "This method is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -698,7 +698,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -855,7 +855,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1150,7 +1150,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1261,7 +1261,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [
@@ -1420,7 +1420,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts."
+                "text": "This overload is not available in polyglot AppHosts."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
@@ -128,7 +128,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot supply IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -222,7 +225,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot supply IProjectMetadata types."
+              }
             }
           ],
           "docs": {
@@ -392,7 +398,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<DacDeployOptions> is not ATS-compatible. Use the publish profile path overload instead."
+              }
             }
           ],
           "docs": {
@@ -492,7 +501,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<DacDeployOptions> is not ATS-compatible, and polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -662,7 +674,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -824,7 +839,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -900,7 +918,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withSqlServerDatabaseReference"
+              ],
+              "arguments": {
+                "MethodName": "withReference"
+              }
             }
           ],
           "docs": {
@@ -994,7 +1018,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withConnectionStringReference"
+              ],
+              "arguments": {
+                "MethodName": "withConnectionReference"
+              }
             }
           ],
           "docs": {
@@ -1096,7 +1126,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -1204,7 +1237,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -1368,7 +1404,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Polyglot app hosts cannot create SQL package resources that require IPackageMetadata types."
+              }
             }
           ],
           "docs": {
@@ -2471,7 +2510,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects/SqlProjectResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
@@ -86,7 +86,7 @@
               },
               {
                 "kind": "text",
-                "text": " container image. This overload is not available in polyglot app hosts. Use "
+                "text": " container image. This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",
@@ -200,7 +200,7 @@
               },
               {
                 "kind": "text",
-                "text": " container image. This overload is not available in polyglot app hosts. Use "
+                "text": " container image. This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
@@ -62,7 +62,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<IResourceBuilder<AdminerContainerResource>> is not supported reliably in polyglot app hosts. Use the container options overload instead."
+              }
             }
           ],
           "docs": {
@@ -173,7 +176,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<IResourceBuilder<DbGateContainerResource>> is not supported reliably in polyglot app hosts. Use the container options overload instead."
+              }
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
@@ -64,7 +64,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Action<IResourceBuilder<AdminerContainerResource>> is not supported reliably in polyglot app hosts. Use the container options overload instead."
+                "Reason": "Action<IResourceBuilder<AdminerContainerResource>> is not supported reliably in polyglot AppHosts. Use the container options overload instead."
               }
             }
           ],
@@ -178,7 +178,7 @@
             {
               "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
               "arguments": {
-                "Reason": "Action<IResourceBuilder<DbGateContainerResource>> is not supported reliably in polyglot app hosts. Use the container options overload instead."
+                "Reason": "Action<IResourceBuilder<DbGateContainerResource>> is not supported reliably in polyglot AppHosts. Use the container options overload instead."
               }
             }
           ],

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
@@ -149,7 +149,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use "
+                "text": "This overload is not available in polyglot AppHosts. Use "
               },
               {
                 "kind": "cref",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
@@ -133,7 +133,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Action<IResourceBuilder<SqliteWebResource>> is not ATS-compatible. Use the overload without the callback instead."
+              }
             }
           ],
           "docs": {
@@ -234,7 +237,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteResource.cs",
@@ -344,7 +350,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Sqlite/SqliteWebResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Stripe.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Stripe.13.4.0.json
@@ -296,7 +296,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withListenExternalService"
+              ]
             }
           ],
           "docs": {
@@ -384,7 +387,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withStripeReference"
+              ]
             }
           ],
           "docs": {
@@ -459,7 +465,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Stripe/StripeResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
@@ -848,7 +848,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the exported string-based overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the exported string-based overload instead."
               }
             ],
             "returns": [
@@ -1003,7 +1003,7 @@
             "remarks": [
               {
                 "kind": "text",
-                "text": "This overload is not available in polyglot app hosts. Use the exported overload instead."
+                "text": "This overload is not available in polyglot AppHosts. Use the exported overload instead."
               }
             ],
             "returns": [

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
@@ -416,7 +416,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withNamespaceCreationScript"
+              ],
+              "arguments": {
+                "MethodName": "withCreationScript"
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -503,7 +509,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withDatabaseCreationScript"
+              ],
+              "arguments": {
+                "MethodName": "withCreationScript"
+              }
             },
             {
               "name": "System.Diagnostics.CodeAnalysis.ExperimentalAttribute",
@@ -820,7 +832,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Uses Microsoft.Extensions.Logging.LogLevel, which is not ATS-compatible. Use the exported string-based overload instead."
+              }
             }
           ],
           "docs": {
@@ -885,7 +900,13 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withSurrealDbOtlpExporter"
+              ],
+              "arguments": {
+                "MethodName": "withSurrealDbOtlpExporter"
+              }
             }
           ],
           "docs": {
@@ -958,7 +979,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportIgnoreAttribute"
+              "name": "Aspire.Hosting.AspireExportIgnoreAttribute",
+              "arguments": {
+                "Reason": "Uses Action<IResourceBuilder<SurrealistContainerResource>>, which is not ATS-compatible. Use the exported overload instead."
+              }
             }
           ],
           "docs": {
@@ -1049,7 +1073,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbDatabaseResource.cs",
@@ -1197,7 +1224,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbNamespaceResource.cs",
@@ -1361,7 +1391,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.SurrealDb/SurrealDbServerResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Umami.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Umami.13.4.0.json
@@ -242,7 +242,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.Umami/UmamiResource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Zitadel.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.Zitadel.13.4.0.json
@@ -268,7 +268,10 @@
           ],
           "attributes": [
             {
-              "name": "Aspire.Hosting.AspireExportAttribute"
+              "name": "Aspire.Hosting.AspireExportAttribute",
+              "constructorArguments": [
+                "withExistingDatabase"
+              ]
             }
           ],
           "docs": {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.k6.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Hosting.k6.13.4.0.json
@@ -313,7 +313,10 @@
       },
       "attributes": [
         {
-          "name": "Aspire.Hosting.AspireExportAttribute"
+          "name": "Aspire.Hosting.AspireExportAttribute",
+          "arguments": {
+            "ExposeProperties": "True"
+          }
         }
       ],
       "sourceFile": "src/CommunityToolkit.Aspire.Hosting.k6/K6Resource.cs",

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.KurrentDB.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.KurrentDB.13.4.0.json
@@ -61,7 +61,50 @@
               "isOptional": true
             }
           ],
-          "docs": {},
+          "docs": {
+            "summary": [
+              {
+                "kind": "text",
+                "text": " Runs the health check, returning the status of the component being checked. "
+              }
+            ],
+            "returns": [
+              {
+                "kind": "text",
+                "text": "A "
+              },
+              {
+                "kind": "cref",
+                "value": "T:System.Threading.Tasks.Task`1"
+              },
+              {
+                "kind": "text",
+                "text": " that completes when the health check has finished, yielding the status of the component being checked."
+              }
+            ],
+            "parameters": {
+              "cancellationToken": [
+                {
+                  "kind": "text",
+                  "text": "A "
+                },
+                {
+                  "kind": "cref",
+                  "value": "T:System.Threading.CancellationToken"
+                },
+                {
+                  "kind": "text",
+                  "text": " that can be used to cancel the health check."
+                }
+              ],
+              "context": [
+                {
+                  "kind": "text",
+                  "text": "A context object associated with the current execution."
+                }
+              ]
+            }
+          },
           "sourceFile": "src/CommunityToolkit.Aspire.KurrentDB/KurrentDBHealthCheck.cs",
           "sourceLines": "26-45"
         },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite.9.7.2.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite.9.7.2.json
@@ -2,7 +2,7 @@
   "package": {
     "name": "CommunityToolkit.Aspire.Microsoft.EntityFrameworkCore.Sqlite",
     "version": "9.7.2",
-    "targetFramework": "net9.0",
+    "targetFramework": "net10.0",
     "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
     "sourceCommit": "c7dedf100938dcdcc84f8348ea76032f1fd180b5"
   },

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Minio.Client.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.Minio.Client.13.4.0.json
@@ -116,9 +116,8 @@
           "name": "ServiceLifetime",
           "kind": "field",
           "accessibility": "public",
-          "signature": "public ServiceLifetime? MinioClientSettings.ServiceLifetime",
-          "returnType": "Microsoft.Extensions.DependencyInjection.ServiceLifetime?",
-          "isReturnNullable": true,
+          "signature": "public ServiceLifetime MinioClientSettings.ServiceLifetime",
+          "returnType": "Microsoft.Extensions.DependencyInjection.ServiceLifetime",
           "docs": {
             "summary": [
               {

--- a/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.SurrealDb.13.4.0.json
+++ b/src/frontend/src/data/pkgs/CommunityToolkit.Aspire.SurrealDb.13.4.0.json
@@ -95,9 +95,8 @@
           "name": "Lifetime",
           "kind": "property",
           "accessibility": "public",
-          "signature": "public ServiceLifetime? SurrealDbClientSettings.Lifetime",
-          "returnType": "Microsoft.Extensions.DependencyInjection.ServiceLifetime?",
-          "isReturnNullable": true,
+          "signature": "public ServiceLifetime SurrealDbClientSettings.Lifetime",
+          "returnType": "Microsoft.Extensions.DependencyInjection.ServiceLifetime",
           "hasGet": true,
           "hasSet": true,
           "docs": {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -7247,7 +7248,7 @@
       "name": "withHttpHealthCheck",
       "capabilityId": "Aspire.Hosting/withExternalServiceHttpHealthCheck",
       "qualifiedName": "withHttpHealthCheck",
-      "description": "Adds an HTTP health check to the external service for polyglot AppHosts.",
+      "description": "Adds an HTTP health check to the external service for polyglot app hosts.",
       "kind": "Method",
       "signature": "withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): ExternalServiceResource",
       "parameters": [
@@ -8626,6 +8627,7 @@
       "implementedInterfaces": [
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "model",
@@ -8668,6 +8670,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -8709,6 +8712,7 @@
       "implementedInterfaces": [
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "model",
@@ -8746,6 +8750,7 @@
       "kind": "handle",
       "description": "Represents a callback context for the list of command-line arguments associated with an executable resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "args",
@@ -8812,6 +8817,7 @@
       "kind": "handle",
       "description": "Provides an ATS-first editor for command-line arguments within polyglot callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "add",
@@ -8845,6 +8851,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -8884,6 +8891,7 @@
       "description": "Represents options for pushing container images to a registry.",
       "remarks": "This class allows customization of how container images are named and tagged when pushed to a container registry.\nThe `RemoteImageName` specifies the repository path (without registry endpoint or tag),\nand `RemoteImageTag` specifies the tag to apply. Use `GetFullRemoteImageNameAsync`\nto construct the complete image reference including registry endpoint and tag.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "remoteImageName",
@@ -8960,6 +8968,7 @@
       "exposeProperties": true,
       "description": "Provides context information for container image push options callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "cancellationToken",
@@ -9016,6 +9025,7 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -9056,6 +9066,7 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResourceAnnotation"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "isReadOnly",
@@ -9126,6 +9137,7 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -9165,6 +9177,9 @@
         "Aspire.Hosting.ApplicationModel.IContainerRegistry",
         "Aspire.Hosting.ApplicationModel.IResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -9180,6 +9195,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -9725,6 +9743,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -9733,6 +9755,7 @@
       "kind": "handle",
       "description": "Represents a distributed application.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "findResourceByName",
@@ -9778,6 +9801,7 @@
       "kind": "handle",
       "description": "Builder for creating Dockerfiles programmatically.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addContainerFilesStages",
@@ -9859,6 +9883,9 @@
       "kind": "handle",
       "description": "Represents a stage within a multi-stage Dockerfile.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Docker.DockerfileStatement"
+      ],
       "capabilities": [
         {
           "name": "addContainerFiles",
@@ -10174,6 +10201,7 @@
       "exposeProperties": true,
       "description": "Provides context information for Dockerfile build callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "builder",
@@ -10239,6 +10267,7 @@
       "kind": "handle",
       "description": "Provides context for Dockerfile factory functions.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -10268,6 +10297,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -10397,6 +10430,7 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "endpointName",
@@ -10694,6 +10728,7 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "endpoint",
@@ -10744,8 +10779,9 @@
       "fullName": "Aspire.Hosting.ApplicationModel.EndpointUpdateContext",
       "kind": "handle",
       "exposeProperties": true,
-      "description": "Provides a mutable callback context for updating an endpoint in polyglot AppHosts.",
+      "description": "Provides a mutable callback context for updating an endpoint in polyglot app hosts.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "excludeReferenceEndpoint",
@@ -11099,6 +11135,7 @@
       "kind": "handle",
       "description": "Represents a callback context for environment variables associated with a publisher.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "environment",
@@ -11165,6 +11202,7 @@
       "kind": "handle",
       "description": "Provides an ATS-first editor for environment variables within polyglot callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "set",
@@ -11207,6 +11245,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -11290,6 +11331,7 @@
       "exposeProperties": true,
       "description": "Context for {@ats-ref method:ResourceCommandAnnotation.ExecuteCommand}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "arguments",
@@ -11359,6 +11401,7 @@
       "description": "Represents a store for managing files in the Aspire hosting environment that can be reused across runs.",
       "remarks": "The store is created under the AppHost obj folder, or under the path specified by the\nASPIRE__STORE__PATH environment variable. Each application gets its own store so files\ndo not conflict with unrelated applications.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getFileNameWithContent",
@@ -11408,6 +11451,7 @@
       "kind": "handle",
       "isInterface": true,
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -11417,6 +11461,7 @@
       "isInterface": true,
       "description": "Builder for gathering and resolving the execution configuration (arguments and environment variables) for a specific resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "build",
@@ -11536,6 +11581,7 @@
       "isInterface": true,
       "description": "Configuration (arguments and environment variables) to apply to a specific resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getCertificateTrustData",
@@ -11577,6 +11623,7 @@
       "description": "Represents a value that provides both a runtime value and a manifest expression.",
       "remarks": "Expression values can be used anywhere both a runtime value and a publish-time\nmanifest expression are needed.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -11590,6 +11637,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "eventing",
@@ -11670,6 +11718,7 @@
       "isInterface": true,
       "description": "Represents a resource that can be hosted by an application.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "createExecutionConfiguration",
@@ -12660,6 +12709,7 @@
       "isInterface": true,
       "description": "Represents a resource that is associated with commandline arguments.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "withArgs",
@@ -12724,6 +12774,7 @@
       "isInterface": true,
       "description": "Represents a resource that has a connection string associated with it.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getConnectionProperty",
@@ -12807,6 +12858,7 @@
       "isInterface": true,
       "description": "Represents a resource that has endpoints associated with it.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "asHttp2Service",
@@ -13403,6 +13455,7 @@
       "isInterface": true,
       "description": "Represents a resource that is associated with an environment.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "withCertificateTrustScope",
@@ -13664,6 +13717,7 @@
       "isInterface": true,
       "description": "Represents a resource that has a parent resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -13673,6 +13727,7 @@
       "isInterface": true,
       "description": "Represents a resource that can wait for other resources to be running, health, and/or completed.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "waitFor",
@@ -13775,6 +13830,7 @@
       "kind": "handle",
       "description": "Provides a narrow logging surface for polyglot callback contexts.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "debug",
@@ -13869,6 +13925,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IValueProvider"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withCustomInput",
@@ -13938,6 +13997,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -14021,6 +14083,7 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getValueAsync",
@@ -14051,6 +14114,7 @@
       "exposeProperties": true,
       "description": "A builder for creating {@ats-ref type:ReferenceExpression} instances.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "appendFormatted",
@@ -14160,6 +14224,7 @@
       "kind": "handle",
       "description": "A service to execute resource commands.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "executeCommandAsync",
@@ -14212,6 +14277,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -14251,6 +14317,7 @@
       "implementedInterfaces": [
         "System.IDisposable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "completeLog",
@@ -14300,6 +14367,7 @@
       "implementedInterfaces": [
         "System.IDisposable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "publishResourceUpdate",
@@ -14447,6 +14515,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -14489,6 +14558,7 @@
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent",
         "Aspire.Hosting.Eventing.IDistributedApplicationResourceEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resource",
@@ -14526,6 +14596,7 @@
       "kind": "handle",
       "description": "Represents a callback context for resource URLs.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "executionContext",
@@ -14611,6 +14682,7 @@
       "kind": "handle",
       "description": "Provides an ATS-first editor for resource URLs within polyglot callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "add",
@@ -14692,6 +14764,7 @@
       "exposeProperties": true,
       "description": "Context for {@ats-ref method:ResourceCommandAnnotation.UpdateState}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "resourceSnapshot",
@@ -14716,6 +14789,7 @@
       "exposeProperties": true,
       "description": "Context passed to ATS-friendly eventing subscriber registrations.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "cancellationToken",
@@ -14849,6 +14923,7 @@
         "System.IAsyncDisposable",
         "System.IDisposable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "run",
@@ -14882,6 +14957,7 @@
       "exposeProperties": true,
       "description": "Exposes the global contextual information for this invocation of the AppHost.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "isPublishMode",
@@ -14980,6 +15056,7 @@
       "kind": "handle",
       "description": "Configuration options and references that need to be exposed to the {@ats-ref type:DistributedApplicationExecutionContext}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -14988,6 +15065,7 @@
       "kind": "handle",
       "description": "Represents a subscription to an event that is published during the lifecycle of the AppHost.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -14996,6 +15074,9 @@
       "kind": "handle",
       "description": "Represents a subscription to an event that is published during the lifecycle of the AppHost for a specific resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Eventing.DistributedApplicationEventSubscription"
+      ],
       "capabilities": []
     },
     {
@@ -15005,6 +15086,7 @@
       "isInterface": true,
       "description": "Represents an event that is published during the lifecycle of the AppHost.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -15015,6 +15097,7 @@
       "exposeMethods": true,
       "description": "Supports publishing and subscribing to events which are executed during the AppHost lifecycle.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "unsubscribe",
@@ -15045,6 +15128,7 @@
       "isInterface": true,
       "description": "Represents an event that is published during the lifecycle of the AppHost for a specific resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -15054,12 +15138,15 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHttpHealthCheck",
           "capabilityId": "Aspire.Hosting/withExternalServiceHttpHealthCheck",
           "qualifiedName": "withHttpHealthCheck",
-          "description": "Adds an HTTP health check to the external service for polyglot AppHosts.",
+          "description": "Adds an HTTP health check to the external service for polyglot app hosts.",
           "kind": "Method",
           "signature": "withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): ExternalServiceResource",
           "parameters": [
@@ -15096,6 +15183,7 @@
       "isInterface": true,
       "description": "A builder for creating instances of {@ats-ref type:DistributedApplication}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addConnectionString",
@@ -15820,6 +15908,7 @@
       "exposeProperties": true,
       "description": "Represents the context for validating inputs in an inputs dialog interaction.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addValidationError",
@@ -15887,6 +15976,7 @@
         "System.Collections.Generic.IReadOnlyList`1[[Aspire.Hosting.InteractionInput]]",
         "System.Collections.IEnumerable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "toArray",
@@ -15911,6 +16001,7 @@
       "kind": "handle",
       "isInterface": true,
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "clearContainerFilesSources",
@@ -15961,6 +16052,7 @@
       "exposeMethods": true,
       "description": "Defines an interface for managing user secrets with support for read and write operations.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getOrSetSecret",
@@ -16105,6 +16197,7 @@
       "isInterface": true,
       "description": "Represents a pipeline for executing deployment steps in a distributed application.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addStep",
@@ -16192,6 +16285,7 @@
       "isInterface": true,
       "description": "Represents a publishing step, which can contain multiple tasks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "completeStep",
@@ -16356,6 +16450,7 @@
       "isInterface": true,
       "description": "Represents a publishing task, which belongs to a step.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "completeTask",
@@ -16474,6 +16569,7 @@
       "kind": "handle",
       "description": "Provides contextual information for pipeline configuration callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "getSteps",
@@ -16533,6 +16629,7 @@
       "exposeProperties": true,
       "description": "Provides contextual information and services for the pipeline execution process of a distributed application.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "cancellationToken",
@@ -16646,6 +16743,7 @@
       "kind": "handle",
       "description": "Provides an ATS-first editor for pipeline configuration callbacks.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "steps",
@@ -16692,6 +16790,7 @@
       "exposeProperties": true,
       "description": "Represents a step in the deployment pipeline.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addTag",
@@ -16834,6 +16933,7 @@
       "description": "Provides contextual information for a specific pipeline step execution.",
       "remarks": "This context combines the shared pipeline context with a step-specific publishing step,\nallowing each step to track its own tasks and completion state independently.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "cancellationToken",
@@ -16957,6 +17057,7 @@
       "exposeProperties": true,
       "description": "Provides contextual information for creating pipeline steps from a {@ats-ref type:PipelineStepAnnotation}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "pipelineContext",
@@ -16996,6 +17097,7 @@
       "description": "Represents pipeline summary information to be displayed after pipeline completion. This is a general-purpose key-value collection that pipeline steps can contribute to.",
       "remarks": "This class provides a flexible way for any pipeline step to contribute\ninformation to be displayed after pipeline execution. The data is stored as\nkey-value pairs that will be formatted as a table or list in the CLI output.\nPipeline steps can add any relevant information such as resource group names,\nsubscription IDs, URLs, namespaces, cluster names, or any other details.\nValues can be plain text or Markdown-formatted by using `MarkdownString`.\nThe summary is available via the `Summary`\nproperty and can be accessed from any pipeline step.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addMarkdown",
@@ -17056,6 +17158,7 @@
       "exposeProperties": true,
       "description": "Various properties to modify the behavior of the project resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "excludeKestrelEndpoints",
@@ -17167,6 +17270,7 @@
       "implementedInterfaces": [
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "model",
@@ -17207,6 +17311,7 @@
       "implementedInterfaces": [
         "Aspire.Hosting.Eventing.IDistributedApplicationEvent"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "model",
@@ -17249,16 +17354,19 @@
         {
           "name": "CertificateBundlePath",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "The path to the PEM certificate bundle file in the resource context (e.g., container filesystem)."
         },
         {
           "name": "CertificateDirectoriesPath",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "The path(s) to the certificate directories in the resource context (e.g., container filesystem)."
         },
         {
           "name": "RootCertificatesPath",
           "type": "string",
+          "isOptional": true,
           "description": "The root path certificates will be written to in the resource context (e.g., container filesystem)."
         },
         {
@@ -17278,36 +17386,43 @@
         {
           "name": "Description",
           "type": "string",
+          "isOptional": true,
           "description": "Optional description of the command, to be shown in the UI. Could be used as a tooltip. May be localized."
         },
         {
           "name": "Parameter",
           "type": "any",
+          "isOptional": true,
           "description": "Obsolete optional parameter that configures the command in some way. Clients must return any value provided by the server when invoking the command."
         },
         {
           "name": "Arguments",
           "type": "InteractionInput[]",
+          "isOptional": true,
           "description": "Gets or sets the invocation arguments accepted by the command."
         },
         {
           "name": "ValidateArguments",
           "type": "callback",
+          "isOptional": true,
           "description": "Gets or sets the callback that validates invocation arguments before the command callback is executed."
         },
         {
           "name": "Visibility",
           "type": "ResourceCommandVisibility",
+          "isOptional": true,
           "description": "Gets or sets where the command is visible to users and clients."
         },
         {
           "name": "ConfirmationMessage",
           "type": "string",
+          "isOptional": true,
           "description": "When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog and the confirmation message before starting the command."
         },
         {
           "name": "IconName",
           "type": "string",
+          "isOptional": true,
           "description": "The icon name for the command. The name should be a valid FluentUI icon name from ."
         },
         {
@@ -17319,11 +17434,13 @@
         {
           "name": "IsHighlighted",
           "type": "boolean",
+          "isOptional": true,
           "description": "A flag indicating whether the command is highlighted in the UI."
         },
         {
           "name": "UpdateState",
           "type": "callback",
+          "isOptional": true,
           "description": "A callback that is used to update the command state. The callback is executed when the command's resource snapshot is updated. If a callback isn't specified, the command is always enabled."
         }
       ]
@@ -17337,6 +17454,7 @@
         {
           "name": "Value",
           "type": "string",
+          "isOptional": true,
           "description": "The value data."
         },
         {
@@ -17362,6 +17480,7 @@
         {
           "name": "Success",
           "type": "boolean",
+          "isOptional": true,
           "description": "A flag that indicates whether the command was successful."
         },
         {
@@ -17400,46 +17519,55 @@
         {
           "name": "MinLength",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the minimum length of the generated value."
         },
         {
           "name": "Lower",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether to include lowercase alphabet characters in the result."
         },
         {
           "name": "Upper",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether to include uppercase alphabet characters in the result."
         },
         {
           "name": "Numeric",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether to include numeric characters in the result."
         },
         {
           "name": "Special",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether to include special characters in the result."
         },
         {
           "name": "MinLower",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the minimum number of lowercase characters in the result."
         },
         {
           "name": "MinUpper",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the minimum number of uppercase characters in the result."
         },
         {
           "name": "MinNumeric",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the minimum number of numeric characters in the result."
         },
         {
           "name": "MinSpecial",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the minimum number of special characters in the result."
         }
       ]
@@ -17453,16 +17581,19 @@
         {
           "name": "Description",
           "type": "string",
+          "isOptional": true,
           "description": "Optional description of the command, to be shown in the UI."
         },
         {
           "name": "ConfirmationMessage",
           "type": "string",
+          "isOptional": true,
           "description": "When a confirmation message is specified, the UI will prompt with an OK/Cancel dialog before starting the command."
         },
         {
           "name": "IconName",
           "type": "string",
+          "isOptional": true,
           "description": "The icon name for the command."
         },
         {
@@ -17474,26 +17605,31 @@
         {
           "name": "IsHighlighted",
           "type": "boolean",
+          "isOptional": true,
           "description": "A flag indicating whether the command is highlighted in the UI."
         },
         {
           "name": "CommandName",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the command name."
         },
         {
           "name": "EndpointName",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the HTTP endpoint name to send the request to when the command is invoked."
         },
         {
           "name": "MethodName",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the HTTP method name to use when sending the request."
         },
         {
           "name": "ResultMode",
           "type": "HttpCommandResultMode",
+          "isOptional": true,
           "description": "Gets or sets how the HTTP response content should be returned as command result data."
         }
       ]
@@ -17507,16 +17643,19 @@
         {
           "name": "CertificatePath",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "Expression that will resolve to the path of the server authentication certificate in PEM format. For containers this will be a path inside the container."
         },
         {
           "name": "KeyPath",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "Expression that will resolve to the path of the server authentication certificate key in PEM format. For containers this will be a path inside the container."
         },
         {
           "name": "PfxPath",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "Expression that will resolve to the path of the server authentication certificate in PFX format. For containers this will be a path inside the container."
         }
       ]
@@ -17530,21 +17669,25 @@
         {
           "name": "ExecutablePath",
           "type": "string",
+          "isOptional": true,
           "description": "The executable path or command name to start."
         },
         {
           "name": "Arguments",
           "type": "string[]",
+          "isOptional": true,
           "description": "The command-line arguments for the process."
         },
         {
           "name": "WorkingDirectory",
           "type": "string",
+          "isOptional": true,
           "description": "The working directory for the process."
         },
         {
           "name": "EnvironmentVariables",
           "type": "Dict<string,string>",
+          "isOptional": true,
           "description": "The environment variables to set for the process."
         },
         {
@@ -17556,6 +17699,7 @@
         {
           "name": "StandardInputContent",
           "type": "string",
+          "isOptional": true,
           "description": "Standard input content to write to the process after it starts."
         },
         {
@@ -17567,6 +17711,7 @@
         {
           "name": "CommandOptions",
           "type": "CommandOptions",
+          "isOptional": true,
           "description": "Optional command configuration."
         },
         {
@@ -17584,6 +17729,7 @@
         {
           "name": "SuccessExitCodes",
           "type": "number[]",
+          "isOptional": true,
           "description": "The exit codes that are treated as a successful command invocation."
         }
       ]
@@ -17597,6 +17743,7 @@
         {
           "name": "CommandOptions",
           "type": "CommandOptions",
+          "isOptional": true,
           "description": "Optional command configuration."
         },
         {
@@ -17614,6 +17761,7 @@
         {
           "name": "SuccessExitCodes",
           "type": "number[]",
+          "isOptional": true,
           "description": "The exit codes that are treated as a successful command invocation."
         }
       ]
@@ -17627,21 +17775,25 @@
         {
           "name": "ExecutablePath",
           "type": "string",
+          "isOptional": true,
           "description": "The executable path or command name to start."
         },
         {
           "name": "Arguments",
           "type": "string[]",
+          "isOptional": true,
           "description": "The command-line arguments for the process."
         },
         {
           "name": "WorkingDirectory",
           "type": "string",
+          "isOptional": true,
           "description": "The working directory for the process."
         },
         {
           "name": "EnvironmentVariables",
           "type": "Dict<string,string>",
+          "isOptional": true,
           "description": "The environment variables to set for the process."
         },
         {
@@ -17653,6 +17805,7 @@
         {
           "name": "StandardInputContent",
           "type": "string",
+          "isOptional": true,
           "description": "Standard input content to write to the process after it starts."
         },
         {
@@ -17672,11 +17825,13 @@
         {
           "name": "Url",
           "type": "string",
+          "isOptional": true,
           "description": "The URL. When rendered as a link this will be used as the link target."
         },
         {
           "name": "DisplayText",
           "type": "string",
+          "isOptional": true,
           "description": "The name of the URL. When rendered as a link this will be used as the linked text."
         },
         {
@@ -17688,6 +17843,7 @@
         {
           "name": "DisplayLocation",
           "type": "UrlDisplayLocation",
+          "isOptional": true,
           "description": "Locations where this URL should be shown on the dashboard. Defaults to `SummaryAndDetails`."
         }
       ]
@@ -17701,6 +17857,7 @@
         {
           "name": "ResourceType",
           "type": "string",
+          "isOptional": true,
           "description": "The type of the resource."
         },
         {
@@ -17738,6 +17895,7 @@
         {
           "name": "Image",
           "type": "string",
+          "isOptional": true,
           "description": "The container image name."
         },
         {
@@ -17757,16 +17915,19 @@
         {
           "name": "Scope",
           "type": "CertificateTrustScope",
+          "isOptional": true,
           "description": "The certificate trust scope."
         },
         {
           "name": "CertificateSubjects",
           "type": "string[]",
+          "isOptional": true,
           "description": "The certificate subjects included in the trust configuration."
         },
         {
           "name": "CustomBundlePaths",
           "type": "string[]",
+          "isOptional": true,
           "description": "The relative custom bundle paths."
         }
       ]
@@ -17780,41 +17941,49 @@
         {
           "name": "Args",
           "type": "string[]",
+          "isOptional": true,
           "description": "The command line arguments."
         },
         {
           "name": "ProjectDirectory",
           "type": "string",
+          "isOptional": true,
           "description": "The directory containing the AppHost project file."
         },
         {
           "name": "AppHostFilePath",
           "type": "string",
+          "isOptional": true,
           "description": "The full path to the AppHost file (e.g., apphost.ts, apphost.py). Used for consistent socket path computation across CLI and AppHost."
         },
         {
           "name": "ContainerRegistryOverride",
           "type": "string",
+          "isOptional": true,
           "description": "When containers are used, use this value to override the container registry."
         },
         {
           "name": "DisableDashboard",
           "type": "boolean",
+          "isOptional": true,
           "description": "Determines whether the dashboard is disabled."
         },
         {
           "name": "DashboardApplicationName",
           "type": "string",
+          "isOptional": true,
           "description": "The application name to display in the dashboard."
         },
         {
           "name": "AllowUnsecuredTransport",
           "type": "boolean",
+          "isOptional": true,
           "description": "Allows the use of HTTP urls for the AppHost resource endpoint."
         },
         {
           "name": "EnableResourceLogging",
           "type": "boolean",
+          "isOptional": true,
           "description": "Enables resource logging."
         }
       ]
@@ -17828,6 +17997,7 @@
         {
           "name": "Subject",
           "type": "string",
+          "isOptional": true,
           "description": "The certificate subject."
         },
         {
@@ -17839,21 +18009,25 @@
         {
           "name": "KeyPathExpression",
           "type": "string",
+          "isOptional": true,
           "description": "The expression for the key path reference."
         },
         {
           "name": "PfxPathExpression",
           "type": "string",
+          "isOptional": true,
           "description": "The expression for the PFX path reference."
         },
         {
           "name": "IsKeyPathReferenced",
           "type": "boolean",
+          "isOptional": true,
           "description": "Indicates whether the key path was referenced."
         },
         {
           "name": "IsPfxPathReferenced",
           "type": "boolean",
+          "isOptional": true,
           "description": "Indicates whether the PFX path was referenced."
         },
         {
@@ -17873,11 +18047,13 @@
         {
           "name": "Subject",
           "type": "string",
+          "isOptional": true,
           "description": "The certificate subject."
         },
         {
           "name": "Issuer",
           "type": "string",
+          "isOptional": true,
           "description": "The certificate issuer."
         },
         {
@@ -17892,7 +18068,7 @@
       "name": "ParameterCustomInputOptions",
       "fullName": "Aspire.Hosting.Ats.ParameterCustomInputOptions",
       "kind": "dto",
-      "description": "Options for customizing parameter inputs from polyglot AppHosts.",
+      "description": "Options for customizing parameter inputs from polyglot app hosts.",
       "fields": [
         {
           "name": "InputType",
@@ -17903,11 +18079,13 @@
         {
           "name": "Label",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the label for the input."
         },
         {
           "name": "Description",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the description for the input."
         },
         {
@@ -17919,16 +18097,19 @@
         {
           "name": "Options",
           "type": "Dict<string,string>",
+          "isOptional": true,
           "description": "Gets or sets the choice options keyed by submitted value."
         },
         {
           "name": "Value",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the initial value of the input."
         },
         {
           "name": "Placeholder",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the placeholder text for the input."
         },
         {
@@ -17960,21 +18141,25 @@
         {
           "name": "ConnectionString",
           "type": "boolean",
+          "isOptional": true,
           "description": "Injects the connection string environment variable."
         },
         {
           "name": "ConnectionProperties",
           "type": "boolean",
+          "isOptional": true,
           "description": "Injects individual connection property environment variables."
         },
         {
           "name": "ServiceDiscovery",
           "type": "boolean",
+          "isOptional": true,
           "description": "Injects service discovery environment variables."
         },
         {
           "name": "Endpoints",
           "type": "boolean",
+          "isOptional": true,
           "description": "Injects endpoint environment variables."
         }
       ]
@@ -17988,11 +18173,13 @@
         {
           "name": "ResourceName",
           "type": "string",
+          "isOptional": true,
           "description": "The resource name."
         },
         {
           "name": "ResourceId",
           "type": "string",
+          "isOptional": true,
           "description": "The unique resource ID."
         },
         {
@@ -18030,6 +18217,7 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the name for the input. Used for accessing inputs by name from a keyed collection."
         },
         {
@@ -18053,6 +18241,7 @@
         {
           "name": "InputType",
           "type": "InputType",
+          "isOptional": true,
           "description": "Gets or sets the type of the input."
         },
         {
@@ -18064,6 +18253,7 @@
         {
           "name": "Options",
           "type": "String]][]",
+          "isOptional": true,
           "description": "Gets or sets the options for the input. Only used by `Choice` inputs."
         },
         {
@@ -18075,6 +18265,7 @@
         {
           "name": "Value",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the value of the input."
         },
         {
@@ -18092,6 +18283,7 @@
         {
           "name": "Disabled",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether a custom choice is allowed. Only used by `Choice` inputs."
         },
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
@@ -18252,7 +18252,7 @@
         },
         {
           "name": "Options",
-          "type": "String]][]",
+          "type": "KeyValuePair<string,string>[]",
           "isOptional": true,
           "description": "Gets or sets the options for the input. Only used by `Choice` inputs."
         },

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.13.4.6.json
@@ -7248,7 +7248,7 @@
       "name": "withHttpHealthCheck",
       "capabilityId": "Aspire.Hosting/withExternalServiceHttpHealthCheck",
       "qualifiedName": "withHttpHealthCheck",
-      "description": "Adds an HTTP health check to the external service for polyglot app hosts.",
+      "description": "Adds an HTTP health check to the external service for polyglot AppHosts.",
       "kind": "Method",
       "signature": "withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): ExternalServiceResource",
       "parameters": [
@@ -10779,7 +10779,7 @@
       "fullName": "Aspire.Hosting.ApplicationModel.EndpointUpdateContext",
       "kind": "handle",
       "exposeProperties": true,
-      "description": "Provides a mutable callback context for updating an endpoint in polyglot app hosts.",
+      "description": "Provides a mutable callback context for updating an endpoint in polyglot AppHosts.",
       "implementedInterfaces": [],
       "baseTypeHierarchy": [],
       "capabilities": [
@@ -15146,7 +15146,7 @@
           "name": "withHttpHealthCheck",
           "capabilityId": "Aspire.Hosting/withExternalServiceHttpHealthCheck",
           "qualifiedName": "withHttpHealthCheck",
-          "description": "Adds an HTTP health check to the external service for polyglot app hosts.",
+          "description": "Adds an HTTP health check to the external service for polyglot AppHosts.",
           "kind": "Method",
           "signature": "withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): ExternalServiceResource",
           "parameters": [
@@ -18068,7 +18068,7 @@
       "name": "ParameterCustomInputOptions",
       "fullName": "Aspire.Hosting.Ats.ParameterCustomInputOptions",
       "kind": "dto",
-      "description": "Options for customizing parameter inputs from polyglot app hosts.",
+      "description": "Options for customizing parameter inputs from polyglot AppHosts.",
       "fields": [
         {
           "name": "InputType",

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -502,6 +503,7 @@
       "isInterface": true,
       "description": "Represents an Azure resource, as a marker interface for {@ats-ref type:IResource}'s that can be deployed to an Azure resource group.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "asExisting",
@@ -675,6 +677,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "getOutput",
@@ -735,6 +740,9 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withLocation",
@@ -793,6 +801,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "configureInfrastructure",
@@ -828,6 +840,10 @@
       "exposeProperties": true,
       "description": "An Azure Provisioning {@ats-ref type:Infrastructure} which represents the root Bicep module that is generated for an Azure resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Azure.Provisioning.Infrastructure",
+        "Azure.Provisioning.Primitives.Provisionable"
+      ],
       "capabilities": []
     },
     {
@@ -839,6 +855,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAppIdentityResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -855,6 +876,7 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "System.IEquatable`1[[Aspire.Hosting.Azure.BicepOutputReference]]"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "name",
@@ -907,6 +929,7 @@
       "isInterface": true,
       "description": "Represents a resource that represents an Azure Key Vault.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     },
     {
@@ -916,6 +939,7 @@
       "isInterface": true,
       "description": "Represents a reference to a secret in an Azure Key Vault resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     }
   ],

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppConfiguration.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.AppConfiguration",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -178,6 +179,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withDataBindMount",
@@ -265,6 +270,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppContainers.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppContainers.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.AppContainers",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -349,6 +350,11 @@
         "Aspire.Hosting.Azure.IAzureComputeEnvironmentResource",
         "Aspire.Hosting.Azure.IAzureContainerRegistry",
         "Aspire.Hosting.Azure.IAzureDelegatedSubnetResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppService.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.AppService.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.AppService",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -251,6 +252,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAzureComputeEnvironmentResource",
         "Aspire.Hosting.Azure.IAzureContainerRegistry"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ApplicationInsights.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.ApplicationInsights",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -65,6 +66,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.CognitiveServices.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.CognitiveServices",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -337,6 +338,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -575,6 +579,11 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ContainerRegistry.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.ContainerRegistry",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -190,6 +191,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAzureContainerRegistryResource",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.CosmosDB.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.CosmosDB",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -285,6 +286,9 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -301,6 +305,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -346,6 +353,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -461,6 +472,11 @@
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.EventHubs.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.EventHubs.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.EventHubs",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -341,6 +342,9 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -359,6 +363,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -522,6 +529,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withConfigurationFile",
@@ -588,6 +599,11 @@
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.FrontDoor.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.FrontDoor.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.FrontDoor",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -61,6 +62,11 @@
         "Aspire.Hosting.ApplicationModel.IAzureResource",
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Functions.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Functions.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Functions",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -210,6 +211,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHostStorage",
@@ -251,6 +256,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -316,6 +324,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -330,6 +342,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEndpoints",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.KeyVault.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.KeyVault.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.KeyVault",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -138,6 +139,11 @@
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addSecret",
@@ -204,6 +210,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzureKeyVaultSecretReference"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Kubernetes",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -393,6 +394,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Kubernetes.KubernetesNodePoolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withSubnet",
@@ -429,6 +434,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAzureComputeEnvironmentResource",
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -726,6 +736,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Azure.Kubernetes.AzureKubernetesEnvironmentResource]]"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Kusto.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Kusto.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Kusto",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -274,6 +275,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addReadWriteDatabase",
@@ -415,6 +421,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHostPort",
@@ -455,6 +465,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Azure.AzureKustoClusterResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Network.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Network.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Network",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -596,6 +597,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withPublicIPAddress",
@@ -631,6 +637,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withSecurityRule",
@@ -664,6 +675,11 @@
         "Aspire.Hosting.ApplicationModel.IAzureResource",
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -699,6 +715,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -709,6 +730,11 @@
         "Aspire.Hosting.ApplicationModel.IAzureResource",
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -721,6 +747,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Azure.AzureVirtualNetworkResource]]"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1027,6 +1056,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addSubnet",
@@ -1071,11 +1105,13 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the name of the access rule. This name must be unique within the perimeter profile."
         },
         {
           "name": "Direction",
           "type": "NetworkSecurityPerimeterAccessRuleDirection",
+          "isOptional": true,
           "description": "Gets or sets the direction of the rule."
         },
         {
@@ -1126,61 +1162,73 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the name of the security rule. This name must be unique within the Network Security Group."
         },
         {
           "name": "Description",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets an optional description for the security rule."
         },
         {
           "name": "Priority",
           "type": "number",
+          "isOptional": true,
           "description": "Gets or sets the priority of the rule. Valid values are between 100 and 4096. Lower numbers have higher priority."
         },
         {
           "name": "Direction",
           "type": "SecurityRuleDirection",
+          "isOptional": true,
           "description": "Gets or sets the direction of the rule."
         },
         {
           "name": "Access",
           "type": "SecurityRuleAccess",
+          "isOptional": true,
           "description": "Gets or sets whether network traffic is allowed or denied."
         },
         {
           "name": "Protocol",
           "type": "SecurityRuleProtocol",
+          "isOptional": true,
           "description": "Gets or sets the network protocol this rule applies to."
         },
         {
           "name": "SourceAddressPrefix",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the source address prefix. Defaults to \"*\" (any)."
         },
         {
           "name": "SourceAddressPrefixReference",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "Gets or sets a `ReferenceExpression` whose value is resolved at deploy time and used as the source address prefix for the rule. Takes precedence over `SourceAddressPrefix`."
         },
         {
           "name": "SourcePortRange",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the source port range. Defaults to \"*\" (any)."
         },
         {
           "name": "DestinationAddressPrefix",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the destination address prefix. Defaults to \"*\" (any)."
         },
         {
           "name": "DestinationAddressPrefixReference",
           "type": "ReferenceExpression",
+          "isOptional": true,
           "description": "Gets or sets a `ReferenceExpression` whose value is resolved at deploy time and used as the destination address prefix for the rule. Takes precedence over `DestinationAddressPrefix`."
         },
         {
           "name": "DestinationPortRange",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the destination port range. Use \"*\" for any, or a range like \"80-443\"."
         }
       ]

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.OperationalInsights.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.OperationalInsights.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.OperationalInsights",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -39,6 +40,11 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.PostgreSQL.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.PostgreSQL",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -160,6 +161,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withPostgresMcp",
@@ -210,6 +214,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Redis.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Redis.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Redis",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -208,6 +209,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Search.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Search.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Search",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -84,6 +85,11 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.ServiceBus.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.ServiceBus",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -1134,6 +1135,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withConfigurationFile",
@@ -1198,6 +1203,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1603,6 +1611,11 @@
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addServiceBusQueue",
@@ -1701,6 +1714,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2052,6 +2068,9 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addServiceBusSubscription",
@@ -2278,46 +2297,55 @@
         {
           "name": "Properties",
           "type": "Dict<string,any>",
+          "isOptional": true,
           "description": "Dictionary object for custom filters."
         },
         {
           "name": "CorrelationId",
           "type": "string",
+          "isOptional": true,
           "description": "Identifier of the correlation."
         },
         {
           "name": "MessageId",
           "type": "string",
+          "isOptional": true,
           "description": "Identifier of the message."
         },
         {
           "name": "SendTo",
           "type": "string",
+          "isOptional": true,
           "description": "Address to send to."
         },
         {
           "name": "ReplyTo",
           "type": "string",
+          "isOptional": true,
           "description": "Address of the queue to reply to."
         },
         {
           "name": "Subject",
           "type": "string",
+          "isOptional": true,
           "description": "Application specific label."
         },
         {
           "name": "SessionId",
           "type": "string",
+          "isOptional": true,
           "description": "Session identifier."
         },
         {
           "name": "ReplyToSessionId",
           "type": "string",
+          "isOptional": true,
           "description": "Session identifier to reply to."
         },
         {
           "name": "ContentType",
           "type": "string",
+          "isOptional": true,
           "description": "Content type of the message."
         },
         {
@@ -2338,16 +2366,19 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "The rule name."
         },
         {
           "name": "CorrelationFilter",
           "type": "AzureServiceBusCorrelationFilter",
+          "isOptional": true,
           "description": "Properties of correlation filter."
         },
         {
           "name": "FilterType",
           "type": "AzureServiceBusFilterType",
+          "isOptional": true,
           "description": "Filter type that is evaluated against a BrokeredMessage."
         }
       ]

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.SignalR.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.SignalR.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.SignalR",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -110,6 +111,11 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "runAsEmulator",
@@ -151,6 +157,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Sql.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Sql.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Sql",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -405,6 +406,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -528,6 +532,11 @@
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTargetNotification"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Storage.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.Storage.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.Storage",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -436,6 +437,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -454,6 +458,9 @@
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -469,6 +476,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Azure.AzureDataLakeStorageResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -488,6 +498,9 @@
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -503,6 +516,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Azure.AzureQueueStorageResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -522,6 +538,9 @@
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -536,6 +555,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -699,6 +722,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParameters",
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -916,6 +944,9 @@
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget",
         "Aspire.Hosting.Azure.IResourceWithAzureFunctionsConfig"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Azure.WebPubSub.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Azure.WebPubSub",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -147,6 +148,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addEventHandler",
@@ -199,6 +203,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Blazor.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Blazor.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Blazor",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -104,6 +105,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Browsers.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Browsers.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Browsers",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.ClickHouse.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.ClickHouse.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.ClickHouse",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/ClickHouse/ClickHouse.Aspire",
+    "sourceCommit": "c851a8bcb7e56a563fa0c1f098ece8cde3f3a715"
   },
   "functions": [
     {
@@ -302,6 +303,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -366,6 +370,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.DevTunnels.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.DevTunnels.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.DevTunnels",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -175,6 +176,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Docker.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Docker.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Docker",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -3919,6 +3920,7 @@
       "exposeProperties": true,
       "description": "Represents a captured environment variable that will be written to the .env file adjacent to the Docker Compose file.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "defaultValue",
@@ -4036,6 +4038,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "otlpGrpcEndpoint",
@@ -4127,6 +4133,9 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IComputeEnvironmentResource",
         "Aspire.Hosting.ApplicationModel.IResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -4349,6 +4358,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Docker.DockerComposeEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "parent",
@@ -4374,6 +4386,7 @@
       "description": "Represents a Docker Compose file with properties and configurations for services, networks, volumes, secrets, configs, and custom extensions.",
       "remarks": "This class is designed to encapsulate the structure of a Docker Compose file as a strongly-typed model.\nIt supports serialization to YAML format for usage in Docker Compose operations.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addConfig",
@@ -4868,6 +4881,9 @@
       "description": "Represents a configuration object in a Docker Compose file.",
       "remarks": "This class models a configuration entry within a Docker Compose file, such as\nfile-based or external configurations. It includes properties to define the\nsource file, external flag, custom name, and additional labels for the configuration.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Docker.Resources.ComposeNodes.NamedComposeMember"
+      ],
       "capabilities": [
         {
           "name": "content",
@@ -5046,6 +5062,9 @@
       "description": "Represents a Docker network configuration as part of a Compose file.",
       "remarks": "This class encapsulates the properties and options related to a network in a Docker Compose file.\nIt includes configurations such as driver type, options, labels, IPAM settings, and more.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Docker.Resources.ComposeNodes.NamedComposeMember"
+      ],
       "capabilities": [
         {
           "name": "attachable",
@@ -5325,6 +5344,7 @@
       "description": "Represents a Secret object in a Docker Compose configuration file.",
       "remarks": "A Secret object is used to define sensitive information to be shared with containers,\nsuch as passwords, keys, or certificates. These secrets can either be externally managed\nor provided locally from a specific file.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "external",
@@ -5468,6 +5488,9 @@
       "description": "Represents a Docker Compose service definition.",
       "remarks": "This class provides YAML mapping for various properties associated with a service in Docker Compose,\nsuch as image, container configuration, environment variables, networks, and more.\nIt is designed to map directly to the service properties defined in a Docker Compose YAML file.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Docker.Resources.ComposeNodes.NamedComposeMember"
+      ],
       "capabilities": [
         {
           "name": "addVolume",
@@ -7126,6 +7149,7 @@
       "exposeProperties": true,
       "description": "Represents a service dependency in a Docker Compose file.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "condition",
@@ -7170,6 +7194,7 @@
       "description": "Represents a reference to a configuration used within a service resource.",
       "remarks": "This class is typically used to define configurations associated with a\nservice in a containerized environment. It includes information about\nthe configuration source, target, ownership, and permissions.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "gid",
@@ -7347,6 +7372,7 @@
       "exposeProperties": true,
       "description": "Represents a reference to a secret within a Docker service configuration.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "gid",
@@ -7525,6 +7551,7 @@
       "description": "Represents the configuration for system resource limits (ulimits) for a container.",
       "remarks": "This class is typically used to specify soft and hard limits for resources\nsuch as file descriptors or process count for Docker containers.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "hard",
@@ -7604,6 +7631,9 @@
       "description": "Represents a volume definition in a Docker Compose configuration file.",
       "remarks": "The `Volume` class is used to define properties and options for volumes in a Docker environment.\nVolumes are used to persist data beyond the lifecycle of a container and can be shared among multiple containers.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Docker.Resources.ComposeNodes.NamedComposeMember"
+      ],
       "capabilities": [
         {
           "name": "driver",

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
@@ -3,14 +3,15 @@
     "name": "Aspire.Hosting.EntityFrameworkCore",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
       "name": "addEFMigrations",
       "capabilityId": "Aspire.Hosting.EntityFrameworkCore/addEFMigrations",
       "qualifiedName": "addEFMigrations",
-      "description": "Adds EF Core migration management for polyglot AppHosts.",
+      "description": "Adds EF Core migration management for polyglot app hosts.",
       "kind": "Method",
       "signature": "addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource",
       "parameters": [
@@ -511,7 +512,7 @@
       "name": "withMigrationsProject",
       "capabilityId": "Aspire.Hosting.EntityFrameworkCore/withMigrationsProject",
       "qualifiedName": "withMigrationsProject",
-      "description": "Configures a separate project containing migrations for polyglot AppHosts.",
+      "description": "Configures a separate project containing migrations for polyglot app hosts.",
       "kind": "Method",
       "signature": "withMigrationsProject(migrationsProject?: ProjectResource): EFMigrationResource",
       "parameters": [
@@ -544,6 +545,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1025,7 +1030,7 @@
           "name": "withMigrationsProject",
           "capabilityId": "Aspire.Hosting.EntityFrameworkCore/withMigrationsProject",
           "qualifiedName": "withMigrationsProject",
-          "description": "Configures a separate project containing migrations for polyglot AppHosts.",
+          "description": "Configures a separate project containing migrations for polyglot app hosts.",
           "kind": "Method",
           "signature": "withMigrationsProject(migrationsProject?: ProjectResource): EFMigrationResource",
           "parameters": [

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.EntityFrameworkCore.13.4.6-preview.1.26319.6.json
@@ -11,7 +11,7 @@
       "name": "addEFMigrations",
       "capabilityId": "Aspire.Hosting.EntityFrameworkCore/addEFMigrations",
       "qualifiedName": "addEFMigrations",
-      "description": "Adds EF Core migration management for polyglot app hosts.",
+      "description": "Adds EF Core migration management for polyglot AppHosts.",
       "kind": "Method",
       "signature": "addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource",
       "parameters": [
@@ -512,7 +512,7 @@
       "name": "withMigrationsProject",
       "capabilityId": "Aspire.Hosting.EntityFrameworkCore/withMigrationsProject",
       "qualifiedName": "withMigrationsProject",
-      "description": "Configures a separate project containing migrations for polyglot app hosts.",
+      "description": "Configures a separate project containing migrations for polyglot AppHosts.",
       "kind": "Method",
       "signature": "withMigrationsProject(migrationsProject?: ProjectResource): EFMigrationResource",
       "parameters": [
@@ -1030,7 +1030,7 @@
           "name": "withMigrationsProject",
           "capabilityId": "Aspire.Hosting.EntityFrameworkCore/withMigrationsProject",
           "qualifiedName": "withMigrationsProject",
-          "description": "Configures a separate project containing migrations for polyglot app hosts.",
+          "description": "Configures a separate project containing migrations for polyglot AppHosts.",
           "kind": "Method",
           "signature": "withMigrationsProject(migrationsProject?: ProjectResource): EFMigrationResource",
           "parameters": [

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -2988,7 +2988,7 @@
       "kind": "handle",
       "exposeProperties": true,
       "description": "A configuration helper for hosted agents.",
-      "remarks": "This type is used instead of `ProjectsAgentVersionCreationOptions` to provide a strongly typed\nconfiguration surface for hosted agent definitions. When used from polyglot app hosts, only the\nATS-compatible properties are exported; Azure SDK-specific members remain .NET-only.",
+      "remarks": "This type is used instead of `ProjectsAgentVersionCreationOptions` to provide a strongly typed\nconfiguration surface for hosted agent definitions. When used from polyglot AppHosts, only the\nATS-compatible properties are exported; Azure SDK-specific members remain .NET-only.",
       "implementedInterfaces": [],
       "baseTypeHierarchy": [],
       "capabilities": [

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -1535,7 +1535,7 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]"
       ],
       "baseTypeHierarchy": [
-        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProjectConnection]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProjectConnection],[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]",
         "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesProjectConnection]]",
         "Aspire.Hosting.Azure.AzureProvisioningResource",
         "Aspire.Hosting.Azure.AzureBicepResource",
@@ -1562,7 +1562,7 @@
         "Aspire.Hosting.Azure.IAzureComputeEnvironmentResource"
       ],
       "baseTypeHierarchy": [
-        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProject]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProject],[Aspire.Hosting.Foundry.FoundryResource]]",
         "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesProject]]",
         "Aspire.Hosting.Azure.AzureProvisioningResource",
         "Aspire.Hosting.Azure.AzureBicepResource",
@@ -2448,7 +2448,7 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]"
       ],
       "baseTypeHierarchy": [
-        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesConnection]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesConnection],[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]",
         "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesConnection]]",
         "Aspire.Hosting.Azure.AzureProvisioningResource",
         "Aspire.Hosting.Azure.AzureBicepResource",

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Foundry.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Foundry",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -1493,6 +1494,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withReference",
@@ -1529,6 +1534,13 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProjectConnection]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesProjectConnection]]",
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -1548,6 +1560,13 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.Azure.IAzureComputeEnvironmentResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesProject]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesProject]]",
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2238,6 +2257,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2255,6 +2278,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2421,6 +2447,13 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResourceWithParent`2[[Azure.Provisioning.CognitiveServices.CognitiveServicesConnection]]",
+        "Aspire.Hosting.Foundry.AzureProvisionableAspireResource`1[[Azure.Provisioning.CognitiveServices.CognitiveServicesConnection]]",
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2431,6 +2464,10 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2465,6 +2502,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2476,6 +2517,10 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -2489,6 +2534,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2500,6 +2549,10 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -2518,6 +2571,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Foundry.FoundryResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2815,6 +2871,11 @@
         "Aspire.Hosting.Azure.IAzureNspAssociationTarget",
         "Aspire.Hosting.Azure.IAzurePrivateEndpointTarget"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Azure.AzureProvisioningResource",
+        "Aspire.Hosting.Azure.AzureBicepResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addDeployment",
@@ -2900,6 +2961,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2912,6 +2976,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -2920,8 +2988,9 @@
       "kind": "handle",
       "exposeProperties": true,
       "description": "A configuration helper for hosted agents.",
-      "remarks": "This type is used instead of `ProjectsAgentVersionCreationOptions` to provide a strongly typed\nconfiguration surface for hosted agent definitions. When used from polyglot AppHosts, only the\nATS-compatible properties are exported; Azure SDK-specific members remain .NET-only.",
+      "remarks": "This type is used instead of `ProjectsAgentVersionCreationOptions` to provide a strongly typed\nconfiguration surface for hosted agent definitions. When used from polyglot app hosts, only the\nATS-compatible properties are exported; Azure SDK-specific members remain .NET-only.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "cpu",
@@ -3061,6 +3130,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -3073,6 +3146,10 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -3084,6 +3161,10 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.Foundry.IFoundryTool"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Foundry.FoundryToolResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }
@@ -3098,16 +3179,19 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "The name of the model."
         },
         {
           "name": "Version",
           "type": "string",
+          "isOptional": true,
           "description": "The version of the model."
         },
         {
           "name": "Format",
           "type": "string",
+          "isOptional": true,
           "description": "The format or provider of the model (e.g., OpenAI, Microsoft, xAi, Deepseek)."
         }
       ]
@@ -3121,6 +3205,7 @@
         {
           "name": "Description",
           "type": "string",
+          "isOptional": true,
           "description": "Human-readable description of the hosted agent surfaced in the Microsoft Foundry portal. When not set, the hosted agent default description is used."
         },
         {
@@ -3164,11 +3249,13 @@
         {
           "name": "Protocol",
           "type": "string",
+          "isOptional": true,
           "description": "The protocol name, such as `responses` or `invocations`."
         },
         {
           "name": "Version",
           "type": "string",
+          "isOptional": true,
           "description": "The protocol version, such as `1.0.0`."
         }
       ]

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Garnet.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Garnet.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Garnet",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -226,6 +227,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.GitHub.Models.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.GitHub.Models.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.GitHub.Models",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -124,6 +125,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithConnectionString",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Go.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Go.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Go",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -238,6 +239,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.JavaScript.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.JavaScript.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.JavaScript",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -590,6 +591,11 @@
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -608,6 +614,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -982,6 +992,11 @@
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "disableBuildValidation",
@@ -1020,6 +1035,11 @@
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -1038,6 +1058,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Kafka.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Kafka.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Kafka",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -242,6 +243,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -418,6 +423,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Keycloak.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Keycloak",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -225,6 +226,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Kubernetes.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Kubernetes",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -1848,6 +1849,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.CertManagerResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withAcmeServer",
@@ -2021,6 +2025,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addIssuer",
@@ -2053,6 +2060,7 @@
       "exposeMethods": true,
       "description": "Provides options for configuring Helm chart deployment settings on a {@ats-ref type:KubernetesEnvironmentResource}.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "withChartDescription",
@@ -2165,6 +2173,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2289,6 +2301,9 @@
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IComputeEnvironmentResource",
         "Aspire.Hosting.ApplicationModel.IResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -2801,6 +2816,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withGatewayAnnotation",
@@ -3113,6 +3131,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHelmChartDestroy",
@@ -3230,6 +3251,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -3538,6 +3562,10 @@
       "kind": "handle",
       "description": "Represents an arbitrary Kubernetes manifest that is emitted with a Kubernetes service.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Kubernetes.Resources.BaseKubernetesResource",
+        "Aspire.Hosting.Kubernetes.Resources.BaseKubernetesObject"
+      ],
       "capabilities": [
         {
           "name": "withAnnotation",
@@ -3651,6 +3679,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -3663,6 +3694,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Maui.13.4.6-preview.1.26319.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Maui",
     "version": "13.4.6-preview.1.26319.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -238,6 +239,10 @@
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -257,6 +262,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -278,6 +287,10 @@
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -297,6 +310,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -318,6 +335,10 @@
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -326,6 +347,9 @@
       "kind": "handle",
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -509,6 +533,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery",
         "Aspire.Hosting.Maui.IMauiPlatformResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ProjectResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Milvus.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Milvus.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Milvus",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -356,6 +357,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -415,6 +419,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -436,6 +444,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.MongoDB.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.MongoDB.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.MongoDB",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -414,6 +415,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -493,6 +497,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -778,6 +786,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.MySql.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.MySql.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.MySql",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -474,6 +475,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -591,6 +595,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -903,6 +911,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Nats.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Nats.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Nats",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -290,6 +291,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.OpenAI.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.OpenAI.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.OpenAI",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -129,6 +130,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHealthCheck",
@@ -160,6 +164,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithConnectionString",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Oracle.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Oracle.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Oracle",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -378,6 +379,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -472,6 +476,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Orleans.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Orleans.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Orleans",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -357,6 +358,7 @@
       "kind": "handle",
       "description": "Describes an Orleans service.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "asClient",
@@ -636,6 +638,7 @@
       "kind": "handle",
       "description": "Represents an Orleans client configuration that can be referenced by application resources.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": []
     }
   ],

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.PostgreSQL.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.PostgreSQL.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.PostgreSQL",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -661,6 +662,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -810,6 +814,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1250,6 +1258,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHostPort",
@@ -1289,6 +1301,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHostPort",
@@ -1327,6 +1343,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Python.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Python.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Python",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -294,6 +295,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withDebugging",
@@ -453,6 +458,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Python.PythonAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Qdrant.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Qdrant.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Qdrant",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -286,6 +287,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.RabbitMQ.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.RabbitMQ.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.RabbitMQ",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -278,6 +279,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Redis.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Redis.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Redis",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -471,6 +472,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -803,6 +808,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withHostPort",
@@ -841,6 +850,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Seq.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Seq.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Seq",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -191,6 +192,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.SqlServer.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.SqlServer.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.SqlServer",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -436,6 +437,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -553,6 +557,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Valkey.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Valkey.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Valkey",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -238,6 +239,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/Aspire.Hosting.Yarp.13.4.6.json
+++ b/src/frontend/src/data/ts-modules/Aspire.Hosting.Yarp.13.4.6.json
@@ -3,7 +3,8 @@
     "name": "Aspire.Hosting.Yarp",
     "version": "13.4.6",
     "language": "typescript",
-    "sourceRepository": "https://github.com/microsoft/aspire"
+    "sourceRepository": "https://github.com/microsoft/aspire",
+    "sourceCommit": "87fe259e4fc244c599019a7b1304c85a1488f248"
   },
   "functions": [
     {
@@ -1272,6 +1273,7 @@
       "exposeMethods": true,
       "description": "Interface to build a configuration file for YARP",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addCatchAllRoute",
@@ -1443,6 +1445,7 @@
       "kind": "handle",
       "description": "Represents a cluster for YARP routes",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "withForwarderRequestConfig",
@@ -1575,6 +1578,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "publishWithStaticFiles",
@@ -1695,6 +1702,7 @@
       "kind": "handle",
       "description": "Represents a route for YARP",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "withMatch",
@@ -2568,16 +2576,19 @@
         {
           "name": "Path",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the health check path."
         },
         {
           "name": "Policy",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the health check policy."
         },
         {
           "name": "Query",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the health check query string."
         },
         {
@@ -2609,6 +2620,7 @@
         {
           "name": "Version",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the HTTP version string."
         },
         {
@@ -2628,16 +2640,19 @@
         {
           "name": "Active",
           "type": "YarpActiveHealthCheckConfig",
+          "isOptional": true,
           "description": "Gets or sets the active health check configuration."
         },
         {
           "name": "AvailableDestinationsPolicy",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the available destinations policy."
         },
         {
           "name": "Passive",
           "type": "YarpPassiveHealthCheckConfig",
+          "isOptional": true,
           "description": "Gets or sets the passive health check configuration."
         }
       ]
@@ -2669,21 +2684,25 @@
         {
           "name": "RequestHeaderEncoding",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the request header encoding."
         },
         {
           "name": "ResponseHeaderEncoding",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the response header encoding."
         },
         {
           "name": "SslProtocols",
           "type": "YarpSslProtocol[]",
+          "isOptional": true,
           "description": "Gets or sets the SSL protocols to enable."
         },
         {
           "name": "WebProxy",
           "type": "YarpWebProxyConfig",
+          "isOptional": true,
           "description": "Gets or sets the web proxy configuration."
         }
       ]
@@ -2703,6 +2722,7 @@
         {
           "name": "Policy",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the health check policy."
         },
         {
@@ -2722,21 +2742,25 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the header name to match."
         },
         {
           "name": "Values",
           "type": "string[]",
+          "isOptional": true,
           "description": "Gets or sets the header values to match."
         },
         {
           "name": "IsCaseSensitive",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether the header comparison is case-sensitive."
         },
         {
           "name": "Mode",
           "type": "HeaderMatchMode",
+          "isOptional": true,
           "description": "Gets or sets the matching mode for the header comparison."
         }
       ]
@@ -2750,26 +2774,31 @@
         {
           "name": "Path",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the path pattern to match."
         },
         {
           "name": "Methods",
           "type": "string[]",
+          "isOptional": true,
           "description": "Gets or sets the HTTP methods to match."
         },
         {
           "name": "Hosts",
           "type": "string[]",
+          "isOptional": true,
           "description": "Gets or sets the host headers to match."
         },
         {
           "name": "Headers",
           "type": "YarpRouteHeaderMatch[]",
+          "isOptional": true,
           "description": "Gets or sets the header match criteria."
         },
         {
           "name": "QueryParameters",
           "type": "YarpRouteQueryParameterMatch[]",
+          "isOptional": true,
           "description": "Gets or sets the query parameter match criteria."
         }
       ]
@@ -2783,21 +2812,25 @@
         {
           "name": "Name",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the query parameter name to match."
         },
         {
           "name": "Values",
           "type": "string[]",
+          "isOptional": true,
           "description": "Gets or sets the query parameter values to match."
         },
         {
           "name": "IsCaseSensitive",
           "type": "boolean",
+          "isOptional": true,
           "description": "Gets or sets a value indicating whether the query parameter comparison is case-sensitive."
         },
         {
           "name": "Mode",
           "type": "QueryParameterMatchMode",
+          "isOptional": true,
           "description": "Gets or sets the matching mode for the query parameter comparison."
         }
       ]
@@ -2811,11 +2844,13 @@
         {
           "name": "AffinityKeyName",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the affinity key name."
         },
         {
           "name": "Cookie",
           "type": "YarpSessionAffinityCookieConfig",
+          "isOptional": true,
           "description": "Gets or sets the cookie configuration."
         },
         {
@@ -2827,11 +2862,13 @@
         {
           "name": "FailurePolicy",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the failure policy."
         },
         {
           "name": "Policy",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the session affinity policy."
         }
       ]
@@ -2845,6 +2882,7 @@
         {
           "name": "Domain",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the cookie domain."
         },
         {
@@ -2874,6 +2912,7 @@
         {
           "name": "Path",
           "type": "string",
+          "isOptional": true,
           "description": "Gets or sets the cookie path."
         },
         {
@@ -2899,6 +2938,7 @@
         {
           "name": "Address",
           "type": "uri",
+          "isOptional": true,
           "description": "Gets or sets the proxy address."
         },
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.ActiveMQ.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.ActiveMQ.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.ActiveMQ",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -377,6 +378,11 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ActiveMQServerResourceBase",
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -396,6 +402,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ActiveMQServerResourceBase",
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     },
@@ -418,6 +429,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Adminer.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Adminer.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Adminer",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -73,6 +74,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -115,6 +116,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Azure.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Azure.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Azure.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -183,6 +184,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Bitwarden.SecretManager.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Bitwarden.SecretManager.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Bitwarden.SecretManager",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -534,6 +535,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addSecret",
@@ -851,6 +855,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.BitwardenSecretManagerResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ParameterResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Bun.13.3.0.json
@@ -1,9 +1,10 @@
 {
   "package": {
     "name": "CommunityToolkit.Aspire.Hosting.Bun",
-    "version": "13.4.0",
+    "version": "13.3.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "0a6068734d939cdf93e8a6a0cab67cf1e5c76953"
   },
   "functions": [
     {
@@ -77,6 +78,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.DbGate.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.DbGate.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.DbGate",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -150,6 +151,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Dbx.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Dbx.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Dbx",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -91,6 +92,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Deno.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Deno.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Deno",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -122,6 +123,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.DuckDB.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.DuckDB.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.DuckDB",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -69,6 +70,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithConnectionString",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Elasticsearch.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -75,6 +76,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Flagd.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Flagd",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -193,6 +194,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Flyway.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Flyway.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Flyway",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -57,6 +58,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.GoFeatureFlag.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.GoFeatureFlag",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -200,6 +201,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Java.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Java.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Java",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -333,6 +334,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -350,6 +355,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.JavaScript.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.JavaScript.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -370,6 +371,11 @@
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -378,6 +384,9 @@
       "kind": "handle",
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -528,6 +537,11 @@
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -536,6 +550,9 @@
       "kind": "handle",
       "implementedInterfaces": [
         "Aspire.Hosting.ApplicationModel.IResource"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.K3s.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.K3s",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -718,6 +719,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "namespace",
@@ -833,6 +838,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1270,6 +1279,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringEnvironmentVariable",
@@ -1409,6 +1421,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.K3sClusterResource]]",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Keycloak.Extensions.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Keycloak.Extensions",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Kind.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Kind.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Kind",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -315,6 +316,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addHelmChart",
@@ -355,6 +359,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.KindClusterResource]]",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "withNamespace",
@@ -391,6 +398,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.Kubernetes.KubernetesEnvironmentResource]]"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -402,6 +412,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent",
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.KindClusterResource]]",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.KindDeployedResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.KurrentDB.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.KurrentDB.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.KurrentDB",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -175,6 +176,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.LavinMQ.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.LavinMQ.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.LavinMQ",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -192,6 +193,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Listmonk.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Listmonk.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Listmonk",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -465,6 +466,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Logto.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Logto.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Logto",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -437,6 +438,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MailPit.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MailPit.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.MailPit",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -192,6 +193,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.McpInspector.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.McpInspector",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -163,6 +164,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithContainerFiles",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.JavaScript.JavaScriptAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Meilisearch.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Meilisearch.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Meilisearch",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -195,6 +196,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Minio.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Minio.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Minio",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -319,6 +320,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MongoDB.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.MongoDB.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MySql.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.MySql.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.MySql.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Ngrok.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Ngrok",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -151,6 +152,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Ollama.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Ollama.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Ollama",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -598,6 +599,7 @@
       "exposeProperties": true,
       "description": "Represents an Ollama resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "addHuggingFaceModel",
@@ -737,6 +739,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -840,6 +846,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -906,6 +915,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -1069,6 +1082,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -1221,6 +1238,7 @@
         "System.IFormattable",
         "System.ISpanFormattable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": []
     }
   ],

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.OpenTelemetryCollector",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -391,6 +392,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "grpcEndpoint",
@@ -467,6 +472,7 @@
       "exposeProperties": true,
       "description": "Settings for configuring an OpenTelemetry Collector resource.",
       "implementedInterfaces": [],
+      "baseTypeHierarchy": [],
       "capabilities": [
         {
           "name": "collectorImage",

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PapercutSmtp.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PapercutSmtp.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.PapercutSmtp",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -120,6 +121,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Perl.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Perl.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Perl",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -344,6 +345,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.PostgreSQL.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.PowerShell.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.PowerShell",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -97,6 +98,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "System.IDisposable"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "addScript",
@@ -134,6 +138,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "System.IDisposable"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Python.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Python.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Python.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -55,6 +56,11 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.Python.PythonAppResource",
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.RavenDB.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.RavenDB",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -341,6 +342,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -405,6 +409,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Redis.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Redis.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Redis.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Rust.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Rust.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Rust",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -87,6 +88,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ExecutableResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.RustFs.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.RustFs.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.RustFs",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -183,6 +184,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": []
     },
     {
@@ -202,6 +206,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SeaweedFS.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SeaweedFS.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.SeaweedFS",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -225,6 +226,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Sftp.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Sftp.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Sftp",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -199,6 +200,10 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -354,6 +359,7 @@
         "System.IFormattable",
         "System.ISpanFormattable"
       ],
+      "baseTypeHierarchy": [],
       "capabilities": []
     }
   ],

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Solr.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Solr.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Solr",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -252,6 +253,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -186,6 +187,9 @@
         "Aspire.Hosting.ApplicationModel.IResource",
         "Aspire.Hosting.ApplicationModel.IResourceWithDacpac",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SqlServer.Extensions.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.SqlServer.Extensions",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Sqlite.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Sqlite",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -161,6 +162,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -217,6 +221,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Squad.13.4.1-beta.701.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Squad.13.4.1-beta.701.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Squad",
     "version": "13.4.1-beta.701",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "be6f2a5046ee6d8498e259118610efdf0f5889e5"
   },
   "functions": [
     {
@@ -47,6 +48,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithConnectionString",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": []
     }

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Stripe.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Stripe.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Stripe",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -208,6 +209,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.SurrealDb.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.SurrealDb",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -519,6 +520,9 @@
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
       ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
+      ],
       "capabilities": [
         {
           "name": "connectionStringExpression",
@@ -602,6 +606,9 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.SurrealDbServerResource]]",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {
@@ -733,6 +740,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.ApplicationModel.IValueProvider",
         "Aspire.Hosting.ApplicationModel.IValueWithReferences"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Umami.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Umami.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Umami",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -109,6 +110,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport",
         "Aspire.Hosting.IResourceWithServiceDiscovery"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Zitadel.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.Zitadel.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.Zitadel",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -136,6 +137,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.k6.13.4.0.json
+++ b/src/frontend/src/data/ts-modules/CommunityToolkit.Aspire.Hosting.k6.13.4.0.json
@@ -3,7 +3,8 @@
     "name": "CommunityToolkit.Aspire.Hosting.k6",
     "version": "13.4.0",
     "language": "typescript",
-    "sourceRepository": "https://github.com/CommunityToolkit/Aspire"
+    "sourceRepository": "https://github.com/CommunityToolkit/Aspire",
+    "sourceCommit": "d9dc6fc02412d7398c5722840513d99965a6e98f"
   },
   "functions": [
     {
@@ -126,6 +127,10 @@
         "Aspire.Hosting.ApplicationModel.IResourceWithEnvironment",
         "Aspire.Hosting.ApplicationModel.IResourceWithProbes",
         "Aspire.Hosting.ApplicationModel.IResourceWithWaitSupport"
+      ],
+      "baseTypeHierarchy": [
+        "Aspire.Hosting.ApplicationModel.ContainerResource",
+        "Aspire.Hosting.ApplicationModel.Resource"
       ],
       "capabilities": [
         {

--- a/src/frontend/src/data/twoslash/aspire.d.ts
+++ b/src/frontend/src/data/twoslash/aspire.d.ts
@@ -24,34 +24,6 @@ export type PropertyAccessor<T> = (T extends object ? T : unknown) & (() => Prom
 
 // ---- enums ----
 /**
- * Enum Aspire.Hosting.ApplicationModel.InputType
- */
-export type InputType = "Text" | "Number" | "Choice" | "SecretText";
-export declare const InputType: {
-  readonly Text: "Text";
-  readonly Number: "Number";
-  readonly Choice: "Choice";
-  readonly SecretText: "SecretText";
-};
-
-export interface ParameterCustomInputOptions {
-  inputType?: InputType;
-  label?: string;
-  placeholder?: string;
-  options?: Record<string, string>;
-}
-
-export interface BeforePublishEvent extends IDistributedApplicationEvent {
-  model: PropertyAccessor<DistributedApplicationModel>;
-  services: PropertyAccessor<IServiceProvider>;
-}
-
-export interface AfterPublishEvent extends IDistributedApplicationEvent {
-  model: PropertyAccessor<DistributedApplicationModel>;
-  services: PropertyAccessor<IServiceProvider>;
-}
-
-/**
  * Enum Aspire.Hosting.ApplicationModel.CertificateTrustScope
  */
 
@@ -205,6 +177,19 @@ export type DistributedApplicationOperation = "Run" | "Publish";
 export declare const DistributedApplicationOperation: {
   readonly Run: "Run";
   readonly Publish: "Publish";
+};
+
+/**
+ * Enum Aspire.Hosting.InputType
+ */
+
+export type InputType = "Text" | "SecretText" | "Choice" | "Boolean" | "Number";
+export declare const InputType: {
+  readonly Text: "Text";
+  readonly SecretText: "SecretText";
+  readonly Choice: "Choice";
+  readonly Boolean: "Boolean";
+  readonly Number: "Number";
 };
 
 /**
@@ -541,10 +526,10 @@ export declare const KeyType: {
  */
 
 export interface CertificateTrustExecutionConfigurationContext {
-  certificateBundlePath: ReferenceExpression;
-  certificateDirectoriesPath: ReferenceExpression;
-  rootCertificatesPath: string;
-  isContainer: boolean;
+  certificateBundlePath?: ReferenceExpression;
+  certificateDirectoriesPath?: ReferenceExpression;
+  rootCertificatesPath?: string;
+  isContainer?: boolean;
 }
 
 /**
@@ -552,16 +537,16 @@ export interface CertificateTrustExecutionConfigurationContext {
  */
 
 export interface CommandOptions {
-  description: string;
-  parameter: any;
-  arguments: InteractionInput[];
-  validateArguments: callback;
-  visibility: ResourceCommandVisibility;
-  confirmationMessage: string;
-  iconName: string;
-  iconVariant: IconVariant;
-  isHighlighted: boolean;
-  updateState: callback;
+  description?: string;
+  parameter?: any;
+  arguments?: InteractionInput[];
+  validateArguments?: callback;
+  visibility?: ResourceCommandVisibility;
+  confirmationMessage?: string;
+  iconName?: string;
+  iconVariant?: IconVariant;
+  isHighlighted?: boolean;
+  updateState?: callback;
 }
 
 /**
@@ -569,9 +554,9 @@ export interface CommandOptions {
  */
 
 export interface CommandResultData {
-  value: string;
-  format: CommandResultFormat;
-  displayImmediately: boolean;
+  value?: string;
+  format?: CommandResultFormat;
+  displayImmediately?: boolean;
 }
 
 /**
@@ -579,11 +564,11 @@ export interface CommandResultData {
  */
 
 export interface ExecuteCommandResult {
-  success: boolean;
-  canceled: boolean;
-  errorMessage: string;
-  message: string;
-  data: CommandResultData;
+  success?: boolean;
+  canceled?: boolean;
+  errorMessage?: string;
+  message?: string;
+  data?: CommandResultData;
 }
 
 /**
@@ -591,15 +576,15 @@ export interface ExecuteCommandResult {
  */
 
 export interface GenerateParameterDefault {
-  minLength: number;
-  lower: boolean;
-  upper: boolean;
-  numeric: boolean;
-  special: boolean;
-  minLower: number;
-  minUpper: number;
-  minNumeric: number;
-  minSpecial: number;
+  minLength?: number;
+  lower?: boolean;
+  upper?: boolean;
+  numeric?: boolean;
+  special?: boolean;
+  minLower?: number;
+  minUpper?: number;
+  minNumeric?: number;
+  minSpecial?: number;
 }
 
 /**
@@ -607,15 +592,15 @@ export interface GenerateParameterDefault {
  */
 
 export interface HttpCommandExportOptions {
-  description: string;
-  confirmationMessage: string;
-  iconName: string;
-  iconVariant: IconVariant;
-  isHighlighted: boolean;
-  commandName: string;
-  endpointName: string;
-  methodName: string;
-  resultMode: HttpCommandResultMode;
+  description?: string;
+  confirmationMessage?: string;
+  iconName?: string;
+  iconVariant?: IconVariant;
+  isHighlighted?: boolean;
+  commandName?: string;
+  endpointName?: string;
+  methodName?: string;
+  resultMode?: HttpCommandResultMode;
 }
 
 /**
@@ -623,9 +608,9 @@ export interface HttpCommandExportOptions {
  */
 
 export interface HttpsCertificateExecutionConfigurationContext {
-  certificatePath: ReferenceExpression;
-  keyPath: ReferenceExpression;
-  pfxPath: ReferenceExpression;
+  certificatePath?: ReferenceExpression;
+  keyPath?: ReferenceExpression;
+  pfxPath?: ReferenceExpression;
 }
 
 /**
@@ -633,17 +618,17 @@ export interface HttpsCertificateExecutionConfigurationContext {
  */
 
 export interface ProcessCommandExportOptions {
-  executablePath: string;
-  arguments: string[];
-  workingDirectory: string;
-  environmentVariables: Dict<string,string>;
-  inheritEnvironmentVariables: boolean;
-  standardInputContent: string;
-  killEntireProcessTree: boolean;
-  commandOptions: CommandOptions;
-  maxOutputLineCount: number;
-  displayImmediately: boolean;
-  successExitCodes: number[];
+  executablePath?: string;
+  arguments?: string[];
+  workingDirectory?: string;
+  environmentVariables?: Dict<string,string>;
+  inheritEnvironmentVariables?: boolean;
+  standardInputContent?: string;
+  killEntireProcessTree?: boolean;
+  commandOptions?: CommandOptions;
+  maxOutputLineCount?: number;
+  displayImmediately?: boolean;
+  successExitCodes?: number[];
 }
 
 /**
@@ -651,10 +636,10 @@ export interface ProcessCommandExportOptions {
  */
 
 export interface ProcessCommandResultExportOptions {
-  commandOptions: CommandOptions;
-  maxOutputLineCount: number;
-  displayImmediately: boolean;
-  successExitCodes: number[];
+  commandOptions?: CommandOptions;
+  maxOutputLineCount?: number;
+  displayImmediately?: boolean;
+  successExitCodes?: number[];
 }
 
 /**
@@ -662,13 +647,13 @@ export interface ProcessCommandResultExportOptions {
  */
 
 export interface ProcessCommandSpecExportData {
-  executablePath: string;
-  arguments: string[];
-  workingDirectory: string;
-  environmentVariables: Dict<string,string>;
-  inheritEnvironmentVariables: boolean;
-  standardInputContent: string;
-  killEntireProcessTree: boolean;
+  executablePath?: string;
+  arguments?: string[];
+  workingDirectory?: string;
+  environmentVariables?: Dict<string,string>;
+  inheritEnvironmentVariables?: boolean;
+  standardInputContent?: string;
+  killEntireProcessTree?: boolean;
 }
 
 /**
@@ -676,10 +661,10 @@ export interface ProcessCommandSpecExportData {
  */
 
 export interface ResourceUrlAnnotation {
-  url: string;
-  displayText: string;
-  endpoint: EndpointReference;
-  displayLocation: UrlDisplayLocation;
+  url?: string;
+  displayText?: string;
+  endpoint?: EndpointReference;
+  displayLocation?: UrlDisplayLocation;
 }
 
 /**
@@ -687,11 +672,11 @@ export interface ResourceUrlAnnotation {
  */
 
 export interface UpdateCommandStateResourceSnapshot {
-  resourceType: string;
-  state: string;
-  stateStyle: string;
-  healthStatus: HealthStatus;
-  exitCode: number;
+  resourceType?: string;
+  state?: string;
+  stateStyle?: string;
+  healthStatus?: HealthStatus;
+  exitCode?: number;
 }
 
 /**
@@ -699,8 +684,8 @@ export interface UpdateCommandStateResourceSnapshot {
  */
 
 export interface AddContainerOptions {
-  image: string;
-  tag: string;
+  image?: string;
+  tag?: string;
 }
 
 /**
@@ -708,9 +693,9 @@ export interface AddContainerOptions {
  */
 
 export interface CertificateTrustExecutionConfigurationExportData {
-  scope: CertificateTrustScope;
-  certificateSubjects: string[];
-  customBundlePaths: string[];
+  scope?: CertificateTrustScope;
+  certificateSubjects?: string[];
+  customBundlePaths?: string[];
 }
 
 /**
@@ -718,14 +703,14 @@ export interface CertificateTrustExecutionConfigurationExportData {
  */
 
 export interface CreateBuilderOptions {
-  args: string[];
-  projectDirectory: string;
-  appHostFilePath: string;
-  containerRegistryOverride: string;
-  disableDashboard: boolean;
-  dashboardApplicationName: string;
-  allowUnsecuredTransport: boolean;
-  enableResourceLogging: boolean;
+  args?: string[];
+  projectDirectory?: string;
+  appHostFilePath?: string;
+  containerRegistryOverride?: string;
+  disableDashboard?: boolean;
+  dashboardApplicationName?: string;
+  allowUnsecuredTransport?: boolean;
+  enableResourceLogging?: boolean;
 }
 
 /**
@@ -733,13 +718,13 @@ export interface CreateBuilderOptions {
  */
 
 export interface HttpsCertificateExecutionConfigurationExportData {
-  subject: string;
-  thumbprint: string;
-  keyPathExpression: string;
-  pfxPathExpression: string;
-  isKeyPathReferenced: boolean;
-  isPfxPathReferenced: boolean;
-  password: string;
+  subject?: string;
+  thumbprint?: string;
+  keyPathExpression?: string;
+  pfxPathExpression?: string;
+  isKeyPathReferenced?: boolean;
+  isPfxPathReferenced?: boolean;
+  password?: string;
 }
 
 /**
@@ -747,9 +732,26 @@ export interface HttpsCertificateExecutionConfigurationExportData {
  */
 
 export interface HttpsCertificateInfo {
-  subject: string;
-  issuer: string;
-  thumbprint: string;
+  subject?: string;
+  issuer?: string;
+  thumbprint?: string;
+}
+
+/**
+ * DTO Aspire.Hosting.Ats.ParameterCustomInputOptions
+ */
+
+export interface ParameterCustomInputOptions {
+  inputType?: InputType;
+  label?: string;
+  description?: string;
+  enableDescriptionMarkdown?: boolean;
+  options?: Dict<string,string>;
+  value?: string;
+  placeholder?: string;
+  allowCustomChoice?: boolean;
+  disabled?: boolean;
+  maxLength?: number;
 }
 
 /**
@@ -757,10 +759,10 @@ export interface HttpsCertificateInfo {
  */
 
 export interface ReferenceEnvironmentInjectionOptions {
-  connectionString: boolean;
-  connectionProperties: boolean;
-  serviceDiscovery: boolean;
-  endpoints: boolean;
+  connectionString?: boolean;
+  connectionProperties?: boolean;
+  serviceDiscovery?: boolean;
+  endpoints?: boolean;
 }
 
 /**
@@ -768,12 +770,12 @@ export interface ReferenceEnvironmentInjectionOptions {
  */
 
 export interface ResourceEventDto {
-  resourceName: string;
-  resourceId: string;
-  state: string;
-  stateStyle: string;
-  healthStatus: string;
-  exitCode: number;
+  resourceName?: string;
+  resourceId?: string;
+  state?: string;
+  stateStyle?: string;
+  healthStatus?: string;
+  exitCode?: number;
 }
 
 /**
@@ -781,19 +783,19 @@ export interface ResourceEventDto {
  */
 
 export interface InteractionInput {
-  name: string;
-  label: string;
-  description: string;
-  enableDescriptionMarkdown: boolean;
-  inputType: InputType;
-  required: boolean;
-  options: String[];
-  dynamicLoading: InputLoadOptions;
-  value: string;
-  placeholder: string;
-  allowCustomChoice: boolean;
-  disabled: boolean;
-  maxLength: number;
+  name?: string;
+  label?: string;
+  description?: string;
+  enableDescriptionMarkdown?: boolean;
+  inputType?: InputType;
+  required?: boolean;
+  options?: String[];
+  dynamicLoading?: InputLoadOptions;
+  value?: string;
+  placeholder?: string;
+  allowCustomChoice?: boolean;
+  disabled?: boolean;
+  maxLength?: number;
 }
 
 /**
@@ -801,7 +803,7 @@ export interface InteractionInput {
  */
 
 export interface AzureContainerAppScaleConfig {
-  minReplicas: number;
+  minReplicas?: number;
 }
 
 /**
@@ -809,7 +811,7 @@ export interface AzureContainerAppScaleConfig {
  */
 
 export interface AzureAppServiceSiteConfig {
-  isAlwaysOn: boolean;
+  isAlwaysOn?: boolean;
 }
 
 /**
@@ -817,14 +819,14 @@ export interface AzureAppServiceSiteConfig {
  */
 
 export interface AzureNspAccessRule {
-  name: string;
-  direction: NetworkSecurityPerimeterAccessRuleDirection;
-  addressPrefixes: List<string>;
-  addressPrefixReferences: List<ReferenceExpression>;
-  subscriptions: List<string>;
-  subscriptionReferences: List<ReferenceExpression>;
-  fullyQualifiedDomainNames: List<string>;
-  fullyQualifiedDomainNameReferences: List<ReferenceExpression>;
+  name?: string;
+  direction?: NetworkSecurityPerimeterAccessRuleDirection;
+  addressPrefixes?: List<string>;
+  addressPrefixReferences?: List<ReferenceExpression>;
+  subscriptions?: List<string>;
+  subscriptionReferences?: List<ReferenceExpression>;
+  fullyQualifiedDomainNames?: List<string>;
+  fullyQualifiedDomainNameReferences?: List<ReferenceExpression>;
 }
 
 /**
@@ -832,18 +834,18 @@ export interface AzureNspAccessRule {
  */
 
 export interface AzureSecurityRule {
-  name: string;
-  description: string;
-  priority: number;
-  direction: SecurityRuleDirection;
-  access: SecurityRuleAccess;
-  protocol: SecurityRuleProtocol;
-  sourceAddressPrefix: string;
-  sourceAddressPrefixReference: ReferenceExpression;
-  sourcePortRange: string;
-  destinationAddressPrefix: string;
-  destinationAddressPrefixReference: ReferenceExpression;
-  destinationPortRange: string;
+  name?: string;
+  description?: string;
+  priority?: number;
+  direction?: SecurityRuleDirection;
+  access?: SecurityRuleAccess;
+  protocol?: SecurityRuleProtocol;
+  sourceAddressPrefix?: string;
+  sourceAddressPrefixReference?: ReferenceExpression;
+  sourcePortRange?: string;
+  destinationAddressPrefix?: string;
+  destinationAddressPrefixReference?: ReferenceExpression;
+  destinationPortRange?: string;
 }
 
 /**
@@ -851,16 +853,16 @@ export interface AzureSecurityRule {
  */
 
 export interface AzureServiceBusCorrelationFilter {
-  properties: Dict<string,any>;
-  correlationId: string;
-  messageId: string;
-  sendTo: string;
-  replyTo: string;
-  subject: string;
-  sessionId: string;
-  replyToSessionId: string;
-  contentType: string;
-  requiresPreprocessing: boolean;
+  properties?: Dict<string,any>;
+  correlationId?: string;
+  messageId?: string;
+  sendTo?: string;
+  replyTo?: string;
+  subject?: string;
+  sessionId?: string;
+  replyToSessionId?: string;
+  contentType?: string;
+  requiresPreprocessing?: boolean;
 }
 
 /**
@@ -868,9 +870,9 @@ export interface AzureServiceBusCorrelationFilter {
  */
 
 export interface AzureServiceBusRule {
-  name: string;
-  correlationFilter: AzureServiceBusCorrelationFilter;
-  filterType: AzureServiceBusFilterType;
+  name?: string;
+  correlationFilter?: AzureServiceBusCorrelationFilter;
+  filterType?: AzureServiceBusFilterType;
 }
 
 /**
@@ -878,9 +880,9 @@ export interface AzureServiceBusRule {
  */
 
 export interface FoundryModel {
-  name: string;
-  version: string;
-  format: string;
+  name?: string;
+  version?: string;
+  format?: string;
 }
 
 /**
@@ -888,12 +890,12 @@ export interface FoundryModel {
  */
 
 export interface HostedAgentOptions {
-  description: string;
-  cpu: number;
-  memory: number;
-  metadata: Dict<string,string>;
-  environmentVariables: Dict<string,string>;
-  protocols: List<HostedAgentProtocolVersion>;
+  description?: string;
+  cpu?: number;
+  memory?: number;
+  metadata?: Dict<string,string>;
+  environmentVariables?: Dict<string,string>;
+  protocols?: List<HostedAgentProtocolVersion>;
 }
 
 /**
@@ -901,8 +903,8 @@ export interface HostedAgentOptions {
  */
 
 export interface HostedAgentProtocolVersion {
-  protocol: string;
-  version: string;
+  protocol?: string;
+  version?: string;
 }
 
 /**
@@ -910,12 +912,12 @@ export interface HostedAgentProtocolVersion {
  */
 
 export interface YarpActiveHealthCheckConfig {
-  enabled: boolean;
-  interval: timespan;
-  path: string;
-  policy: string;
-  query: string;
-  timeout: timespan;
+  enabled?: boolean;
+  interval?: timespan;
+  path?: string;
+  policy?: string;
+  query?: string;
+  timeout?: timespan;
 }
 
 /**
@@ -923,10 +925,10 @@ export interface YarpActiveHealthCheckConfig {
  */
 
 export interface YarpForwarderRequestConfig {
-  activityTimeout: timespan;
-  allowResponseBuffering: boolean;
-  version: string;
-  versionPolicy: HttpVersionPolicy;
+  activityTimeout?: timespan;
+  allowResponseBuffering?: boolean;
+  version?: string;
+  versionPolicy?: HttpVersionPolicy;
 }
 
 /**
@@ -934,9 +936,9 @@ export interface YarpForwarderRequestConfig {
  */
 
 export interface YarpHealthCheckConfig {
-  active: YarpActiveHealthCheckConfig;
-  availableDestinationsPolicy: string;
-  passive: YarpPassiveHealthCheckConfig;
+  active?: YarpActiveHealthCheckConfig;
+  availableDestinationsPolicy?: string;
+  passive?: YarpPassiveHealthCheckConfig;
 }
 
 /**
@@ -944,13 +946,13 @@ export interface YarpHealthCheckConfig {
  */
 
 export interface YarpHttpClientConfig {
-  dangerousAcceptAnyServerCertificate: boolean;
-  enableMultipleHttp2Connections: boolean;
-  maxConnectionsPerServer: number;
-  requestHeaderEncoding: string;
-  responseHeaderEncoding: string;
-  sslProtocols: YarpSslProtocol[];
-  webProxy: YarpWebProxyConfig;
+  dangerousAcceptAnyServerCertificate?: boolean;
+  enableMultipleHttp2Connections?: boolean;
+  maxConnectionsPerServer?: number;
+  requestHeaderEncoding?: string;
+  responseHeaderEncoding?: string;
+  sslProtocols?: YarpSslProtocol[];
+  webProxy?: YarpWebProxyConfig;
 }
 
 /**
@@ -958,9 +960,9 @@ export interface YarpHttpClientConfig {
  */
 
 export interface YarpPassiveHealthCheckConfig {
-  enabled: boolean;
-  policy: string;
-  reactivationPeriod: timespan;
+  enabled?: boolean;
+  policy?: string;
+  reactivationPeriod?: timespan;
 }
 
 /**
@@ -968,10 +970,10 @@ export interface YarpPassiveHealthCheckConfig {
  */
 
 export interface YarpRouteHeaderMatch {
-  name: string;
-  values: string[];
-  isCaseSensitive: boolean;
-  mode: HeaderMatchMode;
+  name?: string;
+  values?: string[];
+  isCaseSensitive?: boolean;
+  mode?: HeaderMatchMode;
 }
 
 /**
@@ -979,11 +981,11 @@ export interface YarpRouteHeaderMatch {
  */
 
 export interface YarpRouteMatch {
-  path: string;
-  methods: string[];
-  hosts: string[];
-  headers: YarpRouteHeaderMatch[];
-  queryParameters: YarpRouteQueryParameterMatch[];
+  path?: string;
+  methods?: string[];
+  hosts?: string[];
+  headers?: YarpRouteHeaderMatch[];
+  queryParameters?: YarpRouteQueryParameterMatch[];
 }
 
 /**
@@ -991,10 +993,10 @@ export interface YarpRouteMatch {
  */
 
 export interface YarpRouteQueryParameterMatch {
-  name: string;
-  values: string[];
-  isCaseSensitive: boolean;
-  mode: QueryParameterMatchMode;
+  name?: string;
+  values?: string[];
+  isCaseSensitive?: boolean;
+  mode?: QueryParameterMatchMode;
 }
 
 /**
@@ -1002,11 +1004,11 @@ export interface YarpRouteQueryParameterMatch {
  */
 
 export interface YarpSessionAffinityConfig {
-  affinityKeyName: string;
-  cookie: YarpSessionAffinityCookieConfig;
-  enabled: boolean;
-  failurePolicy: string;
-  policy: string;
+  affinityKeyName?: string;
+  cookie?: YarpSessionAffinityCookieConfig;
+  enabled?: boolean;
+  failurePolicy?: string;
+  policy?: string;
 }
 
 /**
@@ -1014,14 +1016,14 @@ export interface YarpSessionAffinityConfig {
  */
 
 export interface YarpSessionAffinityCookieConfig {
-  domain: string;
-  expiration: timespan;
-  httpOnly: boolean;
-  isEssential: boolean;
-  maxAge: timespan;
-  path: string;
-  sameSite: SameSiteMode;
-  securePolicy: CookieSecurePolicy;
+  domain?: string;
+  expiration?: timespan;
+  httpOnly?: boolean;
+  isEssential?: boolean;
+  maxAge?: timespan;
+  path?: string;
+  sameSite?: SameSiteMode;
+  securePolicy?: CookieSecurePolicy;
 }
 
 /**
@@ -1029,9 +1031,9 @@ export interface YarpSessionAffinityCookieConfig {
  */
 
 export interface YarpWebProxyConfig {
-  address: uri;
-  bypassOnLocal: boolean;
-  useDefaultCredentials: boolean;
+  address?: uri;
+  bypassOnLocal?: boolean;
+  useDefaultCredentials?: boolean;
 }
 
 // ---- handle types ----
@@ -2195,11 +2197,6 @@ export interface IResource {
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
 
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
   withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): this;
   /**
    * Adds a relationship to another resource using its builder.
@@ -2332,11 +2329,6 @@ export interface IResourceWithEndpoints {
    */
 
   withExternalHttpEndpoints(): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
   /**
    * Adds an HTTP resource command
    */
@@ -2964,12 +2956,12 @@ export interface IDistributedApplicationResourceEvent {
 
 export interface ExternalServiceResource extends IResource {
   /**
-   * Adds an HTTP health check to the external service for polyglot AppHosts.
+   * Adds an HTTP health check to the external service for polyglot app hosts.
    */
 
   withHttpHealthCheck(options?: { path?: string; statusCode?: number; endpointName?: string }): this;
   /**
-   * Adds an HTTP health check to the external service for polyglot AppHosts.
+   * Adds an HTTP health check to the external service for polyglot app hosts.
    */
 
   withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): this;
@@ -3005,11 +2997,6 @@ export interface IDistributedApplicationBuilder {
    */
 
   addContainerRegistry(name: string, endpoint: string | ParameterResource, repository?: string | ParameterResource): ContainerRegistryResource;
-  /**
-   * Adds a C# application resource
-   */
-
-  addCSharpApp(name: string, path: string, options?: { options?: ProjectResourceOptions }): CSharpAppResource;
   /**
    * Adds a C# application resource
    */
@@ -6930,12 +6917,12 @@ export interface EFMigrationResource extends ContainerResource, IComputeResource
 
   withMigrationOutputDirectory(outputDirectory: string): this;
   /**
-   * Configures a separate project containing migrations for polyglot AppHosts.
+   * Configures a separate project containing migrations for polyglot app hosts.
    */
 
   withMigrationsProject(options?: { migrationsProject?: ProjectResource }): this;
   /**
-   * Configures a separate project containing migrations for polyglot AppHosts.
+   * Configures a separate project containing migrations for polyglot app hosts.
    */
 
   withMigrationsProject(migrationsProject?: ProjectResource): this;
@@ -6957,14 +6944,14 @@ export interface AzureAISearchToolResource extends FoundryToolResource, IResourc
  * Handle Aspire.Hosting.Foundry.AzureCognitiveServicesProjectConnectionResource
  */
 
-export interface AzureCognitiveServicesProjectConnectionResource extends IAzureResource, IResource, IResourceWithParameters, IResourceWithParent {
+export interface AzureCognitiveServicesProjectConnectionResource extends AzureBicepResource, AzureProvisioningResource, IAzureResource, IResource, IResourceWithParameters, IResourceWithParent {
 }
 
 /**
  * Handle Aspire.Hosting.Foundry.AzureCognitiveServicesProjectResource
  */
 
-export interface AzureCognitiveServicesProjectResource extends IAzureResource, IComputeEnvironmentResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithConnectionString, IResourceWithParameters, IResourceWithParent, IValueProvider, IValueWithReferences, IAzureComputeEnvironmentResource {
+export interface AzureCognitiveServicesProjectResource extends AzureBicepResource, AzureProvisioningResource, IAzureResource, IComputeEnvironmentResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithConnectionString, IResourceWithParameters, IResourceWithParent, IValueProvider, IValueWithReferences, IAzureComputeEnvironmentResource {
   /**
    * Adds an Azure AI Search tool to a Microsoft Foundry project, enabling agents to ground their responses using data from an Azure AI Search index.
    */
@@ -7180,7 +7167,7 @@ export interface AzurePromptAgentResource extends IExpressionValue, IManifestExp
  * Handle Aspire.Hosting.Foundry.BingGroundingConnectionResource
  */
 
-export interface BingGroundingConnectionResource extends IAzureResource, IResource, IResourceWithParameters, IResourceWithParent {
+export interface BingGroundingConnectionResource extends AzureBicepResource, AzureProvisioningResource, IAzureResource, IResource, IResourceWithParameters, IResourceWithParent {
 }
 
 /**
@@ -7507,7 +7494,7 @@ export interface GitHubModelResource extends IExpressionValue, IManifestExpressi
  * Handle Aspire.Hosting.Go.GoAppResource
  */
 
-export interface GoAppResource extends ExecutableResource, ContainerResource, IComputeResource, IContainerFilesDestinationResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface GoAppResource extends ExecutableResource, IComputeResource, IContainerFilesDestinationResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
   /**
    * Passes extra arguments to the Go program at runtime. In normal run mode they appear after `go run .`; in Delve mode after the `--` separator.
    */
@@ -10368,14 +10355,14 @@ export interface YarpRoute {
  * Handle Aspire.Hosting.ApplicationModel.ActiveMQArtemisServerResource
  */
 
-export interface ActiveMQArtemisServerResource extends ActiveMQServerResourceBase, ContainerResource, IComputeResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
+export interface ActiveMQArtemisServerResource extends ContainerResource, ActiveMQServerResourceBase, IComputeResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
 }
 
 /**
  * Handle Aspire.Hosting.ApplicationModel.ActiveMQServerResource
  */
 
-export interface ActiveMQServerResource extends ActiveMQServerResourceBase, ContainerResource, IComputeResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
+export interface ActiveMQServerResource extends ContainerResource, ActiveMQServerResourceBase, IComputeResource, IExpressionValue, IManifestExpressionProvider, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
 }
 
 /**
@@ -10668,7 +10655,7 @@ export interface DbxContainerResource extends ContainerResource, IComputeResourc
  * Handle Aspire.Hosting.ApplicationModel.DenoAppResource
  */
 
-export interface DenoAppResource extends ExecutableResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface DenoAppResource extends ExecutableResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
   /**
    * Ensures the Deno packages are installed before the application starts using Deno as the package manager.
    */
@@ -10821,7 +10808,7 @@ export interface JavaAppContainerResource extends ContainerResource, IComputeRes
  * Handle Aspire.Hosting.ApplicationModel.JavaAppExecutableResource
  */
 
-export interface JavaAppExecutableResource extends ExecutableResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface JavaAppExecutableResource extends ExecutableResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
   /**
    * Gets or sets the path to the JAR file to execute.
    */
@@ -10863,7 +10850,7 @@ export interface JavaAppExecutableResource extends ExecutableResource, Container
  * Handle Aspire.Hosting.ApplicationModel.NxAppResource
  */
 
-export interface NxAppResource extends ExecutableResource, JavaScriptAppResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
+export interface NxAppResource extends ExecutableResource, JavaScriptAppResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
 }
 
 /**
@@ -10907,7 +10894,7 @@ export interface NxResource extends IResource {
  * Handle Aspire.Hosting.ApplicationModel.TurborepoAppResource
  */
 
-export interface TurborepoAppResource extends ExecutableResource, JavaScriptAppResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
+export interface TurborepoAppResource extends ExecutableResource, JavaScriptAppResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
 }
 
 /**
@@ -11587,7 +11574,7 @@ export interface MailPitContainerResource extends ContainerResource, IComputeRes
  * Handle Aspire.Hosting.ApplicationModel.McpInspectorResource
  */
 
-export interface McpInspectorResource extends ExecutableResource, JavaScriptAppResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
+export interface McpInspectorResource extends ExecutableResource, JavaScriptAppResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithContainerFiles, IResourceWithServiceDiscovery {
   /**
    * Configures the MCP Inspector to use bun as the package manager.
    */
@@ -11812,7 +11799,7 @@ export interface IOllamaResource {
  * Handle Aspire.Hosting.ApplicationModel.OllamaExecutableResource
  */
 
-export interface OllamaExecutableResource extends ExecutableResource, ContainerResource, IComputeResource, IExpressionValue, IManifestExpressionProvider, IOllamaResource, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
+export interface OllamaExecutableResource extends ExecutableResource, IComputeResource, IExpressionValue, IManifestExpressionProvider, IOllamaResource, IResource, IResourceWithArgs, IResourceWithConnectionString, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IValueProvider, IValueWithReferences {
   /**
    * Gets the connection string expression for the Ollama server.
    */
@@ -12123,7 +12110,7 @@ export interface PapercutSmtpContainerResource extends ContainerResource, ICompu
  * Handle Aspire.Hosting.ApplicationModel.PerlAppResource
  */
 
-export interface PerlAppResource extends ExecutableResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface PerlAppResource extends ExecutableResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
   /**
    * Configures the Perl application to use Carton as its package manager. Carton manages dependencies via `cpanfile` and a lock file (`cpanfile.snapshot`), enabling reproducible builds. Use `WithProjectDependencies``1` to run `carton install` at startup.
    */
@@ -12216,7 +12203,7 @@ export interface PowerShellScriptResource extends IResource, IResourceWithArgs, 
  * Handle Aspire.Hosting.ApplicationModel.StreamlitAppResource
  */
 
-export interface StreamlitAppResource extends ExecutableResource, PythonAppResource, ContainerResource, IComputeResource, IContainerFilesDestinationResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface StreamlitAppResource extends ExecutableResource, PythonAppResource, IComputeResource, IContainerFilesDestinationResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
 }
 
 /**
@@ -12337,7 +12324,7 @@ export interface RavenDBServerResource extends ContainerResource, IComputeResour
  * Handle Aspire.Hosting.ApplicationModel.RustAppExecutableResource
  */
 
-export interface RustAppExecutableResource extends ExecutableResource, ContainerResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
+export interface RustAppExecutableResource extends ExecutableResource, IComputeResource, IResource, IResourceWithArgs, IResourceWithEndpoints, IResourceWithEnvironment, IResourceWithProbes, IResourceWithWaitSupport, IResourceWithServiceDiscovery {
 }
 
 /**
@@ -15508,11 +15495,6 @@ export interface ContainerRegistryResource {
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
 
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
   withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): this;
   /**
    * Adds a relationship to another resource using its builder.
@@ -15832,11 +15814,6 @@ export interface ContainerResource {
    * Adds an HTTP resource command
    */
 
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
   withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): this;
   /**
    * Adds an HTTP endpoint
@@ -15988,11 +15965,6 @@ export interface ContainerResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -16521,11 +16493,6 @@ export interface CSharpAppResource {
    * Adds an HTTP resource command
    */
 
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
   withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): this;
   /**
    * Adds an HTTP endpoint
@@ -16677,11 +16644,6 @@ export interface CSharpAppResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -16898,12 +16860,12 @@ export interface CSharpAppResource {
 
   publishAsDockerComposeService(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): this;
   /**
-   * Adds EF Core migration management for polyglot AppHosts.
+   * Adds EF Core migration management for polyglot app hosts.
    */
 
   addEFMigrations(name: string, options?: { dbContextTypeName?: string }): EFMigrationResource;
   /**
-   * Adds EF Core migration management for polyglot AppHosts.
+   * Adds EF Core migration management for polyglot app hosts.
    */
 
   addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource;
@@ -17224,11 +17186,6 @@ export interface DotnetToolResource {
    * Adds an HTTP resource command
    */
 
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
   withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): this;
   /**
    * Adds an HTTP endpoint
@@ -17380,11 +17337,6 @@ export interface DotnetToolResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -17901,11 +17853,6 @@ export interface ExecutableResource {
    * Adds an HTTP resource command
    */
 
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
   withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): this;
   /**
    * Adds an HTTP endpoint
@@ -18057,11 +18004,6 @@ export interface ExecutableResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -18511,11 +18453,6 @@ export interface ExternalServiceResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -19816,11 +19753,6 @@ export interface ParameterResource {
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
 
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
   withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: ProcessCommandResultExportOptions): this;
   /**
    * Adds a relationship to another resource using its builder.
@@ -20170,11 +20102,6 @@ export interface ProjectResource {
    * Adds an HTTP resource command
    */
 
-  withHttpCommand(path: string, displayName: string, options?: { options?: HttpCommandExportOptions }): this;
-  /**
-   * Adds an HTTP resource command
-   */
-
   withHttpCommand(path: string, displayName: string, options?: HttpCommandExportOptions): this;
   /**
    * Adds an HTTP endpoint
@@ -20326,11 +20253,6 @@ export interface ProjectResource {
    */
 
   withProcessCommand(commandName: string, displayName: string, options: ProcessCommandExportOptions): this;
-  /**
-   * Adds a command to the resource that starts a local process created by a callback when invoked.
-   */
-
-  withProcessCommandFactory(commandName: string, displayName: string, createProcessSpec: (arg: ExecuteCommandContext) => Promise<ProcessCommandSpecExportData>, options?: { options?: ProcessCommandResultExportOptions }): this;
   /**
    * Adds a command to the resource that starts a local process created by a callback when invoked.
    */
@@ -20542,12 +20464,12 @@ export interface ProjectResource {
 
   publishAsDockerComposeService(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): this;
   /**
-   * Adds EF Core migration management for polyglot AppHosts.
+   * Adds EF Core migration management for polyglot app hosts.
    */
 
   addEFMigrations(name: string, options?: { dbContextTypeName?: string }): EFMigrationResource;
   /**
-   * Adds EF Core migration management for polyglot AppHosts.
+   * Adds EF Core migration management for polyglot app hosts.
    */
 
   addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource;

--- a/src/frontend/src/data/twoslash/aspire.d.ts
+++ b/src/frontend/src/data/twoslash/aspire.d.ts
@@ -2956,12 +2956,12 @@ export interface IDistributedApplicationResourceEvent {
 
 export interface ExternalServiceResource extends IResource {
   /**
-   * Adds an HTTP health check to the external service for polyglot app hosts.
+   * Adds an HTTP health check to the external service for polyglot AppHosts.
    */
 
   withHttpHealthCheck(options?: { path?: string; statusCode?: number; endpointName?: string }): this;
   /**
-   * Adds an HTTP health check to the external service for polyglot app hosts.
+   * Adds an HTTP health check to the external service for polyglot AppHosts.
    */
 
   withHttpHealthCheck(path?: string, statusCode?: number, endpointName?: string): this;
@@ -6917,12 +6917,12 @@ export interface EFMigrationResource extends ContainerResource, IComputeResource
 
   withMigrationOutputDirectory(outputDirectory: string): this;
   /**
-   * Configures a separate project containing migrations for polyglot app hosts.
+   * Configures a separate project containing migrations for polyglot AppHosts.
    */
 
   withMigrationsProject(options?: { migrationsProject?: ProjectResource }): this;
   /**
-   * Configures a separate project containing migrations for polyglot app hosts.
+   * Configures a separate project containing migrations for polyglot AppHosts.
    */
 
   withMigrationsProject(migrationsProject?: ProjectResource): this;
@@ -16860,12 +16860,12 @@ export interface CSharpAppResource {
 
   publishAsDockerComposeService(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): this;
   /**
-   * Adds EF Core migration management for polyglot app hosts.
+   * Adds EF Core migration management for polyglot AppHosts.
    */
 
   addEFMigrations(name: string, options?: { dbContextTypeName?: string }): EFMigrationResource;
   /**
-   * Adds EF Core migration management for polyglot app hosts.
+   * Adds EF Core migration management for polyglot AppHosts.
    */
 
   addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource;
@@ -20464,12 +20464,12 @@ export interface ProjectResource {
 
   publishAsDockerComposeService(configure: (arg1: DockerComposeServiceResource, arg2: Service) => Promise<void>): this;
   /**
-   * Adds EF Core migration management for polyglot app hosts.
+   * Adds EF Core migration management for polyglot AppHosts.
    */
 
   addEFMigrations(name: string, options?: { dbContextTypeName?: string }): EFMigrationResource;
   /**
-   * Adds EF Core migration management for polyglot app hosts.
+   * Adds EF Core migration management for polyglot AppHosts.
    */
 
   addEFMigrations(name: string, dbContextTypeName?: string): EFMigrationResource;

--- a/src/frontend/src/data/twoslash/aspire.d.ts
+++ b/src/frontend/src/data/twoslash/aspire.d.ts
@@ -789,7 +789,7 @@ export interface InteractionInput {
   enableDescriptionMarkdown?: boolean;
   inputType?: InputType;
   required?: boolean;
-  options?: String[];
+  options?: KeyValuePair<string,string>[];
   dynamicLoading?: InputLoadOptions;
   value?: string;
   placeholder?: string;
@@ -20947,6 +20947,7 @@ export interface ISpanFormattable {}
 export interface IValueProvider {}
 export interface IValueWithReferences {}
 export interface InputLoadOptions {}
+export interface KeyValuePair<T = unknown, T1 = unknown> {}
 export interface List<T = unknown> {}
 export interface NetworkSecurityPerimeterAccessRuleDirection {}
 export interface NetworkSecurityPerimeterAssociationAccessMode {}
@@ -20958,7 +20959,6 @@ export interface SameSiteMode {}
 export interface SecurityRuleAccess {}
 export interface SecurityRuleDirection {}
 export interface SecurityRuleProtocol {}
-export interface String {}
 export interface UnixFileMode {}
 export interface arg {}
 export interface arg1 {}

--- a/src/frontend/src/pages/reference/api/csharp/[package]/[type]/[memberKind].astro
+++ b/src/frontend/src/pages/reference/api/csharp/[package]/[type]/[memberKind].astro
@@ -75,7 +75,7 @@ const renderedMembers = allMembers
   .map((member: any, index: number) => ({
     member,
     exactAnchor: resolvedAnchors[index].exact,
-    anchorAlias: resolvedAnchors[index].alias,
+    anchorAliases: resolvedAnchors[index].aliases,
   }))
   .filter(({ member }) => member.kind === kind);
 const filteredMembers = renderedMembers.map(({ member }) => member);
@@ -141,10 +141,10 @@ const headings: { depth: 2 | 3; slug: string; text: string }[] = renderedMembers
   {/* Member cards */}
   <div class="ml">
     <div class="ml-cards">
-      {renderedMembers.map(({ member, anchorAlias, exactAnchor }) => (
+      {renderedMembers.map(({ member, anchorAliases, exactAnchor }) => (
         <MemberCard
           member={member}
-          anchorAlias={anchorAlias}
+          anchorAliases={anchorAliases}
           exactAnchor={exactAnchor}
           allTypes={allTypes}
           packageName={pkg.package.name}

--- a/src/frontend/src/pages/reference/api/csharp/[package]/[type]/[memberKind].astro
+++ b/src/frontend/src/pages/reference/api/csharp/[package]/[type]/[memberKind].astro
@@ -20,8 +20,8 @@ import {
   shortTypeName,
   typeHref,
   getPackages,
-  memberSlug,
   memberDisplayName,
+  resolveMemberAnchors,
 } from '@utils/packages';
 
 /** Reverse map: slug ΓåÆ kind (e.g. 'properties' ΓåÆ 'property'). */
@@ -69,7 +69,16 @@ const { pkg, type, allTypes, kind } = Astro.props;
 const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 const apiSidebar = await getApiReferenceSidebar({ packageName: pkg.package.name });
 
-const filteredMembers = (type.members ?? []).filter((m: any) => m.kind === kind);
+const allMembers: any[] = type.members ?? [];
+const resolvedAnchors = resolveMemberAnchors(allMembers);
+const renderedMembers = allMembers
+  .map((member: any, index: number) => ({
+    member,
+    exactAnchor: resolvedAnchors[index].exact,
+    anchorAlias: resolvedAnchors[index].alias,
+  }))
+  .filter(({ member }) => member.kind === kind);
+const filteredMembers = renderedMembers.map(({ member }) => member);
 const kindLabel = memberKindLabels[kind] ?? kind;
 const displayName = type.name + (type.isGeneric && type.genericParameters?.length
   ? `<${type.genericParameters.map((g: any) => g.name).join(', ')}>`
@@ -86,10 +95,10 @@ const kindLabelMap: Record<string, string> = {
 };
 
 /* Build heading list for right-side TOC ΓÇö one entry per member. */
-const headings: { depth: 2 | 3; slug: string; text: string }[] = filteredMembers.map((m: any) => ({
+const headings: { depth: 2 | 3; slug: string; text: string }[] = renderedMembers.map(({ member, exactAnchor }) => ({
   depth: 2 as const,
-  slug: memberSlug(m),
-  text: m.name === '.ctor' ? displayName : memberDisplayName(m),
+  slug: exactAnchor,
+  text: member.name === '.ctor' ? displayName : memberDisplayName(member),
 }));
 ---
 
@@ -132,9 +141,11 @@ const headings: { depth: 2 | 3; slug: string; text: string }[] = filteredMembers
   {/* Member cards */}
   <div class="ml">
     <div class="ml-cards">
-      {filteredMembers.map((m: any) => (
+      {renderedMembers.map(({ member, anchorAlias, exactAnchor }) => (
         <MemberCard
-          member={m}
+          member={member}
+          anchorAlias={anchorAlias}
+          exactAnchor={exactAnchor}
           allTypes={allTypes}
           packageName={pkg.package.name}
           sourceBaseUrl={pkg.package.sourceRepository && pkg.package.sourceCommit

--- a/src/frontend/src/pages/reference/api/csharp/[package]/index.astro
+++ b/src/frontend/src/pages/reference/api/csharp/[package]/index.astro
@@ -7,7 +7,7 @@
  * and collapsible namespace sections.
  */
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import { genericArity, typeDisplayName, groupTypesByNamespace, typeHref, nugetHref, packageSlug, slugify, getPackages, memberSlug } from '@utils/packages';
+import { genericArity, typeDisplayName, groupTypesByNamespace, typeHref, nugetHref, packageSlug, slugify, getPackages, resolveMemberAnchors } from '@utils/packages';
 import { getApiReferenceSidebar } from '@utils/api-sidebar';
 import InpageSearch from '@components/api-reference/InpageSearch.astro';
 import Expand from '@components/Expand.astro';
@@ -87,11 +87,12 @@ for (const type of validTypes) {
   });
 
   const members: any[] = type.members ?? [];
-  for (const member of members) {
+  const memberAnchors = resolveMemberAnchors(members);
+  for (const [memberIndex, member] of members.entries()) {
     memberCount++;
     const memberName = member.name === '.ctor' ? `${type.name} (constructor)` : member.name;
     const memberFull = `${type.fullName ?? type.name}.${member.name === '.ctor' ? '.ctor' : member.name}`;
-    const slug = memberSlug(member);
+    const slug = memberAnchors[memberIndex].exact;
     const defaultSlug = memberName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     pkgIndex.push({
       n: memberName,

--- a/src/frontend/src/pages/reference/api/csharp/index.astro
+++ b/src/frontend/src/pages/reference/api/csharp/index.astro
@@ -7,7 +7,7 @@
  * The search index is built at build time from all package JSON data.
  */
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import { packageSlug, slugify, genericArity, getPackages } from '@utils/packages';
+import { packageSlug, slugify, genericArity, getPackages, memberNameSlug, resolveMemberAnchors } from '@utils/packages';
 import { getApiReferenceSidebar } from '@utils/api-sidebar';
 import ApiSearchBar from '@components/api-reference/ApiSearchBar.astro';
 import Breadcrumb from '@components/Breadcrumb.astro';
@@ -42,6 +42,8 @@ interface IndexEntry {
   t?: string;
   /** Package version */
   v?: string;
+  /** Exact overload/member anchor */
+  a?: string;
 }
 
 /** Extract plain-text summary from doc nodes. */
@@ -84,10 +86,13 @@ for (const pkg of sorted) {
 
     // Index members (methods, properties, constructors, fields, events, indexers)
     const members: any[] = type.members ?? [];
-    for (const member of members) {
+    const resolvedAnchors = resolveMemberAnchors(members);
+    for (const [memberIndex, member] of members.entries()) {
       memberCount++;
       const memberName = member.name === '.ctor' ? `${type.name} (constructor)` : member.name;
       const memberFull = `${type.fullName ?? type.name}.${member.name === '.ctor' ? '.ctor' : member.name}`;
+      const anchor = resolvedAnchors[memberIndex].exact;
+      const nameAnchor = memberNameSlug(member);
       index.push({
         n: memberName,
         f: memberFull,
@@ -96,6 +101,7 @@ for (const pkg of sorted) {
         p: pkgName,
         s: extractSummary(member.docs?.summary),
         t: type.name,
+        ...(anchor !== nameAnchor ? { a: anchor } : {}),
         ...(typeSlug !== type.name.toLowerCase() ? { ts: typeSlug } : {}),
         ...(pkgVersion ? { v: pkgVersion } : {}),
       });
@@ -185,6 +191,8 @@ const indexJson = JSON.stringify(index);
     ts?: string;
     /** Package version */
     v?: string;
+    /** Exact overload/member anchor */
+    a?: string;
   }
 
   const PAGE_SIZE = 10;
@@ -611,7 +619,7 @@ const indexJson = JSON.stringify(index);
       let href: string;
       if (isMember) {
         const kindSlug = MEMBER_KIND_SLUGS[entry.k] ?? entry.k;
-        const anchorName = entry.n.includes('(constructor)') ? 'constructor' : entry.n.toLowerCase().replace(/[^a-z0-9]/g, '-');
+        const anchorName = entry.a ?? (entry.n.includes('(constructor)') ? 'constructor' : entry.n.toLowerCase().replace(/[^a-z0-9]/g, '-'));
         href = `${this.base}/reference/api/csharp/${entry.p.toLowerCase()}/${entry.ts ?? entry.t!.toLowerCase()}/${kindSlug}/#${anchorName}`;
       } else {
         href = `${this.base}/reference/api/csharp/${entry.p.toLowerCase()}/${entry.g ?? entry.n.toLowerCase()}/`;

--- a/src/frontend/src/utils/api-member-anchors.ts
+++ b/src/frontend/src/utils/api-member-anchors.ts
@@ -1,0 +1,139 @@
+export interface ApiMemberAnchor {
+  name: string;
+  kind?: string;
+  signature?: string;
+  genericParameters?: unknown[];
+  parameters?: { type: string; modifier?: string }[];
+}
+
+export interface ResolvedMemberAnchor {
+  exact: string;
+  alias?: string;
+}
+
+export function memberNameSlug(member: Pick<ApiMemberAnchor, 'name'>): string {
+  const name = member.name === '.ctor' ? 'constructor' : member.name;
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+export function memberSlug(member: ApiMemberAnchor): string {
+  let base = member.name === '.ctor' ? 'constructor' : member.name;
+  if (member.kind === 'indexer' && member.parameters?.length) {
+    const paramTypes = member.parameters.map((parameter) => shortTypeName(parameter.type)).join(', ');
+    base = `this[${paramTypes}]`;
+  } else if ((member.kind === 'method' || member.kind === 'constructor') && member.parameters) {
+    const paramTypes = member.parameters.map((parameter) => shortTypeName(parameter.type)).join(', ');
+    base = `${base}(${paramTypes})`;
+  }
+  return base
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function signatureDiscriminator(member: ApiMemberAnchor): string {
+  const signature =
+    member.signature ??
+    [
+      member.kind ?? '',
+      member.name,
+      `generic:${member.genericParameters?.length ?? 0}`,
+      ...(member.parameters ?? []).map(
+        (parameter) => `${parameter.modifier ?? ''}:${parameter.type}`
+      ),
+    ].join('|');
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < signature.length; index++) {
+    hash ^= signature.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function resolveMemberAnchors(
+  members: ApiMemberAnchor[]
+): ResolvedMemberAnchor[] {
+  const baseAnchors = members.map(memberSlug);
+  const baseCounts = new Map<string, number>();
+  for (const anchor of baseAnchors) {
+    baseCounts.set(anchor, (baseCounts.get(anchor) ?? 0) + 1);
+  }
+
+  const usedExactAnchors = new Set<string>();
+  const exactAnchors = baseAnchors.map((baseAnchor, index) => {
+    const initial =
+      (baseCounts.get(baseAnchor) ?? 0) > 1
+        ? `${baseAnchor}-${signatureDiscriminator(members[index])}`
+        : baseAnchor;
+    let exact = initial;
+    let duplicateIndex = 2;
+    while (usedExactAnchors.has(exact)) {
+      exact = `${initial}-${duplicateIndex}`;
+      duplicateIndex++;
+    }
+    usedExactAnchors.add(exact);
+    return exact;
+  });
+
+  const reservedExactAnchors = new Set(exactAnchors);
+  const claimedAliases = new Set<string>();
+
+  return members.map((member, index) => {
+    const nameAnchor = memberNameSlug(member);
+    const exactAnchor = exactAnchors[index];
+    if (
+      nameAnchor === exactAnchor ||
+      reservedExactAnchors.has(nameAnchor) ||
+      claimedAliases.has(nameAnchor)
+    ) {
+      return { exact: exactAnchor };
+    }
+
+    claimedAliases.add(nameAnchor);
+    return { exact: exactAnchor, alias: nameAnchor };
+  });
+}
+
+export function memberAnchorAliases(
+  members: ApiMemberAnchor[]
+): Array<string | undefined> {
+  return resolveMemberAnchors(members).map(({ alias }) => alias);
+}
+
+export function shortTypeName(fullName: string): string {
+  let firstAngle = -1;
+  for (let index = 0; index < fullName.length; index++) {
+    if (fullName[index] === '<') {
+      firstAngle = index;
+      break;
+    }
+  }
+
+  if (firstAngle < 0) {
+    return fullName.split('.').pop() ?? fullName;
+  }
+
+  const outerShort = fullName.slice(0, firstAngle).split('.').pop() ?? fullName;
+  const lastAngle = fullName.lastIndexOf('>');
+  const argsContent = fullName.slice(firstAngle + 1, lastAngle);
+  const args: string[] = [];
+  let current = '';
+  let depth = 0;
+
+  for (const character of argsContent) {
+    if (character === '<') depth++;
+    if (character === '>') depth--;
+    if (character === ',' && depth === 0) {
+      args.push(current.trim());
+      current = '';
+    } else {
+      current += character;
+    }
+  }
+  if (current.trim()) args.push(current.trim());
+
+  return `${outerShort}<${args.map((argument) => shortTypeName(argument)).join(', ')}>`;
+}

--- a/src/frontend/src/utils/api-member-anchors.ts
+++ b/src/frontend/src/utils/api-member-anchors.ts
@@ -8,7 +8,7 @@ export interface ApiMemberAnchor {
 
 export interface ResolvedMemberAnchor {
   exact: string;
-  alias?: string;
+  aliases: string[];
 }
 
 export function memberNameSlug(member: Pick<ApiMemberAnchor, 'name'>): string {
@@ -83,24 +83,44 @@ export function resolveMemberAnchors(
 
   return members.map((member, index) => {
     const nameAnchor = memberNameSlug(member);
+    const baseAnchor = baseAnchors[index];
     const exactAnchor = exactAnchors[index];
-    if (
-      nameAnchor === exactAnchor ||
-      reservedExactAnchors.has(nameAnchor) ||
-      claimedAliases.has(nameAnchor)
-    ) {
-      return { exact: exactAnchor };
+    const aliases: string[] = [];
+    const candidates = [
+      nameAnchor,
+      (baseCounts.get(baseAnchor) ?? 0) > 1 ? baseAnchor : undefined,
+    ];
+
+    for (const candidate of candidates) {
+      if (
+        !candidate ||
+        candidate === exactAnchor ||
+        aliases.includes(candidate) ||
+        reservedExactAnchors.has(candidate) ||
+        claimedAliases.has(candidate)
+      ) {
+        continue;
+      }
+
+      claimedAliases.add(candidate);
+      aliases.push(candidate);
     }
 
-    claimedAliases.add(nameAnchor);
-    return { exact: exactAnchor, alias: nameAnchor };
+    return { exact: exactAnchor, aliases };
   });
+}
+
+export function resolveMemberAnchorMap<T extends ApiMemberAnchor>(
+  members: T[]
+): Map<T, ResolvedMemberAnchor> {
+  const resolved = resolveMemberAnchors(members);
+  return new Map(members.map((member, index) => [member, resolved[index]] as const));
 }
 
 export function memberAnchorAliases(
   members: ApiMemberAnchor[]
 ): Array<string | undefined> {
-  return resolveMemberAnchors(members).map(({ alias }) => alias);
+  return resolveMemberAnchors(members).map(({ aliases }) => aliases[0]);
 }
 
 export function shortTypeName(fullName: string): string {

--- a/src/frontend/src/utils/csharp-api-markdown.ts
+++ b/src/frontend/src/utils/csharp-api-markdown.ts
@@ -17,9 +17,9 @@ import {
   memberDisplayName,
   memberKindLabels,
   memberKindSlugs,
-  memberSlug,
   packageSlug,
   parseSeeAlso,
+  resolveMemberAnchorMap,
   shortTypeName,
   slugify,
   typeDisplayName,
@@ -320,6 +320,7 @@ export function renderCSharpMemberKindMarkdown(
   };
 
   const members = (type.members ?? []).filter((member: any) => member.kind === kind);
+  const anchorByMember = resolveMemberAnchorMap(type.members ?? []);
   const displayName = typeDisplayName(type);
 
   return finalizeMarkdown([
@@ -334,9 +335,20 @@ export function renderCSharpMemberKindMarkdown(
       { label: 'Members', value: inlineCode(String(members.length)) },
     ]),
     renderCSharpDocMarkdown(type.docs?.summary, context),
-    ...members.map((member: any) =>
-      section(getCSharpMemberHeading(member, type.name), renderCSharpMemberMarkdown(member, type, context, pkg), 2)
-    ),
+    ...members.map((member: any) => {
+      const anchors = anchorByMember.get(member)!;
+      const explicitAnchors = [...anchors.aliases, anchors.exact]
+        .map((anchor) => `<a id="${anchor}"></a>`)
+        .join('\n');
+      return [
+        explicitAnchors,
+        section(
+          getCSharpMemberHeading(member, type.name),
+          renderCSharpMemberMarkdown(member, type, context, pkg),
+          2
+        ),
+      ].join('\n\n');
+    }),
   ]);
 }
 
@@ -511,7 +523,9 @@ function renderEnumMembersMarkdown(enumMembers: any[], hasFlags: boolean): strin
 }
 
 function renderTypeMemberOverview(type: any, packageName: string, allTypes: any[], base: string): string {
-  const groups = groupMembersByKind(type.members ?? []);
+  const members: any[] = type.members ?? [];
+  const groups = groupMembersByKind(members);
+  const anchorByMember = resolveMemberAnchorMap(members);
   const nestedTypes: string[] = Array.isArray(type.nestedTypes) ? type.nestedTypes : [];
 
   if (groups.size === 0 && nestedTypes.length === 0) {
@@ -528,7 +542,7 @@ function renderTypeMemberOverview(type: any, packageName: string, allTypes: any[
     const lines = members.map((member: any) => {
       const rawDisplayName = memberDisplayName(member);
       const displayName = member.name === '.ctor' ? rawDisplayName.replace('.ctor', type.name) : rawDisplayName;
-      const href = `${csharpMemberKindMdHref(base, packageName, type.name, genericArity(type), kind)}#${memberSlug(member)}`;
+      const href = `${csharpMemberKindMdHref(base, packageName, type.name, genericArity(type), kind)}#${anchorByMember.get(member)!.exact}`;
       const returnType = member.returnType && member.returnType !== 'void'
         ? ` : ${formatCSharpTypeReferenceMarkdown(member.returnType, context)}`
         : '';
@@ -821,7 +835,8 @@ function resolveCrefMarkdown(cref: string, context: CSharpDocContext): { href: s
             : 'method';
 
     const memberParams = paramStart >= 0 ? splitCrefParams(fullName.slice(paramStart + 1, fullName.lastIndexOf(')'))) : [];
-    const candidateMembers = (ownerType.members ?? []).filter((member: any) => {
+    const ownerMembers: any[] = ownerType.members ?? [];
+    const candidateMembers = ownerMembers.filter((member: any) => {
       if (memberName === '.ctor') {
         return member.name === '.ctor';
       }
@@ -845,7 +860,9 @@ function resolveCrefMarkdown(cref: string, context: CSharpDocContext): { href: s
       genericArity(ownerType),
       matchedMember?.kind ?? memberKind
     );
-    const anchor = matchedMember ? `#${memberSlug(matchedMember)}` : '';
+    const anchor = matchedMember
+      ? `#${resolveMemberAnchorMap(ownerMembers).get(matchedMember)!.exact}`
+      : '';
     const label = matchedMember
       ? `${ownerType.name}.${getCSharpMemberHeading(matchedMember, ownerType.name)}`
       : cleanCrefLabel(cref);

--- a/src/frontend/src/utils/packages.ts
+++ b/src/frontend/src/utils/packages.ts
@@ -4,6 +4,15 @@
 
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
+import { shortTypeName } from './api-member-anchors';
+
+export {
+  memberAnchorAliases,
+  memberNameSlug,
+  memberSlug,
+  resolveMemberAnchors,
+  shortTypeName,
+} from './api-member-anchors';
 
 export interface GenericParameter {
   name: string;
@@ -193,30 +202,6 @@ export function groupTypesByNamespace(types: PackageType[]): Map<string, Package
 }
 
 /**
- * Generate a URL-safe anchor slug for a member.
- * Includes parameter types for indexers, methods, and constructors to
- * disambiguate overloads.
- */
-export function memberSlug(member: {
-  name: string;
-  kind?: string;
-  parameters?: { type: string }[];
-}): string {
-  let base = member.name === '.ctor' ? 'constructor' : member.name;
-  if (member.kind === 'indexer' && member.parameters?.length) {
-    const paramTypes = member.parameters.map((p) => shortTypeName(p.type)).join(', ');
-    base = `this[${paramTypes}]`;
-  } else if ((member.kind === 'method' || member.kind === 'constructor') && member.parameters) {
-    const paramTypes = member.parameters.map((p) => shortTypeName(p.type)).join(', ');
-    base = `${base}(${paramTypes})`;
-  }
-  return base
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-/**
  * Display name for a member, including parameter types for indexers,
  * methods, and constructors.
  * e.g. `this[string]`, `Add(string, int)`, `Constructor(ILogger)`.
@@ -304,42 +289,6 @@ export function resolveTypeLink(
  *   `System.IEquatable<SampleApi.ValidationError>`  →  `IEquatable<ValidationError>`
  *   `SampleApi.PagedResult<T>`                      →  `PagedResult<T>`
  */
-export function shortTypeName(fullName: string): string {
-  let firstAngle = -1;
-  for (let i = 0; i < fullName.length; i++) {
-    if (fullName[i] === '<') {
-      firstAngle = i;
-      break;
-    }
-  }
-
-  if (firstAngle < 0) {
-    return fullName.split('.').pop() ?? fullName;
-  }
-
-  const outerShort = fullName.slice(0, firstAngle).split('.').pop() ?? fullName;
-  const lastAngle = fullName.lastIndexOf('>');
-  const argsContent = fullName.slice(firstAngle + 1, lastAngle);
-
-  const args: string[] = [];
-  let current = '';
-  let depth = 0;
-  for (const ch of argsContent) {
-    if (ch === '<') depth++;
-    if (ch === '>') depth--;
-    if (ch === ',' && depth === 0) {
-      args.push(current.trim());
-      current = '';
-    } else {
-      current += ch;
-    }
-  }
-  if (current.trim()) args.push(current.trim());
-
-  const shortArgs = args.map((a) => shortTypeName(a));
-  return `${outerShort}<${shortArgs.join(', ')}>`;
-}
-
 /**
  * Parse a `seeAlso` doc-id reference like `T:SampleApi.Customer` or
  * `P:SampleApi.Customer.Id`.

--- a/src/frontend/src/utils/packages.ts
+++ b/src/frontend/src/utils/packages.ts
@@ -10,6 +10,7 @@ export {
   memberAnchorAliases,
   memberNameSlug,
   memberSlug,
+  resolveMemberAnchorMap,
   resolveMemberAnchors,
   shortTypeName,
 } from './api-member-anchors';

--- a/src/frontend/src/utils/ts-modules.ts
+++ b/src/frontend/src/utils/ts-modules.ts
@@ -49,6 +49,7 @@ export interface TsHandleType extends TsNamedItem {
   kind?: 'handle';
   exposeProperties?: boolean;
   implementedInterfaces?: string[];
+  baseTypeHierarchy?: string[];
   capabilities?: TsFunction[];
 }
 

--- a/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
+++ b/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
@@ -1,11 +1,27 @@
 import { expect, test } from '@playwright/test';
 
-test('C# method name deep links scroll to the requested member', async ({ page }) => {
-  await page.goto(
-    '/reference/api/csharp/aspire.hosting.sqlserver/sqlserverbuilderextensions/methods/#withhostport'
-  );
+const methodsPath =
+  '/reference/api/csharp/aspire.hosting.sqlserver/sqlserverbuilderextensions/methods/';
 
+test('C# method name and overload deep links scroll to and highlight the requested member', async ({
+  page,
+}) => {
+  await page.goto(`${methodsPath}#withhostport`);
   const member = page.locator('#withhostport');
   await expect(member).toHaveCount(1);
   await expect(member).toBeInViewport();
+  const highlightedBackground = await member.evaluate(
+    (element) => getComputedStyle(element).backgroundColor
+  );
+
+  await page.goto(`${methodsPath}#withhostport-int32`);
+  const exactAnchor = page.locator('#withhostport-int32');
+  await expect(exactAnchor).toHaveCount(1);
+  await expect.poll(() => exactAnchor.evaluate((element) => element.matches(':target'))).toBe(true);
+
+  const exactMember = exactAnchor.locator('..');
+  await expect(exactMember).toBeInViewport();
+  await expect
+    .poll(() => exactMember.evaluate((element) => getComputedStyle(element).backgroundColor))
+    .toBe(highlightedBackground);
 });

--- a/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
+++ b/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
@@ -14,9 +14,13 @@ test('C# method name and overload deep links scroll to and highlight the request
     (element) => getComputedStyle(element).backgroundColor
   );
 
-  await page.goto(`${methodsPath}#withhostport-int32`);
-  const exactAnchor = page.locator('#withhostport-int32');
-  await expect(exactAnchor).toHaveCount(1);
+  const exactAnchorId = await member.locator('.mc-exact-anchor').getAttribute('id');
+  if (!exactAnchorId) {
+    throw new Error('Expected the aliased member to expose an exact overload anchor.');
+  }
+
+  await page.goto(`${methodsPath}#${exactAnchorId}`);
+  const exactAnchor = page.locator(`#${exactAnchorId}`);
   await expect.poll(() => exactAnchor.evaluate((element) => element.matches(':target'))).toBe(true);
 
   const exactMember = exactAnchor.locator('..');

--- a/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
+++ b/src/frontend/tests/e2e/api-reference-deep-links.spec.ts
@@ -1,0 +1,11 @@
+import { expect, test } from '@playwright/test';
+
+test('C# method name deep links scroll to the requested member', async ({ page }) => {
+  await page.goto(
+    '/reference/api/csharp/aspire.hosting.sqlserver/sqlserverbuilderextensions/methods/#withhostport'
+  );
+
+  const member = page.locator('#withhostport');
+  await expect(member).toHaveCount(1);
+  await expect(member).toBeInViewport();
+});

--- a/src/frontend/tests/unit/api-markdown.vitest.test.ts
+++ b/src/frontend/tests/unit/api-markdown.vitest.test.ts
@@ -7,8 +7,12 @@
 */
 import { describe, expect, it, vi } from 'vitest';
 
-import { renderCSharpDocMarkdown } from '@utils/csharp-api-markdown';
-import { memberKindSlugs } from '@utils/packages';
+import {
+  renderCSharpDocMarkdown,
+  renderCSharpMemberKindMarkdown,
+  renderCSharpTypeMarkdown,
+} from '@utils/csharp-api-markdown';
+import { memberKindSlugs, resolveMemberAnchors } from '@utils/packages';
 import { tsSlugify } from '@utils/ts-modules';
 import { renderTypeScriptItemMarkdown, renderTypeScriptModuleMarkdown } from '@utils/typescript-api-markdown';
 import type { TsApiDocument, TsHandleType } from '@utils/ts-modules';
@@ -293,6 +297,52 @@ describe('API markdown helpers', () => {
     const markdown = renderTypeScriptItemMarkdown(pkg, item, 'handle', '');
 
     expect(markdown).toContain('[GitHub](https://github.com/microsoft/aspire/tree/abc123)');
+  });
+
+  it('uses resolved exact anchors for colliding C# member links and crefs', () => {
+    const members = [
+      {
+        name: 'Run',
+        kind: 'method',
+        signature: 'public void Widget.Run(int value)',
+        parameters: [{ name: 'value', type: 'System.Int32' }],
+        returnType: 'void',
+      },
+      {
+        name: 'Run',
+        kind: 'method',
+        signature: 'public void Widget.Run(params int[] values)',
+        parameters: [{ name: 'values', type: 'System.Int32[]', modifier: 'params' }],
+        returnType: 'void',
+      },
+    ];
+    const type = {
+      name: 'Widget',
+      fullName: 'Sample.Widget',
+      namespace: 'Sample',
+      kind: 'class',
+      members,
+    };
+    const pkg = {
+      package: { name: 'Sample.Package', version: '1.0.0' },
+      types: [type],
+    };
+    const anchors = resolveMemberAnchors(members);
+
+    const typeMarkdown = renderCSharpTypeMarkdown(pkg, type, [type], '');
+    expect(typeMarkdown).toContain(`methods.md#${anchors[0].exact}`);
+    expect(typeMarkdown).toContain(`methods.md#${anchors[1].exact}`);
+
+    const memberMarkdown = renderCSharpMemberKindMarkdown(pkg, type, 'method', [type], '');
+    expect(memberMarkdown).toContain(`<a id="${anchors[0].exact}"></a>`);
+    expect(memberMarkdown).toContain(`<a id="${anchors[1].exact}"></a>`);
+    expect(memberMarkdown).toContain(`<a id="${anchors[0].aliases[0]}"></a>`);
+
+    const crefMarkdown = renderCSharpDocMarkdown(
+      [{ kind: 'cref', value: 'M:Sample.Widget.Run(System.Int32)' }],
+      { allTypes: [type], base: '', packageName: pkg.package.name }
+    );
+    expect(crefMarkdown).toContain(`methods.md#${anchors[0].exact}`);
   });
 });
 

--- a/src/frontend/tests/unit/api-member-anchors.vitest.test.ts
+++ b/src/frontend/tests/unit/api-member-anchors.vitest.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from 'vitest';
+
+import {
+  memberAnchorAliases,
+  memberNameSlug,
+  memberSlug,
+  resolveMemberAnchors,
+} from '../../src/utils/api-member-anchors';
+
+test('C# member anchors support stable name links and precise overload links', () => {
+  const member = {
+    name: 'WithHostPort',
+    kind: 'method',
+    parameters: [{ type: 'System.Int32?' }],
+  };
+
+  expect(memberNameSlug(member)).toBe('withhostport');
+  expect(memberSlug(member)).toBe('withhostport-int32');
+});
+
+test('name aliases never collide with parameterless overload anchors', () => {
+  const members = [
+    {
+      name: '.ctor',
+      kind: 'constructor',
+      parameters: [{ type: 'System.String' }],
+    },
+    {
+      name: '.ctor',
+      kind: 'constructor',
+      parameters: [],
+    },
+  ];
+
+  expect(memberAnchorAliases(members)).toEqual([undefined, undefined]);
+  expect(members.map(memberSlug)).toEqual(['constructor-string', 'constructor']);
+});
+
+test('the first overload receives the stable name alias when no exact name anchor exists', () => {
+  const members = [
+    {
+      name: 'WithHostPort',
+      kind: 'method',
+      parameters: [{ type: 'System.Int32?' }],
+    },
+    {
+      name: 'WithHostPort',
+      kind: 'method',
+      parameters: [{ type: 'System.Int32?' }, { type: 'System.String' }],
+    },
+  ];
+
+  expect(memberAnchorAliases(members)).toEqual(['withhostport', undefined]);
+});
+
+test('colliding overload slugs receive distinct signature discriminators', () => {
+  const members = [
+    {
+      name: 'WithHiddenOnCompletion',
+      kind: 'method',
+      parameters: [{ type: 'System.Int32' }],
+    },
+    {
+      name: 'WithHiddenOnCompletion',
+      kind: 'method',
+      parameters: [{ type: 'System.Int32[]', modifier: 'params' }],
+    },
+  ];
+
+  expect(members.map(memberSlug)).toEqual([
+    'withhiddenoncompletion-int32',
+    'withhiddenoncompletion-int32',
+  ]);
+  const anchors = resolveMemberAnchors(members);
+  expect(anchors[0].exact).not.toBe(anchors[1].exact);
+  expect(anchors[0].alias).toBe('withhiddenoncompletion');
+  expect(anchors[1].alias).toBeUndefined();
+});

--- a/src/frontend/tests/unit/api-member-anchors.vitest.test.ts
+++ b/src/frontend/tests/unit/api-member-anchors.vitest.test.ts
@@ -73,6 +73,9 @@ test('colliding overload slugs receive distinct signature discriminators', () =>
   ]);
   const anchors = resolveMemberAnchors(members);
   expect(anchors[0].exact).not.toBe(anchors[1].exact);
-  expect(anchors[0].alias).toBe('withhiddenoncompletion');
-  expect(anchors[1].alias).toBeUndefined();
+  expect(anchors[0].aliases).toEqual([
+    'withhiddenoncompletion',
+    'withhiddenoncompletion-int32',
+  ]);
+  expect(anchors[1].aliases).toEqual([]);
 });

--- a/src/frontend/tests/unit/api-reference-components.vitest.test.ts
+++ b/src/frontend/tests/unit/api-reference-components.vitest.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest';
+
+import MemberCard from '@components/api-reference/MemberCard.astro';
+import MemberOverviewList from '@components/api-reference/MemberOverviewList.astro';
+import { resolveMemberAnchors } from '@utils/packages';
+import { renderComponent } from './astro-test-utils';
+
+const members = [
+  {
+    name: 'Run',
+    kind: 'method',
+    signature: 'public void Widget.Run(int value)',
+    parameters: [{ name: 'value', type: 'System.Int32' }],
+    returnType: 'void',
+  },
+  {
+    name: 'Run',
+    kind: 'method',
+    signature: 'public void Widget.Run(params int[] values)',
+    parameters: [{ name: 'values', type: 'System.Int32[]', modifier: 'params' }],
+    returnType: 'void',
+  },
+];
+
+test('member components render resolved links and legacy collision aliases', async () => {
+  const anchors = resolveMemberAnchors(members);
+  const first = anchors[0];
+
+  const card = await renderComponent(MemberCard, {
+    props: {
+      member: members[0],
+      exactAnchor: first.exact,
+      anchorAliases: first.aliases,
+    },
+  });
+  expect(card).toContain(`id="${first.aliases[0]}"`);
+  expect(card).toContain(`id="${first.exact}"`);
+  expect(card).toContain('id="run-int32"');
+
+  const overview = await renderComponent(MemberOverviewList, {
+    props: {
+      members,
+      typeName: 'Widget',
+      packageName: 'Sample.Package',
+    },
+  });
+  expect(overview).toContain(`methods/#${anchors[0].exact}`);
+  expect(overview).toContain(`methods/#${anchors[1].exact}`);
+});

--- a/src/frontend/tests/unit/normalize-generated-api-data.vitest.test.ts
+++ b/src/frontend/tests/unit/normalize-generated-api-data.vitest.test.ts
@@ -43,9 +43,9 @@ describe('normalizeApiJsonText — C# API (pkgs) shape', () => {
     expect(text).toContain('"text": " relative to the AppHost project directory. "');
   });
 
-  test('leaves plural "app hosts" untouched (matches the forbidden-words boundary)', () => {
+  test('normalizes the plural form in triple-slash prose', () => {
     const { text } = normalizeApiJsonText(doc);
-    expect(text).toContain(`"text": "Not available in polyglot ${APP_HOST}s."`);
+    expect(text).toContain('"text": "Not available in polyglot AppHosts."');
   });
 
   test('never rewrites the text of code-bearing nodes (code, cref)', () => {
@@ -57,7 +57,7 @@ describe('normalizeApiJsonText — C# API (pkgs) shape', () => {
   });
 
   test('counts exactly the changed occurrences', () => {
-    expect(normalizeApiJsonText(doc).changes).toBe(1);
+    expect(normalizeApiJsonText(doc).changes).toBe(2);
   });
 });
 

--- a/src/frontend/tests/unit/normalize-generated-api-data.vitest.test.ts
+++ b/src/frontend/tests/unit/normalize-generated-api-data.vitest.test.ts
@@ -34,7 +34,13 @@ describe('normalizeApiJsonText — C# API (pkgs) shape', () => {
     `        "text": "${APP_HOST}"`,
     '      }',
     '    ]',
-    '  }',
+    '  },',
+    '  "attributes": [{',
+    '    "name": "Aspire.Hosting.AspireExportIgnoreAttribute",',
+    '    "arguments": {',
+    `      "Reason": "Use the direct export in polyglot ${APP_HOST}s."`,
+    '    }',
+    '  }]',
     '}',
   ]);
 
@@ -48,6 +54,11 @@ describe('normalizeApiJsonText — C# API (pkgs) shape', () => {
     expect(text).toContain('"text": "Not available in polyglot AppHosts."');
   });
 
+  test('normalizes export-ignore reason prose', () => {
+    const { text } = normalizeApiJsonText(doc);
+    expect(text).toContain('"Reason": "Use the direct export in polyglot AppHosts."');
+  });
+
   test('never rewrites the text of code-bearing nodes (code, cref)', () => {
     const { text } = normalizeApiJsonText(doc);
     expect(text).toContain(`"text": "${DOTNET_ASPIRE} run"`);
@@ -57,7 +68,7 @@ describe('normalizeApiJsonText — C# API (pkgs) shape', () => {
   });
 
   test('counts exactly the changed occurrences', () => {
-    expect(normalizeApiJsonText(doc).changes).toBe(2);
+    expect(normalizeApiJsonText(doc).changes).toBe(3);
   });
 });
 

--- a/src/frontend/tests/unit/twoslash-types-generator.vitest.test.ts
+++ b/src/frontend/tests/unit/twoslash-types-generator.vitest.test.ts
@@ -50,16 +50,41 @@ describe('generate-twoslash-types', () => {
     expect(output).not.toMatch(/^\s*PasswordParameter:/m);
   });
 
+  test('preserves optional DTO fields', () => {
+    expect(output).toMatch(
+      /export interface CertificateTrustExecutionConfigurationContext\s*\{[^}]*\bisContainer\?: boolean;/s
+    );
+  });
+
   test('emits an options-object overload for primitive-only param lists', () => {
     // withDataVolume(options?: { ... }) is the canonical shape produced when all
     // params are primitives — generator pairs it with a positional overload.
     expect(output).toMatch(/withDataVolume\(options\?: \{/);
   });
 
-  test('does not merge post-snapshot declarations with generated DTOs', () => {
+  test('does not wrap an existing options DTO in another options object', () => {
+    expect(output).not.toMatch(/options\?: \{\s*options\?:/);
+  });
+
+  test('does not infer ContainerResource from marker interfaces', () => {
+    expect(output).not.toMatch(
+      /export interface \w+[^{]*extends[^{]*(?:ExecutableResource[^{]*ContainerResource|ContainerResource[^{]*ExecutableResource)/
+    );
+  });
+
+  test('prefers generated DTO metadata over post-snapshot shims', () => {
     const declarations = output.match(/export interface ParameterCustomInputOptions\b/g) ?? [];
 
     expect(declarations).toHaveLength(1);
     expect(output).toMatch(/inputType\?: InputType/);
+    expect(output).toMatch(/label\?: string/);
+    expect(output).toMatch(/description\?: string/);
+    expect(output).toMatch(/enableDescriptionMarkdown\?: boolean/);
+    expect(output).toMatch(/options\?: Dict<string,string>/);
+    expect(output).toMatch(/value\?: string/);
+    expect(output).toMatch(/placeholder\?: string/);
+    expect(output).toMatch(/allowCustomChoice\?: boolean/);
+    expect(output).toMatch(/disabled\?: boolean/);
+    expect(output).toMatch(/maxLength\?: number/);
   });
 });

--- a/src/frontend/tests/unit/update-samples.vitest.test.ts
+++ b/src/frontend/tests/unit/update-samples.vitest.test.ts
@@ -162,8 +162,15 @@ describe('Aspire terminology normalization in code', () => {
   });
 
   test('normalizes the plural form in code comments', () => {
-    const input = `// Works across polyglot ${legacyAppHostName}s.`;
-    expect(normalizeAspireTerminologyInCode(input)).toBe('// Works across polyglot AppHosts.');
+    const input = `// Polyglot ${legacyAppHostName}s use the exported API.`;
+    expect(normalizeAspireTerminologyInCode(input)).toBe(
+      '// Polyglot AppHosts use the exported API.'
+    );
+  });
+
+  test('preserves verb usage of hosts', () => {
+    const input = `// The ${legacyAppHostName}s a service.`;
+    expect(normalizeAspireTerminologyInCode(input)).toBe(input);
   });
 
   test('preserves inline code and is idempotent', () => {

--- a/src/frontend/tests/unit/update-samples.vitest.test.ts
+++ b/src/frontend/tests/unit/update-samples.vitest.test.ts
@@ -161,9 +161,9 @@ describe('Aspire terminology normalization in code', () => {
     );
   });
 
-  test('leaves plural "app hosts" untouched to match the forbidden-words boundary', () => {
+  test('normalizes the plural form in code comments', () => {
     const input = `// Works across polyglot ${legacyAppHostName}s.`;
-    expect(normalizeAspireTerminologyInCode(input)).toBe(input);
+    expect(normalizeAspireTerminologyInCode(input)).toBe('// Works across polyglot AppHosts.');
   });
 
   test('preserves inline code and is idempotent', () => {

--- a/src/frontend/tests/unit/validate-generated-api-data.vitest.test.ts
+++ b/src/frontend/tests/unit/validate-generated-api-data.vitest.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'vitest';
 
 import {
+  type GitCommandResult,
   type ValidationInput,
+  loadJsonFromHead,
   validateGeneratedApiData,
 } from '../../scripts/validate-generated-api-data';
 
@@ -73,7 +75,7 @@ function createValidInput(): ValidationInput {
                 'Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.ExecutableResource]]',
               ],
               baseTypeHierarchy: [
-                'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource]]',
+                'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource',
               ],
             },
           ],
@@ -119,6 +121,16 @@ describe('validateGeneratedApiData', () => {
     );
   });
 
+  test('rejects DTO field types that differ from declarations', () => {
+    const input = createValidInput();
+    input.modules[0].data.dtoTypes![0].fields![0].type = 'String]][]';
+    input.declarations = input.declarations.replace('port?: number', 'port?: string[]');
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash DTO FooOptions.port type string[] does not match ts-modules metadata String]][].'
+    );
+  });
+
   test('rejects required DTO metadata', () => {
     const input = createValidInput();
     input.modules[0].data.dtoTypes![0].fields![1].isOptional = false;
@@ -155,6 +167,28 @@ describe('validateGeneratedApiData', () => {
 
     expect(validateGeneratedApiData(input).errors).toContain(
       'Twoslash handle MissingResource is missing its declaration.'
+    );
+  });
+
+  test('rejects malformed generated generic base types', () => {
+    const input = createValidInput();
+    input.packages[0].data.types![0].baseType =
+      'Aspire.Hosting.ApplicationModel.PairResource<System.String, System.Int32>';
+    input.modules[0].data.handleTypes![1].baseTypeHierarchy = [
+      'Aspire.Hosting.ApplicationModel.PairResource`2[[System.String]]',
+    ];
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'TypeScript handle FooResource base type Aspire.Hosting.ApplicationModel.PairResource`2[[System.String]] does not match C# metadata Aspire.Hosting.ApplicationModel.PairResource<System.String, System.Int32>.'
+    );
+  });
+
+  test('rejects missing generated base hierarchy metadata', () => {
+    const input = createValidInput();
+    input.modules[0].data.handleTypes![1].baseTypeHierarchy = [];
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'TypeScript handle FooResource is missing base hierarchy metadata for C# base type Aspire.Hosting.ApplicationModel.ExecutableResource.'
     );
   });
 
@@ -231,5 +265,45 @@ describe('validateGeneratedApiData', () => {
       'Stale C# API output Aspire.Hosting.Foo@1.0.0; catalog version is 2.0.0.'
     );
     expect(errors).toContain('Missing C# API output for catalog package Aspire.Hosting.Foo@2.0.0.');
+  });
+});
+
+describe('loadJsonFromHead', () => {
+  test('returns undefined only when the path is absent from HEAD', () => {
+    const calls: string[][] = [];
+    const git = (arguments_: string[]): GitCommandResult => {
+      calls.push(arguments_);
+      return { status: 0, stdout: '', stderr: '' };
+    };
+
+    expect(loadJsonFromHead('repo', 'missing.json', git)).toBeUndefined();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('ls-tree');
+  });
+
+  test('propagates failures while checking HEAD', () => {
+    const git = (): GitCommandResult => ({
+      status: 128,
+      stdout: '',
+      stderr: 'fatal: invalid object name HEAD',
+    });
+
+    expect(() => loadJsonFromHead('repo', 'data.json', git)).toThrow(
+      'git ls-tree failed: fatal: invalid object name HEAD'
+    );
+  });
+
+  test('propagates failures while reading a confirmed baseline', () => {
+    let call = 0;
+    const git = (): GitCommandResult => {
+      call++;
+      return call === 1
+        ? { status: 0, stdout: 'data.json\n', stderr: '' }
+        : { status: 128, stdout: '', stderr: 'fatal: permission denied' };
+    };
+
+    expect(() => loadJsonFromHead('repo', 'data.json', git)).toThrow(
+      'git show failed: fatal: permission denied'
+    );
   });
 });

--- a/src/frontend/tests/unit/validate-generated-api-data.vitest.test.ts
+++ b/src/frontend/tests/unit/validate-generated-api-data.vitest.test.ts
@@ -1,0 +1,235 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  type ValidationInput,
+  validateGeneratedApiData,
+} from '../../scripts/validate-generated-api-data';
+
+function createValidInput(): ValidationInput {
+  const pkg = {
+    package: {
+      name: 'Aspire.Hosting.Foo',
+      version: '1.0.0',
+      sourceRepository: 'https://github.com/example/foo',
+      sourceCommit: 'abc123',
+    },
+    types: [
+      {
+        name: 'FooResource',
+        fullName: 'Aspire.Hosting.ApplicationModel.FooResource',
+        kind: 'class',
+        baseType: 'Aspire.Hosting.ApplicationModel.ExecutableResource',
+        members: [
+          {
+            name: 'AddFoo',
+            kind: 'method',
+            signature: 'AddFoo(string name)',
+            parameters: [{ name: 'name', type: 'System.String' }],
+            attributes: [
+              {
+                name: 'Aspire.Hosting.AspireExportAttribute',
+                constructorArguments: ['addFoo'],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  return {
+    catalog: [{ title: 'Aspire.Hosting.Foo', version: '1.0.0' }],
+    packages: [
+      {
+        fileName: 'Aspire.Hosting.Foo.1.0.0.json',
+        data: structuredClone(pkg),
+        baseline: structuredClone(pkg),
+      },
+    ],
+    modules: [
+      {
+        fileName: 'Aspire.Hosting.Foo.1.0.0.json',
+        data: {
+          package: structuredClone(pkg.package),
+          functions: [{}],
+          dtoTypes: [
+            {
+              name: 'FooOptions',
+              fields: [
+                { name: 'Port', type: 'number', isOptional: true },
+                { name: 'Host', type: 'string', isOptional: true },
+              ],
+            },
+          ],
+          handleTypes: [
+            {
+              name: 'ExecutableResource',
+              fullName: 'Aspire.Hosting.ApplicationModel.ExecutableResource',
+            },
+            {
+              name: 'FooResource',
+              fullName: 'Aspire.Hosting.ApplicationModel.FooResource',
+              implementedInterfaces: [
+                'Aspire.Hosting.ApplicationModel.IResourceWithParent`1[[Aspire.Hosting.ApplicationModel.ExecutableResource]]',
+              ],
+              baseTypeHierarchy: [
+                'Aspire.Hosting/Aspire.Hosting.ApplicationModel.ExecutableResource]]',
+              ],
+            },
+          ],
+        },
+      },
+    ],
+    declarations: [
+      'export interface FooOptions {',
+      '  port?: number;',
+      '  host?: string;',
+      '}',
+      'export interface ExecutableResource {',
+      '}',
+      'export interface FooResource extends ExecutableResource {',
+      '}',
+      'export interface FooResource {',
+      '  augmentation?: string;',
+      '}',
+    ].join('\n'),
+  };
+}
+
+describe('validateGeneratedApiData', () => {
+  test('accepts semantically faithful generated data', () => {
+    expect(validateGeneratedApiData(createValidInput()).errors).toEqual([]);
+  });
+
+  test('rejects TypeScript provenance that differs from the C# package', () => {
+    const input = createValidInput();
+    input.modules[0].data.package.sourceRepository = 'https://github.com/example/wrong';
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Source repository mismatch for Aspire.Hosting.Foo@1.0.0: C# has https://github.com/example/foo, TypeScript has https://github.com/example/wrong.'
+    );
+  });
+
+  test('rejects lost DTO optionality', () => {
+    const input = createValidInput();
+    input.declarations = input.declarations.replace('port?: number', 'port: number');
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash DTO FooOptions.port optionality does not match ts-modules metadata.'
+    );
+  });
+
+  test('rejects required DTO metadata', () => {
+    const input = createValidInput();
+    input.modules[0].data.dtoTypes![0].fields![1].isOptional = false;
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'TypeScript DTO FooOptions.host is required, but the SDK emits every DTO field as optional.'
+    );
+  });
+
+  test('rejects a missing DTO declaration', () => {
+    const input = createValidInput();
+    input.modules[0].data.dtoTypes![0].name = 'MissingOptions';
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash DTO MissingOptions is missing its declaration.'
+    );
+  });
+
+  test('rejects inferred handle inheritance not present in metadata', () => {
+    const input = createValidInput();
+    input.declarations = input.declarations.replace(
+      'FooResource extends ExecutableResource',
+      'FooResource extends ExecutableResource, ContainerResource'
+    );
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash handle FooResource has incorrect inheritance (missing: none; unexpected: ContainerResource).'
+    );
+  });
+
+  test('rejects a missing handle declaration', () => {
+    const input = createValidInput();
+    input.modules[0].data.handleTypes![1].name = 'MissingResource';
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash handle MissingResource is missing its declaration.'
+    );
+  });
+
+  test('rejects nested options DTO wrappers', () => {
+    const input = createValidInput();
+    input.declarations +=
+      '\nexport interface BadOverload {\n  add(options?: { options?: FooOptions }): FooResource;\n}';
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Twoslash declarations contain a nested single-DTO options wrapper.'
+    );
+  });
+
+  test('rejects same-version attribute payload loss', () => {
+    const input = createValidInput();
+    input.packages[0].data.types![0].members![0].attributes = [
+      { name: 'Aspire.Hosting.AspireExportAttribute' },
+    ];
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Attribute payload changed or disappeared for Aspire.Hosting.Foo@1.0.0 at type:Aspire.Hosting.ApplicationModel.FooResource/member:method:AddFoo(System.String)|Aspire.Hosting.AspireExportAttribute|0.'
+    );
+  });
+
+  test('rejects same-version named attribute argument loss', () => {
+    const input = createValidInput();
+    const baselineAttributes = input.packages[0].baseline!.types![0].members![0].attributes!;
+    const generatedAttributes = input.packages[0].data.types![0].members![0].attributes!;
+    baselineAttributes.push({
+      name: 'Aspire.Hosting.AspireExportIgnoreAttribute',
+      arguments: { Reason: 'Not supported.' },
+    });
+    generatedAttributes.push({
+      name: 'Aspire.Hosting.AspireExportIgnoreAttribute',
+    });
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Attribute payload changed or disappeared for Aspire.Hosting.Foo@1.0.0 at type:Aspire.Hosting.ApplicationModel.FooResource/member:method:AddFoo(System.String)|Aspire.Hosting.AspireExportIgnoreAttribute|0.'
+    );
+  });
+
+  test('rejects same-version marker attribute loss', () => {
+    const input = createValidInput();
+    input.packages[0].baseline!.types![0].members![0].attributes!.push({
+      name: 'Aspire.Hosting.AspireDtoAttribute',
+    });
+
+    expect(validateGeneratedApiData(input).errors).toContain(
+      'Attribute payload changed or disappeared for Aspire.Hosting.Foo@1.0.0 at type:Aspire.Hosting.ApplicationModel.FooResource/member:method:AddFoo(System.String)|Aspire.Hosting.AspireDtoAttribute|0.'
+    );
+  });
+
+  test('allows same-version attribute payload values to change when their shape is retained', () => {
+    const input = createValidInput();
+    input.packages[0].data.types![0].members![0].attributes![0].constructorArguments = [
+      'renamedAddFoo',
+    ];
+
+    expect(
+      validateGeneratedApiData(input).errors.filter((error) =>
+        error.startsWith('Attribute payload changed or disappeared')
+      )
+    ).toEqual([]);
+  });
+
+  test('rejects duplicate and stale generated identities', () => {
+    const input = createValidInput();
+    input.packages.push(structuredClone(input.packages[0]));
+    input.catalog[0].version = '2.0.0';
+    const errors = validateGeneratedApiData(input).errors;
+
+    expect(errors).toContain('pkgs contains duplicate package identity Aspire.Hosting.Foo@1.0.0.');
+    expect(errors).toContain(
+      'Stale C# API output Aspire.Hosting.Foo@1.0.0; catalog version is 2.0.0.'
+    );
+    expect(errors).toContain('Missing C# API output for catalog package Aspire.Hosting.Foo@2.0.0.');
+  });
+});

--- a/src/tools/AtsJsonGenerator/Helpers/AtsTransformer.cs
+++ b/src/tools/AtsJsonGenerator/Helpers/AtsTransformer.cs
@@ -307,7 +307,101 @@ internal static class AtsTransformer
     internal static string SimplifyTypeId(string typeId)
     {
         var stripped = StripAssemblyPrefix(typeId);
-        return SimpleName(stripped);
+        return FormatReflectionType(stripped);
+    }
+
+    private static string FormatReflectionType(string typeName)
+    {
+        var arraySuffix = "";
+        while (typeName.EndsWith("[]", StringComparison.Ordinal))
+        {
+            arraySuffix += "[]";
+            typeName = typeName[..^2];
+        }
+
+        var arityIndex = typeName.IndexOf('`');
+        var argumentsIndex = arityIndex >= 0
+            ? typeName.IndexOf("[[", arityIndex, StringComparison.Ordinal)
+            : -1;
+        if (arityIndex >= 0 &&
+            argumentsIndex >= 0 &&
+            TrySplitReflectionGenericArguments(typeName, argumentsIndex, out var arguments))
+        {
+            var genericName = SimpleName(typeName[..arityIndex]);
+            var formattedArguments = arguments.Select(FormatReflectionType);
+            return $"{genericName}<{string.Join(",", formattedArguments)}>{arraySuffix}";
+        }
+
+        return $"{FormatPrimitiveType(SimpleName(typeName))}{arraySuffix}";
+    }
+
+    private static bool TrySplitReflectionGenericArguments(
+        string typeName,
+        int startIndex,
+        out List<string> arguments)
+    {
+        arguments = [];
+        var argumentStart = startIndex + 2;
+        var depth = 1;
+        var i = argumentStart;
+
+        while (i < typeName.Length)
+        {
+            if (i + 1 < typeName.Length && typeName[i] == '[' && typeName[i + 1] == ']')
+            {
+                i += 2;
+                continue;
+            }
+
+            if (i + 1 < typeName.Length && typeName[i] == '[' && typeName[i + 1] == '[')
+            {
+                depth++;
+                i += 2;
+                continue;
+            }
+
+            if (i + 1 < typeName.Length && typeName[i] == ']' && typeName[i + 1] == ']')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    arguments.Add(typeName[argumentStart..i]);
+                    return i + 2 == typeName.Length;
+                }
+                i += 2;
+                continue;
+            }
+
+            if (depth == 1 &&
+                i + 2 < typeName.Length &&
+                typeName[i] == ']' &&
+                typeName[i + 1] == ',' &&
+                typeName[i + 2] == '[')
+            {
+                arguments.Add(typeName[argumentStart..i]);
+                argumentStart = i + 3;
+                i += 3;
+                continue;
+            }
+
+            i++;
+        }
+
+        arguments = [];
+        return false;
+    }
+
+    private static string FormatPrimitiveType(string typeName)
+    {
+        return typeName switch
+        {
+            "String" => "string",
+            "Boolean" => "boolean",
+            "Byte" or "SByte" or "Int16" or "UInt16" or "Int32" or "UInt32" or
+                "Int64" or "UInt64" or "Single" or "Double" or "Decimal" => "number",
+            "Object" => "unknown",
+            _ => typeName,
+        };
     }
 
     /// <summary>
@@ -342,41 +436,109 @@ internal static class AtsTransformer
         {
             if (i + 1 < typeId.Length && typeId[i] == '[' && typeId[i + 1] == '[')
             {
-                result.Append("[[");
-                i += 2;
-
-                // Read the type name (up to the first comma or closing bracket)
-                while (i < typeId.Length && typeId[i] != ',' && typeId[i] != ']')
+                if (TryCleanGenericArgumentList(typeId, i, out var cleaned, out var nextIndex))
                 {
-                    result.Append(typeId[i]);
-                    i++;
-                }
-
-                // Skip assembly metadata: everything between the comma and "]]"
-                var depth = 1;
-                while (i < typeId.Length && depth > 0)
-                {
-                    if (i + 1 < typeId.Length && typeId[i] == ']' && typeId[i + 1] == ']')
-                    {
-                        depth--;
-                        if (depth == 0)
-                        {
-                            result.Append("]]");
-                            i += 2;
-                            break;
-                        }
-                    }
-                    i++;
+                    result.Append(cleaned);
+                    i = nextIndex;
+                    continue;
                 }
             }
-            else
-            {
-                result.Append(typeId[i]);
-                i++;
-            }
+
+            result.Append(typeId[i]);
+            i++;
         }
 
         return result.ToString();
+    }
+
+    private static bool TryCleanGenericArgumentList(
+        string typeId,
+        int startIndex,
+        out string cleaned,
+        out int nextIndex)
+    {
+        var result = new System.Text.StringBuilder();
+        result.Append("[[");
+        var i = startIndex + 2;
+
+        while (i < typeId.Length)
+        {
+            var argumentStart = i;
+            var bracketDepth = 0;
+            while (i < typeId.Length)
+            {
+                if (typeId[i] == '[')
+                {
+                    bracketDepth++;
+                }
+                else if (typeId[i] == ']')
+                {
+                    if (bracketDepth == 0)
+                    {
+                        break;
+                    }
+                    bracketDepth--;
+                }
+                i++;
+            }
+
+            if (i >= typeId.Length)
+            {
+                cleaned = "";
+                nextIndex = startIndex;
+                return false;
+            }
+
+            var argument = typeId[argumentStart..i];
+            var assemblySeparator = FindTopLevelComma(argument);
+            var typeName = assemblySeparator >= 0 ? argument[..assemblySeparator] : argument;
+            result.Append(CleanAssemblyQualifiedGenerics(typeName.Trim()));
+
+            if (i + 1 < typeId.Length && typeId[i + 1] == ']')
+            {
+                result.Append("]]");
+                cleaned = result.ToString();
+                nextIndex = i + 2;
+                return true;
+            }
+
+            if (i + 2 < typeId.Length && typeId[i + 1] == ',' && typeId[i + 2] == '[')
+            {
+                result.Append("],[");
+                i += 3;
+                continue;
+            }
+
+            cleaned = "";
+            nextIndex = startIndex;
+            return false;
+        }
+
+        cleaned = "";
+        nextIndex = startIndex;
+        return false;
+    }
+
+    private static int FindTopLevelComma(string value)
+    {
+        var bracketDepth = 0;
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '[')
+            {
+                bracketDepth++;
+            }
+            else if (value[i] == ']')
+            {
+                bracketDepth--;
+            }
+            else if (value[i] == ',' && bracketDepth == 0)
+            {
+                return i;
+            }
+        }
+
+        return -1;
     }
 
     /// <summary>

--- a/src/tools/AtsJsonGenerator/Helpers/AtsTransformer.cs
+++ b/src/tools/AtsJsonGenerator/Helpers/AtsTransformer.cs
@@ -123,6 +123,9 @@ internal static class AtsTransformer
                 .Select(i => StripAssemblyPrefix(i.TypeId))
                 .OrderBy(i => i)
                 .ToList(),
+            BaseTypeHierarchy = h.BaseTypeHierarchy
+                .Select(i => StripAssemblyPrefix(i.TypeId))
+                .ToList(),
         };
     }
 
@@ -203,7 +206,9 @@ internal static class AtsTransformer
             {
                 Name = p.Name,
                 Type = FormatTypeRef(p.Type),
-                IsOptional = p.IsOptional,
+                // The Aspire TypeScript SDK intentionally emits DTOs as partial
+                // object shapes, regardless of the raw ATS property's nullability.
+                IsOptional = true,
                 Description = NormalizeDoc(p.Documentation?.Summary) ?? NormalizeDoc(p.Description),
             }).ToList(),
         };

--- a/src/tools/AtsJsonGenerator/Helpers/Models.cs
+++ b/src/tools/AtsJsonGenerator/Helpers/Models.cs
@@ -398,6 +398,9 @@ internal sealed class TsHandleTypeModel
     [JsonPropertyName("implementedInterfaces")]
     public List<string> ImplementedInterfaces { get; init; } = [];
 
+    [JsonPropertyName("baseTypeHierarchy")]
+    public List<string> BaseTypeHierarchy { get; init; } = [];
+
     /// <summary>
     /// Capabilities that target this handle type.
     /// </summary>

--- a/src/tools/AtsJsonGenerator/generate-ts-api-json.ps1
+++ b/src/tools/AtsJsonGenerator/generate-ts-api-json.ps1
@@ -78,18 +78,18 @@ $RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
 $ToolProject = Join-Path $ScriptDir "AtsJsonGenerator.csproj"
 $AspireCliPath = if ([string]::IsNullOrWhiteSpace($env:ASPIRE_CLI_PATH)) { "aspire" } else { $env:ASPIRE_CLI_PATH }
 
-if (-not $OutputDir) {
-    $OutputDir = Join-Path $RepoRoot "src\frontend\src\data\ts-modules"
+$FinalOutputDir = if ($OutputDir) {
+    [System.IO.Path]::GetFullPath($OutputDir)
 }
-
-if (-not (Test-Path $OutputDir)) {
-    New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+else {
+    Join-Path $RepoRoot "src\frontend\src\data\ts-modules"
 }
+$OutputDir = Join-Path ([System.IO.Path]::GetDirectoryName($FinalOutputDir)) (
+    ".$([System.IO.Path]::GetFileName($FinalOutputDir))-staging-$([Guid]::NewGuid().ToString('N'))")
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 
 $TempDir = Join-Path $OutputDir ".tmp-dumps"
-if (-not (Test-Path $TempDir)) {
-    New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
-}
+New-Item -ItemType Directory -Path $TempDir -Force | Out-Null
 
 function Remove-StaleTsModuleFiles {
     param(
@@ -397,6 +397,37 @@ function Test-IsTypeScriptSdkPackage {
     )
 }
 
+function Get-CSharpHostingPackageMetadata {
+    $packageJsonDir = if (-not [string]::IsNullOrWhiteSpace($env:ASPIRE_API_PKGS_DIR)) {
+        [System.IO.Path]::GetFullPath($env:ASPIRE_API_PKGS_DIR)
+    }
+    else {
+        Join-Path $RepoRoot "src\frontend\src\data\pkgs"
+    }
+    if (-not (Test-Path $packageJsonDir)) {
+        return @()
+    }
+
+    return @(
+        Get-ChildItem -Path $packageJsonDir -Filter '*.json' -File |
+            ForEach-Object {
+                $json = Get-Content $_.FullName -Raw | ConvertFrom-Json
+                if ((Test-IsTypeScriptSdkPackage -PackageName $json.package.name) -and
+                    -not [string]::IsNullOrWhiteSpace($json.package.version)) {
+                    $sourceRepository = $json.package.PSObject.Properties["sourceRepository"]
+                    $sourceCommit = $json.package.PSObject.Properties["sourceCommit"]
+                    [PSCustomObject]@{
+                        Name             = [string]$json.package.name
+                        Version          = [string]$json.package.version
+                        SourceRepository = if ($sourceRepository) { [string]$sourceRepository.Value } else { $null }
+                        SourceCommit     = if ($sourceCommit) { [string]$sourceCommit.Value } else { $null }
+                        Path             = $_.FullName
+                    }
+                }
+            }
+    )
+}
+
 function Get-PackageSourceRepository {
     [CmdletBinding()]
     param([string]$PackageName)
@@ -415,44 +446,33 @@ function Get-PackageSourceRepository {
     return $null
 }
 
-if (-not $AspireRepoPath -and (-not $NuGetPackageVersion -or $NuGetPackageVersion.Count -eq 0)) {
+$generatedPackageMetadata = @(Get-CSharpHostingPackageMetadata)
+$packageMetadataBySpec = @{}
+foreach ($metadata in $generatedPackageMetadata) {
+    $spec = "$($metadata.Name)@$($metadata.Version)"
+    if ($packageMetadataBySpec.ContainsKey($spec)) {
+        throw "Duplicate generated C# package metadata for '$spec': '$($packageMetadataBySpec[$spec].Path)' and '$($metadata.Path)'."
+    }
+    $packageMetadataBySpec[$spec] = $metadata
+}
+
+$hasExplicitNuGetPackageVersion = $NuGetPackageVersion -and $NuGetPackageVersion.Count -gt 0
+if (-not $AspireRepoPath -and -not $hasExplicitNuGetPackageVersion) {
     Write-Host "No -AspireRepoPath or -NuGetPackageVersion provided. Auto-detecting from generated C# package JSON..." -ForegroundColor Cyan
 
-    $packageJsonDir = Join-Path $RepoRoot "src\frontend\src\data\pkgs"
-    if (-not (Test-Path $packageJsonDir)) {
-        Write-Error "C# package JSON directory not found at $packageJsonDir"
-        return
-    }
-
-    $packageFiles = @(Get-ChildItem -Path $packageJsonDir -Filter '*.json' -File)
-    if ($packageFiles.Count -eq 0) {
-        Write-Error "No generated C# package JSON files found in $packageJsonDir"
-        return
-    }
-
-    $hostingPackages = @(
-        $packageFiles |
-            ForEach-Object {
-                $json = Get-Content $_.FullName -Raw | ConvertFrom-Json
-                [PSCustomObject]@{
-                    Name         = $json.package.name
-                    Version      = $json.package.version
-                    LastWriteUtc = $_.LastWriteTimeUtc
-                }
-            } |
-            Where-Object {
-                (Test-IsTypeScriptSdkPackage -PackageName $_.Name) -and
-                -not [string]::IsNullOrWhiteSpace($_.Version)
-            } |
-            Group-Object Name |
-            ForEach-Object {
-                $_.Group | Sort-Object LastWriteUtc -Descending | Select-Object -First 1
-            }
-    )
+    $hostingPackages = @($generatedPackageMetadata)
 
     if ($hostingPackages.Count -eq 0) {
-        Write-Error "No TypeScript SDK package JSON files found in $packageJsonDir"
+        Write-Error "No TypeScript SDK package JSON files found in src/frontend/src/data/pkgs"
         return
+    }
+
+    $duplicatePackages = @($hostingPackages | Group-Object Name | Where-Object Count -gt 1)
+    if ($duplicatePackages.Count -gt 0) {
+        $details = $duplicatePackages | ForEach-Object {
+            "$($_.Name): $((@($_.Group) | ForEach-Object { "$($_.Version) [$($_.Path)]" }) -join ', ')"
+        }
+        throw "Multiple generated C# package versions prevent deterministic TypeScript API generation:`n  $($details -join "`n  ")"
     }
 
     # Build Name@Version entries directly from the generated C# package data.
@@ -527,6 +547,8 @@ if ($AspireRepoPath) {
         $Packages += @{
             Name = "Aspire.Hosting"
             DumpArgs = @($coreCsproj)
+            SourceRepository = Get-PackageSourceRepository -PackageName "Aspire.Hosting"
+            SourceCommit = $null
         }
         }
     }
@@ -557,6 +579,8 @@ if ($AspireRepoPath) {
             $Packages += @{
                 Name = $dir.Name
                 DumpArgs = @($csproj)
+                SourceRepository = Get-PackageSourceRepository -PackageName $dir.Name
+                SourceCommit = $null
             }
         }
     }
@@ -573,6 +597,10 @@ if ($NuGetPackageVersion -and $NuGetPackageVersion.Count -gt 0) {
         }
         $pkgName = $Matches[1]
         $pkgVersion = $Matches[2]
+        $packageMetadata = $packageMetadataBySpec["$pkgName@$pkgVersion"]
+        if ($null -eq $packageMetadata) {
+            throw "No exact generated C# package metadata was found for '$pkgName@$pkgVersion'. Run generate-package-json.ps1 first."
+        }
 
         if (-not (Test-IsTypeScriptSdkPackage -PackageName $pkgName)) {
             Write-Warning "Skipping $pkgName — only Aspire.Hosting* and CommunityToolkit.Aspire.Hosting* packages have ATS capabilities"
@@ -583,6 +611,8 @@ if ($NuGetPackageVersion -and $NuGetPackageVersion.Count -gt 0) {
             Name = $pkgName
             Version = $pkgVersion
             DumpArgs = @("$pkgName@$pkgVersion")
+            SourceRepository = $packageMetadata.SourceRepository
+            SourceCommit = $packageMetadata.SourceCommit
         }
     }
 }
@@ -623,8 +653,9 @@ Write-Host ""
 Write-Host "Building AtsJsonGenerator..." -ForegroundColor Cyan
 & dotnet build $ToolProject --nologo -v q 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to build AtsJsonGenerator"
-    return
+    Write-Host "Failed to build AtsJsonGenerator" -ForegroundColor Red
+    Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+    exit 1
 }
 
 # ── Generate ATS dumps ─────────────────────────────────────────────────────────
@@ -636,6 +667,10 @@ $integrationPackages = @($Packages | Where-Object { $_.Name -ne "Aspire.Hosting"
 $success = 0
 $failed = 0
 $skipped = 0
+$failedPackageNames = [System.Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
+$skippedPackageNames = [System.Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
 $coreOutputFile = $null
 
 # Process core first
@@ -664,12 +699,14 @@ foreach ($pkg in $corePackages) {
             Write-Warning "  aspire sdk dump failed (exit $($proc.ExitCode))"
             if ($stderr) { Write-Warning "  $stderr" }
             $failed++
+            [void]$failedPackageNames.Add($name)
             continue
         }
 
         if (-not (Test-Path $dumpFile)) {
             Write-Warning "  Dump file not created"
             $failed++
+            [void]$failedPackageNames.Add($name)
             continue
         }
 
@@ -680,6 +717,7 @@ foreach ($pkg in $corePackages) {
     catch {
         Write-Warning "  Error running aspire sdk dump: $_"
         $failed++
+        [void]$failedPackageNames.Add($name)
         continue
     }
 
@@ -692,9 +730,12 @@ foreach ($pkg in $corePackages) {
             "--output", $outputFile,
             "--package-name", $name
         )
-        $sourceRepository = Get-PackageSourceRepository -PackageName $name
+        $sourceRepository = $pkg.SourceRepository
         if ($sourceRepository) {
             $transformArgs += @("--source-repo", $sourceRepository)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($pkg.SourceCommit)) {
+            $transformArgs += @("--source-commit", $pkg.SourceCommit)
         }
 
         & dotnet @transformArgs 2>&1 | ForEach-Object {
@@ -714,11 +755,13 @@ foreach ($pkg in $corePackages) {
         } else {
             Write-Warning "  Transform failed"
             $failed++
+            [void]$failedPackageNames.Add($name)
         }
     }
     catch {
         Write-Warning "  Error transforming: $_"
         $failed++
+        [void]$failedPackageNames.Add($name)
     }
 }
 
@@ -754,12 +797,14 @@ foreach ($pkg in $integrationPackages | Sort-Object { $_.Name }) {
             Write-Warning "  aspire sdk dump failed (exit $($proc.ExitCode))"
             if ($stderr) { Write-Warning "  $stderr" }
             $failed++
+            [void]$failedPackageNames.Add($name)
             continue
         }
 
         if (-not (Test-Path $dumpFile)) {
             Write-Warning "  Dump file not created"
             $failed++
+            [void]$failedPackageNames.Add($name)
             continue
         }
 
@@ -770,6 +815,7 @@ foreach ($pkg in $integrationPackages | Sort-Object { $_.Name }) {
     catch {
         Write-Warning "  Error running aspire sdk dump: $_"
         $failed++
+        [void]$failedPackageNames.Add($name)
         continue
     }
 
@@ -782,9 +828,12 @@ foreach ($pkg in $integrationPackages | Sort-Object { $_.Name }) {
             "--output", $outputFile,
             "--package-name", $name
         )
-        $sourceRepository = Get-PackageSourceRepository -PackageName $name
+        $sourceRepository = $pkg.SourceRepository
         if ($sourceRepository) {
             $transformArgs += @("--source-repo", $sourceRepository)
+        }
+        if (-not [string]::IsNullOrWhiteSpace($pkg.SourceCommit)) {
+            $transformArgs += @("--source-commit", $pkg.SourceCommit)
         }
 
         # Dedup against core if available
@@ -806,25 +855,34 @@ foreach ($pkg in $integrationPackages | Sort-Object { $_.Name }) {
             }
             if (Remove-EmptyTsModuleFile -PackageName $name -OutputFile $outputFile) {
                 $skipped++
+                [void]$skippedPackageNames.Add($name)
             } else {
                 $success++
             }
         } else {
             Write-Warning "  Transform failed"
             $failed++
+            [void]$failedPackageNames.Add($name)
         }
     }
     catch {
         Write-Warning "  Error transforming: $_"
         $failed++
+        [void]$failedPackageNames.Add($name)
     }
 }
 
-# ── Cleanup ────────────────────────────────────────────────────────────────────
+# ── Reconcile and cleanup ───────────────────────────────────────────────────────
 
 Write-Host ""
 Write-Host "════════════════════════════════════════════════════" -ForegroundColor White
 Write-Host "Complete: $success succeeded, $failed failed, $skipped skipped" -ForegroundColor $(if ($failed -gt 0) { "Yellow" } else { "Green" })
+if ($failedPackageNames.Count -gt 0) {
+    Write-Host "Failed packages: $(($failedPackageNames | Sort-Object) -join ', ')" -ForegroundColor Red
+}
+if ($skippedPackageNames.Count -gt 0) {
+    Write-Host "Skipped packages: $(($skippedPackageNames | Sort-Object) -join ', ')" -ForegroundColor Yellow
+}
 
 # Clean up temp files
 if (Test-Path $TempDir) {
@@ -834,3 +892,47 @@ if (Test-Path $TempDir) {
 if ($aspireCliWorkingDirectory -and (Test-Path $aspireCliWorkingDirectory)) {
     Remove-Item $aspireCliWorkingDirectory -Recurse -Force -ErrorAction SilentlyContinue
 }
+
+if ($failed -gt 0) {
+    Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+New-Item -ItemType Directory -Path $FinalOutputDir -Force | Out-Null
+$stagedFiles = @(Get-ChildItem -Path $OutputDir -Filter "*.json" -File)
+$stagedNames = [System.Collections.Generic.HashSet[string]]::new(
+    [StringComparer]::OrdinalIgnoreCase)
+foreach ($file in $stagedFiles) {
+    [void]$stagedNames.Add($file.Name)
+}
+
+$isFullReconciliation = -not $AspireRepoPath -and -not $PackageFilter -and -not $hasExplicitNuGetPackageVersion
+if ($isFullReconciliation) {
+    foreach ($existingFile in Get-ChildItem -Path $FinalOutputDir -Filter "*.json" -File) {
+        if (-not $stagedNames.Contains($existingFile.Name)) {
+            Remove-Item -Path $existingFile.FullName -Force
+            Write-Host "Removed stale module: $($existingFile.Name)" -ForegroundColor DarkYellow
+        }
+    }
+}
+else {
+    foreach ($pkg in $Packages) {
+        $packageFilePattern = "^{0}(?:\.\d.*)?\.json$" -f [regex]::Escape($pkg.Name)
+        $stagedForPackage = @($stagedFiles | Where-Object {
+            $_.Name -match $packageFilePattern
+        })
+        foreach ($existingFile in Get-ChildItem -Path $FinalOutputDir -Filter "*.json" -File | Where-Object {
+            $_.Name -match $packageFilePattern
+        }) {
+            if ($existingFile.Name -notin $stagedForPackage.Name) {
+                Remove-Item -Path $existingFile.FullName -Force
+                Write-Host "Removed stale module: $($existingFile.Name)" -ForegroundColor DarkYellow
+            }
+        }
+    }
+}
+
+foreach ($file in $stagedFiles) {
+    Copy-Item -Path $file.FullName -Destination (Join-Path $FinalOutputDir $file.Name) -Force
+}
+Remove-Item -Path $OutputDir -Recurse -Force

--- a/src/tools/PackageJsonGenerator/BatchGenerateCommand.cs
+++ b/src/tools/PackageJsonGenerator/BatchGenerateCommand.cs
@@ -75,7 +75,7 @@ internal static class BatchGenerateCommand
         var referenceCache = new ConcurrentDictionary<string, PortableExecutableReference>(
             StringComparer.OrdinalIgnoreCase);
 
-        int success = 0, failed = 0;
+        int success = 0, failed = 0, skipped = 0;
 
         Parallel.ForEach(
             manifest.Packages,
@@ -84,7 +84,7 @@ internal static class BatchGenerateCommand
             {
                 try
                 {
-                    PackageJsonGenerator.GeneratePackageJson(
+                    var generated = PackageJsonGenerator.GeneratePackageJson(
                         pkg.Input,
                         pkg.References,
                         pkg.Output,
@@ -95,7 +95,16 @@ internal static class BatchGenerateCommand
                         pkg.TargetFramework,
                         referenceCache);
 
-                    Interlocked.Increment(ref success);
+                    if (generated)
+                    {
+                        Console.WriteLine($"SUCCEEDED [{pkg.PackageName}]: {pkg.Output}");
+                        Interlocked.Increment(ref success);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"SKIPPED [{pkg.PackageName}]: no public API");
+                        Interlocked.Increment(ref skipped);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -105,7 +114,7 @@ internal static class BatchGenerateCommand
             });
 
         sw.Stop();
-        Console.WriteLine($"Batch complete in {sw.Elapsed.TotalSeconds:F1}s: {success} succeeded, {failed} failed");
+        Console.WriteLine($"Batch complete in {sw.Elapsed.TotalSeconds:F1}s: {success} succeeded, {failed} failed, {skipped} skipped");
 
         return failed > 0 ? 1 : 0;
     }

--- a/src/tools/PackageJsonGenerator/Helpers/CanonicalModelBuilder.cs
+++ b/src/tools/PackageJsonGenerator/Helpers/CanonicalModelBuilder.cs
@@ -571,7 +571,146 @@ internal sealed class CanonicalModelBuilder(Compilation compilation)
             baseSymbol = FindInheritDocSource(symbol);
         }
 
-        return baseSymbol is not null ? ExtractDocumentation(baseSymbol, inheritDepth + 1) : null;
+        if (baseSymbol is null)
+        {
+            return null;
+        }
+
+        var inherited = ExtractDocumentation(baseSymbol, inheritDepth + 1);
+        if (inherited is not null)
+        {
+            SubstituteInheritedTypeParameters(inherited, baseSymbol);
+        }
+
+        return inherited;
+    }
+
+    private static void SubstituteInheritedTypeParameters(
+        CanonicalDocumentation documentation,
+        ISymbol sourceSymbol)
+    {
+        var substitutions = new Dictionary<string, ITypeSymbol>(StringComparer.Ordinal);
+        AddTypeParameterSubstitutions(sourceSymbol.ContainingType, substitutions);
+        if (sourceSymbol is INamedTypeSymbol namedType)
+        {
+            AddTypeParameterSubstitutions(namedType, substitutions);
+        }
+        if (sourceSymbol is IMethodSymbol method)
+        {
+            AddTypeParameterSubstitutions(method, substitutions);
+        }
+
+        if (substitutions.Count == 0)
+        {
+            return;
+        }
+
+        SubstituteDocNodes(documentation.Summary, substitutions);
+        SubstituteDocNodes(documentation.Remarks, substitutions);
+        SubstituteDocNodes(documentation.Returns, substitutions);
+        SubstituteDocNodes(documentation.Value, substitutions);
+        foreach (var nodes in documentation.Parameters?.Values ?? Enumerable.Empty<List<DocNode>>())
+        {
+            SubstituteDocNodes(nodes, substitutions);
+        }
+        foreach (var nodes in documentation.TypeParameters?.Values ?? Enumerable.Empty<List<DocNode>>())
+        {
+            SubstituteDocNodes(nodes, substitutions);
+        }
+        foreach (var exception in documentation.Exceptions ?? [])
+        {
+            SubstituteDocNodes(exception.Description, substitutions);
+        }
+        foreach (var example in documentation.Examples ?? [])
+        {
+            SubstituteDocNodes(example.Description, substitutions);
+        }
+    }
+
+    private static void AddTypeParameterSubstitutions(
+        INamedTypeSymbol? type,
+        Dictionary<string, ITypeSymbol> substitutions)
+    {
+        if (type is null)
+        {
+            return;
+        }
+
+        AddTypeParameterSubstitutions(type.ContainingType, substitutions);
+        AddTypeParameterSubstitutions(
+            type.OriginalDefinition.TypeParameters,
+            type.TypeArguments,
+            substitutions);
+    }
+
+    private static void AddTypeParameterSubstitutions(
+        IMethodSymbol method,
+        Dictionary<string, ITypeSymbol> substitutions)
+    {
+        AddTypeParameterSubstitutions(
+            method.OriginalDefinition.TypeParameters,
+            method.TypeArguments,
+            substitutions);
+    }
+
+    private static void AddTypeParameterSubstitutions(
+        ImmutableArray<ITypeParameterSymbol> parameters,
+        ImmutableArray<ITypeSymbol> arguments,
+        Dictionary<string, ITypeSymbol> substitutions)
+    {
+        for (var index = 0; index < Math.Min(parameters.Length, arguments.Length); index++)
+        {
+            var argument = arguments[index];
+            if (SymbolEqualityComparer.Default.Equals(parameters[index], argument))
+            {
+                continue;
+            }
+
+            substitutions[parameters[index].Name] = argument;
+        }
+    }
+
+    private static void SubstituteDocNodes(
+        List<DocNode>? nodes,
+        IReadOnlyDictionary<string, ITypeSymbol> substitutions)
+    {
+        foreach (var node in nodes ?? [])
+        {
+            if (node.Kind == "typeparamref" &&
+                node.Value is not null &&
+                substitutions.TryGetValue(node.Value, out var argument))
+            {
+                if (argument is ITypeParameterSymbol typeParameter)
+                {
+                    node.Value = typeParameter.Name;
+                }
+                else
+                {
+                    var documentationId = argument.GetDocumentationCommentId();
+                    if (documentationId is not null)
+                    {
+                        node.Kind = "cref";
+                        node.Value = documentationId;
+                        node.Text = null;
+                    }
+                    else
+                    {
+                        node.Kind = "code";
+                        node.Text = argument.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
+                        node.Value = null;
+                    }
+                }
+            }
+
+            SubstituteDocNodes(node.Children, substitutions);
+            SubstituteDocNodes(node.Header?.Term, substitutions);
+            SubstituteDocNodes(node.Header?.Description, substitutions);
+            foreach (var item in node.Items ?? [])
+            {
+                SubstituteDocNodes(item.Term, substitutions);
+                SubstituteDocNodes(item.Description, substitutions);
+            }
+        }
     }
 
     /// <summary>

--- a/src/tools/PackageJsonGenerator/PackageJsonGenerator.cs
+++ b/src/tools/PackageJsonGenerator/PackageJsonGenerator.cs
@@ -14,7 +14,7 @@ public static class PackageJsonGenerator
 {
     private const string NewAspireRepositoryUrl = "https://github.com/microsoft/aspire";
 
-    public static void GeneratePackageJson(string? inputAssembly, string[]? references, string? outputFile, string? versionOverride = null, string? packageNameOverride = null, string? sourceRepoOverride = null, string? sourceCommitOverride = null, string? targetFrameworkOverride = null, ConcurrentDictionary<string, PortableExecutableReference>? referenceCache = null)
+    public static bool GeneratePackageJson(string? inputAssembly, string[]? references, string? outputFile, string? versionOverride = null, string? packageNameOverride = null, string? sourceRepoOverride = null, string? sourceCommitOverride = null, string? targetFrameworkOverride = null, ConcurrentDictionary<string, PortableExecutableReference>? referenceCache = null)
     {
         if (string.IsNullOrEmpty(inputAssembly))
         {
@@ -40,20 +40,25 @@ public static class PackageJsonGenerator
             references: resolvedRefs.Concat([inputReference]));
 
         var assemblySymbol = (IAssemblySymbol)compilation.GetAssemblyOrModuleSymbol(inputReference)!;
+        var packageName = !string.IsNullOrEmpty(packageNameOverride)
+            ? packageNameOverride
+            : assemblySymbol.Name;
 
         // Collect all public types from the assembly
         var types = new List<INamedTypeSymbol>();
         CollectTypes(assemblySymbol.GlobalNamespace, types, assemblySymbol);
 
+        ValidateRelevantAttributes(types, packageName);
+        ValidateReferencedAssemblies(compilation, assemblySymbol, packageName);
+        ValidatePublicApiTypes(types, packageName);
+
         if (types.Count == 0)
         {
             Console.WriteLine($"No public types found in assembly: {assemblySymbol.Name}");
-            return;
+            return false;
         }
 
-        var assemblyName = !string.IsNullOrEmpty(packageNameOverride)
-            ? packageNameOverride
-            : assemblySymbol.Name;
+        var assemblyName = packageName;
         var assemblyVersion = !string.IsNullOrEmpty(versionOverride)
             ? versionOverride
             : assemblySymbol.Identity.Version.ToString();
@@ -173,6 +178,7 @@ public static class PackageJsonGenerator
 
         var wroteFile = StableFileWriter.WriteIfChanged(outputFile, schemaJson);
         Console.WriteLine($"{(wroteFile ? "Generated" : "Unchanged")}: {outputFile}");
+        return true;
     }
 
     internal static PortableExecutableReference CreateMetadataReference(string path)
@@ -224,6 +230,271 @@ public static class PackageJsonGenerator
         return type.Name.StartsWith("<") ||
                type.GetAttributes().Any(a =>
                    a.AttributeClass?.Name == "CompilerGeneratedAttribute");
+    }
+
+    private static void ValidateReferencedAssemblies(
+        Compilation compilation,
+        IAssemblySymbol assembly,
+        string packageName)
+    {
+        var missingReferences = assembly.Modules
+            .SelectMany(module => module.ReferencedAssemblySymbols)
+            .Where(reference => compilation.GetMetadataReference(reference) is null)
+            .Select(reference => reference.Identity.ToString())
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(identity => identity, StringComparer.Ordinal)
+            .ToArray();
+
+        if (missingReferences.Length > 0)
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageName}' assembly '{assembly.Name}' has unresolved referenced assemblies: {string.Join(", ", missingReferences)}.");
+        }
+    }
+
+    private static void ValidateRelevantAttributes(IEnumerable<INamedTypeSymbol> types, string packageName)
+    {
+        foreach (var symbol in EnumerateAttributedSymbols(types))
+        {
+            foreach (var attribute in symbol.GetAttributes())
+            {
+                var attributeName = GetRelevantAttributeName(attribute);
+                if (attributeName is null)
+                {
+                    continue;
+                }
+
+                string? problem = null;
+                if (attribute.AttributeClass is null || attribute.AttributeClass.TypeKind == TypeKind.Error)
+                {
+                    problem = "attribute class could not be resolved";
+                }
+                else if (attribute.AttributeConstructor is null ||
+                         attribute.AttributeConstructor.ContainingType.TypeKind == TypeKind.Error)
+                {
+                    problem = "attribute constructor could not be resolved";
+                }
+                else if (attribute.ConstructorArguments.Any(ContainsErrorValue))
+                {
+                    problem = "constructor arguments contain an unresolved value";
+                }
+                else if (attribute.NamedArguments.Any(argument => ContainsErrorValue(argument.Value)))
+                {
+                    problem = "named arguments contain an unresolved value";
+                }
+
+                if (problem is not null)
+                {
+                    throw new InvalidOperationException(
+                        $"Package '{packageName}', symbol '{symbol.ToDisplayString()}', attribute '{attributeName}': {problem}.");
+                }
+            }
+        }
+    }
+
+    private static IEnumerable<ISymbol> EnumerateAttributedSymbols(IEnumerable<INamedTypeSymbol> types)
+    {
+        var seen = new HashSet<ISymbol>(SymbolEqualityComparer.Default);
+
+        foreach (var type in types)
+        {
+            if (seen.Add(type))
+            {
+                yield return type;
+            }
+
+            foreach (var member in type.GetMembers())
+            {
+                if (seen.Add(member))
+                {
+                    yield return member;
+                }
+
+                if (member is IMethodSymbol method)
+                {
+                    foreach (var parameter in method.Parameters)
+                    {
+                        if (seen.Add(parameter))
+                        {
+                            yield return parameter;
+                        }
+                    }
+                }
+                else if (member is IPropertySymbol property)
+                {
+                    foreach (var parameter in property.Parameters)
+                    {
+                        if (seen.Add(parameter))
+                        {
+                            yield return parameter;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static string? GetRelevantAttributeName(AttributeData attribute)
+    {
+        string[] relevantAttributeNames =
+        [
+            "AspireExportAttribute",
+            "AspireExportIgnoreAttribute",
+            "AspireDtoAttribute",
+            "AspireUnionAttribute",
+        ];
+
+        var className = attribute.AttributeClass?.Name;
+        if (className is not null && relevantAttributeNames.Contains(className, StringComparer.Ordinal))
+        {
+            return className;
+        }
+
+        var constructorTypeName = attribute.AttributeConstructor?.ContainingType.Name;
+        if (constructorTypeName is not null &&
+            relevantAttributeNames.Contains(constructorTypeName, StringComparer.Ordinal))
+        {
+            return constructorTypeName;
+        }
+
+        var display = attribute.ToString();
+        return relevantAttributeNames.FirstOrDefault(
+            name => display.Contains(name, StringComparison.Ordinal));
+    }
+
+    private static bool ContainsErrorValue(TypedConstant constant)
+    {
+        if (constant.Kind == TypedConstantKind.Error || ContainsErrorType(constant.Type))
+        {
+            return true;
+        }
+
+        if (constant.Kind == TypedConstantKind.Array)
+        {
+            return constant.Values.Any(ContainsErrorValue);
+        }
+
+        if (constant.Value is ITypeSymbol typeValue && ContainsErrorType(typeValue))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static void ValidatePublicApiTypes(IEnumerable<INamedTypeSymbol> types, string packageName)
+    {
+        foreach (var type in types)
+        {
+            ValidateTypeReference(type, type.BaseType, "base type", packageName);
+            foreach (var interfaceType in type.Interfaces)
+            {
+                ValidateTypeReference(type, interfaceType, "implemented interface", packageName);
+            }
+            ValidateTypeParameterConstraints(type, type.TypeParameters, packageName);
+
+            if (type.DelegateInvokeMethod is { } delegateInvoke)
+            {
+                ValidateMethodTypes(delegateInvoke, packageName);
+            }
+
+            foreach (var member in type.GetMembers()
+                         .Where(member => member.DeclaredAccessibility == Accessibility.Public &&
+                                          !member.IsImplicitlyDeclared))
+            {
+                switch (member)
+                {
+                    case IMethodSymbol method:
+                        ValidateMethodTypes(method, packageName);
+                        break;
+                    case IPropertySymbol property:
+                        ValidateTypeReference(property, property.Type, "property type", packageName);
+                        foreach (var parameter in property.Parameters)
+                        {
+                            ValidateTypeReference(parameter, parameter.Type, "parameter type", packageName);
+                        }
+                        break;
+                    case IFieldSymbol field:
+                        ValidateTypeReference(field, field.Type, "field type", packageName);
+                        break;
+                    case IEventSymbol eventSymbol:
+                        ValidateTypeReference(eventSymbol, eventSymbol.Type, "event type", packageName);
+                        break;
+                }
+            }
+        }
+    }
+
+    private static void ValidateMethodTypes(IMethodSymbol method, string packageName)
+    {
+        if (method.MethodKind != MethodKind.Constructor &&
+            method.MethodKind != MethodKind.StaticConstructor)
+        {
+            ValidateTypeReference(method, method.ReturnType, "return type", packageName);
+        }
+
+        foreach (var parameter in method.Parameters)
+        {
+            ValidateTypeReference(parameter, parameter.Type, "parameter type", packageName);
+        }
+        ValidateTypeParameterConstraints(method, method.TypeParameters, packageName);
+    }
+
+    private static void ValidateTypeParameterConstraints(
+        ISymbol owner,
+        IEnumerable<ITypeParameterSymbol> typeParameters,
+        string packageName)
+    {
+        foreach (var typeParameter in typeParameters)
+        {
+            foreach (var constraintType in typeParameter.ConstraintTypes)
+            {
+                ValidateTypeReference(
+                    owner,
+                    constraintType,
+                    $"constraint for type parameter '{typeParameter.Name}'",
+                    packageName);
+            }
+        }
+    }
+
+    private static void ValidateTypeReference(
+        ISymbol owner,
+        ITypeSymbol? type,
+        string location,
+        string packageName)
+    {
+        if (type is not null && ContainsErrorType(type))
+        {
+            throw new InvalidOperationException(
+                $"Package '{packageName}', symbol '{owner.ToDisplayString()}', {location} contains unresolved public API type '{type.ToDisplayString()}'.");
+        }
+    }
+
+    private static bool ContainsErrorType(ITypeSymbol? type)
+    {
+        if (type is null)
+        {
+            return false;
+        }
+
+        if (type.TypeKind == TypeKind.Error)
+        {
+            return true;
+        }
+
+        return type switch
+        {
+            IArrayTypeSymbol arrayType => ContainsErrorType(arrayType.ElementType),
+            IPointerTypeSymbol pointerType => ContainsErrorType(pointerType.PointedAtType),
+            IFunctionPointerTypeSymbol functionPointer =>
+                ContainsErrorType(functionPointer.Signature.ReturnType) ||
+                functionPointer.Signature.Parameters.Any(parameter => ContainsErrorType(parameter.Type)),
+            INamedTypeSymbol namedType =>
+                ContainsErrorType(namedType.ContainingType) ||
+                namedType.TypeArguments.Any(ContainsErrorType),
+            _ => false,
+        };
     }
 
     /// <summary>

--- a/src/tools/PackageJsonGenerator/README.md
+++ b/src/tools/PackageJsonGenerator/README.md
@@ -107,6 +107,8 @@ dotnet run --project ../PackageJsonGenerator/PackageJsonGenerator.csproj -- \
 - Output is deterministically formatted (alphabetically sorted) for version control friendliness
 - Only `public` types and members are included in the output
 - Compiler-generated types (e.g., closure classes) are automatically filtered out
-- The emitted `targetFramework` should match the selected `lib/<tfm>` folder for the analyzed package
-- The companion `generate-package-json.ps1` script resolves official `Aspire.*` packages from a branch-specific Azure Artifacts feed on `release/*` branches and uses nuget.org elsewhere
+- The emitted `targetFramework` matches the compile/runtime asset selected by NuGet for the analyzed package
+- The companion `generate-package-json.ps1` script restores every package independently, uses catalog-pinned versions, and reads `project.assets.json` for exact direct and transitive package references
+- Metadata loading includes the matching .NET and ASP.NET Core reference packs; official `Aspire.*` packages resolve from a branch-specific Azure Artifacts feed on `release/*` branches and use nuget.org elsewhere
+- Generation fails when input references or Aspire export attribute metadata cannot be resolved, rather than emitting incomplete attribute payloads
 - When the matching `microsoft/aspire` release branch is not publicly reachable yet, set `ASPIRE_RELEASE_FEED_URL`, `ASPIRE_RELEASE_FEED_NAME`, or `ASPIRE_RELEASE_COMMIT` before running the script

--- a/src/tools/PackageJsonGenerator/generate-package-json.ps1
+++ b/src/tools/PackageJsonGenerator/generate-package-json.ps1
@@ -1,16 +1,15 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Downloads NuGet packages (if not already cached) and generates Package.Version.json
+    Restores NuGet packages and generates Package.Version.json
     files for each using the PackageJsonGenerator tool.
 
 .DESCRIPTION
     For each package in the list, this script:
     1. Queries the NuGet V3 API for the latest stable version (or latest preview if no stable exists).
-    2. Checks the local NuGet cache for the package.
-    3. Downloads the package via `dotnet restore` if not cached.
-    4. Locates the best-matching TFM lib folder inside the package.
-    5. Runs the PackageJsonGenerator tool in batch mode, passing all packages at once
+    2. Restores each package into an isolated project.
+    3. Reads NuGet's exact direct and transitive assets from project.assets.json.
+    4. Runs the PackageJsonGenerator tool in batch mode, passing all packages at once
        for parallel processing.
 
 .PARAMETER Packages
@@ -22,8 +21,7 @@
     Defaults to <repo-root>/src/frontend/src/data/packages.
 
 .PARAMETER Framework
-    Fallback target framework moniker used when restoring packages or when a
-    lib folder/framework cannot be inferred automatically.
+    Target framework moniker used for each isolated NuGet restore.
     Defaults to "net10.0".
 
 .PARAMETER Parallelism
@@ -65,16 +63,18 @@ $script:NuGetSourceMetadataCache = @{}
 # ── Resolve paths ──────────────────────────────────────────────────────────────
 
 $ScriptDir = $PSScriptRoot
-$RepoRoot = (Resolve-Path (Join-Path $ScriptDir "..\..\..")).Path
+$RepoRoot = (Resolve-Path ([System.IO.Path]::Combine($ScriptDir, "..", "..", ".."))).Path
 $ToolProject = Join-Path $ScriptDir "PackageJsonGenerator.csproj"
 
-if (-not $OutputDir) {
-    $OutputDir = Join-Path $RepoRoot "src\frontend\src\data\pkgs"
+$FinalOutputDir = if ($OutputDir) {
+    [System.IO.Path]::GetFullPath($OutputDir)
 }
-
-if (-not (Test-Path $OutputDir)) {
-    New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
+else {
+    [System.IO.Path]::Combine($RepoRoot, "src", "frontend", "src", "data", "pkgs")
 }
+$OutputDir = Join-Path ([System.IO.Path]::GetDirectoryName($FinalOutputDir)) (
+    ".$([System.IO.Path]::GetFileName($FinalOutputDir))-staging-$([Guid]::NewGuid().ToString('N'))")
+New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 
 function Remove-StalePackageJsonFiles {
     [CmdletBinding()]
@@ -98,30 +98,31 @@ function Remove-StalePackageJsonFiles {
 
 # ── Default package list ───────────────────────────────────────────────────────
 
-if (-not $Packages -or $Packages.Count -eq 0) {
-    # Read from aspire-integrations.json
-    $integrationsFile = Join-Path $RepoRoot "src\frontend\src\data\aspire-integrations.json"
-    if (Test-Path $integrationsFile) {
-        $integrations = Get-Content $integrationsFile -Raw | ConvertFrom-Json
+$integrationsFile = [System.IO.Path]::Combine($RepoRoot, "src", "frontend", "src", "data", "aspire-integrations.json")
+$integrations = if (Test-Path $integrationsFile) {
+    @(Get-Content $integrationsFile -Raw | ConvertFrom-Json)
+}
+else {
+    @()
+}
+$catalogVersions = @{}
+foreach ($integration in $integrations) {
+    if (-not [string]::IsNullOrWhiteSpace($integration.title) -and
+        -not [string]::IsNullOrWhiteSpace($integration.version)) {
+        $catalogVersions[$integration.title] = $integration.version
+    }
+}
+
+$isFullReconciliation = -not $Packages -or $Packages.Count -eq 0
+if ($isFullReconciliation) {
+    if ($integrations.Count -gt 0) {
         $Packages = @($integrations | ForEach-Object { $_.title } | Sort-Object -Unique)
         Write-Host "Loaded $($Packages.Count) packages from aspire-integrations.json"
     }
     else {
         Write-Error "No packages specified and aspire-integrations.json not found at $integrationsFile"
-        return
+        exit 1
     }
-}
-
-# ── NuGet cache location ──────────────────────────────────────────────────────
-
-$NuGetCache = if ($env:NUGET_PACKAGES) {
-    $env:NUGET_PACKAGES
-}
-elseif ($IsWindows -or $env:OS -eq "Windows_NT") {
-    Join-Path $env:USERPROFILE ".nuget\packages"
-}
-else {
-    Join-Path $HOME ".nuget/packages"
 }
 
 # ── NuGet API helpers ─────────────────────────────────────────────────────────
@@ -404,21 +405,55 @@ function Get-LatestNuGetVersion {
     return $null
 }
 
-function Get-CachedPackagePath {
+function ConvertTo-NativeAssetPath {
+    [CmdletBinding()]
+    param([string]$Path)
+
+    return $Path.Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+}
+
+function Get-AssetPaths {
     [CmdletBinding()]
     param(
-        [string]$PackageId,
-        [string]$Version
+        [object]$TargetLibrary,
+        [string]$AssetKind,
+        [string]$PackagePath
     )
 
-    $packageDir = Join-Path $NuGetCache "$($PackageId.ToLowerInvariant())\$Version"
-    if (Test-Path $packageDir) {
-        return $packageDir
+    $assetProperty = $TargetLibrary.PSObject.Properties[$AssetKind]
+    if (-not $assetProperty) {
+        return @()
     }
+
+    return @($assetProperty.Value.PSObject.Properties |
+        Where-Object { $_.Name -ne "_._" -and $_.Name.EndsWith(".dll", [System.StringComparison]::OrdinalIgnoreCase) } |
+        ForEach-Object {
+            $path = Join-Path $PackagePath (ConvertTo-NativeAssetPath -Path $_.Name)
+            if (Test-Path $path) {
+                [System.IO.Path]::GetFullPath($path)
+            }
+        })
+}
+
+function Resolve-RestoredPackagePath {
+    [CmdletBinding()]
+    param(
+        [string[]]$PackageFolders,
+        [string]$LibraryPath
+    )
+
+    $nativeLibraryPath = ConvertTo-NativeAssetPath -Path $LibraryPath
+    foreach ($packageFolder in $PackageFolders) {
+        $candidate = Join-Path $packageFolder $nativeLibraryPath
+        if (Test-Path $candidate) {
+            return [System.IO.Path]::GetFullPath($candidate)
+        }
+    }
+
     return $null
 }
 
-function Install-NuGetPackage {
+function Resolve-NuGetPackageRestoreGraph {
     [CmdletBinding()]
     param(
         [string]$PackageId,
@@ -426,24 +461,29 @@ function Install-NuGetPackage {
         [string[]]$RestoreSources
     )
 
-    # Create a temp project to restore the package into the global cache
-    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "pkgjson-$([System.Guid]::NewGuid().ToString('N').Substring(0,8))"
-    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    # A separate restore project is intentional: it prevents NuGet from unifying
+    # dependency versions across otherwise unrelated packages.
+    $workRoot = Join-Path $ScriptDir ".package-json-generator-work"
+    $restoreDir = Join-Path $workRoot "restore-$([System.Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $restoreDir -Force | Out-Null
 
     try {
+        $escapedPackageId = [System.Security.SecurityElement]::Escape($PackageId)
+        $escapedVersion = [System.Security.SecurityElement]::Escape($Version)
+        $escapedFramework = [System.Security.SecurityElement]::Escape($Framework)
         $csproj = @"
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>$Framework</TargetFramework>
+    <TargetFramework>$escapedFramework</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="$PackageId" Version="$Version" />
+    <PackageReference Include="$escapedPackageId" Version="[$escapedVersion]" />
   </ItemGroup>
 </Project>
 "@
-        $csprojPath = Join-Path $tempDir "Temp.csproj"
-        $nugetConfigPath = Join-Path $tempDir "NuGet.config"
+        $csprojPath = Join-Path $restoreDir "Restore.csproj"
+        $nugetConfigPath = Join-Path $restoreDir "NuGet.config"
         $csproj | Set-Content $csprojPath -Encoding UTF8
 
         $sourceEntries = @($RestoreSources | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique)
@@ -469,80 +509,130 @@ function Install-NuGetPackage {
 
         $restoreResult = & dotnet restore $csprojPath --configfile $nugetConfigPath --verbosity quiet 2>&1
         if ($LASTEXITCODE -ne 0) {
-            Write-Warning "dotnet restore failed for $PackageId $Version`n$restoreResult"
-            return $false
+            throw "dotnet restore failed for $PackageId $Version`n$restoreResult"
         }
-        return $true
+
+        $assetsPath = [System.IO.Path]::Combine($restoreDir, "obj", "project.assets.json")
+        if (-not (Test-Path $assetsPath)) {
+            throw "NuGet restore did not produce project.assets.json for $PackageId $Version."
+        }
+
+        $assets = Get-Content $assetsPath -Raw | ConvertFrom-Json
+        $targetProperty = $assets.targets.PSObject.Properties |
+            Where-Object {
+                $_.Name.Equals($Framework, [System.StringComparison]::OrdinalIgnoreCase) -or
+                $_.Name.StartsWith("$Framework/", [System.StringComparison]::OrdinalIgnoreCase)
+            } |
+            Select-Object -First 1
+        if (-not $targetProperty) {
+            $availableTargets = @($assets.targets.PSObject.Properties.Name) -join ", "
+            throw "NuGet restore graph for $PackageId $Version does not contain target '$Framework'. Available targets: $availableTargets."
+        }
+
+        $rootLibraryProperty = $targetProperty.Value.PSObject.Properties |
+            Where-Object {
+                $separatorIndex = $_.Name.LastIndexOf('/')
+                $separatorIndex -gt 0 -and
+                    $_.Name.Substring(0, $separatorIndex).Equals($PackageId, [System.StringComparison]::OrdinalIgnoreCase)
+            } |
+            Select-Object -First 1
+        if (-not $rootLibraryProperty) {
+            throw "NuGet restore graph target '$($targetProperty.Name)' does not contain $PackageId $Version."
+        }
+        $rootVersion = $rootLibraryProperty.Name.Substring($rootLibraryProperty.Name.LastIndexOf('/') + 1)
+        if (-not $rootVersion.Equals($Version, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "NuGet restored $PackageId $rootVersion instead of the requested exact version $Version."
+        }
+
+        $packageFolders = @($assets.packageFolders.PSObject.Properties.Name)
+        if ($packageFolders.Count -eq 0) {
+            throw "NuGet restore graph for $PackageId $Version does not specify a package folder."
+        }
+
+        $compileReferences = @()
+        $runtimeReferences = @()
+        $selectedReferences = @()
+        $rootCompileAssets = @()
+        $rootRuntimeAssets = @()
+        $rootPackagePath = $null
+
+        foreach ($targetLibraryProperty in $targetProperty.Value.PSObject.Properties) {
+            $libraryMetadataProperty = $assets.libraries.PSObject.Properties |
+                Where-Object { $_.Name.Equals($targetLibraryProperty.Name, [System.StringComparison]::OrdinalIgnoreCase) } |
+                Select-Object -First 1
+            if (-not $libraryMetadataProperty -or $libraryMetadataProperty.Value.type -ne "package") {
+                continue
+            }
+
+            $libraryPath = Resolve-RestoredPackagePath `
+                -PackageFolders $packageFolders `
+                -LibraryPath $libraryMetadataProperty.Value.path
+            if (-not $libraryPath) {
+                throw "Package assets for '$($targetLibraryProperty.Name)' were not found in NuGet's package folders."
+            }
+            $compileAssets = @(Get-AssetPaths -TargetLibrary $targetLibraryProperty.Value -AssetKind "compile" -PackagePath $libraryPath)
+            $runtimeAssets = @(Get-AssetPaths -TargetLibrary $targetLibraryProperty.Value -AssetKind "runtime" -PackagePath $libraryPath)
+
+            $compileReferences += $compileAssets
+            $runtimeReferences += $runtimeAssets
+
+            if ($targetLibraryProperty.Name.Equals($rootLibraryProperty.Name, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $rootPackagePath = $libraryPath
+                $rootCompileAssets = $compileAssets
+                $rootRuntimeAssets = $runtimeAssets
+                continue
+            }
+
+            # Compile assets are NuGet's exact choice for metadata consumption.
+            # Runtime assets are used only for packages that expose no compile asset.
+            $selectedAssets = if ($compileAssets.Count -gt 0) { $compileAssets } else { $runtimeAssets }
+            $selectedReferences += $selectedAssets
+        }
+
+        if (-not $rootPackagePath) {
+            throw "Could not locate the restored package path for $PackageId $Version."
+        }
+
+        $rootAssets = @(if ($rootRuntimeAssets.Count -gt 0) { $rootRuntimeAssets } else { $rootCompileAssets })
+        if ($rootAssets.Count -eq 0) {
+            return [PSCustomObject]@{
+                PackagePath       = $rootPackagePath
+                InputAssembly     = $null
+                References        = @()
+                CompileReferences = @($compileReferences | Select-Object -Unique)
+                RuntimeReferences = @($runtimeReferences | Select-Object -Unique)
+                TargetFramework   = $Framework
+            }
+        }
+
+        $inputAssembly = $rootAssets |
+            Where-Object { [System.IO.Path]::GetFileName($_).Equals("$PackageId.dll", [System.StringComparison]::OrdinalIgnoreCase) } |
+            Select-Object -First 1
+        if (-not $inputAssembly) {
+            $inputAssembly = $rootAssets | Select-Object -First 1
+        }
+
+        # Preserve sibling assemblies from the selected root package asset group.
+        $selectedReferences += $rootAssets | Where-Object {
+            -not $_.Equals($inputAssembly, [System.StringComparison]::OrdinalIgnoreCase)
+        }
+
+        # The restore target is authoritative. The selected asset may come from
+        # an older compatible lib/ref folder, but NuGet resolved it for this TFM.
+        $selectedTfm = ($targetProperty.Name -split '/', 2)[0]
+
+        return [PSCustomObject]@{
+            PackagePath       = $rootPackagePath
+            InputAssembly     = $inputAssembly
+            References        = @($selectedReferences | Select-Object -Unique)
+            CompileReferences = @($compileReferences | Select-Object -Unique)
+            RuntimeReferences = @($runtimeReferences | Select-Object -Unique)
+            TargetFramework   = $selectedTfm
+        }
     }
     finally {
-        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item $restoreDir -Recurse -Force -ErrorAction SilentlyContinue
     }
-}
-
-# ── TFM selection ─────────────────────────────────────────────────────────────
-
-function Get-BestLibFolder {
-    [CmdletBinding()]
-    param(
-        [string]$PackagePath
-    )
-
-    $libDir = Join-Path $PackagePath "lib"
-    if (-not (Test-Path $libDir)) {
-        return $null
-    }
-
-    $tfmFolders = @(Get-ChildItem -Directory $libDir | Select-Object -ExpandProperty Name)
-
-    if ($tfmFolders.Count -eq 0) {
-        return $null
-    }
-
-    $bestTfm = $tfmFolders |
-        Sort-Object -Property @(
-            @{ Expression = {
-                $normalized = $_.TrimStart('.').ToLowerInvariant()
-                if ($normalized -match '^net(\d+)(?:\.(\d+))?$') { return 0 }
-                if ($normalized -match '^netcoreapp(\d+)(?:\.(\d+))?$') { return 1 }
-                if ($normalized -match '^netstandard(\d+)(?:\.(\d+))?$') { return 2 }
-                return 9
-            }; Ascending = $true },
-            @{ Expression = {
-                $normalized = $_.TrimStart('.').ToLowerInvariant()
-                if ($normalized -match '^(?:net|netcoreapp|netstandard)(\d+)(?:\.(\d+))?$') { return [int]$Matches[1] }
-                return -1
-            }; Descending = $true },
-            @{ Expression = {
-                $normalized = $_.TrimStart('.').ToLowerInvariant()
-                if ($normalized -match '^(?:net|netcoreapp|netstandard)(\d+)(?:\.(\d+))?$' -and $Matches[2]) { return [int]$Matches[2] }
-                return -1
-            }; Descending = $true },
-            @{ Expression = { $_.ToLowerInvariant() }; Descending = $true }
-        ) |
-        Select-Object -First 1
-
-    return Join-Path $libDir $bestTfm
-}
-
-function Get-PreferredTfm {
-    [CmdletBinding()]
-    param(
-        [string]$Tfm,
-        [string]$FallbackTfm
-    )
-
-    if ([string]::IsNullOrWhiteSpace($Tfm)) {
-        return $FallbackTfm
-    }
-
-    $normalized = $Tfm.TrimStart('.').ToLowerInvariant()
-    if ($normalized -match '^(net\d+(?:\.\d+)?|netcoreapp\d+(?:\.\d+)?|netstandard\d+(?:\.\d+)?)$') {
-        return $normalized
-    }
-
-    return $FallbackTfm
-
-    return $null
 }
 
 # ── Collect runtime reference assemblies ──────────────────────────────────────
@@ -551,119 +641,51 @@ function Get-RuntimeReferenceAssemblies {
     [CmdletBinding()]
     param([string]$Tfm)
 
-    # Find the .NET reference assemblies (packs) for the given TFM
-    $dotnetRoot = Split-Path (Get-Command dotnet).Source
-    $tfmVersion = $Tfm -replace '^net', ''
-
-    $refPackBase = Join-Path $dotnetRoot "packs\Microsoft.NETCore.App.Ref"
-    if (-not (Test-Path $refPackBase)) {
-        Write-Warning "Could not find reference pack at $refPackBase"
-        return @()
-    }
-
-    # Find the best matching version directory
-    $versionDirs = @(Get-ChildItem -Directory $refPackBase |
-        Where-Object { $_.Name.StartsWith($tfmVersion) } |
-        Sort-Object Name -Descending)
-
-    if ($versionDirs.Count -eq 0) {
-        # Fallback: any version directory
-        $versionDirs = @(Get-ChildItem -Directory $refPackBase | Sort-Object Name -Descending)
-    }
-
-    if ($versionDirs.Count -eq 0) {
-        Write-Warning "No reference assembly versions found in $refPackBase"
-        return @()
-    }
-
-    $refDir = Join-Path $versionDirs[0].FullName "ref\$Tfm"
-    if (-not (Test-Path $refDir)) {
-        # Try without exact TFM match
-        $refSubDirs = @(Get-ChildItem -Directory (Join-Path $versionDirs[0].FullName "ref") |
-            Sort-Object Name -Descending)
-        if ($refSubDirs.Count -gt 0) {
-            $refDir = $refSubDirs[0].FullName
+    # Metadata loading needs both the base runtime and ASP.NET Core reference
+    # packs. Some hosting packages expose ASP.NET Core types without declaring
+    # a transitive FrameworkReference in their NuGet metadata.
+    $dotnetRoot = $env:DOTNET_ROOT
+    if ([string]::IsNullOrWhiteSpace($dotnetRoot) -or -not (Test-Path $dotnetRoot)) {
+        $sdkListing = @(& dotnet --list-sdks 2>$null)
+        $sdkRootLine = $sdkListing | Select-Object -Last 1
+        if ($sdkRootLine -match '\[(.+)\]\s*$') {
+            $dotnetRoot = Split-Path $Matches[1] -Parent
         }
         else {
-            Write-Warning "No ref folder found under $($versionDirs[0].FullName)"
-            return @()
+            $dotnetRoot = Split-Path (Get-Command dotnet).Source
         }
     }
+    $tfmVersion = $Tfm -replace '^net', ''
 
-    return @(Get-ChildItem -Path $refDir -Filter "*.dll" | Select-Object -ExpandProperty FullName)
-}
-
-# ── Collect dependency DLLs from NuGet cache ─────────────────────────────────
-
-function Get-PackageDependencyDlls {
-    [CmdletBinding()]
-    param(
-        [string]$PackagePath,
-        [string]$PreferredTfm
-    )
-
-    # Look for .nuspec to find dependencies
-    $nuspecFiles = @(Get-ChildItem -Path $PackagePath -Filter "*.nuspec" -ErrorAction SilentlyContinue)
-    if ($nuspecFiles.Count -eq 0) {
-        return @()
-    }
-
-    $dlls = @()
-    [xml]$nuspec = Get-Content $nuspecFiles[0].FullName -Raw
-    $ns = @{ "nu" = $nuspec.DocumentElement.NamespaceURI }
-
-    $depGroups = $nuspec | Select-Xml -XPath "//nu:dependencies/nu:group" -Namespace $ns
-    if (-not $depGroups) {
-        return @()
-    }
-
-    # Find the best matching dependency group
-    $bestGroup = $null
-    foreach ($group in $depGroups) {
-        $groupTfm = $group.Node.GetAttribute("targetFramework")
-        if ($groupTfm -eq $PreferredTfm -or $groupTfm -eq ".$PreferredTfm" -or $groupTfm -match $PreferredTfm.Replace(".", "\.")) {
-            $bestGroup = $group.Node
-            break
-        }
-    }
-
-    # Fallback to any net8+ group
-    if (-not $bestGroup) {
-        foreach ($group in $depGroups) {
-            $groupTfm = $group.Node.GetAttribute("targetFramework")
-            if ($groupTfm -match "net[89]|net1[0-9]") {
-                $bestGroup = $group.Node
-                break
+    $referenceAssemblies = @()
+    foreach ($packName in @("Microsoft.NETCore.App.Ref", "Microsoft.AspNetCore.App.Ref")) {
+        $refPackBase = [System.IO.Path]::Combine($dotnetRoot, "packs", $packName)
+        if (-not (Test-Path $refPackBase)) {
+            if ($packName -eq "Microsoft.NETCore.App.Ref") {
+                Write-Warning "Could not find required reference pack at $refPackBase"
             }
+            continue
         }
-    }
 
-    if (-not $bestGroup) {
-        return @()
-    }
-
-    $dependencies = $bestGroup | Select-Xml -XPath "nu:dependency" -Namespace $ns
-    foreach ($dep in $dependencies) {
-        $depId = $dep.Node.GetAttribute("id")
-        $depVersion = $dep.Node.GetAttribute("version")
-
-        # Resolve version range to a concrete version from cache
-        $depCacheDir = Join-Path $NuGetCache $depId.ToLowerInvariant()
-        if (Test-Path $depCacheDir) {
-            $versions = @(Get-ChildItem -Directory $depCacheDir | Select-Object -ExpandProperty Name | Sort-Object -Descending)
-            if ($versions.Count -gt 0) {
-                $selectedVersion = $versions[0]
-                $depPkgPath = Join-Path $depCacheDir $selectedVersion
-                $depLibFolder = Get-BestLibFolder -PackagePath $depPkgPath
-                if ($depLibFolder) {
-                    $depDlls = Get-ChildItem -Path $depLibFolder -Filter "*.dll" -ErrorAction SilentlyContinue
-                    $dlls += $depDlls | Select-Object -ExpandProperty FullName
-                }
-            }
+        $versionDirs = @(Get-ChildItem -Directory $refPackBase |
+            Where-Object { $_.Name.StartsWith($tfmVersion) } |
+            Sort-Object { [version]($_.Name -replace '-.*$', '') } -Descending)
+        if ($versionDirs.Count -eq 0) {
+            Write-Warning "No $Tfm reference assembly version found in $refPackBase"
+            continue
         }
+
+        $refDir = [System.IO.Path]::Combine($versionDirs[0].FullName, "ref", $Tfm)
+        if (-not (Test-Path $refDir)) {
+            Write-Warning "No $Tfm ref folder found under $($versionDirs[0].FullName)"
+            continue
+        }
+
+        $referenceAssemblies += Get-ChildItem -Path $refDir -Filter "*.dll" |
+            Select-Object -ExpandProperty FullName
     }
 
-    return $dlls
+    return @($referenceAssemblies | Select-Object -Unique)
 }
 
 function Get-CachedRuntimeReferenceAssemblies {
@@ -701,8 +723,9 @@ if ($officialFeed.IsRelease) {
 Write-Host "Building PackageJsonGenerator..." -ForegroundColor Cyan
 $buildResult = & dotnet build $ToolProject --configuration Release --verbosity quiet 2>&1
 if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to build PackageJsonGenerator:`n$buildResult"
-    return
+    Write-Host "Failed to build PackageJsonGenerator:`n$buildResult" -ForegroundColor Red
+    Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+    exit 1
 }
 Write-Host "Build succeeded." -ForegroundColor Green
 
@@ -712,6 +735,10 @@ $successCount = 0
 $failCount = 0
 $skipCount = 0
 $runtimeRefsByTfm = @{}
+$failedPackageNames = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+$skippedPackageNames = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
 
 # Phase 1: Resolve versions and prepare package info
 # Use parallel NuGet resolution when processing many packages
@@ -719,8 +746,19 @@ Write-Host "`nResolving package versions..." -ForegroundColor Cyan
 
 $packageInfos = @()
 $packageSourceMetadata = @{}
+$packagesToResolve = @()
 
 foreach ($packageId in $Packages) {
+    if ($catalogVersions.ContainsKey($packageId)) {
+        $packageInfos += [PSCustomObject]@{
+            PackageId = $packageId
+            Version   = $catalogVersions[$packageId]
+        }
+    }
+    else {
+        $packagesToResolve += $packageId
+    }
+
     if ($officialFeed.IsRelease -and (Test-IsOfficialAspirePackage -PackageId $packageId)) {
         $packageSourceMetadata[$packageId] = [PSCustomObject]@{
             PackageBaseAddress = $officialAspireSource.PackageBaseAddress
@@ -737,9 +775,9 @@ foreach ($packageId in $Packages) {
     }
 }
 
-if ($Packages.Count -gt 3 -and -not $Sequential) {
+if ($packagesToResolve.Count -gt 3 -and -not $Sequential) {
     # Parallel NuGet version resolution
-    $resolvedVersions = $Packages | ForEach-Object -Parallel {
+    $resolvedVersions = $packagesToResolve | ForEach-Object -Parallel {
         $sourceMap = $using:packageSourceMetadata
         $packageId = $_
         $sourceInfo = $sourceMap[$packageId]
@@ -770,29 +808,31 @@ if ($Packages.Count -gt 3 -and -not $Sequential) {
 
     foreach ($resolved in $resolvedVersions) {
         if (-not $resolved.Version) {
-            Write-Warning "Could not resolve version for $($resolved.PackageId) from $($resolved.Source) — skipping."
-            $skipCount++
+            Write-Warning "Could not resolve version for $($resolved.PackageId) from $($resolved.Source)."
+            $failCount++
+            [void]$failedPackageNames.Add($resolved.PackageId)
             continue
         }
         $packageInfos += $resolved
     }
 } else {
     # Sequential resolution (small batch or forced)
-    foreach ($packageId in $Packages) {
+    foreach ($packageId in $packagesToResolve) {
         $sourceInfo = $packageSourceMetadata[$packageId]
         $version = Get-LatestNuGetVersion -PackageId $packageId -PackageBaseAddress $sourceInfo.PackageBaseAddress
         if (-not $version) {
-            Write-Warning "Could not resolve version for $packageId from $($sourceInfo.DisplaySource) — skipping."
-            $skipCount++
+            Write-Warning "Could not resolve version for $packageId from $($sourceInfo.DisplaySource)."
+            $failCount++
+            [void]$failedPackageNames.Add($packageId)
             continue
         }
         $packageInfos += [PSCustomObject]@{ PackageId = $packageId; Version = $version }
     }
 }
 
-Write-Host "Resolved $($packageInfos.Count) package versions ($skipCount skipped)."
+Write-Host "Resolved $($packageInfos.Count) package versions ($failCount failed)."
 
-# Phase 2: Ensure packages are cached and prepare manifest entries
+# Phase 2: Restore exact package graphs and prepare manifest entries
 Write-Host "Preparing packages..." -ForegroundColor Cyan
 
 $manifestEntries = @()
@@ -802,78 +842,46 @@ foreach ($info in $packageInfos) {
     $version = $info.Version
     $sourceInfo = $packageSourceMetadata[$packageId]
 
-    # Check cache / download
-    $cachedPath = Get-CachedPackagePath -PackageId $packageId -Version $version
-    if (-not $cachedPath) {
-        Write-Host "  Downloading: $packageId $version from $($sourceInfo.DisplaySource)" -ForegroundColor Yellow
-        $installed = Install-NuGetPackage -PackageId $packageId -Version $version -RestoreSources $sourceInfo.RestoreSources
-        if (-not $installed) {
-            Write-Warning "Failed to download $packageId $version — skipping."
-            $failCount++
-            continue
-        }
-        $cachedPath = Get-CachedPackagePath -PackageId $packageId -Version $version
-        if (-not $cachedPath) {
-            Write-Warning "Package not found in cache after download — skipping."
-            $failCount++
-            continue
-        }
+    try {
+        Write-Host "  Restoring: $packageId $version from $($sourceInfo.DisplaySource)" -ForegroundColor Yellow
+        $restoreGraph = Resolve-NuGetPackageRestoreGraph `
+            -PackageId $packageId `
+            -Version $version `
+            -RestoreSources $sourceInfo.RestoreSources
     }
-
-    # Find the lib folder with DLLs
-    $libFolder = Get-BestLibFolder -PackagePath $cachedPath
-    if (-not $libFolder) {
-        Write-Warning "No lib folder found for $packageId $version — skipping."
-        $skipCount++
+    catch {
+        Write-Warning "Failed to restore $packageId $version`: $_"
+        $failCount++
+        [void]$failedPackageNames.Add($packageId)
         continue
     }
 
-    $selectedTfm = Split-Path $libFolder -Leaf
-    $preferredTfm = Get-PreferredTfm -Tfm $selectedTfm -FallbackTfm $Framework
-
-    # Find the main assembly
-    $mainDll = Join-Path $libFolder "$packageId.dll"
-    if (-not (Test-Path $mainDll)) {
-        $firstDll = Get-ChildItem -Path $libFolder -Filter "*.dll" | Select-Object -First 1
-        if ($firstDll) {
-            $mainDll = $firstDll.FullName
-        }
-        else {
-            Write-Warning "No DLLs found in $libFolder — skipping."
-            $skipCount++
-            continue
-        }
+    if (-not $restoreGraph.InputAssembly) {
+        Write-Warning "No compile/runtime assemblies selected by NuGet for $packageId $version — skipping."
+        $skipCount++
+        [void]$skippedPackageNames.Add($packageId)
+        continue
     }
 
-    # Collect references: runtime refs + package dependency DLLs + sibling DLLs
-    $references = @()
-    $references += Get-CachedRuntimeReferenceAssemblies -Tfm $preferredTfm -Cache $runtimeRefsByTfm
-
-    $siblingDlls = @(Get-ChildItem -Path $libFolder -Filter "*.dll" |
-        Where-Object { $_.FullName -ne $mainDll } |
-        Select-Object -ExpandProperty FullName)
-    $references += $siblingDlls
-
-    $depDlls = @(Get-PackageDependencyDlls -PackagePath $cachedPath -PreferredTfm $preferredTfm)
-    $references += $depDlls
-
-    # Deduplicate
+    # NuGet's assets file supplies exact direct and transitive package assets.
+    $references = @($restoreGraph.References)
+    $references += Get-CachedRuntimeReferenceAssemblies -Tfm $restoreGraph.TargetFramework -Cache $runtimeRefsByTfm
     $references = @($references | Select-Object -Unique)
 
     # Build output path
     $outputFile = Join-Path $OutputDir "$packageId.$version.json"
 
-    Write-Host "  Prepared: $packageId $version ($(Split-Path $libFolder -Leaf))"
+    Write-Host "  Prepared: $packageId $version ($($restoreGraph.TargetFramework))"
 
     $manifestEntries += [PSCustomObject]@{
-        input          = $mainDll
+        input          = $restoreGraph.InputAssembly
         references     = $references
         output         = $outputFile
         packageVersion = $version
         packageName    = $packageId
         sourceRepo     = $null
         sourceCommit   = $null
-        targetFramework = $selectedTfm
+        targetFramework = $restoreGraph.TargetFramework
     }
 }
 
@@ -881,13 +889,19 @@ Write-Host "Prepared $($manifestEntries.Count) packages for generation."
 
 if ($manifestEntries.Count -eq 0) {
     Write-Host "`nNo packages to process." -ForegroundColor Yellow
-    return
+    if ($failCount -gt 0) {
+        Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item (Join-Path $ScriptDir ".package-json-generator-work") -Recurse -Force -ErrorAction SilentlyContinue
+        exit 1
+    }
 }
 
 # Phase 3: Generate JSON files
-if (-not $Sequential -and $manifestEntries.Count -gt 1) {
+if (-not $Sequential -and $manifestEntries.Count -gt 0) {
     # ── Batch mode: write manifest and run tool once ──────────────────────────
-    $manifestFile = Join-Path ([System.IO.Path]::GetTempPath()) "pkgjson-manifest-$([System.Guid]::NewGuid().ToString('N').Substring(0,8)).json"
+    $manifestDirectory = Join-Path $ScriptDir ".package-json-generator-work"
+    New-Item -ItemType Directory -Path $manifestDirectory -Force | Out-Null
+    $manifestFile = Join-Path $manifestDirectory "manifest-$([System.Guid]::NewGuid().ToString('N')).json"
 
     $manifest = @{ packages = $manifestEntries }
     $manifest | ConvertTo-Json -Depth 4 | Set-Content $manifestFile -Encoding UTF8
@@ -897,12 +911,29 @@ if (-not $Sequential -and $manifestEntries.Count -gt 1) {
     $parallelismArg = if ($Parallelism -gt 0) { $Parallelism } else { [Environment]::ProcessorCount }
     Write-Host "  Parallelism: $parallelismArg"
 
-    & dotnet run --project $ToolProject --configuration Release --no-build -- `
-        batch --manifest $manifestFile --parallelism $parallelismArg 2>&1 | ForEach-Object {
+    $batchOutput = @(& dotnet run --project $ToolProject --configuration Release --no-build -- `
+        batch --manifest $manifestFile --parallelism $parallelismArg 2>&1)
+    $batchExitCode = $LASTEXITCODE
+    $succeededPackages = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $failedPackages = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+    $skippedPackages = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+
+    $batchOutput | ForEach-Object {
         if ($_ -match "^Generated:") {
             Write-Host "  $_" -ForegroundColor Green
         }
+        elseif ($_ -match "^SUCCEEDED \[(.+)\]:") {
+            [void]$succeededPackages.Add($Matches[1])
+            Write-Host "  $_" -ForegroundColor Green
+        }
+        elseif ($_ -match "^SKIPPED \[(.+)\]:") {
+            [void]$skippedPackages.Add($Matches[1])
+            Write-Host "  $_" -ForegroundColor Yellow
+        }
         elseif ($_ -match "^FAILED") {
+            if ($_ -match "^FAILED \[(.+)\]:") {
+                [void]$failedPackages.Add($Matches[1])
+            }
             Write-Host "  $_" -ForegroundColor Red
         }
         elseif ($_ -match "^Batch complete") {
@@ -913,18 +944,26 @@ if (-not $Sequential -and $manifestEntries.Count -gt 1) {
         }
     }
 
-    if ($LASTEXITCODE -eq 0) {
-        $successCount = $manifestEntries.Count
-
-        foreach ($entry in $manifestEntries) {
+    foreach ($entry in $manifestEntries) {
+        if ($succeededPackages.Contains($entry.packageName)) {
+            $successCount++
             if (Test-Path $entry.output) {
                 Remove-StalePackageJsonFiles -PackageName $entry.packageName -CurrentOutputFile $entry.output -OutputDirectory $OutputDir
             }
         }
+        elseif ($skippedPackages.Contains($entry.packageName)) {
+            $skipCount++
+            [void]$skippedPackageNames.Add($entry.packageName)
+        }
+        else {
+            # Includes explicit failures and packages omitted by a crashed batch.
+            $failCount++
+            [void]$failedPackageNames.Add($entry.packageName)
+        }
     }
-    else {
-        # Parse output for success/fail counts if available
-        $failCount += $manifestEntries.Count
+
+    if ($batchExitCode -ne 0 -and $failedPackages.Count -eq 0) {
+        Write-Warning "Batch tool exited with code $batchExitCode without reporting individual failures."
     }
 
     # Clean up manifest
@@ -936,30 +975,53 @@ else {
 
     foreach ($entry in $manifestEntries) {
         Write-Host "  Generating: $(Split-Path $entry.output -Leaf)"
-        $refArgs = @($entry.references | ForEach-Object { "--reference"; $_ })
-
-        & dotnet run --project $ToolProject --configuration Release --no-build -- `
-            --input $entry.input `
-            @refArgs `
-            --output $entry.output `
-            --package-version $entry.packageVersion `
-            --package-name $entry.packageName `
-            --target-framework $entry.targetFramework 2>&1 | ForEach-Object {
-            if ($_ -match "^Generated:") {
+        # Use the manifest transport even for one package. Passing hundreds of
+        # reference paths directly can exceed Windows' command-line limit.
+        $manifestDirectory = Join-Path $ScriptDir ".package-json-generator-work"
+        New-Item -ItemType Directory -Path $manifestDirectory -Force | Out-Null
+        $manifestFile = Join-Path $manifestDirectory "manifest-$([System.Guid]::NewGuid().ToString('N')).json"
+        @{ packages = @($entry) } | ConvertTo-Json -Depth 4 | Set-Content $manifestFile -Encoding UTF8
+        try {
+            $generationOutput = @(& dotnet run --project $ToolProject --configuration Release --no-build -- `
+                batch --manifest $manifestFile --parallelism 1 2>&1)
+            $generationExitCode = $LASTEXITCODE
+        }
+        finally {
+            Remove-Item $manifestFile -Force -ErrorAction SilentlyContinue
+        }
+        $generationOutput | ForEach-Object {
+            if ($_ -match "^(Generated:|SUCCEEDED )") {
                 Write-Host "  $_" -ForegroundColor Green
+            }
+            elseif ($_ -match "^SKIPPED ") {
+                Write-Host "  $_" -ForegroundColor Yellow
+            }
+            elseif ($_ -match "^FAILED ") {
+                Write-Host "  $_" -ForegroundColor Red
             }
             else {
                 Write-Host "  $_"
             }
         }
 
-        if ($LASTEXITCODE -eq 0 -and (Test-Path $entry.output)) {
+        $succeeded = $generationOutput | Where-Object {
+            $_ -match ("^SUCCEEDED \[{0}\]:" -f [regex]::Escape($entry.packageName))
+        }
+        $skipped = $generationOutput | Where-Object {
+            $_ -match ("^SKIPPED \[{0}\]:" -f [regex]::Escape($entry.packageName))
+        }
+        if ($generationExitCode -eq 0 -and $skipped) {
+            $skipCount++
+            [void]$skippedPackageNames.Add($entry.packageName)
+        }
+        elseif ($generationExitCode -eq 0 -and $succeeded -and (Test-Path $entry.output)) {
             $successCount++
             Remove-StalePackageJsonFiles -PackageName $entry.packageName -CurrentOutputFile $entry.output -OutputDirectory $OutputDir
         }
         else {
-            Write-Warning "Tool exited with code $LASTEXITCODE for $($entry.packageName)"
+            Write-Warning "Tool exited with code $generationExitCode for $($entry.packageName)"
             $failCount++
+            [void]$failedPackageNames.Add($entry.packageName)
         }
     }
 }
@@ -968,4 +1030,50 @@ else {
 
 Write-Host "`n════════════════════════════════════════" -ForegroundColor DarkGray
 Write-Host "Done! Success: $successCount | Failed: $failCount | Skipped: $skipCount" -ForegroundColor Cyan
-Write-Host "Output: $OutputDir"
+if ($failedPackageNames.Count -gt 0) {
+    Write-Host "Failed packages: $(($failedPackageNames | Sort-Object) -join ', ')" -ForegroundColor Red
+}
+if ($skippedPackageNames.Count -gt 0) {
+    Write-Host "Skipped packages: $(($skippedPackageNames | Sort-Object) -join ', ')" -ForegroundColor Yellow
+}
+Write-Host "Output: $FinalOutputDir"
+
+Remove-Item (Join-Path $ScriptDir ".package-json-generator-work") -Recurse -Force -ErrorAction SilentlyContinue
+
+if ($failCount -gt 0) {
+    Remove-Item -Path $OutputDir -Recurse -Force -ErrorAction SilentlyContinue
+    exit 1
+}
+
+New-Item -ItemType Directory -Path $FinalOutputDir -Force | Out-Null
+$stagedFiles = @(Get-ChildItem -Path $OutputDir -Filter "*.json" -File)
+$stagedNames = [System.Collections.Generic.HashSet[string]]::new(
+    [System.StringComparer]::OrdinalIgnoreCase)
+foreach ($file in $stagedFiles) {
+    [void]$stagedNames.Add($file.Name)
+}
+
+if ($isFullReconciliation) {
+    foreach ($existingFile in Get-ChildItem -Path $FinalOutputDir -Filter "*.json" -File) {
+        if (-not $stagedNames.Contains($existingFile.Name)) {
+            Remove-Item -Path $existingFile.FullName -Force
+            Write-Host "Removed stale package data: $($existingFile.Name)" -ForegroundColor DarkYellow
+        }
+    }
+}
+else {
+    foreach ($packageId in $Packages) {
+        $namePattern = "^{0}\.\d.*\.json$" -f [regex]::Escape($packageId)
+        foreach ($existingFile in Get-ChildItem -Path $FinalOutputDir -Filter "*.json" -File) {
+            if ($existingFile.Name -match $namePattern -and -not $stagedNames.Contains($existingFile.Name)) {
+                Remove-Item -Path $existingFile.FullName -Force
+                Write-Host "Removed stale package data: $($existingFile.Name)" -ForegroundColor DarkYellow
+            }
+        }
+    }
+}
+
+foreach ($file in $stagedFiles) {
+    Copy-Item -Path $file.FullName -Destination (Join-Path $FinalOutputDir $file.Name) -Force
+}
+Remove-Item -Path $OutputDir -Recurse -Force

--- a/src/tools/PackageJsonGenerator/generate-package-json.ps1
+++ b/src/tools/PackageJsonGenerator/generate-package-json.ps1
@@ -944,11 +944,34 @@ if (-not $Sequential -and $manifestEntries.Count -gt 0) {
         }
     }
 
+    if ($batchExitCode -ne 0) {
+        Write-Warning "Batch tool exited with code $batchExitCode; no reported result will be published."
+    }
+
     foreach ($entry in $manifestEntries) {
-        if ($succeededPackages.Contains($entry.packageName)) {
-            $successCount++
-            if (Test-Path $entry.output) {
+        $reportedStatusCount =
+            [int]($succeededPackages.Contains($entry.packageName)) +
+            [int]($skippedPackages.Contains($entry.packageName)) +
+            [int]($failedPackages.Contains($entry.packageName))
+
+        if ($batchExitCode -ne 0) {
+            $failCount++
+            [void]$failedPackageNames.Add($entry.packageName)
+        }
+        elseif ($reportedStatusCount -ne 1) {
+            Write-Warning "Batch tool reported $reportedStatusCount terminal statuses for $($entry.packageName); expected exactly one."
+            $failCount++
+            [void]$failedPackageNames.Add($entry.packageName)
+        }
+        elseif ($succeededPackages.Contains($entry.packageName)) {
+            if (Test-Path -LiteralPath $entry.output -PathType Leaf) {
+                $successCount++
                 Remove-StalePackageJsonFiles -PackageName $entry.packageName -CurrentOutputFile $entry.output -OutputDirectory $OutputDir
+            }
+            else {
+                Write-Warning "Batch tool reported success for $($entry.packageName) without creating $($entry.output)."
+                $failCount++
+                [void]$failedPackageNames.Add($entry.packageName)
             }
         }
         elseif ($skippedPackages.Contains($entry.packageName)) {
@@ -956,14 +979,9 @@ if (-not $Sequential -and $manifestEntries.Count -gt 0) {
             [void]$skippedPackageNames.Add($entry.packageName)
         }
         else {
-            # Includes explicit failures and packages omitted by a crashed batch.
             $failCount++
             [void]$failedPackageNames.Add($entry.packageName)
         }
-    }
-
-    if ($batchExitCode -ne 0 -and $failedPackages.Count -eq 0) {
-        Write-Warning "Batch tool exited with code $batchExitCode without reporting individual failures."
     }
 
     # Clean up manifest

--- a/tests/AtsJsonGenerator.Tests/AtsJsonGeneratorTests.cs
+++ b/tests/AtsJsonGenerator.Tests/AtsJsonGeneratorTests.cs
@@ -31,6 +31,19 @@ public sealed class AtsJsonGeneratorTests
                     AtsTypeId = "Contoso.Assembly/Contoso.Builder",
                     ExposeMethods = true,
                     ExposeProperties = true,
+                    BaseTypeHierarchy =
+                    [
+                        new AtsDumpTypeRef
+                        {
+                            TypeId = "Contoso.Assembly/Contoso.BaseBuilder",
+                            Category = "Type",
+                        },
+                        new AtsDumpTypeRef
+                        {
+                            TypeId = "Contoso.Assembly/Contoso.RootBuilder",
+                            Category = "Type",
+                        },
+                    ],
                 },
             ],
             Capabilities =
@@ -129,6 +142,7 @@ public sealed class AtsJsonGeneratorTests
                         new AtsDumpDtoProperty
                         {
                             Name = "Names",
+                            IsOptional = true,
                             Type = new AtsDumpTypeRef
                             {
                                 TypeId = "string",
@@ -138,6 +152,16 @@ public sealed class AtsJsonGeneratorTests
                                     TypeId = "string",
                                     Category = "Primitive",
                                 },
+                            },
+                        },
+                        new AtsDumpDtoProperty
+                        {
+                            Name = "Region",
+                            IsOptional = false,
+                            Type = new AtsDumpTypeRef
+                            {
+                                TypeId = "string",
+                                Category = "Primitive",
                             },
                         },
                     ],
@@ -225,12 +249,28 @@ public sealed class AtsJsonGeneratorTests
 
         var handle = Assert.Single(result.HandleTypes);
         Assert.Equal("Contoso.Builder", handle.FullName);
+        Assert.Equal(
+            ["Contoso.BaseBuilder", "Contoso.RootBuilder"],
+            handle.BaseTypeHierarchy);
         var handleCapability = Assert.Single(handle.Capabilities);
         Assert.Equal("unique-capability", handleCapability.CapabilityId);
 
         var dto = Assert.Single(result.DtoTypes);
         Assert.Equal("Contoso.UniqueOptions", dto.FullName);
-        Assert.Equal("string[]", Assert.Single(dto.Fields).Type);
+        Assert.Collection(
+            dto.Fields,
+            field =>
+            {
+                Assert.Equal("Names", field.Name);
+                Assert.Equal("string[]", field.Type);
+                Assert.True(field.IsOptional);
+            },
+            field =>
+            {
+                Assert.Equal("Region", field.Name);
+                Assert.Equal("string", field.Type);
+                Assert.True(field.IsOptional);
+            });
 
         var enumType = Assert.Single(result.EnumTypes);
         Assert.Equal("Contoso.UniqueMode", enumType.FullName);

--- a/tests/AtsJsonGenerator.Tests/AtsTransformerHelperTests.cs
+++ b/tests/AtsJsonGenerator.Tests/AtsTransformerHelperTests.cs
@@ -15,6 +15,28 @@ public sealed class AtsTransformerHelperTests
     }
 
     [Fact]
+    public void StripAssemblyPrefix_PreservesEveryGenericArgument()
+    {
+        var typeId = "Test.Assembly/Contoso.Pair`2[[Contoso.Widget, Contoso.Assembly, Version=1.0.0.0],[Contoso.Gadget, Contoso.Assembly, Version=1.0.0.0]]";
+
+        var stripped = AtsTransformer.StripAssemblyPrefix(typeId);
+
+        Assert.Equal("Contoso.Pair`2[[Contoso.Widget],[Contoso.Gadget]]", stripped);
+    }
+
+    [Fact]
+    public void StripAssemblyPrefix_CleansNestedGenericArguments()
+    {
+        var typeId = "Test.Assembly/Contoso.Pair`2[[Contoso.Widget, Contoso.Assembly],[System.Collections.Generic.IReadOnlyList`1[[Contoso.Gadget, Contoso.Assembly]], System.Collections]]";
+
+        var stripped = AtsTransformer.StripAssemblyPrefix(typeId);
+
+        Assert.Equal(
+            "Contoso.Pair`2[[Contoso.Widget],[System.Collections.Generic.IReadOnlyList`1[[Contoso.Gadget]]]]",
+            stripped);
+    }
+
+    [Fact]
     public void FormatTypeRef_FormatsArrayTypes()
     {
         var typeRef = new AtsDumpTypeRef
@@ -31,5 +53,47 @@ public sealed class AtsTransformerHelperTests
         var formatted = AtsTransformer.FormatTypeRef(typeRef);
 
         Assert.Equal("string[]", formatted);
+    }
+
+    [Fact]
+    public void FormatTypeRef_FormatsMultiArgumentReflectionGenerics()
+    {
+        var typeRef = new AtsDumpTypeRef
+        {
+            TypeId = "System.Private.CoreLib/System.Collections.Generic.KeyValuePair`2[[System.String, System.Private.CoreLib],[System.String, System.Private.CoreLib]][]",
+            Category = "Unknown",
+        };
+
+        var formatted = AtsTransformer.FormatTypeRef(typeRef);
+
+        Assert.Equal("KeyValuePair<string,string>[]", formatted);
+    }
+
+    [Fact]
+    public void FormatTypeRef_FormatsNestedReflectionGenerics()
+    {
+        var typeRef = new AtsDumpTypeRef
+        {
+            TypeId = "Test.Assembly/Contoso.Pair`2[[Contoso.Widget, Contoso.Assembly],[System.Collections.Generic.IReadOnlyList`1[[Contoso.Gadget, Contoso.Assembly]], System.Collections]]",
+            Category = "Unknown",
+        };
+
+        var formatted = AtsTransformer.FormatTypeRef(typeRef);
+
+        Assert.Equal("Pair<Widget,IReadOnlyList<Gadget>>", formatted);
+    }
+
+    [Fact]
+    public void FormatTypeRef_FormatsArrayGenericArguments()
+    {
+        var typeRef = new AtsDumpTypeRef
+        {
+            TypeId = "System.Private.CoreLib/System.Collections.Generic.IReadOnlyList`1[[System.String[], System.Private.CoreLib]]",
+            Category = "Unknown",
+        };
+
+        var formatted = AtsTransformer.FormatTypeRef(typeRef);
+
+        Assert.Equal("IReadOnlyList<string[]>", formatted);
     }
 }

--- a/tests/PackageJsonGenerator.Tests/PackageJsonGeneratorTests.cs
+++ b/tests/PackageJsonGenerator.Tests/PackageJsonGeneratorTests.cs
@@ -139,6 +139,63 @@ public sealed class PackageJsonGeneratorTests
     }
 
     [Fact]
+    public void GeneratePackageJson_SubstitutesClosedGenericTypesInInheritedDocumentation()
+    {
+        using var assembly = TestAssembly.Create(
+            """
+            namespace Sample.Library;
+
+            public abstract class ResourceWithParent<T>
+                where T : class
+            {
+                /// <summary>Gets the parent resource of type <typeparamref name="T"/>.</summary>
+                public abstract T Parent { get; }
+            }
+
+            public sealed class EnvironmentResource
+            {
+            }
+
+            public sealed class ChildResource : ResourceWithParent<EnvironmentResource>
+            {
+                /// <inheritdoc/>
+                public override EnvironmentResource Parent => new();
+            }
+            """);
+
+        var outputPath = Path.Combine(assembly.DirectoryPath, "Package.json");
+
+        PackageJsonGenerator.GeneratePackageJson(
+            assembly.AssemblyPath,
+            assembly.References,
+            outputPath,
+            versionOverride: "1.2.3",
+            packageNameOverride: "Sample.Package",
+            targetFrameworkOverride: "net8.0");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(outputPath));
+        var summary = document.RootElement
+            .GetProperty("types")
+            .EnumerateArray()
+            .Single(t => t.GetProperty("name").GetString() == "ChildResource")
+            .GetProperty("members")
+            .EnumerateArray()
+            .Single(m => m.GetProperty("name").GetString() == "Parent")
+            .GetProperty("docs")
+            .GetProperty("summary")
+            .EnumerateArray()
+            .ToArray();
+
+        Assert.DoesNotContain(summary, node => node.GetProperty("kind").GetString() == "typeparamref");
+        var inheritedType = Assert.Single(
+            summary,
+            node => node.GetProperty("kind").GetString() == "cref");
+        Assert.Equal(
+            "T:Sample.Library.EnvironmentResource",
+            inheritedType.GetProperty("value").GetString());
+    }
+
+    [Fact]
     public void GeneratePackageJson_NormalizesToLfAndSkipsRewritingUnchangedOutput()
     {
         using var assembly = TestAssembly.Create(

--- a/tests/PackageJsonGenerator.Tests/PackageJsonGeneratorTests.cs
+++ b/tests/PackageJsonGenerator.Tests/PackageJsonGeneratorTests.cs
@@ -328,6 +328,253 @@ public sealed class PackageJsonGeneratorTests
         Assert.Contains("Placeholder", description!);
     }
 
+    [Fact]
+    public void GeneratePackageJson_PreservesAspireAttributeConstructorAndNamedArguments()
+    {
+        using var attributes = TestAssembly.Create(
+            AspireAttributesSource,
+            assemblyName: "Aspire.Attribute.Dependency");
+        using var consumer = TestAssembly.Create(
+            AspireConsumerSource,
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [attributes.AssemblyPath]);
+        var outputPath = Path.Combine(consumer.DirectoryPath, "Package.json");
+
+        PackageJsonGenerator.GeneratePackageJson(
+            consumer.AssemblyPath,
+            consumer.References,
+            outputPath,
+            packageNameOverride: "Aspire.Consumer.Package");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(outputPath));
+        var attribute = document.RootElement
+            .GetProperty("types")
+            .EnumerateArray()
+            .Single(type => type.GetProperty("name").GetString() == "ExportedResource")
+            .GetProperty("attributes")
+            .EnumerateArray()
+            .Single();
+
+        Assert.Equal(
+            ["resource-name", "3"],
+            attribute.GetProperty("constructorArguments")
+                .EnumerateArray()
+                .Select(argument => argument.GetString()));
+        Assert.Equal(
+            "named-value",
+            attribute.GetProperty("arguments").GetProperty("Alias").GetString());
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenAspireAttributeDependencyIsMismatched()
+    {
+        using var attributes = TestAssembly.Create(
+            AspireAttributesSource,
+            assemblyName: "Aspire.Attribute.Dependency");
+        using var consumer = TestAssembly.Create(
+            AspireConsumerSource,
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [attributes.AssemblyPath]);
+        using var mismatchedAttributes = TestAssembly.Create(
+            """
+            using System;
+            using System.Reflection;
+            [assembly: AssemblyVersion("1.0.0.0")]
+            namespace Aspire.Hosting;
+            [AttributeUsage(AttributeTargets.All)]
+            public sealed class AspireExportAttribute : Attribute
+            {
+                public string? Alias { get; set; }
+            }
+            """,
+            assemblyName: "Aspire.Attribute.Dependency");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != attributes.AssemblyPath), mismatchedAttributes.AssemblyPath],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("ExportedResource", exception.Message);
+        Assert.Contains("AspireExportAttribute", exception.Message);
+        Assert.Contains("constructor", exception.Message);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenReferencedAttributeAssemblyIsMissing()
+    {
+        using var attributes = TestAssembly.Create(
+            AspireAttributesSource,
+            assemblyName: "Aspire.Attribute.Dependency");
+        using var consumer = TestAssembly.Create(
+            AspireConsumerSource,
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [attributes.AssemblyPath]);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != attributes.AssemblyPath)],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("ExportedResource", exception.Message);
+        Assert.Contains("AspireExportAttribute", exception.Message);
+        Assert.Contains("class", exception.Message);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenInputAssemblyReferenceIsMissing()
+    {
+        using var dependency = TestAssembly.Create(
+            "namespace External.Dependency; public class ExternalBase;",
+            assemblyName: "External.Dependency");
+        using var consumer = TestAssembly.Create(
+            "namespace Sample.Library; public sealed class ExportedResource : External.Dependency.ExternalBase;",
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [dependency.AssemblyPath]);
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != dependency.AssemblyPath)],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("unresolved referenced assemblies", exception.Message);
+        Assert.Contains("External.Dependency", exception.Message);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenPublicApiTypeCannotBeResolved()
+    {
+        using var dependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class ExpectedType;",
+            assemblyName: "External.Dependency");
+        using var consumer = TestAssembly.Create(
+            "namespace Sample.Library; public sealed class ExportedResource { public External.Dependency.ExpectedType GetValue() => new(); }",
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [dependency.AssemblyPath]);
+        using var mismatchedDependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class OtherType;",
+            assemblyName: "External.Dependency");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != dependency.AssemblyPath), mismatchedDependency.AssemblyPath],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("GetValue", exception.Message);
+        Assert.Contains("unresolved public API type", exception.Message);
+        Assert.Contains("ExpectedType", exception.Message);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenTypeAttributeArgumentCannotBeResolved()
+    {
+        using var dependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class ExpectedType;",
+            assemblyName: "External.Dependency");
+        using var consumer = TestAssembly.Create(
+            """
+            using System;
+            namespace Aspire.Hosting
+            {
+                [AttributeUsage(AttributeTargets.All)]
+                public sealed class AspireExportAttribute(Type resourceType) : Attribute;
+            }
+            namespace Sample.Library
+            {
+                [Aspire.Hosting.AspireExport(typeof(External.Dependency.ExpectedType))]
+                public sealed class ExportedResource;
+            }
+            """,
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [dependency.AssemblyPath]);
+        using var mismatchedDependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class OtherType;",
+            assemblyName: "External.Dependency");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != dependency.AssemblyPath), mismatchedDependency.AssemblyPath],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("AspireExportAttribute", exception.Message);
+        Assert.Contains("constructor arguments contain an unresolved value", exception.Message);
+    }
+
+    [Fact]
+    public void GeneratePackageJson_FailsWhenTypeArrayAttributeArgumentCannotBeResolved()
+    {
+        using var dependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class ExpectedType;",
+            assemblyName: "External.Dependency");
+        using var consumer = TestAssembly.Create(
+            """
+            using System;
+            namespace Aspire.Hosting
+            {
+                [AttributeUsage(AttributeTargets.All)]
+                public sealed class AspireUnionAttribute(params Type[] resourceTypes) : Attribute;
+            }
+            namespace Sample.Library
+            {
+                [Aspire.Hosting.AspireUnion(typeof(External.Dependency.ExpectedType), typeof(string))]
+                public sealed class ExportedResource;
+            }
+            """,
+            assemblyName: "Aspire.Consumer",
+            additionalReferences: [dependency.AssemblyPath]);
+        using var mismatchedDependency = TestAssembly.Create(
+            "namespace External.Dependency; public sealed class OtherType;",
+            assemblyName: "External.Dependency");
+
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            PackageJsonGenerator.GeneratePackageJson(
+                consumer.AssemblyPath,
+                [.. consumer.References.Where(reference => reference != dependency.AssemblyPath), mismatchedDependency.AssemblyPath],
+                Path.Combine(consumer.DirectoryPath, "Package.json"),
+                packageNameOverride: "Aspire.Consumer.Package"));
+
+        Assert.Contains("Aspire.Consumer.Package", exception.Message);
+        Assert.Contains("AspireUnionAttribute", exception.Message);
+        Assert.Contains("constructor arguments contain an unresolved value", exception.Message);
+    }
+
+    private const string AspireAttributesSource =
+        """
+        using System;
+        using System.Reflection;
+        [assembly: AssemblyVersion("1.0.0.0")]
+        namespace Aspire.Hosting;
+        [AttributeUsage(AttributeTargets.All)]
+        public sealed class AspireExportAttribute(string name, int order) : Attribute
+        {
+            public string Name { get; } = name;
+            public int Order { get; } = order;
+            public string? Alias { get; set; }
+        }
+        """;
+
+    private const string AspireConsumerSource =
+        """
+        using Aspire.Hosting;
+        namespace Sample.Library;
+        [AspireExport("resource-name", 3, Alias = "named-value")]
+        public sealed class ExportedResource;
+        """;
+
     private sealed class TestAssembly : IDisposable
     {
         private TestAssembly(string directoryPath, string assemblyPath, string[] references)
@@ -345,10 +592,19 @@ public sealed class PackageJsonGeneratorTests
 
         public static TestAssembly Create(string source) => Create([source]);
 
-        public static TestAssembly Create(string[] sources)
+        public static TestAssembly Create(
+            string source,
+            string assemblyName,
+            string[]? additionalReferences = null) =>
+            Create([source], assemblyName, additionalReferences);
+
+        public static TestAssembly Create(
+            string[] sources,
+            string assemblyName = "Sample.Library",
+            string[]? additionalReferences = null)
         {
             var tempDirectory = Directory.CreateTempSubdirectory("pkg-generator-tests-");
-            var assemblyPath = Path.Combine(tempDirectory.FullName, "Sample.Library.dll");
+            var assemblyPath = Path.Combine(tempDirectory.FullName, $"{assemblyName}.dll");
             var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
             var xmlPath = Path.ChangeExtension(assemblyPath, ".xml");
 
@@ -358,10 +614,11 @@ public sealed class PackageJsonGeneratorTests
 
             var references = trustedPlatformAssemblies
                 .Where(path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                .Concat(additionalReferences ?? [])
                 .ToArray();
 
             var compilation = CSharpCompilation.Create(
-                assemblyName: "Sample.Library",
+                assemblyName: assemblyName,
                 syntaxTrees: sources.Select(s => CSharpSyntaxTree.ParseText(s)),
                 references: references.Select(reference => MetadataReference.CreateFromFile(reference)),
                 options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));


### PR DESCRIPTION
## Summary

- make C# and TypeScript API-data generation exact, fail-closed, and transactional
- preserve package provenance, attribute payloads, DTO optionality, inheritance, and options shapes across generated artifacts
- add semantic regression gates and regenerate the checked-in API data
- normalize singular and plural `app host` terminology extracted from documentation comments and export-ignore reasons to `AppHost` and `AppHosts`, with a matching forbidden-words guard
- add stable C# member-name anchors so name and exact-overload deep links scroll to and highlight the expected method while overload links remain unique

## Validation

- PackageJsonGenerator: 38 tests passed
- AtsJsonGenerator: 5 tests passed
- focused frontend API/Twoslash tests: 27 tests passed
- AppHost terminology and Twoslash generation: 62 tests passed
- generated API semantic validation passed for 179 catalog packages, 109 TypeScript modules, 41 DTOs, and 327 handles
- all 348 Twoslash documentation blocks compiled without unexpected failures
- 8,281 C# members across 1,573 types produced collision-free anchors; `WithHostPort` resolves to `#withhostport`

Fixes #1462