### PR TITLE
Fix WithTerminal columns default

### DIFF
--- a/src/frontend/src/content/docs/app-host/with-terminal.mdx
+++ b/src/frontend/src/content/docs/app-host/with-terminal.mdx
@@ -72,7 +72,7 @@ The terminal session is described by a set of options with sensible defaults:
 
 | Option              | Default | Description                                                                                                                                                     |
 | ------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Columns`           | `120` (11 )   | The initial number of columns for the terminal grid.                                                                                                            |
+| `Columns`           | `120`   | The initial number of columns for the terminal grid.                                                                                                            |
 | `Rows`              | `30`    | The initial number of rows for the terminal grid.                                                                                                               |
 | `ShowTerminalHost`  | `false` | Whether the hidden per-replica terminal host resources appear in the dashboard and CLI resource lists. Set to `true` to diagnose terminal-host startup or connectivity issues. |
 


### PR DESCRIPTION
## Summary
- Restore the documented `WithTerminal` `Columns` default to `120`.
- Preserve the nearby validation note for `Columns` and `Rows`.

## Checks
- `git diff --check`
- Targeted assertions for the corrected default and preserved `ArgumentOutOfRangeException` note
- `pnpm --dir .\src\frontend exec prettier --check src/content/docs/app-host/with-terminal.mdx` *(fails identically on the unmodified `release/13.5` file)*