### PR TITLE
Document Azure Artifacts package search issue

### DIFF
--- a/src/frontend/src/content/docs/get-started/troubleshooting.mdx
+++ b/src/frontend/src/content/docs/get-started/troubleshooting.mdx
@@ -167,6 +167,18 @@ Also verify:
   [Service discovery](/fundamentals/service-discovery/).
 </LearnMore>
 
+## `aspire add` finds no packages with an Azure Artifacts feed
+
+**Symptoms**: When an authenticated Azure DevOps or Azure Artifacts NuGet feed is configured, `aspire add` reports that no packages were found or the Aspire CLI logs a `JsonReaderException`.
+
+**Cause**: The NuGet Azure Artifacts Credential Provider can write `[CredentialProvider]` progress text to standard output before the `dotnet package search --format json` response. Older Aspire CLI versions tried to parse all of that output as JSON.
+
+**Solution**: Update to the latest Aspire CLI:
+
+```bash title="Update the Aspire CLI"
+aspire update --self
+```
+
 ## TypeScript AppHost issues
 
 ### "Command not found" errors


### PR DESCRIPTION
## Summary

- document the `aspire add` no-packages symptom caused by authenticated Azure Artifacts feeds
- explain how credential-provider progress output disrupted JSON parsing in older Aspire CLI versions
- direct affected users to update with `aspire update --self`

Related to microsoft/aspire#19343.

## Validation

- `pnpm --dir src/frontend exec prettier --check src/content/docs/get-started/troubleshooting.mdx`
- `pnpm --dir src/frontend exec astro sync`
- rendered `/get-started/troubleshooting/` locally and confirmed HTTP 200 with the new heading and update command