### PR TITLE
[docs] Document concrete Eventing.Subscribe<T> requirement

### DIFF
--- a/src/frontend/src/content/docs/app-host/eventing.mdx
+++ b/src/frontend/src/content/docs/app-host/eventing.mdx
@@ -113,6 +113,15 @@ builder.Eventing.Subscribe<AfterResourcesCreatedEvent>(
   callbacks like `onResourceReady`.
 </Aside>
 
+<Aside type="caution">
+  `Eventing.Subscribe<T>()` requires `T` to be a concrete event type.
+  Subscribing to an interface or abstract class throws an `ArgumentException`.
+  For `IDistributedApplicationEvent`, the exception message is
+  `Cannot subscribe to interface or abstract type 'IDistributedApplicationEvent'. Subscribe to a concrete event type instead.`
+  Use a concrete event type such as `BeforeStartEvent` or
+  `AfterResourcesCreatedEvent`.
+</Aside>
+
 When the AppHost is run, by the time the Aspire dashboard is displayed, you should see the following log output in the console:
 
 ```plaintext {2,12} data-disable-copy


### PR DESCRIPTION
## Summary

- Documents the public requirement that `Eventing.Subscribe<T>()` use a concrete event type.
- Preserves the exact public `ArgumentException` behavior and directs users to concrete event types such as `BeforeStartEvent` or `AfterResourcesCreatedEvent`.
- Changes only `src/frontend/src/content/docs/app-host/eventing.mdx`.

Related to microsoft/aspire#17094.

## Target

This targets `main` because [#1233](https://github.com/microsoft/aspire.dev/pull/1233) squash-merged `release/13.5` into `main` and the release branch was deleted. The branch was created directly from resulting `main` commit `785524f8ce21b9b17029f88123411c5c53d833db`.

This clean main-based draft supersedes #1532, which GitHub automatically retargeted after the release branch deletion and expanded to 418 files because squash ancestry did not contain the old release head.

## Validation

- Repository Prettier check passed for `eventing.mdx`.
- `git diff --check` passed.
- The committed blob matches the previously source-audited one-file correction and contains no interface-subscription sample.

No reviewers requested yet. Auto-merge must remain off.