### PR TITLE
Add release-date badge and release-tag link to What's new pages

### DIFF
--- a/src/frontend/src/components/starlight/MarkdownContent.astro
+++ b/src/frontend/src/components/starlight/MarkdownContent.astro
@@ -1,8 +1,10 @@
 ---
 import DefaultMarkdownContent from '@astrojs/starlight/components/MarkdownContent.astro';
+import { Badge, Icon } from '@astrojs/starlight/components';
 import StarlightImageZoom from 'starlight-image-zoom/components/ImageZoom.astro';
 import Breadcrumb from '@components/Breadcrumb.astro';
 import { getContentBreadcrumbs } from '@utils/content-breadcrumbs';
+import { getWhatsNewRelease } from '@utils/whats-new';
 
 const routeData = Astro.locals.starlightRoute;
 const pageData = routeData?.entry?.data as { crumbs?: boolean; publishDate?: Date } | undefined;
@@ -18,23 +20,41 @@ const formattedDate = publishDate
       timeZone: 'UTC',
     })
   : undefined;
+
+const route = routeData as
+  | { slug?: string; id?: string; entry?: { slug?: string; id?: string } }
+  | undefined;
+const release = getWhatsNewRelease(
+  route?.slug ?? route?.entry?.slug ?? route?.id ?? route?.entry?.id
+);
 ---
 
 <StarlightImageZoom />
 {crumbs && <Breadcrumb crumbs={crumbs} />}
 {
   formattedDate && (
-    <p class="publish-date">
-      <time datetime={publishDate!.toISOString().slice(0, 10)}>Released {formattedDate}</time>
-    </p>
+    <div class="release-meta">
+      <Badge text={`Released ${formattedDate}`} variant="note" size="large" class="release-badge" />
+      {release && (
+        <a class="release-notes-link" href={release.releaseNotesUrl}>
+          <Icon name="github" class="d-inline" /> Aspire {release.version} release notes on GitHub
+        </a>
+      )}
+    </div>
   )
 }
 <DefaultMarkdownContent><slot /></DefaultMarkdownContent>
 
 <style>
-  .publish-date {
+  .release-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 1rem;
     margin-block: 0 1.5rem;
+  }
+
+  .release-notes-link {
     font-size: var(--sl-text-sm);
-    color: var(--sl-color-gray-3);
   }
 </style>

--- a/src/frontend/src/content/docs/ja/whats-new/aspire-13-3.mdx
+++ b/src/frontend/src/content/docs/ja/whats-new/aspire-13-3.mdx
@@ -1230,10 +1230,6 @@ aspire new aspire-py-starter --use-redis-cache true
   [aspire new コマンド](/ja/reference/cli/commands/aspire-new/)を参照してください。
 </LearnMore>
 
-## 🐛 バグ修正と完全な変更ログ
-
-このリリースでのバグ修正と小さな変更の完全なリストについては、[GitHub の Aspire 13.3 リリースノート](https://github.com/microsoft/aspire/releases/tag/v13.3.0)を参照してください。
-
 ## 🙏 コミュニティ貢献
 
 Aspire はオープンに構築され、このリリースはあなたなしでは不可能でした。Aspire 13.3 を可能にするのに役立ったすべてのコミュニティ貢献者へ大きな感謝 — ライフサイクル Subscribe 拡張メソッドの [@afscrome](https://github.com/afscrome)、ドキュメントとテンプレートポーリッシュの [@spboyer](https://github.com/spboyer)、[@holystix04](https://github.com/holystix04)、[@tranhoangtu-it](https://github.com/tranhoangtu-it)。私たちは常に [コミュニティ貢献](/ja/community/contributors/)を見て興奮します！関心がある場合は、[貢献ガイド](/ja/community/contributor-guide/)をチェックしてください。

--- a/src/frontend/src/content/docs/whats-new/aspire-13-3.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-3.mdx
@@ -1230,10 +1230,6 @@ aspire new aspire-py-starter --use-redis-cache true
   [aspire new command](/reference/cli/commands/aspire-new/).
 </LearnMore>
 
-## 🐛 Bug fixes and full changelog
-
-For the complete list of bug fixes and smaller changes in this release, see the [Aspire 13.3 release notes on GitHub](https://github.com/microsoft/aspire/releases/tag/v13.3.0).
-
 ## 🙏 Community contributions
 
 Aspire is built in the open, and this release wouldn't be what it is without you. A huge thank you to all community contributors who helped make Aspire 13.3 possible — including [@afscrome](https://github.com/afscrome) for the lifecycle Subscribe extension methods, [@spboyer](https://github.com/spboyer) for documentation and template polish, [@holystix04](https://github.com/holystix04), and [@tranhoangtu-it](https://github.com/tranhoangtu-it). We're always excited to [see community contributions](/community/contributors/)! If you'd like to get involved, check out our [contributing guide](/community/contributor-guide/).

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -663,10 +663,6 @@ The default PostgreSQL container image has been bumped from 17.6 to 18.3. Postgr
   For PostgreSQL hosting setup and data volume guidance, see the [PostgreSQL integration](/integrations/databases/postgres/postgres-host/#postgresql-18-data-directory-change).
 </LearnMore>
 
-## 🐛 Bug fixes and full changelog
-
-For the complete list of bug fixes and smaller changes in this release, see the [Aspire 13.4 release notes on GitHub](https://github.com/microsoft/aspire/releases/tag/v13.4.0).
-
 ## 🙏 Community contributions
 
 Aspire is built in the open, and this release wouldn't be what it is without you. A huge thank you to all community contributors who helped make Aspire 13.4 possible — including [@edmondshtogu](https://github.com/edmondshtogu) for the work behind the Go hosting integration, [@javiercn](https://github.com/javiercn) for Blazor WebAssembly hosting, [@afscrome](https://github.com/afscrome) for `WithHidden()`, dynamically assigned dashboard endpoint ports, and an `aspire ps` hang fix, [@mtmk](https://github.com/mtmk) for the NATS client update, [@ellahathaway](https://github.com/ellahathaway) for friendlier `aspire new` NuGet feed errors, [@nightt5879](https://github.com/nightt5879) for the console logs empty state, [@vsantele](https://github.com/vsantele) for pnpm workspace Dockerfile support, [@sliekens](https://github.com/sliekens) for Docker Compose `.env` improvements, [@Bertolossi](https://github.com/Bertolossi) for fixing an `aspire run` watch-mode hang, and [@arpitjain099](https://github.com/arpitjain099) for CI permission hardening. We're always excited to [see community contributions](/community/contributors/)! If you'd like to get involved, check out our [contributing guide](/community/contributor-guide/).

--- a/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-4.mdx
@@ -7,6 +7,7 @@ sidebar:
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
+publishDate: 2026-06-01
 ---
 
 import {

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -7,6 +7,7 @@ sidebar:
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
+publishDate: 2026-08-18
 ---
 
 import {

--- a/src/frontend/src/utils/whats-new.ts
+++ b/src/frontend/src/utils/whats-new.ts
@@ -1,0 +1,59 @@
+/**
+ * Helpers for the "What's new in Aspire N.N" release-notes pages.
+ *
+ * A single source of truth for turning a page's route path into the Aspire
+ * release it documents, so the release-date badge and the GitHub release-tag
+ * link rendered by `components/starlight/MarkdownContent.astro` stay in sync.
+ */
+
+/**
+ * Matches a versioned What's New route path, capturing the major and (optional)
+ * minor version. Anchored to the end so it also matches locale-prefixed ids
+ * (e.g. `ja/whats-new/aspire-13-3`) and ignores unversioned pages such as
+ * `whats-new/upgrade-aspire`.
+ */
+const WHATS_NEW_RELEASE_PATTERN = /whats-new\/aspire-(\d+)(?:-(\d+))?$/i;
+
+export interface WhatsNewRelease {
+  /** Display version, e.g. `13.5` (minor defaults to `0` for the `.0` GA page). */
+  version: string;
+  /** GitHub release tag in `microsoft/aspire`, e.g. `v13.5.0`. */
+  tag: string;
+  /** Absolute URL to the GitHub release notes for this release. */
+  releaseNotesUrl: string;
+}
+
+/**
+ * Resolve the Aspire release a What's New page documents from its route path,
+ * or `undefined` when the path isn't a versioned What's New release-notes page.
+ *
+ * The route path may include a locale prefix, a leading/trailing slash, and a
+ * `.md`/`.mdx` extension — all are tolerated. The GitHub release tag for a
+ * "What's new in Aspire X.Y" page is the GA tag `vX.Y.0`.
+ */
+export function getWhatsNewRelease(routePath: string | undefined | null): WhatsNewRelease | undefined {
+  if (!routePath) {
+    return undefined;
+  }
+
+  const normalized = routePath
+    .replace(/\\/g, '/')
+    .replace(/\/$/, '')
+    .replace(/\.mdx?$/i, '');
+
+  const match = WHATS_NEW_RELEASE_PATTERN.exec(normalized);
+  if (!match) {
+    return undefined;
+  }
+
+  const major = match[1];
+  const minor = match[2] ?? '0';
+  const version = `${major}.${minor}`;
+  const tag = `v${version}.0`;
+
+  return {
+    version,
+    tag,
+    releaseNotesUrl: `https://github.com/microsoft/aspire/releases/tag/${tag}`,
+  };
+}

--- a/src/frontend/tests/unit/whats-new.vitest.test.ts
+++ b/src/frontend/tests/unit/whats-new.vitest.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { getWhatsNewRelease } from '@utils/whats-new';
+
+describe('getWhatsNewRelease', () => {
+  it('resolves a minor release page to its version, tag, and release-notes URL', () => {
+    expect(getWhatsNewRelease('whats-new/aspire-13-5')).toEqual({
+      version: '13.5',
+      tag: 'v13.5.0',
+      releaseNotesUrl: 'https://github.com/microsoft/aspire/releases/tag/v13.5.0',
+    });
+  });
+
+  it('treats a major-only page as the .0 GA release', () => {
+    expect(getWhatsNewRelease('whats-new/aspire-13')).toEqual({
+      version: '13.0',
+      tag: 'v13.0.0',
+      releaseNotesUrl: 'https://github.com/microsoft/aspire/releases/tag/v13.0.0',
+    });
+  });
+
+  it('tolerates a locale prefix, a .mdx extension, and a trailing slash', () => {
+    expect(getWhatsNewRelease('ja/whats-new/aspire-13-3.mdx')?.version).toBe('13.3');
+    expect(getWhatsNewRelease('whats-new/aspire-9-5/')?.tag).toBe('v9.5.0');
+    expect(getWhatsNewRelease('whats-new\\aspire-13-4.mdx')?.version).toBe('13.4');
+  });
+
+  it('returns undefined for non-versioned or non-release pages', () => {
+    expect(getWhatsNewRelease('whats-new/upgrade-aspire')).toBeUndefined();
+    expect(getWhatsNewRelease('get-started/install-cli')).toBeUndefined();
+    expect(getWhatsNewRelease(undefined)).toBeUndefined();
+    expect(getWhatsNewRelease('')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Every **What''s new in Aspire N.N** release-notes page now shows a standardized **`Released {date}`** badge and a link to that release''s **GitHub release notes** — including **13.4** and **13.5**, which previously had no release date at all.

Because the badge is rendered centrally in the shared `MarkdownContent` override, **all existing What''s new pages** (9.x, 13.0–13.3, and their `ja` translations) pick this up automatically from their existing `publishDate` — no per-page markup. The old plain gray "Released …" line is replaced by the badge across the board.

## Why

The What''s new pages already set a `publishDate` that the shared override rendered as small gray text, but:

- **13.4** and **13.5** had no `publishDate`, so they showed nothing.
- No page linked to its GitHub release tag.

This brings every page in line with the standardized release header (release-date badge + release-tag link) introduced by the `whatsnew` skill in #1538 — centrally, so all pages stay consistent with no per-page churn.

## Changes

- **`components/starlight/MarkdownContent.astro`** — render the release date as a Starlight `<Badge variant="note" size="large">` and append a GitHub release-notes link. Both are driven by the page''s existing `publishDate` and route, so every current and future What''s new page gets them automatically.
- **`utils/whats-new.ts`** (new) — `getWhatsNewRelease()` maps a What''s new route path (locale-prefix / extension / trailing-slash tolerant) to its `vX.Y.0` tag in `microsoft/aspire`, and returns `undefined` for non-release pages so nothing renders there.
- **`tests/unit/whats-new.vitest.test.ts`** (new) — unit coverage for the helper.
- **`whats-new/aspire-13-4.mdx`** / **`aspire-13-5.mdx`** — add `publishDate` (`2026-06-01` / `2026-08-18`, the GitHub release dates).
- **`whats-new/aspire-13-3.mdx`, `aspire-13-4.mdx`, `ja/whats-new/aspire-13-3.mdx`** — remove the now-redundant bottom **"Bug fixes and full changelog -> release notes on GitHub"** pointer, since the new top badge links to the exact same release notes. (The issue-**milestone** links on 13.2 / 9.1 / 9.4 point to a different resource — an issues list — and are intentionally left intact.)

## Validation

- `pnpm test:unit` -> **372 passed** (incl. the new `whats-new` suite).
- Rendered locally with `astro dev`: confirmed the badge + correct tag link on 13.5, 13.4, 13.3, 9.5, and 13.0, plus the localized `ja/whats-new/aspire-13-3`; confirmed the removed changelog sections are gone and the pages flow cleanly into "Community contributions"; verified non-release pages (e.g. `upgrade-aspire`, `get-started/install-cli`) render nothing and don''t error.
