### PR TITLE
Clarify ASPIRE011 run preflight wording

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -169,5 +169,5 @@ Set `AspireCliInvocationMode` in your AppHost `.csproj`:
 ```
 
 :::note
-`dotnet run` is noninteractive, so `dnx` restores and executes without prompting for confirmation and uses your configured NuGet sources. Restore or probe failures fail explicitly instead of falling back to an incomplete direct launch. If `dnx` can't be found on `PATH` when `Dnx` or `DnxPinned` mode is configured, the build emits error `ASPIRE011`. Install or use the .NET SDK 10.0 or later, set `AspireCliInvocationMode` to `Path` to use the global `aspire` command, or set `AspireCliPath` to an explicit Aspire CLI executable.
+`dotnet run` is noninteractive, so `dnx` restores and executes without prompting for confirmation and uses your configured NuGet sources. Restore or probe failures fail explicitly instead of falling back to an incomplete direct launch. If `dnx` can't be found on `PATH` when `Dnx` or `DnxPinned` mode is configured, the run preflight emits error `ASPIRE011` when it prepares the launch command. Install or use the .NET SDK 10.0 or later, set `AspireCliInvocationMode` to `Path` to use the global `aspire` command, or set `AspireCliPath` to an explicit Aspire CLI executable.
 :::


### PR DESCRIPTION
## Summary

- clarify that missing `dnx` produces `ASPIRE011` during run preflight
- distinguish launch-command preparation from a regular build

## Validation

- `git diff --check`
- one file with one insertion and one deletion on current `main`
- repository Prettier reports only two pre-existing deltas in this file; formatting a temporary copy does not modify the changed sentence