### PR TITLE
Fix TypeScript withEndpointsInEnvironment docs on project-resources page

### DIFF
--- a/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
@@ -413,7 +413,20 @@ builder.AddProject<Projects.Networking_ApiService>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost doesn't currently expose `WithEndpointsInEnvironment`. To exclude an endpoint from environment variable injection, define only the endpoints you need and omit the `admin` endpoint from the project resource.
+The TypeScript AppHost exposes `withEndpointsInEnvironment`, but it takes an **allow-list of endpoint names to include** (`string[]`)—the inverse of the C# predicate above, which _excludes_ endpoints. List the endpoints you want to keep in environment variables:
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addProject("apiservice", "../Networking.ApiService/Networking.ApiService.csproj")
+    .withHttpsEndpoint()
+    .withHttpsEndpoint({ port: 19227, name: "admin" })
+    .withEndpointsInEnvironment(["https"]); // include only "https"; "admin" is excluded
+
+await builder.build().run();
+```
 </TabItem>
 </Tabs>
 

--- a/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
@@ -413,8 +413,6 @@ builder.AddProject<Projects.Networking_ApiService>("apiservice")
 ```
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
-The TypeScript AppHost exposes `withEndpointsInEnvironment`, but it takes an **allow-list of endpoint names to include** (`string[]`)—the inverse of the C# predicate above, which _excludes_ endpoints. List the endpoints you want to keep in environment variables:
-
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 


### PR DESCRIPTION
## Summary

Fixes #1464.

The TypeScript tab of the **Filter endpoints in environment variables** section on the `integrations/dotnet/project-resources` page incorrectly claimed the TypeScript AppHost doesn't expose `WithEndpointsInEnvironment`. It does — via the ATS-friendly array overload `withEndpointsInEnvironment(endpointNames: string[])` (`[AspireExport]` in `Aspire.Hosting/Ats/CoreExports.cs`).

## Changes

- Replace the "doesn't currently expose" note with the correct allow-list guidance and a runnable `apphost.mts` example.
- Call out the semantic difference: the TypeScript overload takes an **allow-list of endpoint names to include** (`string[]`), which is the inverse of the C# predicate overload shown alongside it (which *excludes* endpoints).

## Verification

- The repo's own `whats-new/aspire-13-5.mdx` already documents that project resources "gain `withEndpointsInEnvironment()` to control which endpoints are injected into environment variables."
- The `{ port, name }` option shape for `withHttpsEndpoint` matches existing TypeScript examples in the repo.
- Block is plain ```` ```typescript ```` (not `twoslash`), so no compilation step applies.

Targets `release/13.5` per the issue.