### PR TITLE
Document dashboard time format behavior

### DIFF
--- a/src/frontend/src/content/docs/dashboard/explore.mdx
+++ b/src/frontend/src/content/docs/dashboard/explore.mdx
@@ -601,7 +601,7 @@ The Aspire dashboard provides a settings dialog that allows you to configure the
 
 By default, the theme is set to follow the System theme, which means the dashboard uses the same theme as your operating system. You can also select the **Light** or **Dark** theme to override the system theme. Theme selections are persisted.
 
-The **Time format** preference supports **System**, **12-hour**, and **24-hour** formats. **System** uses the resolved time format, while **12-hour** and **24-hour** override it. The selected or resolved time format also applies to metrics chart axis labels.
+The **Time format** preference provides **System**, **12-hour**, and **24-hour** options. **System** follows the browser's time format, while **12-hour** and **24-hour** override it. The resulting format applies to metrics chart axis labels.
 
 The following screenshot shows the theme selection dialog, with the default System theme selected:
 

--- a/src/frontend/src/content/docs/dashboard/explore.mdx
+++ b/src/frontend/src/content/docs/dashboard/explore.mdx
@@ -597,9 +597,11 @@ For information on returning command result payloads from custom commands, see [
 
 <span id="theme-selection"></span>
 
-The Aspire dashboard provides a settings dialog that allows you to configure the theme, the language, manage logs and telemetry data, and view the .NET version used by the dashboard.
+The Aspire dashboard provides a settings dialog that allows you to configure the theme, language, and time format, manage logs and telemetry data, and view the .NET version used by the dashboard.
 
 By default, the theme is set to follow the System theme, which means the dashboard uses the same theme as your operating system. You can also select the **Light** or **Dark** theme to override the system theme. Theme selections are persisted.
+
+The **Time format** preference supports **System**, **12-hour**, and **24-hour** formats. **System** uses the resolved time format, while **12-hour** and **24-hour** override it. The selected or resolved time format also applies to metrics chart axis labels.
 
 The following screenshot shows the theme selection dialog, with the default System theme selected:
 


### PR DESCRIPTION
## Summary

- Document the dashboard's **System**, **12-hour**, and **24-hour** time format options.
- Clarify that the selected or resolved format applies to metrics chart axis labels.

## Context

This manually recovers the documentation for microsoft/aspire#19043 after two trusted documentation workflow attempts skipped the source change based only on historical release-note coverage.

## Validation

- Prettier check for the edited MDX range
- Astro content sync