### PR TITLE
[docs] Remove hidden Aspire Skills remote-fetch flag

### DIFF
--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-init.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-agent-init.mdx
@@ -52,19 +52,6 @@ The Aspire skills bundle includes six workflow skills: `aspire`, `aspire-init`, 
 
 Standalone `aspire agent init` pre-selects the bundle skills that are safe to add to an existing workspace: `aspire`, `aspire-init`, `aspire-orchestration`, `aspire-monitoring`, and `aspire-deployment`. The `aspireify` skill remains available but opt-in because it's a one-time AppHost wiring workflow. When `aspire init` chains into agent setup, `aspireify` is pre-selected because it is the natural follow-up after adding an AppHost skeleton to an existing repository.
 
-Remote bundle fetching is off by default in Aspire 13.4. To opt into downloading matching Aspire skills releases from GitHub, enable the preview feature:
-
-```bash title="Aspire CLI"
-aspire config set features.aspireSkillsRemoteFetchEnabled true
-```
-
-<Aside type="note">
-  The `features.aspireSkillsRemoteFetchEnabled` setting is hidden from `aspire
-  config` output and the generated VS Code settings schemas as of Aspire
-  13.6&mdash;it's still off by default and still works if you set it directly,
-  as shown above.
-</Aside>
-
 ### Bundle integrity verification
 
 The CLI verifies the embedded and remotely-fetched Aspire skills bundle using


### PR DESCRIPTION
## Summary

Removes public instructions for the hidden `features.aspireSkillsRemoteFetchEnabled` preview setting from the `aspire agent init` documentation. Preserves the SHA-512 bundle integrity documentation introduced by #1485.

## Third-party links and affiliations

None.

## Validation

- Confirmed the repository no longer references `aspireSkillsRemoteFetchEnabled`.
- Ran `git diff --check`.