### PR TITLE
docs: correct custom resource command CLI arguments to named options

### DIFF
--- a/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
+++ b/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
@@ -1139,7 +1139,7 @@ The `InputType` enum controls how the dashboard renders the field and how built-
 |-------|-----------------|--------------|---------------------|
 | `Text` | Single-line text box | `--<name> <value>` string option | `Required`, `MaxLength` |
 | `Number` | Number input | `--<name> <value>` parsed as number | Must be a valid number |
-| `Boolean` | Checkbox | `--<name>` flag (`true` when present) | Must be `true` or `false` |
+| `Boolean` | Checkbox | `--<name>` (sets `true`) or `--<name> <value>` | Must be `true` or `false` |
 | `Choice` | Drop-down list | `--<name> <value>` matching one of `Options` | Must be a member of `Options` |
 | `SecretText` | Masked text box | `--<name> <value>` string option | `Required`, `MaxLength` |
 
@@ -1190,8 +1190,16 @@ aspire resource myservice send-message --text "Hello world" --repeat 3 --apphost
 
 In the example above, `--text` sets the `text` argument and `--repeat` sets the `repeat` argument. Each option name matches the input's `Name`, and a kebab-case alias is also accepted for multi-word names. For example, an input named `LogLevel` accepts both `--LogLevel` and `--log-level`.
 
+If an argument's option name matches one of the Aspire CLI's own options (for example the global `--log-level` / `-l` option, or `--apphost`), the CLI binds it during its own parsing pass and it never reaches the command. Separate the command's options from the CLI's options with a `--` delimiter to force them through:
+
+```bash title="Terminal"
+aspire resource myservice configure -- --log-level Debug
+```
+
+The command's `--help` output flags any names that collide with a CLI option and shows the `--` form to use.
+
 <Aside type="note">
-The CLI passes all option values as strings; the AppHost performs type coercion and built-in validation before invoking the command callback. If a required argument is missing, the CLI reports `Required option '--<name>' was not provided.` and doesn't invoke the callback. Any value that fails validation returns a structured error the same way.
+The CLI parses and validates values before forwarding them to the AppHost as strings: it parses `Number` and `Boolean` inputs and enforces the built-in rules (such as `Required` and `Choice` membership). If a required argument is missing, the CLI reports `Required option '--<name>' was not provided.` and doesn't invoke the callback. Any value that fails validation returns a structured error the same way.
 </Aside>
 
 ## Argument validation

--- a/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
+++ b/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
@@ -1041,7 +1041,7 @@ fi
 
 ## Command arguments
 
-Commands can declare input arguments that the dashboard renders as a prompt dialog before execution and that the CLI accepts as ordered positional values. Arguments are defined by setting `CommandOptions.Arguments` to an array of `InteractionInput` objects.
+Commands can declare input arguments that the dashboard renders as a prompt dialog before execution and that the CLI accepts as named `--<name>` options. Arguments are defined by setting `CommandOptions.Arguments` to an array of `InteractionInput` objects.
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
@@ -1121,7 +1121,7 @@ await builder.build().run();
 
 ### InteractionInput properties
 
-Each `InteractionInput` object in the `Arguments` array configures one input field in the dashboard prompt and one positional argument for the CLI:
+Each `InteractionInput` object in the `Arguments` array configures one input field in the dashboard prompt and one named `--<name>` option for the CLI:
 
 | Property | Type | Description |
 |----------|------|-------------|
@@ -1137,11 +1137,11 @@ The `InputType` enum controls how the dashboard renders the field and how built-
 
 | Value | Dashboard widget | CLI behavior | Built-in validation |
 |-------|-----------------|--------------|---------------------|
-| `Text` | Single-line text box | Positional string value | `Required`, `MaxLength` |
-| `Number` | Number input | Positional string parsed as number | Must be a valid number |
-| `Boolean` | Checkbox | `true` or `false` string | Must be `true` or `false` |
-| `Choice` | Drop-down list | String must match one of `Options` | Must be a member of `Options` |
-| `SecretText` | Masked text box | Positional string value | `Required`, `MaxLength` |
+| `Text` | Single-line text box | `--<name> <value>` string option | `Required`, `MaxLength` |
+| `Number` | Number input | `--<name> <value>` parsed as number | Must be a valid number |
+| `Boolean` | Checkbox | `--<name>` flag (`true` when present) | Must be `true` or `false` |
+| `Choice` | Drop-down list | `--<name> <value>` matching one of `Options` | Must be a member of `Options` |
+| `SecretText` | Masked text box | `--<name> <value>` string option | `Required`, `MaxLength` |
 
 ### Read argument values at runtime
 
@@ -1182,16 +1182,16 @@ Use `requiredValue` for arguments declared with `required: true` to get a non-nu
 
 ### Pass arguments from the CLI
 
-When invoking a command from the CLI, supply argument values as ordered positional tokens after the command name. The CLI maps them onto the declared `Arguments` array by position:
+When invoking a command from the CLI, supply argument values as named `--<name>` options after the command name. Each declared argument is exposed as its own option, so the order you pass them in doesn't matter:
 
 ```bash title="Terminal"
-aspire resource myservice send-message "Hello world" 3 --apphost MyApp.AppHost.csproj
+aspire resource myservice send-message --text "Hello world" --repeat 3 --apphost MyApp.AppHost.csproj
 ```
 
-In the example above, `"Hello world"` maps to the first argument (`text`) and `3` maps to the second (`repeat`).
+In the example above, `--text` sets the `text` argument and `--repeat` sets the `repeat` argument. Each option name matches the input's `Name`, and a kebab-case alias is also accepted for multi-word names. For example, an input named `LogLevel` accepts both `--LogLevel` and `--log-level`.
 
 <Aside type="note">
-The CLI passes all positional values as strings; the AppHost performs type coercion and built-in validation before invoking the command callback. If a required argument is missing or a value fails validation, the CLI receives a structured error instead of invoking the callback.
+The CLI passes all option values as strings; the AppHost performs type coercion and built-in validation before invoking the command callback. If a required argument is missing, the CLI reports `Required option '--<name>' was not provided.` and doesn't invoke the callback. Any value that fails validation returns a structured error the same way.
 </Aside>
 
 ## Argument validation


### PR DESCRIPTION
Fixes #1463.

The `fundamentals/custom-resource-commands` page described custom resource command CLI arguments as **ordered positional values**, but the CLI actually exposes each declared input as a named `--<name>` option. The documented example (`send-message "Hello world" 3`) fails in practice because those tokens are treated as unknown, not bound positionally.

## Changes

- **"Command arguments" intro** and the **`InteractionInput` properties** lead-in now say the CLI accepts named `--<name>` options.
- **`InputType` table (CLI behavior column)** — replaced "Positional string value" / "Positional string parsed as number" with the actual option forms (`--<name> <value>`, and `--<name>` flag for booleans).
- **"Pass arguments from the CLI" section** — the example now uses `--text "Hello world" --repeat 3`, notes that argument order doesn't matter, documents the kebab-case aliases (e.g. an input named `LogLevel` accepts both `--LogLevel` and `--log-level`), and shows the `Required option '--<name>' was not provided.` error.

## Source of truth

Verified against [`ResourceCommand.cs`](https://github.com/microsoft/aspire/blob/release/13.5/src/Aspire.Cli/Commands/ResourceCommand.cs) on `release/13.5`:

- Each input becomes `new Option<...>($"--{optionName}")`, where `optionName` is the kebab-cased `Name`, with the exact `Name` added as an alias.
- Missing required inputs produce `Required option '--<name>' was not provided.`.
- Leftover positional tokens are forwarded as unknown argument names, not bound positionally.

All angle brackets in the new copy stay inside inline-code spans / code fences, so MDX doesn't parse them as JSX (matching the existing `IReadOnlyList<...>` table cell).

Targets `release/13.5` as requested in the issue.
