### PR TITLE
Add interaction file upload security guidance

### DIFF
--- a/src/frontend/src/content/docs/extensibility/interaction-service.mdx
+++ b/src/frontend/src/content/docs/extensibility/interaction-service.mdx
@@ -864,6 +864,8 @@ The `File` input type enables users to select and upload files through the nativ
 
 :::danger[File upload security considerations]
 
+File upload functionality is a common source of exploitable vulnerabilities. Use caution when accepting or processing uploaded content:
+
 - **Validate uploaded content**: Treat every uploaded file as untrusted input. Before processing it, validate its size and content using checks appropriate for the expected format. A file name, extension, or `FileFilter` match doesn't establish that the content is safe or valid.
 - **Limit file size**: The AppHost temporarily stores uploaded files on disk while the prompt is active. Set `MaxFileSize` to an appropriate limit for the expected content to constrain disk usage and reject oversized uploads.
 - **Use safe file names**: Don't use the uploaded file's name directly when saving it to physical storage. If the workflow requires a specific file name, validate it against the exact expected value; otherwise, generate a safe, application-controlled name. In .NET, combine [`Path.GetRandomFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.getrandomfilename) with a trusted storage directory, or use [`Path.GetTempFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.gettempfilename) to create a full path for temporary storage. Use equivalent secure APIs in other languages.

--- a/src/frontend/src/content/docs/extensibility/interaction-service.mdx
+++ b/src/frontend/src/content/docs/extensibility/interaction-service.mdx
@@ -862,6 +862,12 @@ Prompting the user for a password and confirming they match is referred to as "d
 
 The `File` input type enables users to select and upload files through the native OS/browser file picker in the dashboard, or by providing a file path in the CLI. Files are uploaded to the AppHost and stored on disk, with metadata available through the `InteractionFile` class.
 
+:::danger[Uploaded files are untrusted]
+Treat every uploaded file as untrusted input. Before processing it, validate its size and content using checks appropriate for the expected format; a file name, extension, or `FileFilter` match doesn't establish that the content is safe or valid. Configure downstream parsers and tools securely, isolate processing where appropriate, and don't execute an uploaded file merely because its name or extension is expected.
+
+Don't use the uploaded file's name directly when saving it to physical storage. If the workflow requires a specific file name, validate it against the exact expected value; otherwise, generate a safe, application-controlled name. In .NET, combine [`Path.GetRandomFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.getrandomfilename) with a trusted storage directory, or use [`Path.GetTempFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.gettempfilename) to create a full path for temporary storage. Use equivalent secure APIs in other languages.
+:::
+
 <Tabs syncKey='aspire-lang'>
 <TabItem id='csharp' label='C#'>
 

--- a/src/frontend/src/content/docs/extensibility/interaction-service.mdx
+++ b/src/frontend/src/content/docs/extensibility/interaction-service.mdx
@@ -862,10 +862,13 @@ Prompting the user for a password and confirming they match is referred to as "d
 
 The `File` input type enables users to select and upload files through the native OS/browser file picker in the dashboard, or by providing a file path in the CLI. Files are uploaded to the AppHost and stored on disk, with metadata available through the `InteractionFile` class.
 
-:::danger[Uploaded files are untrusted]
-Treat every uploaded file as untrusted input. Before processing it, validate its size and content using checks appropriate for the expected format; a file name, extension, or `FileFilter` match doesn't establish that the content is safe or valid. Configure downstream parsers and tools securely, isolate processing where appropriate, and don't execute an uploaded file merely because its name or extension is expected.
+:::danger[File upload security considerations]
 
-Don't use the uploaded file's name directly when saving it to physical storage. If the workflow requires a specific file name, validate it against the exact expected value; otherwise, generate a safe, application-controlled name. In .NET, combine [`Path.GetRandomFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.getrandomfilename) with a trusted storage directory, or use [`Path.GetTempFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.gettempfilename) to create a full path for temporary storage. Use equivalent secure APIs in other languages.
+- **Validate uploaded content**: Treat every uploaded file as untrusted input. Before processing it, validate its size and content using checks appropriate for the expected format. A file name, extension, or `FileFilter` match doesn't establish that the content is safe or valid.
+- **Limit file size**: The AppHost temporarily stores uploaded files on disk while the prompt is active. Set `MaxFileSize` to an appropriate limit for the expected content to constrain disk usage and reject oversized uploads.
+- **Use safe file names**: Don't use the uploaded file's name directly when saving it to physical storage. If the workflow requires a specific file name, validate it against the exact expected value; otherwise, generate a safe, application-controlled name. In .NET, combine [`Path.GetRandomFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.getrandomfilename) with a trusted storage directory, or use [`Path.GetTempFileName()`](https://learn.microsoft.com/dotnet/api/system.io.path.gettempfilename) to create a full path for temporary storage. Use equivalent secure APIs in other languages.
+- **Process files securely**: Configure downstream parsers and tools securely, isolate processing where appropriate, and don't execute an uploaded file merely because its name or extension is expected.
+
 :::
 
 <Tabs syncKey='aspire-lang'>


### PR DESCRIPTION
## Summary

- Warn AppHost authors that uploaded files are untrusted and file uploads are a common source of exploitable vulnerabilities.
- Document content validation, secure downstream processing, safe storage names, and temporary disk storage.
- Recommend setting an appropriate `MaxFileSize` to constrain disk usage and reject oversized uploads.

## Third-party links and affiliations

None. The added API links point to Microsoft Learn.

## Validation

- `pnpm exec prettier --check src/content/docs/extensibility/interaction-service.mdx`
- Editor diagnostics for `interaction-service.mdx`
- `git diff --check`