### PR TITLE
Render theme-aware sample images that link to their full-size asset

### DIFF
--- a/src/frontend/src/utils/sample-readme-images.ts
+++ b/src/frontend/src/utils/sample-readme-images.ts
@@ -10,22 +10,65 @@ function isWhitespacePhrasing(node: PhrasingContent): boolean {
   return node.type === 'text' && node.value.trim() === '';
 }
 
+/**
+ * Resolve a paragraph child down to the standalone image it represents, or
+ * `null` when it isn't one.
+ *
+ * A bare `image` node is returned as-is. GitHub READMEs also very commonly link
+ * a screenshot thumbnail to its full-size asset — `[![alt](thumb)](full)` —
+ * which parses to a `link` node wrapping a single `image` (plus optional
+ * whitespace). We unwrap that to the inner image so theme-aware screenshots
+ * render through the sample media pipeline instead of leaking into the README
+ * body as broken `<img src="~/assets/…">` tags (the `~/assets/…` alias only
+ * resolves through Astro's build-time image importer, never in the browser).
+ */
+function asStandaloneImage(child: PhrasingContent): Image | null {
+  if (child.type === 'image') {
+    return child;
+  }
+
+  if (child.type === 'link') {
+    let image: Image | null = null;
+
+    for (const grandchild of child.children) {
+      if (grandchild.type === 'image') {
+        if (image) {
+          return null;
+        }
+
+        image = grandchild;
+      } else if (!isWhitespacePhrasing(grandchild)) {
+        return null;
+      }
+    }
+
+    return image;
+  }
+
+  return null;
+}
+
 export function getStandaloneImageNodes(node: RootContent): Image[] | null {
   if (node.type !== 'paragraph') {
     return null;
   }
 
-  const children = node.children;
-  const imageNodes = children.filter((child): child is Image => child.type === 'image');
-  const hasOnlyImagesAndWhitespace = children.every(
-    (child) => child.type === 'image' || isWhitespacePhrasing(child)
-  );
+  const imageNodes: Image[] = [];
 
-  if (!hasOnlyImagesAndWhitespace || imageNodes.length === 0) {
-    return null;
+  for (const child of node.children) {
+    if (isWhitespacePhrasing(child)) {
+      continue;
+    }
+
+    const image = asStandaloneImage(child);
+    if (!image) {
+      return null;
+    }
+
+    imageNodes.push(image);
   }
 
-  return imageNodes;
+  return imageNodes.length > 0 ? imageNodes : null;
 }
 
 export function getThemeImageNodePair(

--- a/src/frontend/tests/unit/sample-readme-images.vitest.test.ts
+++ b/src/frontend/tests/unit/sample-readme-images.vitest.test.ts
@@ -1,0 +1,132 @@
+import type { Root, RootContent } from 'mdast';
+import { markdownToMdast } from 'satteri';
+import { describe, expect, it } from 'vitest';
+
+import {
+  getStandaloneImageNodes,
+  getThemeImageNodePair,
+  isStandaloneSampleImageBlock,
+} from '@utils/sample-readme-images';
+
+// These fixtures are intentionally synthetic. They exercise the *structural*
+// markdown shapes a sample README can contain — bare images, thumbnails linked
+// to a full-size asset (`[![alt](thumb)](full)`), theme suffixes — without
+// hard-coding any real file names from the upstream `dotnet/aspire-samples`
+// repo, whose asset paths can change independently of this site.
+
+// Parse a README snippet the same way `SampleDetail.astro` does and return the
+// first top-level block, so the assertions run against the exact MDAST that
+// `satteri` produces rather than a hand-built tree that could drift.
+function firstBlock(markdown: string): RootContent {
+  const root = markdownToMdast(markdown, {
+    features: { gfm: true, frontmatter: false },
+  }) as Root;
+
+  const block = root.children[0];
+  if (!block) {
+    throw new Error('expected the markdown to parse to at least one block');
+  }
+
+  return block;
+}
+
+// Build the `~/assets/...` src the sample image importer rewrites README images
+// to, optionally tagged with a GitHub theme suffix.
+function assetSrc(file: string, theme?: 'light' | 'dark'): string {
+  const suffix = theme ? `#gh-${theme}-mode-only` : '';
+  return `~/assets/samples/example/${file}${suffix}`;
+}
+
+// A thumbnail linked to its full-size asset: `[![alt](thumb)](full)`.
+function linkedImage(alt: string, src: string, href = './full.png'): string {
+  return `[![${alt}](${src})](${href})`;
+}
+
+describe('link-wrapped standalone sample images', () => {
+  it('unwraps a linked light/dark theme pair to its inner image nodes', () => {
+    const lightSrc = assetSrc('screenshot-light.png', 'light');
+    const darkSrc = assetSrc('screenshot-dark.png', 'dark');
+    const markdown = [
+      linkedImage('Screenshot, light theme', lightSrc),
+      linkedImage('Screenshot, dark theme', darkSrc),
+    ].join('\n');
+
+    const images = getStandaloneImageNodes(firstBlock(markdown));
+
+    expect(images?.map((image) => image.url)).toEqual([lightSrc, darkSrc]);
+  });
+
+  it('detects the theme pair from the unwrapped linked images', () => {
+    const lightSrc = assetSrc('screenshot-light.png', 'light');
+    const darkSrc = assetSrc('screenshot-dark.png', 'dark');
+    const markdown = [
+      linkedImage('Screenshot, light theme', lightSrc),
+      linkedImage('Screenshot, dark theme', darkSrc),
+    ].join('\n');
+
+    const pair = getThemeImageNodePair(getStandaloneImageNodes(firstBlock(markdown)) ?? []);
+
+    expect(pair?.light.url).toBe(lightSrc);
+    expect(pair?.dark.url).toBe(darkSrc);
+  });
+
+  it('treats a linked theme pair as a standalone image block', () => {
+    const markdown = [
+      linkedImage('Screenshot, light theme', assetSrc('screenshot-light.png', 'light')),
+      linkedImage('Screenshot, dark theme', assetSrc('screenshot-dark.png', 'dark')),
+    ].join('\n');
+
+    expect(isStandaloneSampleImageBlock(firstBlock(markdown))).toBe(true);
+  });
+
+  it('treats a single linked screenshot as a standalone image block', () => {
+    const src = assetSrc('screenshot.png');
+    const block = firstBlock(linkedImage('Screenshot', src));
+
+    expect(getStandaloneImageNodes(block)?.map((image) => image.url)).toEqual([src]);
+    expect(isStandaloneSampleImageBlock(block)).toBe(true);
+  });
+});
+
+describe('bare (unwrapped) sample images remain standalone', () => {
+  it('handles a bare light/dark theme pair', () => {
+    const lightSrc = assetSrc('screenshot-light.png', 'light');
+    const darkSrc = assetSrc('screenshot-dark.png', 'dark');
+    const markdown = [
+      `![Screenshot, light theme](${lightSrc})`,
+      `![Screenshot, dark theme](${darkSrc})`,
+    ].join('\n');
+
+    const images = getStandaloneImageNodes(firstBlock(markdown)) ?? [];
+
+    expect(images.map((image) => image.url)).toEqual([lightSrc, darkSrc]);
+    expect(getThemeImageNodePair(images)).not.toBeNull();
+    expect(isStandaloneSampleImageBlock(firstBlock(markdown))).toBe(true);
+  });
+
+  it('handles a single bare image', () => {
+    const src = assetSrc('screenshot.png');
+    const block = firstBlock(`![Screenshot](${src})`);
+
+    expect(getStandaloneImageNodes(block)?.map((image) => image.url)).toEqual([src]);
+    expect(isStandaloneSampleImageBlock(block)).toBe(true);
+  });
+});
+
+describe('non-standalone paragraphs are left in the README body', () => {
+  it('does not treat a plain text link as an image block', () => {
+    const block = firstBlock('[Read the docs](https://example.com/docs)');
+
+    expect(getStandaloneImageNodes(block)).toBeNull();
+    expect(isStandaloneSampleImageBlock(block)).toBe(false);
+  });
+
+  it('does not treat a linked image mixed with prose as an image block', () => {
+    const block = firstBlock(
+      `See ${linkedImage('shot', assetSrc('screenshot.png'))} for the full view.`
+    );
+
+    expect(getStandaloneImageNodes(block)).toBeNull();
+    expect(isStandaloneSampleImageBlock(block)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Theme-aware sample screenshots stopped rendering on generated sample reference pages — for example [`/reference/samples/image-gallery/`](https://aspire.dev/reference/samples/image-gallery/) showed broken image icons instead of the light/dark previews.

Sample READMEs frequently link a screenshot thumbnail to its full-size asset with the ubiquitous GitHub pattern `[![alt](thumb)](full)`. That parses to a paragraph of `link` nodes wrapping `image` nodes rather than bare `image` nodes, so `getStandaloneImageNodes` (which only inspected direct `image` children) stopped recognizing them as standalone sample images. The blocks then fell through to raw HTML rendering and surfaced as broken `<img src="~/assets/...">` tags — the `~/assets/...` alias only resolves through Astro's build-time image importer, never in the browser — instead of being routed to the theme-aware sample media pipeline.

This change unwraps `link` children whose sole content is a single image, so both the light/dark theme-pair detection and the standalone-block skip logic see the inner images again. Bare images keep their existing behavior.

## Third-party links and affiliations

None.

## Validation

- Added `src/frontend/tests/unit/sample-readme-images.vitest.test.ts`, which parses the real README markdown via `satteri` (the same parser `SampleDetail.astro` uses) and asserts the linked light/dark pair is detected as a standalone theme block. The new cases fail on `main` and pass with this change.
- `pnpm test:unit` — all 31 files / 376 tests pass.
- ESLint clean on the changed files; Prettier-formatted.
