### PR TITLE
Add /whatsnew release-notes authoring skill

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -22,3 +22,4 @@ there's no central registry to update. Add a new skill by creating `.agents/skil
 | [`twoslash-validator`](./twoslash-validator/SKILL.md) | Validate and fix two-slash TypeScript code samples. |
 | [`update-integrations`](./update-integrations/SKILL.md) | Sync integration docs links and API reference data. |
 | [`update-samples`](./update-samples/SKILL.md) | Refresh the samples data file from `microsoft/aspire-samples`. |
+| [`whatsnew`](./whatsnew/SKILL.md) | Author a "What's new in Aspire N.N" release-notes page through a step-argument lifecycle: `draft｜scaffold`, `research`, `critique`, `validate`, `polish`, `review`. |

--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -22,4 +22,4 @@ there's no central registry to update. Add a new skill by creating `.agents/skil
 | [`twoslash-validator`](./twoslash-validator/SKILL.md) | Validate and fix two-slash TypeScript code samples. |
 | [`update-integrations`](./update-integrations/SKILL.md) | Sync integration docs links and API reference data. |
 | [`update-samples`](./update-samples/SKILL.md) | Refresh the samples data file from `microsoft/aspire-samples`. |
-| [`whatsnew`](./whatsnew/SKILL.md) | Author a "What's new in Aspire N.N" release-notes page through a step-argument lifecycle: `draft｜scaffold`, `research`, `critique`, `validate`, `polish`, `review`. |
+| [`whatsnew`](./whatsnew/SKILL.md) | Author a "What's new in Aspire N.N" release-notes page through a step-argument lifecycle: `draft/scaffold`, `research`, `critique`, `validate`, `polish`, `review`. |

--- a/.agents/skills/whatsnew/SKILL.md
+++ b/.agents/skills/whatsnew/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsnew
-description: "Step-argument skill that formalizes writing an Aspire \"What's new in N.N\" release-notes page (src/frontend/src/content/docs/whats-new/aspire-N-N.mdx) as a repeatable lifecycle. Invoke as `/whatsnew {modality}` where modality is one of: draft|scaffold (init), research, critique, validate, polish, review. USE FOR: start/scaffold a new what's-new page for a release, research a release's changes into a dossier, critique a draft, fact-check/validate the diff, polish and run data ingestion, or sign off the PR. DO NOT USE FOR: general docs pages (use doc-writer), reviewing an arbitrary docs PR (use doc-pr-reviewer), or product-repo changes. ORCHESTRATES: doc-writer, doc-pr-reviewer, doc-tester, twoslash-validator, update-integrations, update-samples, container-images."
+description: "Step-argument skill that formalizes writing an Aspire \"What's new in N.N\" release-notes page (src/frontend/src/content/docs/whats-new/aspire-N-N.mdx) as a repeatable lifecycle. Invoke as `/whatsnew {modality}` where modality is one of: draft/scaffold (init), research, critique, validate, polish, review. USE FOR: start/scaffold a new what's-new page for a release, research a release's changes into a dossier, critique a draft, fact-check/validate the diff, polish and run data ingestion, or sign off the PR. DO NOT USE FOR: general docs pages (use doc-writer), reviewing an arbitrary docs PR (use doc-pr-reviewer), or product-repo changes. ORCHESTRATES: doc-writer, doc-pr-reviewer, doc-tester, twoslash-validator, update-integrations, update-samples, container-images."
 ---
 
 # What's-new release-notes skill
@@ -10,7 +10,7 @@ Aspire N.N"** page as a single, step-argument skill with a repeatable lifecycle.
 Invoke it as `/whatsnew {modality}` — the modality argument selects one phase:
 
 ```
-{draft｜scaffold} → {research} → {critique} → {validate} → {polish} → {review}
+{draft/scaffold} → {research} → {critique} → {validate} → {polish} → {review}
    init/structure    dossier      self-review   fact-check    edits+data    sign-off
 ```
 
@@ -43,13 +43,11 @@ infer from context — e.g. a fresh release with no page → `draft`).
 ## Cross-cutting rules (apply to every phase)
 
 ### Git / branching / PR
-- Release work uses **`release/{N.N}` branches on `upstream`** (`microsoft/aspire.dev`).
-- Always cut `release/{N.N}` from the **latest `upstream/main`** (fetch first) to avoid
-  merge conflicts.
-- Iterate via a **draft PR** `release/{N.N}` → `upstream` `main`; `{review}` undrafts it.
-- `aspire.dev` is **not** an IEvangelist repo → **standard git-flow (PRs)**, target
-  `upstream`. The `dapine/{context}` feature-branch prefix does **not** apply to
-  `release/*` branches.
+- Release work happens on a **`release/{N.N}` branch** in the repository.
+- Cut `release/{N.N}` from the **latest default branch** (e.g. `main`) — fetch first so
+  you branch from an up-to-date base and avoid merge conflicts.
+- Iterate via a **draft PR** from `release/{N.N}` into the repository's **default
+  branch**; `{review}` marks it ready for review.
 
 ### Voice & quality (see `writing-guidelines.md` + `doc-writer`)
 - **Impact first, positives first, KISS.** No walls of text, no marketing fluff.
@@ -72,7 +70,7 @@ infer from context — e.g. a fresh release with no page → `draft`).
 | What's-new pages | `src/frontend/src/content/docs/whats-new/aspire-N-N.mdx` (JA under `.../ja/whats-new/`) |
 | Version constants | `src/frontend/config/aspire-versions.mjs` (`currentAspireMajorMinorVersion`, `currentAspireVersion`) |
 | Sidebar | `src/frontend/config/sidebar/docs.topics.ts` (What's-new `items`) |
-| Announcement banner | `banner:` frontmatter on `content/docs/index.mdx`, `docs.mdx`, `community/index.mdx`, and each `{locale}/index.mdx` (+ `ja/docs.mdx`); rendered by `src/frontend/src/components/starlight/Banner.astro` |
+| Announcement banner | `banner:` frontmatter on `src/frontend/src/content/docs/index.mdx`, `src/frontend/src/content/docs/docs.mdx`, `src/frontend/src/content/docs/community/index.mdx`, and each `src/frontend/src/content/docs/{locale}/index.mdx` (+ `.../ja/docs.mdx`); rendered by `src/frontend/src/components/starlight/Banner.astro` |
 | Assets | `src/frontend/src/assets/whats-new/aspire-<version>/` |
 | Container image data | `src/frontend/src/data/container-images.json` |
 | Diagnostics articles | `src/frontend/src/content/docs/diagnostics/aspire<area><NNN>.mdx` → `/diagnostics/aspire<NNN>/` |

--- a/.agents/skills/whatsnew/SKILL.md
+++ b/.agents/skills/whatsnew/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: whatsnew
+description: "Step-argument skill that formalizes writing an Aspire \"What's new in N.N\" release-notes page (src/frontend/src/content/docs/whats-new/aspire-N-N.mdx) as a repeatable lifecycle. Invoke as `/whatsnew {modality}` where modality is one of: draft|scaffold (init), research, critique, validate, polish, review. USE FOR: start/scaffold a new what's-new page for a release, research a release's changes into a dossier, critique a draft, fact-check/validate the diff, polish and run data ingestion, or sign off the PR. DO NOT USE FOR: general docs pages (use doc-writer), reviewing an arbitrary docs PR (use doc-pr-reviewer), or product-repo changes. ORCHESTRATES: doc-writer, doc-pr-reviewer, doc-tester, twoslash-validator, update-integrations, update-samples, container-images."
+---
+
+# What's-new release-notes skill
+
+Formalizes the previously ad-hoc process of writing an Aspire **"What's new in
+Aspire N.N"** page as a single, step-argument skill with a repeatable lifecycle.
+Invoke it as `/whatsnew {modality}` — the modality argument selects one phase:
+
+```
+{draft｜scaffold} → {research} → {critique} → {validate} → {polish} → {review}
+   init/structure    dossier      self-review   fact-check    edits+data    sign-off
+```
+
+Each phase has a dedicated spec under [`references/`](./references/). This skill
+**orchestrates** existing skills — it does not duplicate them.
+
+## Dispatch on the modality argument
+
+Read the argument, then follow the matching spec. `draft`, `scaffold`, and `init`
+are aliases for the same phase. If no argument is given, ask which phase to run (or
+infer from context — e.g. a fresh release with no page → `draft`).
+
+| Modality | Alias | Purpose | Spec | Edits content? |
+|----------|-------|---------|------|----------------|
+| `draft` | `scaffold`, `init` | Stand up branch, draft PR, skeleton MDX, banner, sidebar, version constants. **Structure only.** | [`01-draft-scaffold.md`](./references/01-draft-scaffold.md) | Skeleton only |
+| `research` | — | Enumerate every change into an impact-focused **dossier** (scratch, not shipped). | [`02-research.md`](./references/02-research.md) | No |
+| `critique` | — | Content-quality **self-review** of draft vs dossier; severity-ranked findings. | [`03-critique.md`](./references/03-critique.md) | **No — reports only** |
+| `validate` | — | **Ralph loop** with `doc-pr-reviewer` until 100% factual; samples/links/assets. **No `pnpm build`.** | [`04-validate.md`](./references/04-validate.md) | Fixes only |
+| `polish` | — | Editorial pass + CI triage + diagnostics-author `@mentions` + **automated data ingestion**. | [`05-polish.md`](./references/05-polish.md) | **Yes** |
+| `review` | — | Undraft PR, description, reviewers + `doc-tester` **blind** run of every in-article scenario. | [`06-review.md`](./references/06-review.md) | No |
+
+## Supporting references
+
+- [`whats-new-template.mdx`](./references/whats-new-template.mdx) — structure-only
+  skeleton the `draft` phase copies (with scaffold tokens + the standardized header +
+  the mandated section taxonomy).
+- [`writing-guidelines.md`](./references/writing-guidelines.md) — humanized voice +
+  the maintainer content standards. Defers to `doc-writer` for canonical style.
+
+## Cross-cutting rules (apply to every phase)
+
+### Git / branching / PR
+- Release work uses **`release/{N.N}` branches on `upstream`** (`microsoft/aspire.dev`).
+- Always cut `release/{N.N}` from the **latest `upstream/main`** (fetch first) to avoid
+  merge conflicts.
+- Iterate via a **draft PR** `release/{N.N}` → `upstream` `main`; `{review}` undrafts it.
+- `aspire.dev` is **not** an IEvangelist repo → **standard git-flow (PRs)**, target
+  `upstream`. The `dapine/{context}` feature-branch prefix does **not** apply to
+  `release/*` branches.
+
+### Voice & quality (see `writing-guidelines.md` + `doc-writer`)
+- **Impact first, positives first, KISS.** No walls of text, no marketing fluff.
+- **Judicious `<Aside>`** — a spotlight, not a floodlight. Don't burn the reader's eyes.
+- **Content standards:** Deployment and Integrations are **separate** sections; a
+  distinct **"New integrations"** section for brand-new ones; a **"Default container
+  image updates"** section for tag bumps; the standardized header (release-date badge +
+  release-tag link) on new articles only.
+
+### Safety / mechanics
+- **Never run `pnpm build` locally** — validate build-readiness by inspection.
+- Each modality is **idempotent** — safe to re-run; `critique`/`validate` loop to
+  convergence.
+- Prefer built-in tools over shell; Windows-friendly paths.
+
+## Key repository paths
+
+| What | Path |
+|------|------|
+| What's-new pages | `src/frontend/src/content/docs/whats-new/aspire-N-N.mdx` (JA under `.../ja/whats-new/`) |
+| Version constants | `src/frontend/config/aspire-versions.mjs` (`currentAspireMajorMinorVersion`, `currentAspireVersion`) |
+| Sidebar | `src/frontend/config/sidebar/docs.topics.ts` (What's-new `items`) |
+| Announcement banner | `banner:` frontmatter on `content/docs/index.mdx`, `docs.mdx`, `community/index.mdx`, and each `{locale}/index.mdx` (+ `ja/docs.mdx`); rendered by `src/frontend/src/components/starlight/Banner.astro` |
+| Assets | `src/frontend/src/assets/whats-new/aspire-<version>/` |
+| Container image data | `src/frontend/src/data/container-images.json` |
+| Diagnostics articles | `src/frontend/src/content/docs/diagnostics/aspire<area><NNN>.mdx` → `/diagnostics/aspire<NNN>/` |
+| Data ingestion | `src/frontend/scripts/update-integration-data.ps1` (`pnpm update:all`) |
+
+## Orchestrated skills
+
+`doc-writer` (voice/style) · `doc-pr-reviewer` (validate loop) · `doc-tester` (review
+blind run) · `twoslash-validator` (TS samples) · `update-integrations` /
+`update-samples` / `container-images` (polish data ingestion).

--- a/.agents/skills/whatsnew/SKILL.md
+++ b/.agents/skills/whatsnew/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: whatsnew
-description: "Step-argument skill that formalizes writing an Aspire \"What's new in N.N\" release-notes page (src/frontend/src/content/docs/whats-new/aspire-N-N.mdx) as a repeatable lifecycle. Invoke as `/whatsnew {modality}` where modality is one of: draft/scaffold (init), research, critique, validate, polish, review. USE FOR: start/scaffold a new what's-new page for a release, research a release's changes into a dossier, critique a draft, fact-check/validate the diff, polish and run data ingestion, or sign off the PR. DO NOT USE FOR: general docs pages (use doc-writer), reviewing an arbitrary docs PR (use doc-pr-reviewer), or product-repo changes. ORCHESTRATES: doc-writer, doc-pr-reviewer, doc-tester, twoslash-validator, update-integrations, update-samples, container-images."
+description: "Step-argument skill that formalizes writing an Aspire \"What's new in N.N\" release-notes page (src/frontend/src/content/docs/whats-new/aspire-N-N.mdx) as a repeatable lifecycle. Invoke as `/whatsnew {modality}` where modality is one of: draft/scaffold (init), research, critique, validate, polish, review. USE FOR: start/scaffold a new what's-new page for a release, research a release's changes into a dossier and author the draft prose, critique a draft, fact-check/validate the diff, polish and run data ingestion, or sign off the PR. DO NOT USE FOR: general docs pages (use doc-writer), reviewing an arbitrary docs PR (use doc-pr-reviewer), or product-repo changes. ORCHESTRATES: doc-writer, doc-pr-reviewer, doc-tester, twoslash-validator, update-integrations, update-samples, container-images."
 ---
 
 # What's-new release-notes skill
@@ -11,11 +11,15 @@ Invoke it as `/whatsnew {modality}` — the modality argument selects one phase:
 
 ```
 {draft/scaffold} → {research} → {critique} → {validate} → {polish} → {review}
-   init/structure    dossier      self-review   fact-check    edits+data    sign-off
+   init/structure   dossier+draft  self-review   fact-check   edits+data    sign-off
 ```
 
 Each phase has a dedicated spec under [`references/`](./references/). This skill
-**orchestrates** existing skills — it does not duplicate them.
+**orchestrates** existing skills — it does not duplicate them. `{research}` is the
+phase that **authors** the article body from its dossier; `{critique}`/`{validate}`
+then review and fact-check that draft, and `{polish}` finalizes it. Because
+`{polish}` edits content *after* `{validate}`, it must end with a **fresh
+`{validate}` pass** so nothing ships unchecked (see below).
 
 ## Dispatch on the modality argument
 
@@ -26,10 +30,10 @@ infer from context — e.g. a fresh release with no page → `draft`).
 | Modality | Alias | Purpose | Spec | Edits content? |
 |----------|-------|---------|------|----------------|
 | `draft` | `scaffold`, `init` | Stand up branch, draft PR, skeleton MDX, banner, sidebar, version constants. **Structure only.** | [`01-draft-scaffold.md`](./references/01-draft-scaffold.md) | Skeleton only |
-| `research` | — | Enumerate every change into an impact-focused **dossier** (scratch, not shipped). | [`02-research.md`](./references/02-research.md) | No |
+| `research` | — | Enumerate every change into an impact-focused **dossier**, then **author the first-draft prose** into the MDX from it. | [`02-research.md`](./references/02-research.md) | **Yes — drafts the body** |
 | `critique` | — | Content-quality **self-review** of draft vs dossier; severity-ranked findings. | [`03-critique.md`](./references/03-critique.md) | **No — reports only** |
 | `validate` | — | **Ralph loop** with `doc-pr-reviewer` until 100% factual; samples/links/assets. **No `pnpm build`.** | [`04-validate.md`](./references/04-validate.md) | Fixes only |
-| `polish` | — | Editorial pass + CI triage + diagnostics-author `@mentions` + **automated data ingestion**. | [`05-polish.md`](./references/05-polish.md) | **Yes** |
+| `polish` | — | Editorial pass + CI triage + diagnostics-author `@mentions` + **automated data ingestion**, then a **final `{validate}` pass**. | [`05-polish.md`](./references/05-polish.md) | **Yes** |
 | `review` | — | Undraft PR, description, reviewers + `doc-tester` **blind** run of every in-article scenario. | [`06-review.md`](./references/06-review.md) | No |
 
 ## Supporting references
@@ -47,7 +51,9 @@ infer from context — e.g. a fresh release with no page → `draft`).
 - Cut `release/{N.N}` from the **latest default branch** (e.g. `main`) — fetch first so
   you branch from an up-to-date base and avoid merge conflicts.
 - Iterate via a **draft PR** from `release/{N.N}` into the repository's **default
-  branch**; `{review}` marks it ready for review.
+  branch**. Open it **after** the scaffold is committed (a branch with no commits
+  ahead of the default branch has no diff, so the PR can't be created); `{review}`
+  marks it ready for review.
 
 ### Voice & quality (see `writing-guidelines.md` + `doc-writer`)
 - **Impact first, positives first, KISS.** No walls of text, no marketing fluff.
@@ -61,6 +67,9 @@ infer from context — e.g. a fresh release with no page → `draft`).
 - **Never run `pnpm build` locally** — validate build-readiness by inspection.
 - Each modality is **idempotent** — safe to re-run; `critique`/`validate` loop to
   convergence.
+- **Re-validate after polish.** Any edit `{polish}` makes lands *after* the
+  `{validate}` gate, so `{polish}` must finish with a fresh `{validate}` pass and
+  `{review}` confirms it — the committed article never bypasses validation.
 - Prefer built-in tools over shell; Windows-friendly paths.
 
 ## Key repository paths

--- a/.agents/skills/whatsnew/SKILL.md
+++ b/.agents/skills/whatsnew/SKILL.md
@@ -35,7 +35,7 @@ infer from context — e.g. a fresh release with no page → `draft`).
 ## Supporting references
 
 - [`whats-new-template.mdx`](./references/whats-new-template.mdx) — structure-only
-  skeleton the `draft` phase copies (with scaffold tokens + the standardized header +
+  skeleton the `draft` phase copies (scaffold tokens, `publishDate` frontmatter, and
   the mandated section taxonomy).
 - [`writing-guidelines.md`](./references/writing-guidelines.md) — humanized voice +
   the maintainer content standards. Defers to `doc-writer` for canonical style.
@@ -54,8 +54,8 @@ infer from context — e.g. a fresh release with no page → `draft`).
 - **Judicious `<Aside>`** — a spotlight, not a floodlight. Don't burn the reader's eyes.
 - **Content standards:** Deployment and Integrations are **separate** sections; a
   distinct **"New integrations"** section for brand-new ones; a **"Default container
-  image updates"** section for tag bumps; the standardized header (release-date badge +
-  release-tag link) on new articles only.
+  image updates"** section for tag bumps. The release-date badge + GitHub release-notes
+  link render **automatically** from `publishDate` + slug — never hand-place them.
 
 ### Safety / mechanics
 - **Never run `pnpm build` locally** — validate build-readiness by inspection.

--- a/.agents/skills/whatsnew/references/01-draft-scaffold.md
+++ b/.agents/skills/whatsnew/references/01-draft-scaffold.md
@@ -1,0 +1,65 @@
+# `{draft｜scaffold}` — initialize a release (structure only)
+
+> Aliases: `draft`, `scaffold`, `init`. **Structure only — no researched content.**
+
+Stand up everything a new "What's new in Aspire N.N" page needs so the team can
+start iterating: the release branch, a draft PR, the skeleton MDX, the site banner,
+the sidebar entry, and the version constants. Idempotent — safe to re-run; detect
+and update what already exists instead of duplicating.
+
+## Input
+
+- Target release `N.N` (e.g. `13.5`). **Prompt for it** if not supplied.
+- Derived: `SLUG = aspire-N-N`, `VERSION_FULL = N.N.0` (unless told otherwise),
+  `RELEASE_TAG_URL = https://github.com/microsoft/aspire/releases/tag/vN.N.0`.
+  `RELEASE_DATE` may be unknown at init — leave the `{{RELEASE_DATE}}` token for
+  {research}/{polish} to fill.
+
+## Actions
+
+1. **Release branch (upstream).** Ensure `release/{N.N}` exists on `upstream`
+   (`microsoft/aspire.dev`). If missing, create it from the **latest**
+   `upstream/main` (fetch first — always branch from up-to-date upstream to avoid
+   later conflicts). `release/*` branches are **not** subject to the `dapine/{context}`
+   feature-branch prefix.
+2. **Draft PR.** Ensure a **draft** PR `release/{N.N}` → `upstream` `main` exists for
+   the team to iterate on. Create it if missing; don't undraft here (that's {review}).
+3. **Scaffold the MDX.** Copy `references/whats-new-template.mdx` to
+   `src/frontend/src/content/docs/whats-new/{SLUG}.mdx`. Replace the scaffold tokens
+   (`{{VERSION_MAJOR_MINOR}}`, `{{VERSION_FULL}}`, `{{SLUG}}`, `{{RELEASE_DATE}}`,
+   `{{RELEASE_TAG_URL}}`) and delete the template's leading comment block. Keep it
+   **structure only** — placeholders and `TODO(...)` markers, no real prose. Preserve
+   the **content-standards taxonomy**: Deployment and Integrations **separate**, plus
+   dedicated **"New integrations"** and **"Default container image updates"** sections.
+   If the file already exists, reconcile structure without clobbering existing content.
+4. **Version constants.** Update `src/frontend/config/aspire-versions.mjs`:
+   `currentAspireMajorMinorVersion = 'N.N'` and `currentAspireVersion = 'N.N.0'` (only
+   when N.N is the new current release). This drives the `%ASPIRE_VERSION%` remark
+   placeholders site-wide.
+5. **Site-wide announcement banner.** The banner is **per-page frontmatter**, not a
+   global config. Update the `banner.content` string **and its link** to point at
+   `/whats-new/{SLUG}/` across every landing page that carries it, and set
+   `bannerAutoDismissAfterDays: 14` (and `bannerExpiresOn` if used):
+   - English: `src/frontend/src/content/docs/index.mdx`, `docs.mdx`,
+     `community/index.mdx`.
+   - Every locale: `src/frontend/src/content/docs/{locale}/index.mdx` (+
+     `ja/docs.mdx`). Translate the announcement text per locale and point at the
+     locale-appropriate whats-new path. (Grep `banner:` under
+     `src/frontend/src/content/docs/` to enumerate current banner pages.)
+6. **Sidebar entry.** In `src/frontend/config/sidebar/docs.topics.ts`, add
+   `{ label: 'Aspire N.N', slug: 'whats-new/{SLUG}' }` at the **top** of the What's-new
+   `items`. Roll the now-older version into the "Previous versions" group per the
+   existing pattern.
+7. **Assets folder.** Create `src/frontend/src/assets/whats-new/aspire-{VERSION_FULL}/`
+   (empty) for screenshots to land later.
+
+## Output
+
+- Committed scaffold on `release/{N.N}`, open **draft** PR to `upstream` `main`.
+
+## Exit criteria
+
+- Page exists and is structurally sound (frontmatter + imports + section skeleton).
+- Sidebar resolves the new slug; banner points at the new article across locales.
+- Version constants updated; draft PR is open.
+- **No researched prose yet** — only structure and placeholders.

--- a/.agents/skills/whatsnew/references/01-draft-scaffold.md
+++ b/.agents/skills/whatsnew/references/01-draft-scaffold.md
@@ -10,10 +10,12 @@ and update what already exists instead of duplicating.
 ## Input
 
 - Target release `N.N` (e.g. `13.5`). **Prompt for it** if not supplied.
-- Derived: `SLUG = aspire-N-N`, `VERSION_FULL = N.N.0` (unless told otherwise),
-  `RELEASE_TAG_URL = https://github.com/microsoft/aspire/releases/tag/vN.N.0`.
-  `RELEASE_DATE` may be unknown at init — leave the `{{RELEASE_DATE}}` token for
-  {research}/{polish} to fill.
+- Derived: `SLUG = aspire-N-N`, `VERSION_FULL = N.N.0` (unless told otherwise). The
+  release-date badge and GitHub release-notes link render **automatically** from the
+  page's `publishDate` frontmatter + slug — no token needed for them.
+- `RELEASE_DATE` (→ frontmatter `publishDate: YYYY-MM-DD`) may be unknown at init.
+  If so, **delete the `publishDate:` line** and let {research}/{polish} add it — the
+  badge simply doesn't render until it's set.
 
 ## Actions
 
@@ -25,8 +27,9 @@ and update what already exists instead of duplicating.
    mark it ready here (that's {review}).
 3. **Scaffold the MDX.** Copy `references/whats-new-template.mdx` to
    `src/frontend/src/content/docs/whats-new/{SLUG}.mdx`. Replace the scaffold tokens
-   (`{{VERSION_MAJOR_MINOR}}`, `{{VERSION_FULL}}`, `{{SLUG}}`, `{{RELEASE_DATE}}`,
-   `{{RELEASE_TAG_URL}}`) and delete the template's leading comment block. Keep it
+   (`{{VERSION_MAJOR_MINOR}}`, `{{VERSION_FULL}}`, `{{SLUG}}`, and `{{RELEASE_DATE}}`
+   → `publishDate`, or drop that line if the date is unknown) and delete the template's
+   leading comment block. Keep it
    **structure only** — placeholders and `TODO(...)` markers, no real prose. Preserve
    the **content-standards taxonomy**: Deployment and Integrations **separate**, plus
    dedicated **"New integrations"** and **"Default container image updates"** sections.

--- a/.agents/skills/whatsnew/references/01-draft-scaffold.md
+++ b/.agents/skills/whatsnew/references/01-draft-scaffold.md
@@ -3,9 +3,10 @@
 > Aliases: `draft`, `scaffold`, `init`. **Structure only — no researched content.**
 
 Stand up everything a new "What's new in Aspire N.N" page needs so the team can
-start iterating: the release branch, a draft PR, the skeleton MDX, the site banner,
-the sidebar entry, and the version constants. Idempotent — safe to re-run; detect
-and update what already exists instead of duplicating.
+start iterating: the release branch, the skeleton MDX, the site banner, the sidebar
+entry, and the version constants — all **committed**, and only then a **draft PR**.
+Idempotent — safe to re-run; detect and update what already exists instead of
+duplicating.
 
 ## Input
 
@@ -21,11 +22,10 @@ and update what already exists instead of duplicating.
 
 1. **Release branch.** Ensure a `release/{N.N}` branch exists in the repository. If
    missing, create it from the **latest default branch** (e.g. `main`) — fetch first so
-   you branch from an up-to-date base and avoid later conflicts.
-2. **Draft PR.** Ensure a **draft** PR from `release/{N.N}` into the repository's
-   **default branch** exists for the team to iterate on. Create it if missing; don't
-   mark it ready here (that's {review}).
-3. **Scaffold the MDX.** Copy `references/whats-new-template.mdx` to
+   you branch from an up-to-date base and avoid later conflicts. **Check it out** now;
+   the draft PR is opened **last**, only after the scaffold is committed (a branch with
+   no commits ahead of the default branch has no diff, so a PR can't be created yet).
+2. **Scaffold the MDX.** Copy `references/whats-new-template.mdx` to
    `src/frontend/src/content/docs/whats-new/{SLUG}.mdx`. Replace the scaffold tokens
    (`{{VERSION_MAJOR_MINOR}}`, `{{VERSION_FULL}}`, `{{SLUG}}`, and `{{RELEASE_DATE}}`
    → `publishDate`, or drop that line if the date is unknown) and delete the template's
@@ -34,11 +34,11 @@ and update what already exists instead of duplicating.
    the **content-standards taxonomy**: Deployment and Integrations **separate**, plus
    dedicated **"New integrations"** and **"Default container image updates"** sections.
    If the file already exists, reconcile structure without clobbering existing content.
-4. **Version constants.** Update `src/frontend/config/aspire-versions.mjs`:
+3. **Version constants.** Update `src/frontend/config/aspire-versions.mjs`:
    `currentAspireMajorMinorVersion = 'N.N'` and `currentAspireVersion = 'N.N.0'` (only
    when N.N is the new current release). This drives the `%ASPIRE_VERSION%` remark
    placeholders site-wide.
-5. **Site-wide announcement banner.** The banner is **per-page frontmatter**, not a
+4. **Site-wide announcement banner.** The banner is **per-page frontmatter**, not a
    global config. Update the `banner.content` string **and its link** to point at
    `/whats-new/{SLUG}/` across every landing page that carries it, and set
    `bannerAutoDismissAfterDays: 14` (and `bannerExpiresOn` if used):
@@ -48,12 +48,17 @@ and update what already exists instead of duplicating.
      `ja/docs.mdx`). Translate the announcement text per locale and point at the
      locale-appropriate whats-new path. (Grep `banner:` under
      `src/frontend/src/content/docs/` to enumerate current banner pages.)
-6. **Sidebar entry.** In `src/frontend/config/sidebar/docs.topics.ts`, add
+5. **Sidebar entry.** In `src/frontend/config/sidebar/docs.topics.ts`, add
    `{ label: 'Aspire N.N', slug: 'whats-new/{SLUG}' }` at the **top** of the What's-new
    `items`. Roll the now-older version into the "Previous versions" group per the
    existing pattern.
-7. **Assets folder.** Create `src/frontend/src/assets/whats-new/aspire-{VERSION_FULL}/`
+6. **Assets folder.** Create `src/frontend/src/assets/whats-new/aspire-{VERSION_FULL}/`
    (empty) for screenshots to land later.
+7. **Commit the scaffold.** Stage and commit all of the above on `release/{N.N}` so the
+   branch has a diff against the default branch (nothing to PR otherwise).
+8. **Draft PR.** *Now* open a **draft** PR from `release/{N.N}` into the repository's
+   **default branch** for the team to iterate on. Create it if missing; don't mark it
+   ready here (that's {review}).
 
 ## Output
 

--- a/.agents/skills/whatsnew/references/01-draft-scaffold.md
+++ b/.agents/skills/whatsnew/references/01-draft-scaffold.md
@@ -1,4 +1,4 @@
-# `{draft｜scaffold}` — initialize a release (structure only)
+# `{draft/scaffold}` — initialize a release (structure only)
 
 > Aliases: `draft`, `scaffold`, `init`. **Structure only — no researched content.**
 
@@ -17,13 +17,12 @@ and update what already exists instead of duplicating.
 
 ## Actions
 
-1. **Release branch (upstream).** Ensure `release/{N.N}` exists on `upstream`
-   (`microsoft/aspire.dev`). If missing, create it from the **latest**
-   `upstream/main` (fetch first — always branch from up-to-date upstream to avoid
-   later conflicts). `release/*` branches are **not** subject to the `dapine/{context}`
-   feature-branch prefix.
-2. **Draft PR.** Ensure a **draft** PR `release/{N.N}` → `upstream` `main` exists for
-   the team to iterate on. Create it if missing; don't undraft here (that's {review}).
+1. **Release branch.** Ensure a `release/{N.N}` branch exists in the repository. If
+   missing, create it from the **latest default branch** (e.g. `main`) — fetch first so
+   you branch from an up-to-date base and avoid later conflicts.
+2. **Draft PR.** Ensure a **draft** PR from `release/{N.N}` into the repository's
+   **default branch** exists for the team to iterate on. Create it if missing; don't
+   mark it ready here (that's {review}).
 3. **Scaffold the MDX.** Copy `references/whats-new-template.mdx` to
    `src/frontend/src/content/docs/whats-new/{SLUG}.mdx`. Replace the scaffold tokens
    (`{{VERSION_MAJOR_MINOR}}`, `{{VERSION_FULL}}`, `{{SLUG}}`, `{{RELEASE_DATE}}`,
@@ -55,7 +54,8 @@ and update what already exists instead of duplicating.
 
 ## Output
 
-- Committed scaffold on `release/{N.N}`, open **draft** PR to `upstream` `main`.
+- Committed scaffold on `release/{N.N}`, with an open **draft** PR into the
+  repository's default branch.
 
 ## Exit criteria
 

--- a/.agents/skills/whatsnew/references/02-research.md
+++ b/.agents/skills/whatsnew/references/02-research.md
@@ -30,8 +30,9 @@ dossier (scratch on the branch / session workspace) — **not** shipped prose.
 4. **Default container image tag bumps.** Diff `container-images.json`; list every
    default image whose **tag** changed (old → new) with any data-volume/migration
    caveat. → "🐳 Default container image updates".
-5. **Header facts.** Record the **release date** (`Released MMMM D, YYYY`) and the
-   release-tag URL for the standardized header.
+5. **Release date.** Record the **release date** → the page's `publishDate`
+   frontmatter (the badge + GitHub release-notes link then render automatically; the
+   release-tag URL is derived from the slug, so there's nothing to hand-author).
 6. **Edges.** Note preview-only/experimental packages, Community-Toolkit changes,
    and **breaking changes** (what changed, who's affected, remediation).
 
@@ -44,7 +45,7 @@ A categorized dossier (scratch, on branch — not shipped) with, per change:
 - Source PR link + contributor handle(s).
 - `LearnMore` target path, or explicit "no target yet".
 - New-integration / image-tag-bump / breaking-change flags as applicable.
-- Release date + release-tag URL for the header.
+- Release date (→ frontmatter `publishDate`).
 
 ## Skills orchestrated
 
@@ -56,4 +57,4 @@ A categorized dossier (scratch, on branch — not shipped) with, per change:
 - Every shipped change has a dossier entry with a source link, an impact note, and a
   `LearnMore` target (or explicit "none yet").
 - New integrations, image-tag bumps, and breaking changes are each explicitly listed.
-- Release date + release-tag URL captured.
+- Release date captured (for `publishDate`).

--- a/.agents/skills/whatsnew/references/02-research.md
+++ b/.agents/skills/whatsnew/references/02-research.md
@@ -1,0 +1,59 @@
+# `{research}` — build the change dossier
+
+Enumerate **every** change in the release and understand each one well enough to
+write a compelling, factual, engaging impact statement. Output is a research
+dossier (scratch on the branch / session workspace) — **not** shipped prose.
+
+## Sources (authoritative)
+
+- `microsoft/aspire` **`release/{N.N}` branch** — the actual code that shipped.
+- **GitHub release notes** — `https://github.com/microsoft/aspire/releases/tag/vN.N.0`
+  (also the canonical **release date** and the header's release-tag URL).
+- **Automated wiki change-log** — `https://github.com/microsoft/aspire/wiki/{N.N}-Change-log`.
+- **Merged PRs + labels**, milestone/issues for `N.N`. Also dashboard/CLI repos where relevant.
+- **`src/frontend/src/data/container-images.json`** — diff prior vs new release to
+  find default container image **tag** bumps.
+
+## Actions
+
+1. **Enumerate & understand.** For each change: what it is, the exact API/CLI surface,
+   and *why it matters to the developer*. Capture the source PR link and candidate
+   **contributor handle(s)**.
+2. **Detect `docs-from-code`.** On each originating PR, check for the `docs-from-code`
+   label. Those automated docs PRs may be **open or already merged into
+   `release/{N.N}`** — meaning deep-link targets for `LearnMore` may already exist on
+   the branch. Record the target path (or an explicit "no target yet").
+3. **Classify against the taxonomy.** Map each change to a top-level section. Keep
+   **Deployment** and **Integrations** distinct. Explicitly separate:
+   - **Brand-new integrations** → "✨ New integrations".
+   - **Changes to existing integrations** → "📦 Integration updates".
+4. **Default container image tag bumps.** Diff `container-images.json`; list every
+   default image whose **tag** changed (old → new) with any data-volume/migration
+   caveat. → "🐳 Default container image updates".
+5. **Header facts.** Record the **release date** (`Released MMMM D, YYYY`) and the
+   release-tag URL for the standardized header.
+6. **Edges.** Note preview-only/experimental packages, Community-Toolkit changes,
+   and **breaking changes** (what changed, who's affected, remediation).
+
+## Output — the dossier
+
+A categorized dossier (scratch, on branch — not shipped) with, per change:
+
+- Section it belongs to (taxonomy-mapped; Integrations/Deployment separate).
+- One-line **impact note** ("compelling, factual, engaging truth").
+- Source PR link + contributor handle(s).
+- `LearnMore` target path, or explicit "no target yet".
+- New-integration / image-tag-bump / breaking-change flags as applicable.
+- Release date + release-tag URL for the header.
+
+## Skills orchestrated
+
+- `container-images` — regenerate/confirm image data if the checked-in JSON is stale
+  (full regeneration is owned by {polish}; here it's for research accuracy only).
+
+## Exit criteria
+
+- Every shipped change has a dossier entry with a source link, an impact note, and a
+  `LearnMore` target (or explicit "none yet").
+- New integrations, image-tag bumps, and breaking changes are each explicitly listed.
+- Release date + release-tag URL captured.

--- a/.agents/skills/whatsnew/references/02-research.md
+++ b/.agents/skills/whatsnew/references/02-research.md
@@ -10,7 +10,7 @@ dossier (scratch on the branch / session workspace) — **not** shipped prose.
 - **GitHub release notes** — `https://github.com/microsoft/aspire/releases/tag/vN.N.0`
   (also the canonical **release date** and the header's release-tag URL).
 - **Automated wiki change-log** — `https://github.com/microsoft/aspire/wiki/{N.N}-Change-log`.
-- **Merged PRs + labels**, milestone/issues for `N.N`. Also dashboard/CLI repos where relevant.
+- **Merged PRs + labels**, milestone/issues for `N.N`. Also, the `microsoft/dcp` repo when relevant.
 - **`src/frontend/src/data/container-images.json`** — diff prior vs new release to
   find default container image **tag** bumps.
 

--- a/.agents/skills/whatsnew/references/02-research.md
+++ b/.agents/skills/whatsnew/references/02-research.md
@@ -1,8 +1,11 @@
-# `{research}` — build the change dossier
+# `{research}` — build the change dossier and draft the article
 
 Enumerate **every** change in the release and understand each one well enough to
-write a compelling, factual, engaging impact statement. Output is a research
-dossier (scratch on the branch / session workspace) — **not** shipped prose.
+write a compelling, factual, engaging impact statement — then **author the
+first-draft prose** into the scaffolded MDX from that dossier. The dossier is the
+reasoning artifact (scratch on the branch / session workspace); the **draft it
+produces is the article body** that `{critique}` and `{validate}` then review.
+This is the phase that turns the skeleton into a real, reviewable page.
 
 ## Sources (authoritative)
 
@@ -27,16 +30,33 @@ dossier (scratch on the branch / session workspace) — **not** shipped prose.
    **Deployment** and **Integrations** distinct. Explicitly separate:
    - **Brand-new integrations** → "✨ New integrations".
    - **Changes to existing integrations** → "📦 Integration updates".
+   Scope: "New integrations" is for **first-party `microsoft/aspire`** integrations
+   only. **Community Toolkit** (`CommunityToolkit/Aspire`) integrations ship on their
+   own cadence with their own release notes — do **not** list them here. Only mention
+   the Toolkit when a **core** integration migrates **to/from** it or is deprecated in
+   favor of it (e.g. a hosting package moving to `CommunityToolkit.Aspire.*`).
 4. **Default container image tag bumps.** Diff `container-images.json`; list every
    default image whose **tag** changed (old → new) with any data-volume/migration
    caveat. → "🐳 Default container image updates".
 5. **Release date.** Record the **release date** → the page's `publishDate`
    frontmatter (the badge + GitHub release-notes link then render automatically; the
    release-tag URL is derived from the slug, so there's nothing to hand-author).
-6. **Edges.** Note preview-only/experimental packages, Community-Toolkit changes,
-   and **breaking changes** (what changed, who's affected, remediation).
+6. **Edges.** Note preview-only/experimental packages, Community Toolkit changes,
+   and **breaking changes** (what changed, who's affected, remediation). If the
+   release ships **no** breaking changes, record that explicitly so the draft omits
+   the section (next step).
+7. **Author the draft.** Populate the scaffolded MDX from the dossier: write the lede,
+   the "This release introduces" bullets (1:1 with the `##` sections, same order), and
+   each section body with impact-first prose, `LearnMore` deep-links, and C#/TypeScript
+   `<Tabs syncKey='aspire-lang'>` where a feature spans AppHost languages. Credit each
+   merged community PR by `@handle`. **Only include sections that apply** — delete any
+   standard section with no content. In particular, when the release has **no breaking
+   changes**, remove the "⚠️ Breaking changes" section *and* the breaking-changes
+   caution `<Aside>` in the Upgrade section (and its "This release introduces" bullet
+   if present). This is a **first draft**: `{critique}` reviews it, `{validate}`
+   fact-checks it, and `{polish}` refines it.
 
-## Output — the dossier
+## Output — the dossier + first draft
 
 A categorized dossier (scratch, on branch — not shipped) with, per change:
 
@@ -46,6 +66,9 @@ A categorized dossier (scratch, on branch — not shipped) with, per change:
 - `LearnMore` target path, or explicit "no target yet".
 - New-integration / image-tag-bump / breaking-change flags as applicable.
 - Release date (→ frontmatter `publishDate`).
+
+…and, authored **from** that dossier, the **populated draft MDX** — the article body
+(lede, intro bullets, and section prose) that becomes the reviewable page.
 
 ## Skills orchestrated
 
@@ -58,3 +81,6 @@ A categorized dossier (scratch, on branch — not shipped) with, per change:
   `LearnMore` target (or explicit "none yet").
 - New integrations, image-tag bumps, and breaking changes are each explicitly listed.
 - Release date captured (for `publishDate`).
+- The scaffolded MDX is **populated from the dossier** (lede, intro bullets, and
+  section bodies) into a reviewable first draft, with inapplicable sections removed
+  (e.g. no "⚠️ Breaking changes" section or caution when the release has none).

--- a/.agents/skills/whatsnew/references/03-critique.md
+++ b/.agents/skills/whatsnew/references/03-critique.md
@@ -5,7 +5,7 @@ actionable, severity-ranked findings report. **Makes no edits** — {polish} act
 
 ## Inputs
 
-- The scaffolded/in-progress `whats-new/aspire-N-N.mdx`.
+- The **draft** `whats-new/aspire-N-N.mdx` (authored in {research} from the dossier).
 - The {research} dossier.
 - [`writing-guidelines.md`](./writing-guidelines.md) and the `doc-writer` skill (style/tone/voice/tech-stack).
 
@@ -25,13 +25,17 @@ actionable, severity-ranked findings report. **Makes no edits** — {polish} act
 **What's-new style adherence**
 - "This release introduces" bullets map **1:1** to the `##` sections, same order.
 - Emoji section headings correct; `####` subsections used where appropriate.
-- `<Aside>` used **judiciously** (not eye-burning); breaking-changes caution present.
+- `<Aside>` used **judiciously** (not eye-burning). Breaking-changes caution present
+  **only** when the release has breaking changes — when it has none, both the caution
+  *and* the "⚠️ Breaking changes" section are omitted (no empty section left behind).
 - C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) wherever a feature spans AppHost languages.
 - `publishDate` frontmatter set (the `Released MMMM D, YYYY` badge + GitHub release-notes link auto-render; no hand-placed header).
 
 **Content standards (mandated)**
 - Deployment and Integrations are **separate** (not over-grouped).
-- A distinct **"✨ New integrations"** section exists when new integrations shipped.
+- A distinct **"✨ New integrations"** section exists when new **first-party**
+  integrations shipped. Community Toolkit integrations are **not** listed here — they
+  ship separately with their own release notes.
 - **"🐳 Default container image updates"** lists every tag bump found in research.
 
 **Completeness**

--- a/.agents/skills/whatsnew/references/03-critique.md
+++ b/.agents/skills/whatsnew/references/03-critique.md
@@ -27,7 +27,7 @@ actionable, severity-ranked findings report. **Makes no edits** — {polish} act
 - Emoji section headings correct; `####` subsections used where appropriate.
 - `<Aside>` used **judiciously** (not eye-burning); breaking-changes caution present.
 - C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) wherever a feature spans AppHost languages.
-- Standardized header present: `Released MMMM D, YYYY` badge + release-tag link.
+- `publishDate` frontmatter set (the `Released MMMM D, YYYY` badge + GitHub release-notes link auto-render; no hand-placed header).
 
 **Content standards (mandated)**
 - Deployment and Integrations are **separate** (not over-grouped).

--- a/.agents/skills/whatsnew/references/03-critique.md
+++ b/.agents/skills/whatsnew/references/03-critique.md
@@ -1,0 +1,51 @@
+# `{critique}` — content-quality review (reports, does not edit)
+
+A rigorous self-review of the **draft** against the **dossier**. Produces an
+actionable, severity-ranked findings report. **Makes no edits** — {polish} acts on it.
+
+## Inputs
+
+- The scaffolded/in-progress `whats-new/aspire-N-N.mdx`.
+- The {research} dossier.
+- [`writing-guidelines.md`](./writing-guidelines.md) and the `doc-writer` skill (style/tone/voice/tech-stack).
+
+## What it evaluates
+
+**Accuracy**
+- Every claim traces to the dossier / a real PR. No invented APIs, flags, or behavior.
+- API names, CLI commands, and version numbers are exact.
+- `LearnMore`/links point at real targets (or are flagged as not-yet-merged
+  `docs-from-code`).
+
+**Engaging, impact-first framing**
+- Sections and bullets lead with developer impact, ordered by customer DX.
+- Positives first; caveats/breaking changes appropriately placed.
+- KISS — no walls of text, no filler, no marketing superlatives.
+
+**What's-new style adherence**
+- "This release introduces" bullets map **1:1** to the `##` sections, same order.
+- Emoji section headings correct; `####` subsections used where appropriate.
+- `<Aside>` used **judiciously** (not eye-burning); breaking-changes caution present.
+- C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) wherever a feature spans AppHost languages.
+- Standardized header present: `Released MMMM D, YYYY` badge + release-tag link.
+
+**Content standards (mandated)**
+- Deployment and Integrations are **separate** (not over-grouped).
+- A distinct **"✨ New integrations"** section exists when new integrations shipped.
+- **"🐳 Default container image updates"** lists every tag bump found in research.
+
+**Completeness**
+- No missing sections vs the dossier; no thin/unsubstantiated statements.
+- Every merged community PR is credited by `@handle`.
+- No dead or placeholder links / leftover `TODO(...)` markers (except intentionally
+  pending `docs-from-code` targets, which must be flagged).
+
+## Output
+
+A severity-ranked findings list — **Blocker / Major / Minor / Nit** — each with the
+location and a concrete suggested fix. **No edits are made in this phase.**
+
+## Exit criteria
+
+- A findings report the author / {polish} can act on directly.
+- Every content standard above has an explicit pass/fail note.

--- a/.agents/skills/whatsnew/references/04-validate.md
+++ b/.agents/skills/whatsnew/references/04-validate.md
@@ -1,0 +1,53 @@
+# `{validate}` — factual + build-readiness correctness (looped)
+
+Prove the article is good-to-go **without running `pnpm build`**. The core is a
+**Ralph loop** around `doc-pr-reviewer` until the (large) diff is 100% factual *and
+still engaging*.
+
+## Does NOT
+
+- **Never runs `pnpm build`** locally. Verify build-readiness by inspection instead.
+
+## Core loop (Ralph)
+
+Run the [`doc-pr-reviewer`](../../doc-pr-reviewer/SKILL.md) skill against the PR diff,
+then **fix → re-review → repeat** until it converges clean:
+
+1. `doc-pr-reviewer` fact-checks every claim against its source of truth
+   (`microsoft/aspire` core, CommunityToolkit/Aspire, Azure SDK where relevant).
+2. Apply fixes for each finding (correct the claim, or cut it).
+3. Re-run until **no factual findings remain** — while keeping the prose engaging
+   (don't sand off the voice to satisfy a nit; fix the fact, keep the impact).
+
+## Also checks
+
+- **TypeScript samples:** run [`twoslash-validator`](../../twoslash-validator/SKILL.md)
+  on every `twoslash` block.
+- **MDX/frontmatter validity:** imports resolve; frontmatter well-formed; emoji `##`
+  headings only in the TOC range (min/max heading level 2).
+- **Sidebar + localization sync:** the new slug is wired in `docs.topics.ts`; note any
+  JA (`ja/whats-new/`) copy that is out of sync (JA translation follows the normal
+  localization flow — flag, don't block).
+- **Links & assets resolve:** every internal link, `LearnMore` target, and
+  image/asset reference exists. For links **into `release/{N.N}`** that may not be
+  merged yet: **block on truly-broken**, **warn on not-yet-merged `docs-from-code`**
+  targets.
+- **Banner + version wiring:** banner points at the new article across locales; version
+  constants in `aspire-versions.mjs` are correct.
+
+## Editorial guardrails enforced here
+
+Order by impact / customer DX · lead with positives · `<Aside>` used judiciously (don't
+burn the reader's eyes) · developer empathy · KISS · no walls of text · a genuinely
+good technical read.
+
+## Skills orchestrated
+
+- `doc-pr-reviewer` (primary, looped) · `twoslash-validator` (TS samples).
+
+## Exit criteria
+
+- `doc-pr-reviewer` converges with **no** factual findings.
+- All `twoslash` samples pass; all links/assets resolve (or are explicitly
+  warn-listed as pending `docs-from-code`).
+- MDX/frontmatter valid; sidebar/banner/version wiring correct.

--- a/.agents/skills/whatsnew/references/05-polish.md
+++ b/.agents/skills/whatsnew/references/05-polish.md
@@ -2,7 +2,8 @@
 
 The one phase that **applies edits**. Turn a validated draft into a finished,
 ship-ready article; triage CI; ping diagnostics authors; and run the automated data
-ingestion once content has settled.
+ingestion once content has settled — then **re-validate**, because every edit here
+lands *after* the `{validate}` gate and must not ship unchecked.
 
 ## Editorial (apply edits)
 
@@ -52,9 +53,25 @@ Once content has settled, regenerate the generated data from the `release/{N.N}`
 - Re-reconcile the image-tag and new/updated integration sections against the
   regenerated data, then commit.
 
+## Re-validate (mandatory gate)
+
+Everything above edits content **after** the `{validate}` gate — prose, frontmatter,
+regenerated data, reconciled sections — so those edits must be re-checked before
+handoff. **Re-run [`{validate}`](./04-validate.md)** on the changed article and loop
+`polish → validate` until it converges clean:
+
+- `doc-pr-reviewer` surfaces **no** new factual findings on the edited prose.
+- `twoslash-validator` passes on any changed/regenerated `twoslash` blocks.
+- MDX/frontmatter still valid; all links/assets still resolve; sidebar/banner/version
+  wiring intact.
+
+`{polish}` is **not done** until this final `{validate}` pass is green (`{review}`
+re-confirms it).
+
 ## Skills orchestrated
 
-- `doc-writer` (voice) · `update-integrations` · `update-samples` · `container-images`.
+- `doc-writer` (voice) · `update-integrations` · `update-samples` · `container-images`
+  · `doc-pr-reviewer` / `twoslash-validator` (final re-validate gate).
 
 ## Exit criteria
 
@@ -62,3 +79,5 @@ Once content has settled, regenerate the generated data from the `release/{N.N}`
 - Generated data regenerated and committed; the three integration/image sections
   reconciled against it.
 - Diagnostics-author `@mentions` posted.
+- A final `{validate}` pass runs **after** all polish edits and converges clean — no
+  polish edit bypasses the validation gate.

--- a/.agents/skills/whatsnew/references/05-polish.md
+++ b/.agents/skills/whatsnew/references/05-polish.md
@@ -15,7 +15,7 @@ ingestion once content has settled.
 - Finalize **contributor thanks** (`@handle` + one-line note per merged community PR).
 - **SEO:** tighten `title`/`description` frontmatter; add descriptive `alt` text to
   every image.
-- Fill the standardized header's `Released MMMM D, YYYY` badge if it was still pending.
+- Set the `publishDate` frontmatter (ISO `YYYY-MM-DD`) if it was still pending — the `Released MMMM D, YYYY` badge auto-renders from it.
 
 ## CI triage
 

--- a/.agents/skills/whatsnew/references/05-polish.md
+++ b/.agents/skills/whatsnew/references/05-polish.md
@@ -1,0 +1,60 @@
+# `{polish}` — final refinements + late automation (applies edits)
+
+The one phase that **applies edits**. Turn a validated draft into a finished,
+ship-ready article; triage CI; ping diagnostics authors; and run the automated data
+ingestion once content has settled.
+
+## Editorial (apply edits)
+
+- Tighten to **KISS**; smooth flow and voice per the `doc-writer` skill; dedupe.
+- Confirm the "This release introduces" bullets map **1:1** to sections (same order).
+- Right-size `<Aside>` usage (judicious — don't burn the reader's eyes).
+- C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) complete and correct.
+- Reconcile **"✨ New integrations"**, **"📦 Integration updates"**, and **"🐳 Default
+  container image updates"** against the freshly regenerated data (below).
+- Finalize **contributor thanks** (`@handle` + one-line note per merged community PR).
+- **SEO:** tighten `title`/`description` frontmatter; add descriptive `alt` text to
+  every image.
+- Fill the standardized header's `Released MMMM D, YYYY` badge if it was still pending.
+
+## CI triage
+
+- Evaluate and resolve CI failures on the PR (lint, link-check, twoslash, build on CI).
+
+## Diagnostics authors (`docs-from-code` follow-up)
+
+For each **new diagnostics article** that originated from a `docs-from-code`-labeled
+`microsoft/aspire` feature PR, `@mention` the original PR author with the standard
+request so the short link gets created and named:
+
+> `@{gh-alias}` Please create an aka link for this new diagnostic and name it
+> accordingly: `https://aka.ms/aspire/diagnostics/{aspireNNN}`
+
+(matching the article's route, e.g. `/diagnostics/aspire010/`). Post these as PR
+comments (also re-affirmed in {review}).
+
+## Automated data ingestion (owned here)
+
+Once content has settled, regenerate the generated data from the `release/{N.N}`
+**staging feed** (`darc-pub-microsoft-aspire-{shortSha}` — resolves `Aspire.*` on
+`release/*` branches):
+
+- Run `src/frontend/scripts/update-integration-data.ps1` (`pnpm update:all`) to
+  regenerate the **C#/TS API JSON** + the **twoslash bundle**.
+- Orchestrate the [`update-integrations`](../../update-integrations/SKILL.md),
+  [`update-samples`](../../update-samples/SKILL.md), and
+  [`container-images`](../../container-images/SKILL.md) skills as needed to refresh
+  **`container-images.json`**, samples, and stats.
+- Re-reconcile the image-tag and new/updated integration sections against the
+  regenerated data, then commit.
+
+## Skills orchestrated
+
+- `doc-writer` (voice) · `update-integrations` · `update-samples` · `container-images`.
+
+## Exit criteria
+
+- Article reads clean and finished; CI is **green**.
+- Generated data regenerated and committed; the three integration/image sections
+  reconciled against it.
+- Diagnostics-author `@mentions` posted.

--- a/.agents/skills/whatsnew/references/05-polish.md
+++ b/.agents/skills/whatsnew/references/05-polish.md
@@ -13,8 +13,12 @@ ingestion once content has settled.
 - Reconcile **"✨ New integrations"**, **"📦 Integration updates"**, and **"🐳 Default
   container image updates"** against the freshly regenerated data (below).
 - Finalize **contributor thanks** (`@handle` + one-line note per merged community PR).
-- **SEO:** tighten `title`/`description` frontmatter; add descriptive `alt` text to
-  every image.
+- **SEO:** tighten `title`/`description` frontmatter and add descriptive `alt` text to
+  every image. Add a custom **`seoTitle`** — the visible `title` ("What's new in Aspire
+  N.N", ~24 chars) is shorter than the optimal 50–60 char social-card range, and
+  `seoTitle` is used **verbatim** as `og:title`/`twitter:title` (no `· Aspire` suffix)
+  without bloating the H1/sidebar label (e.g. `seoTitle: "What's new in Aspire N.N —
+  <headline theme 1>, <headline theme 2>, and more"`).
 - Set the `publishDate` frontmatter (ISO `YYYY-MM-DD`) if it was still pending — the `Released MMMM D, YYYY` badge auto-renders from it.
 
 ## CI triage

--- a/.agents/skills/whatsnew/references/06-review.md
+++ b/.agents/skills/whatsnew/references/06-review.md
@@ -8,7 +8,9 @@ Take the finished article from draft to ready-to-merge, and prove it works by dr
 1. **Mark the PR ready for review** (`release/{N.N}` → the repository's default branch).
 2. **PR description.** Write/refresh it: summary, headline highlights, breaking
    changes, and key links (release tag, notable PRs).
-3. **CI green.** Confirm all checks pass (coordinate with {polish} if not).
+3. **CI green.** Confirm all checks pass (coordinate with {polish} if not), and that
+   {polish}'s **final `{validate}` pass** converged clean — no edit made after the
+   validate gate is shipping unverified.
 4. **Diagnostics `@mentions`.** Ensure the `docs-from-code` diagnostics-author aka-link
    requests are posted on the PR (from {polish}); re-affirm if missing.
 5. **Request reviewers.** Add the right reviewers for a what's-new page.
@@ -22,6 +24,24 @@ Drive the [`doc-tester`](../../doc-tester/SKILL.md) skill to read **only** the f
 **every** test scenario the article documents (upgrade steps, code samples, CLI
 commands, feature walkthroughs). The article must be self-sufficient: a developer
 following it verbatim should succeed.
+
+### Safety & isolation (required)
+
+The article documents **stateful** commands — `aspire update --self` mutates the
+machine's CLI, and feature walkthroughs can deploy to Azure/Kubernetes, publish
+artifacts, or touch external services. Never run these blindly against the working
+machine. Before executing:
+
+- **Disposable environment only.** Run scenarios in a throwaway sandbox (fresh
+  container / VM / temp working directory) that can be discarded afterward — never the
+  dev machine, a shared box, or any production context.
+- **Classify each scenario by side-effect first:** *read-only / local* (safe to run) vs
+  *external or persistent* (installs, `--self` updates, deployments, publishes — anything
+  that writes outside the sandbox or reaches a remote service).
+- **Require explicit authorization** for the external/persistent class; don't execute
+  them without the maintainer's go-ahead. Absent authorization, **inspect / dry-run** the
+  steps for correctness and record them as "verified by inspection, not executed" rather
+  than mutating anything.
 
 - Any scenario that fails blind is a **defect in the article** → bounce back to
   {polish} (or {validate} if it's a factual error), fix, and re-run.

--- a/.agents/skills/whatsnew/references/06-review.md
+++ b/.agents/skills/whatsnew/references/06-review.md
@@ -1,0 +1,40 @@
+# `{review}` — sign-off on the draft PR
+
+Take the finished article from draft to ready-to-merge, and prove it works by driving
+`doc-tester` through a **blind** end-to-end run of the article's own scenarios.
+
+## Actions
+
+1. **Undraft** the PR (`release/{N.N}` → `upstream` `main`).
+2. **PR description.** Write/refresh it: summary, headline highlights, breaking
+   changes, and key links (release tag, notable PRs).
+3. **CI green.** Confirm all checks pass (coordinate with {polish} if not).
+4. **Diagnostics `@mentions`.** Ensure the `docs-from-code` diagnostics-author aka-link
+   requests are posted on the PR (from {polish}); re-affirm if missing.
+5. **Request reviewers.** Add the right reviewers for a what's-new page.
+6. **Final holistic read.** One last impact/DX pass — does the top of the page sell the
+   release honestly and clearly?
+
+## Blind acceptance test (`doc-tester`)
+
+Drive the [`doc-tester`](../../doc-tester/SKILL.md) skill to read **only** the finished
+"What's new in Aspire N.N" article — **no cheating**, no external lookups — and run
+**every** test scenario the article documents (upgrade steps, code samples, CLI
+commands, feature walkthroughs). The article must be self-sufficient: a developer
+following it verbatim should succeed.
+
+- Any scenario that fails blind is a **defect in the article** → bounce back to
+  {polish} (or {validate} if it's a factual error), fix, and re-run.
+
+## Reviewing someone else's what's-new PR
+
+This modality can also **review** a what's-new PR you didn't write: run the same
+content-standard checks ({critique}'s rubric), the {validate} factual loop, and the
+`doc-tester` blind run, then leave review feedback. Targets the `upstream` `aspire.dev`
+PR (standard git-flow).
+
+## Exit criteria
+
+- `doc-tester` passes **every** in-article scenario **blind**.
+- PR is undrafted, description is complete, CI is green, reviewers requested,
+  diagnostics `@mentions` posted — **ready to merge**.

--- a/.agents/skills/whatsnew/references/06-review.md
+++ b/.agents/skills/whatsnew/references/06-review.md
@@ -5,7 +5,7 @@ Take the finished article from draft to ready-to-merge, and prove it works by dr
 
 ## Actions
 
-1. **Undraft** the PR (`release/{N.N}` → `upstream` `main`).
+1. **Mark the PR ready for review** (`release/{N.N}` → the repository's default branch).
 2. **PR description.** Write/refresh it: summary, headline highlights, breaking
    changes, and key links (release tag, notable PRs).
 3. **CI green.** Confirm all checks pass (coordinate with {polish} if not).
@@ -30,8 +30,7 @@ following it verbatim should succeed.
 
 This modality can also **review** a what's-new PR you didn't write: run the same
 content-standard checks ({critique}'s rubric), the {validate} factual loop, and the
-`doc-tester` blind run, then leave review feedback. Targets the `upstream` `aspire.dev`
-PR (standard git-flow).
+`doc-tester` blind run, then leave review feedback on the PR.
 
 ## Exit criteria
 

--- a/.agents/skills/whatsnew/references/whats-new-template.mdx
+++ b/.agents/skills/whatsnew/references/whats-new-template.mdx
@@ -66,6 +66,10 @@ This release introduces:
 <span id="upgrade-to-{{SLUG}}"></span>
 <br />
 
+{/* BREAKING CHANGES ARE CONDITIONAL. If this release ships NO breaking changes,
+    DELETE this caution <Aside> — and the "⚠️ Breaking changes" section below, plus any
+    breaking-changes "This release introduces" bullet. Keep them ONLY when the release
+    actually has breaking changes, and keep the Aside and the section in sync. */}
 <Aside type="caution">
 Aspire {{VERSION_MAJOR_MINOR}} includes breaking changes. Please review the [Breaking changes](#breaking-changes) section before upgrading.
 </Aside>
@@ -129,8 +133,12 @@ TODO(research).
 ## ✨ New integrations
 
 {/* Brand-new integrations get called out here, distinct from "Integration
-    updates" below. One subsection per new integration with a LearnMore link. */}
-TODO(research): list brand-new integrations shipped this release.
+    updates" below. One subsection per new integration with a LearnMore link.
+    SCOPE: first-party microsoft/aspire integrations ONLY. Community Toolkit
+    (CommunityToolkit/Aspire) integrations ship on their own cadence with their own
+    release notes — do NOT list them here. Only mention the Toolkit when a core
+    integration migrates to/from it, or is deprecated in favor of it. */}
+TODO(research): list brand-new (first-party) integrations shipped this release.
 
 ## 📦 Integration updates
 
@@ -152,6 +160,9 @@ Aspire is built in the open. TODO(research): thank community contributors by
 [see community contributions](/community/contributors/)! If you'd like to get
 involved, check out our [contributing guide](/community/contributor-guide/).
 
+{/* CONDITIONAL SECTION — delete this entire section (and the caution <Aside> in the
+    Upgrade section above) when the release has NO breaking changes. Not every release
+    does. Keep it only when there are real breaking changes to document. */}
 ## ⚠️ Breaking changes
 
 <span id="breaking-changes"></span>

--- a/.agents/skills/whatsnew/references/whats-new-template.mdx
+++ b/.agents/skills/whatsnew/references/whats-new-template.mdx
@@ -1,0 +1,163 @@
+---
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT'S NEW SCAFFOLD TEMPLATE  (structure only — copied by `/whatsnew {draft}`)
+#
+# Scaffold-time tokens (the draft phase replaces these literally):
+#   {{VERSION_MAJOR_MINOR}}  → e.g. 13.5
+#   {{VERSION_FULL}}         → e.g. 13.5.0
+#   {{SLUG}}                 → e.g. aspire-13-5   (filename + sidebar slug)
+#   {{RELEASE_DATE}}         → e.g. August 18, 2025   ("Released MMMM D, YYYY")
+#   {{RELEASE_TAG_URL}}      → https://github.com/microsoft/aspire/releases/tag/v{{VERSION_FULL}}
+#
+# Build-time tokens (leave as-is; the remark plugin in astro.config.mjs replaces
+# them at build once this is the current release — see config/aspire-versions.mjs):
+#   %ASPIRE_VERSION_MAJOR_MINOR%   →  currentAspireMajorMinorVersion
+#   %ASPIRE_VERSION%               →  currentAspireVersion
+#
+# Delete this comment block when scaffolding. Keep it STRUCTURE ONLY: headings +
+# placeholders, no researched prose. Content lands in {research}/{polish}.
+# ─────────────────────────────────────────────────────────────────────────────
+title: "What's new in Aspire {{VERSION_MAJOR_MINOR}}"
+description: "TODO(draft): one-sentence, SEO-friendly summary of the headline features in Aspire {{VERSION_MAJOR_MINOR}}. Trimmed to 200 chars for OG."
+sidebar:
+  label: Aspire {{VERSION_MAJOR_MINOR}}
+  order: 0
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
+---
+
+import {
+  Steps,
+  Aside,
+  Icon,
+  Tabs,
+  TabItem,
+  Badge,
+} from '@astrojs/starlight/components';
+import LearnMore from '@components/LearnMore.astro';
+import OsAwareTabs from '@components/OsAwareTabs.astro';
+{/* import { Image } from 'astro:assets'; — add when the first screenshot lands */}
+
+{/* ── Standardized release header (badge + release-tag link) ───────────────── */}
+<Badge text="Released {{RELEASE_DATE}}" variant="note" size="large" class:list={'mb-1'} />
+
+<p>
+  <a href="{{RELEASE_TAG_URL}}"><Icon name="github" class="d-inline" /> Aspire {{VERSION_FULL}} release notes on GitHub</a>
+</p>
+
+Aspire {{VERSION_MAJOR_MINOR}} is here. TODO(draft): 2–4 sentence lede — lead with
+the single biggest customer-facing win, then name the other headline themes.
+Impact-first, positive, KISS. No marketing fluff.
+
+We'd love to hear what you think. Drop by [<Icon name="discord" class='d-inline' /> Discord](https://aka.ms/aspire-discord) to chat with the team and the community, or file feedback and issues on [<Icon name="github" class='d-inline' /> GitHub](https://github.com/microsoft/aspire/issues).
+
+This release introduces:
+
+{/* One bullet per top-level section below, in the SAME order. 1:1 mapping. */}
+- **TODO headline 1** — one-line impact statement.
+- **TODO headline 2** — one-line impact statement.
+- …and much more.
+
+## 🆙 Upgrade to Aspire {{VERSION_MAJOR_MINOR}}
+
+<span id="upgrade-to-{{SLUG}}"></span>
+<br />
+
+<Aside type="caution">
+Aspire {{VERSION_MAJOR_MINOR}} includes breaking changes. Please review the [Breaking changes](#breaking-changes) section before upgrading.
+</Aside>
+
+For general purpose upgrade guidance, see [Upgrade Aspire](/whats-new/upgrade-aspire/).
+
+The easiest way to upgrade to Aspire {{VERSION_MAJOR_MINOR}} is using the [`aspire update` command](/reference/cli/commands/aspire-update/):
+
+<Steps>
+
+1. Update the Aspire CLI itself:
+
+   ```bash title="Aspire CLI — Update the CLI"
+   aspire update --self
+   ```
+
+1. Update your projects (run from the root of your repository):
+
+   ```bash title="Aspire CLI — Update all Aspire packages"
+   aspire update
+   ```
+
+</Steps>
+
+<LearnMore>
+  For more details on installing the Aspire CLI, see [Install the CLI](/get-started/install-cli/).
+</LearnMore>
+
+{/* ─────────────────────────────────────────────────────────────────────────
+     FEATURE SECTIONS
+     Keep sections focused — do NOT merge themes (e.g. no "Deployment and
+     integrations"). Integrations and Deployment are SEPARATE top-level
+     sections. Order sections by customer impact / DX. Add feature-specific
+     sections (e.g. "🌐 TypeScript AppHost", "🧱 Go and Bun") near the top when
+     they are the headline. Remove any standard section that doesn't apply.
+     Use <Tabs syncKey='aspire-lang'> for C#/TypeScript parity, `LearnMore` to
+     deep-link, and <Aside> sparingly for genuinely important call-outs.
+   ───────────────────────────────────────────────────────────────────────── */}
+
+## 🛠️ CLI enhancements
+
+TODO(research): what changed, why it matters to the developer.
+
+## 🧩 App model and AppHost
+
+TODO(research).
+
+## 📊 Dashboard improvements
+
+TODO(research).
+
+## 🚢 Deployment
+
+{/* STANDALONE — never merged with Integrations. Kubernetes/AKS/Azure/Compose. */}
+TODO(research).
+
+## 🧰 VS Code extension
+
+TODO(research).
+
+## ✨ New integrations
+
+{/* Brand-new integrations get called out here, distinct from "Integration
+    updates" below. One subsection per new integration with a LearnMore link. */}
+TODO(research): list brand-new integrations shipped this release.
+
+## 📦 Integration updates
+
+{/* Changes to EXISTING integrations (APIs, defaults, behavior). */}
+TODO(research).
+
+## 🐳 Default container image updates
+
+{/* Call out default container image TAG bumps (source of truth:
+    src/frontend/src/data/container-images.json — diff prior vs this release).
+    We historically under-report these; include the old → new tag and any
+    data-volume / migration caveat. */}
+TODO(research): list default container image tag bumps (old → new).
+
+## 🐛 Bug fixes and full changelog
+
+For the complete list of bug fixes and smaller changes in this release, see the [Aspire {{VERSION_MAJOR_MINOR}} release notes on GitHub]({{RELEASE_TAG_URL}}).
+
+## 🙏 Community contributions
+
+Aspire is built in the open. TODO(research): thank community contributors by
+`@handle` with a one-line note on what they contributed. We're always excited to
+[see community contributions](/community/contributors/)! If you'd like to get
+involved, check out our [contributing guide](/community/contributor-guide/).
+
+## ⚠️ Breaking changes
+
+<span id="breaking-changes"></span>
+
+Aspire {{VERSION_MAJOR_MINOR}} includes breaking changes. TODO(research): one
+subsection (`#### Title`) per breaking change — what changed, who's affected,
+and the exact remediation.

--- a/.agents/skills/whatsnew/references/whats-new-template.mdx
+++ b/.agents/skills/whatsnew/references/whats-new-template.mdx
@@ -22,6 +22,7 @@
 # placeholders, no researched prose. Content lands in {research}/{polish}.
 # ─────────────────────────────────────────────────────────────────────────────
 title: "What's new in Aspire {{VERSION_MAJOR_MINOR}}"
+seoTitle: "TODO(polish): 50–60 char social-card title, e.g. What's new in Aspire {{VERSION_MAJOR_MINOR}} — <theme 1>, <theme 2>, and more"
 description: "TODO(draft): one-sentence, SEO-friendly summary of the headline features in Aspire {{VERSION_MAJOR_MINOR}}. Trimmed to 200 chars for OG."
 sidebar:
   label: Aspire {{VERSION_MAJOR_MINOR}}

--- a/.agents/skills/whatsnew/references/whats-new-template.mdx
+++ b/.agents/skills/whatsnew/references/whats-new-template.mdx
@@ -6,8 +6,12 @@
 #   {{VERSION_MAJOR_MINOR}}  → e.g. 13.5
 #   {{VERSION_FULL}}         → e.g. 13.5.0
 #   {{SLUG}}                 → e.g. aspire-13-5   (filename + sidebar slug)
-#   {{RELEASE_DATE}}         → e.g. August 18, 2025   ("Released MMMM D, YYYY")
-#   {{RELEASE_TAG_URL}}      → https://github.com/microsoft/aspire/releases/tag/v{{VERSION_FULL}}
+#   {{RELEASE_DATE}}         → ISO date e.g. 2026-08-18  (frontmatter `publishDate`; omit
+#                              the line until known — the badge auto-renders once set)
+#
+# NOTE: the "Released {date}" badge and the GitHub release-notes link are rendered
+# centrally from `publishDate` + the page slug (components/starlight/MarkdownContent.astro
+# + utils/whats-new.ts). Never hand-place a badge or release-tag link in the body.
 #
 # Build-time tokens (leave as-is; the remark plugin in astro.config.mjs replaces
 # them at build once this is the current release — see config/aspire-versions.mjs):
@@ -25,6 +29,7 @@ sidebar:
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
+publishDate: {{RELEASE_DATE}}
 ---
 
 import {
@@ -33,18 +38,14 @@ import {
   Icon,
   Tabs,
   TabItem,
-  Badge,
 } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 {/* import { Image } from 'astro:assets'; — add when the first screenshot lands */}
 
-{/* ── Standardized release header (badge + release-tag link) ───────────────── */}
-<Badge text="Released {{RELEASE_DATE}}" variant="note" size="large" class:list={'mb-1'} />
-
-<p>
-  <a href="{{RELEASE_TAG_URL}}"><Icon name="github" class="d-inline" /> Aspire {{VERSION_FULL}} release notes on GitHub</a>
-</p>
+{/* The "Released {date}" badge and the GitHub release-notes link render automatically
+    from the `publishDate` frontmatter + the page slug (MarkdownContent.astro override
+    + utils/whats-new.ts). Do NOT hand-place a badge or release-tag link here. */}
 
 Aspire {{VERSION_MAJOR_MINOR}} is here. TODO(draft): 2–4 sentence lede — lead with
 the single biggest customer-facing win, then name the other headline themes.
@@ -142,10 +143,6 @@ TODO(research).
     We historically under-report these; include the old → new tag and any
     data-volume / migration caveat. */}
 TODO(research): list default container image tag bumps (old → new).
-
-## 🐛 Bug fixes and full changelog
-
-For the complete list of bug fixes and smaller changes in this release, see the [Aspire {{VERSION_MAJOR_MINOR}} release notes on GitHub]({{RELEASE_TAG_URL}}).
 
 ## 🙏 Community contributions
 

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -34,10 +34,10 @@ staff engineer would set reviewing their own team's release notes.
   `description` (headline features, ≤ ~200 chars for OG cards), `sidebar.label:
   "Aspire N.N"`, `sidebar.order: 0`, and `tableOfContents` min/max heading level `2`
   (only `##` sections show in the on-page TOC).
-- **Standardized header (new articles only):** a `Released MMMM D, YYYY`
-  `<Badge variant="note" size="large">` followed by a GitHub release-tag link
-  (`.../releases/tag/vN.N.0`) with `<Icon name="github" />`. Existing pages are left
-  as-is — do not retrofit.
+- **Standardized header (new articles only):** a
+  `<Badge text="Released MMMM D, YYYY" variant="note" size="large" />` followed by a
+  GitHub release-tag link (`.../releases/tag/vN.N.0`) with `<Icon name="github" />`.
+  Existing pages are left as-is — do not retrofit.
 - **Lede:** 2–4 sentences. Lead with the single biggest win, then name the other
   headline themes. Bold the concrete feature names.
 - **Feedback line:** the standard Discord + GitHub issues line (see template) — keep verbatim.
@@ -73,10 +73,10 @@ These are the specific quality gates critique/validate enforce:
 
 ## Language/tech conventions (inherited from doc-writer — quick reference)
 
-- **Aspire**, not ".NET Aspire". **AppHost**, **resource** (not "component"),
-  **integration** (not "connector").
+- **Aspire** is the product name — never prepend the old pre-rebrand qualifier.
+  **AppHost**, **resource** (not "component"), **integration** (not "connector").
 - **Inclusive framing:** name runtimes/languages positively (C#, TypeScript, Python,
-  Go). Avoid "non-.NET" / "other languages" framing.
+  Go) rather than defining any of them in opposition to another.
 - **Second person, active voice, imperative mood.** Concise, professional-approachable.
 - **Dates spelled out:** "August 18, 2025" — never "8/18/25".
 - **C#/TypeScript parity:** when a feature spans AppHost languages, show both with

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -34,6 +34,12 @@ staff engineer would set reviewing their own team's release notes.
   `description` (headline features, ≤ ~200 chars for OG cards), `sidebar.label:
   "Aspire N.N"`, `sidebar.order: 0`, `tableOfContents` min/max heading level `2`
   (only `##` sections show in the on-page TOC), and `publishDate: YYYY-MM-DD`.
+- **`seoTitle` (recommended):** the visible `title` is short (~24 chars), so add a
+  custom `seoTitle` to hit the optimal 50–60 char social-card range. It's used
+  **verbatim** as `og:title`/`twitter:title` (no `· Aspire` suffix appended) and
+  falls back to `title` when unset — so it tunes the social card without touching the
+  visible H1 or sidebar label. Weave in the headline themes, e.g.
+  `seoTitle: "What's new in Aspire N.N — <theme 1>, <theme 2>, and more"`.
 - **Standardized header (automatic — never hand-authored):** the `Released MMMM D,
   YYYY` badge and the GitHub release-notes link render **centrally** from the page's
   `publishDate` frontmatter and its slug (`components/starlight/MarkdownContent.astro`

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -1,0 +1,86 @@
+# What's-new writing guidelines (humanized voice)
+
+> **Source of truth for style:** the [`doc-writer`](../../doc-writer/SKILL.md) skill.
+> This file adds only the **what's-new-specific** conventions on top. When the two
+> ever disagree, `doc-writer` wins for voice/tone/terminology; this file wins for
+> what's-new structure and the content standards below.
+
+A what's-new page is the **first thing** most developers read about a release. It
+has to be accurate to a fault *and* genuinely enjoyable to read. Aim for the bar a
+staff engineer would set reviewing their own team's release notes.
+
+## The bar
+
+- **Impact first.** Every section and bullet leads with *what the developer can now
+  do* and *why it matters* — not the mechanics of how it was built. Order sections
+  and bullets by customer impact / DX, not by internal area or PR order.
+- **Positives first.** Open with wins. Caveats, breaking changes, and limitations
+  come after the value is clear (breaking changes live in their own section).
+- **KISS.** Shortest prose that fully conveys the change. Cut filler, hedging, and
+  restatement. Prefer one strong sentence over three weak ones.
+- **No walls of text.** Break up long passages. A section is bullets + short prose +
+  (optionally) one focused code sample — not an essay.
+- **Judicious alerts.** `<Aside>` is a spotlight; overuse blinds the reader. Reserve
+  it for genuinely important call-outs (breaking changes, required actions, sharp
+  edges). If half the page is asides, none of them land. *Do not burn the reader's eyes.*
+- **Developer empathy.** Write to a busy engineer skimming for what changed. Answer
+  "do I care, and what do I do about it?" fast.
+- **Factual, not marketing.** Concrete capabilities, real API names, honest scope.
+  No superlatives that research can't back. "Compelling, factual, engaging truths."
+
+## What's-new structural conventions
+
+- **Title/frontmatter:** `title: "What's new in Aspire N.N"`, a tight SEO
+  `description` (headline features, ≤ ~200 chars for OG cards), `sidebar.label:
+  "Aspire N.N"`, `sidebar.order: 0`, and `tableOfContents` min/max heading level `2`
+  (only `##` sections show in the on-page TOC).
+- **Standardized header (new articles only):** a `Released MMMM D, YYYY`
+  `<Badge variant="note" size="large">` followed by a GitHub release-tag link
+  (`.../releases/tag/vN.N.0`) with `<Icon name="github" />`. Existing pages are left
+  as-is — do not retrofit.
+- **Lede:** 2–4 sentences. Lead with the single biggest win, then name the other
+  headline themes. Bold the concrete feature names.
+- **Feedback line:** the standard Discord + GitHub issues line (see template) — keep verbatim.
+- **"This release introduces" bullets** map **1:1** to the top-level `##` sections
+  that follow, in the **same order**, and end with "…and much more."
+- **Section headings** are emoji-prefixed `##` (see taxonomy below). Use `####`
+  subsections within a section (e.g. one per breaking change or per new integration).
+- **Upgrade section** comes first after the lede: `## 🆙 Upgrade to Aspire N.N` with a
+  `<span id="upgrade-to-aspire-N-N">` anchor, the breaking-changes caution `<Aside>`,
+  and `<Steps>` for `aspire update --self` / `aspire update`.
+- **Bug fixes** section links to the GitHub release tag rather than re-listing fixes.
+- **Community contributions** thanks contributors by `@handle` with a one-line note
+  on what each shipped. Never omit credit for a merged community PR.
+- **Breaking changes** is the final `##` section, with a `<span id="breaking-changes">`
+  anchor and one `####` per change: what changed, who's affected, exact remediation.
+
+## Content standards (maintainer-mandated)
+
+These are the specific quality gates critique/validate enforce:
+
+1. **Don't over-group sections.** Never merge distinct themes (no "Deployment and
+   integrations"). **Deployment** and **Integrations** are **separate** top-level
+   sections.
+2. **Call out brand-new integrations distinctly.** New integrations go in a dedicated
+   **"✨ New integrations"** section, separate from **"📦 Integration updates"**
+   (changes to existing integrations). New integrations must not be buried.
+3. **Highlight default container image tag bumps.** When a hosting integration's
+   default container image **tag** bumps (e.g. RabbitMQ 4.2→4.3, PostgreSQL
+   17.6→18.3), call it out in **"🐳 Default container image updates"** with old → new
+   tags. Source of truth: `src/frontend/src/data/container-images.json` — diff prior
+   vs new release. We historically under-report these.
+4. **Standardized header** present and correct on new articles (badge + release-tag link).
+
+## Language/tech conventions (inherited from doc-writer — quick reference)
+
+- **Aspire**, not ".NET Aspire". **AppHost**, **resource** (not "component"),
+  **integration** (not "connector").
+- **Inclusive framing:** name runtimes/languages positively (C#, TypeScript, Python,
+  Go). Avoid "non-.NET" / "other languages" framing.
+- **Second person, active voice, imperative mood.** Concise, professional-approachable.
+- **Dates spelled out:** "August 18, 2025" — never "8/18/25".
+- **C#/TypeScript parity:** when a feature spans AppHost languages, show both with
+  `<Tabs syncKey='aspire-lang'>` / `<TabItem>` so the tab choice syncs page-wide.
+- **Version tokens:** in prose for the *current* release you may use the build-time
+  placeholders `%ASPIRE_VERSION%` / `%ASPIRE_VERSION_MAJOR_MINOR%` (replaced by the
+  remark plugin). The article slug, sidebar, and header use the literal version.

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -32,12 +32,13 @@ staff engineer would set reviewing their own team's release notes.
 
 - **Title/frontmatter:** `title: "What's new in Aspire N.N"`, a tight SEO
   `description` (headline features, ≤ ~200 chars for OG cards), `sidebar.label:
-  "Aspire N.N"`, `sidebar.order: 0`, and `tableOfContents` min/max heading level `2`
-  (only `##` sections show in the on-page TOC).
-- **Standardized header (new articles only):** a
-  `<Badge text="Released MMMM D, YYYY" variant="note" size="large" />` followed by a
-  GitHub release-tag link (`.../releases/tag/vN.N.0`) with `<Icon name="github" />`.
-  Existing pages are left as-is — do not retrofit.
+  "Aspire N.N"`, `sidebar.order: 0`, `tableOfContents` min/max heading level `2`
+  (only `##` sections show in the on-page TOC), and `publishDate: YYYY-MM-DD`.
+- **Standardized header (automatic — never hand-authored):** the `Released MMMM D,
+  YYYY` badge and the GitHub release-notes link render **centrally** from the page's
+  `publishDate` frontmatter and its slug (`components/starlight/MarkdownContent.astro`
+  + `utils/whats-new.ts`). Just set `publishDate` — never place a `<Badge>` or a
+  release-tag link in the body. Omit `publishDate` and the badge simply doesn't show.
 - **Lede:** 2–4 sentences. Lead with the single biggest win, then name the other
   headline themes. Bold the concrete feature names.
 - **Feedback line:** the standard Discord + GitHub issues line (see template) — keep verbatim.
@@ -69,7 +70,7 @@ These are the specific quality gates critique/validate enforce:
    17.6→18.3), call it out in **"🐳 Default container image updates"** with old → new
    tags. Source of truth: `src/frontend/src/data/container-images.json` — diff prior
    vs new release. We historically under-report these.
-4. **Standardized header** present and correct on new articles (badge + release-tag link).
+4. **`publishDate` set** in frontmatter — the release-date badge + GitHub release-notes link auto-render (no hand-placed header).
 
 ## Language/tech conventions (inherited from doc-writer — quick reference)
 

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -53,13 +53,17 @@ staff engineer would set reviewing their own team's release notes.
 - **Section headings** are emoji-prefixed `##` (see taxonomy below). Use `####`
   subsections within a section (e.g. one per breaking change or per new integration).
 - **Upgrade section** comes first after the lede: `## 🆙 Upgrade to Aspire N.N` with a
-  `<span id="upgrade-to-aspire-N-N">` anchor, the breaking-changes caution `<Aside>`,
-  and `<Steps>` for `aspire update --self` / `aspire update`.
+  `<span id="upgrade-to-aspire-N-N">` anchor and `<Steps>` for `aspire update --self` /
+  `aspire update`. Include the breaking-changes caution `<Aside>` **only when the
+  release actually has breaking changes** (omit it otherwise — see below).
 - **Bug fixes** section links to the GitHub release tag rather than re-listing fixes.
 - **Community contributions** thanks contributors by `@handle` with a one-line note
   on what each shipped. Never omit credit for a merged community PR.
-- **Breaking changes** is the final `##` section, with a `<span id="breaking-changes">`
-  anchor and one `####` per change: what changed, who's affected, exact remediation.
+- **Breaking changes (conditional).** When the release has them, this is the final
+  `##` section, with a `<span id="breaking-changes">` anchor and one `####` per change:
+  what changed, who's affected, exact remediation. **Not every release ships breaking
+  changes** — when there are none, omit both this section *and* the upgrade caution
+  `<Aside>` (and any breaking-changes intro bullet). Never ship an empty section.
 
 ## Content standards (maintainer-mandated)
 
@@ -70,7 +74,11 @@ These are the specific quality gates critique/validate enforce:
    sections.
 2. **Call out brand-new integrations distinctly.** New integrations go in a dedicated
    **"✨ New integrations"** section, separate from **"📦 Integration updates"**
-   (changes to existing integrations). New integrations must not be buried.
+   (changes to existing integrations). New integrations must not be buried. **Scope:
+   first-party `microsoft/aspire` integrations only** — **Community Toolkit**
+   (`CommunityToolkit/Aspire`) integrations ship on their own cadence with their own
+   release notes, so don't list them here. Mention the Toolkit only when a core
+   integration migrates to/from it or is deprecated in favor of it.
 3. **Highlight default container image tag bumps.** When a hosting integration's
    default container image **tag** bumps (e.g. RabbitMQ 4.2→4.3, PostgreSQL
    17.6→18.3), call it out in **"🐳 Default container image updates"** with old → new


### PR DESCRIPTION
## What

Adds a new internal repo skill, **`whatsnew`**, that formalizes our previously ad-hoc process for authoring **"What's new in Aspire N.N"** release-notes pages. It's a single, step-argument skill invoked as `/whatsnew {modality}`, where the modality selects one phase of a repeatable lifecycle:

```
{draft｜scaffold} → {research} → {critique} → {validate} → {polish} → {review}
```

## Why

Writing a what's-new page touches many moving parts (release branch, draft PR, skeleton MDX, site banner across locales, sidebar, version constants, research dossier, fact-checking, data ingestion, PR sign-off). This skill captures that lifecycle as explicit, repeatable phases with clear inputs/actions/outputs/exit-criteria, and **orchestrates** existing skills rather than duplicating them (`doc-writer`, `doc-pr-reviewer`, `doc-tester`, `twoslash-validator`, `update-integrations`/`update-samples`/`container-images`).

## What's in it

- `.agents/skills/whatsnew/SKILL.md` — modality dispatch table, phase overview, cross-cutting git/branch/PR + humanized-voice rules, and a key repository path map.
- `references/01-06` — per-phase specs (draft/scaffold, research, critique, validate, polish, review).
- `references/writing-guidelines.md` — humanized voice + maintainer content standards; defers to `doc-writer` for canonical style.
- `references/whats-new-template.mdx` — structure-only scaffold with the new **standardized header** (release-date badge + GitHub release-tag link) and the mandated section taxonomy.
- `.agents/skills/README.md` — adds the `whatsnew` row.

## Content standards baked in

- **Deployment** and **Integrations** are **separate** top-level sections (no more over-grouping).
- Dedicated **"✨ New integrations"** section, distinct from **"📦 Integration updates"**.
- Dedicated **"🐳 Default container image updates"** section for default image tag bumps (diffed from `container-images.json`).
- Standardized top-of-page header: `Released MMMM D, YYYY` badge + release-tag link (new articles only).

## Notes

- Documentation/process only — no runtime code and no new what's-new content pages are generated by this PR.
- Validated: SKILL.md frontmatter is discoverable, all cross-reference links resolve, and the template's frontmatter/shape is sound after token replacement.
