### PR TITLE
Order core team roster alphabetically by name

### DIFF
--- a/src/frontend/src/data/core-team.ts
+++ b/src/frontend/src/data/core-team.ts
@@ -8,9 +8,10 @@
  * maintained by hand.
  *
  * Members listed here are intentionally excluded from the generated per-release
- * "Special thanks" list so they are credited once, in the roster. Keep the
- * roster current as membership changes, and set a member's `social` link to
- * override the default GitHub profile link.
+ * "Special thanks" list so they are credited once, in the roster. Entries are
+ * ordered alphabetically by display name; keep the roster current and sorted as
+ * membership changes, and set a member's `social` link to override the default
+ * GitHub profile link.
  *
  * For each member:
  *  - `handle` is the GitHub login. The avatar is derived as
@@ -37,20 +38,20 @@ export interface CoreTeamMember {
 }
 
 export const coreTeam: CoreTeamMember[] = [
-  { handle: 'davidfowl', name: 'David Fowler' },
-  { handle: 'DamianEdwards', name: 'Damian Edwards' },
-  { handle: 'mitchdenny', name: 'Mitch Denny' },
-  { handle: 'eerhardt', name: 'Eric Erhardt' },
-  { handle: 'ellahathaway', name: 'Ella Hathaway' },
-  { handle: 'joperezr', name: 'José Pérez' },
-  { handle: 'JamesNK', name: 'James Newton-King' },
-  { handle: 'sebastienros', name: 'Sébastien Ros' },
-  { handle: 'karolz-ms', name: 'Karol Zadora-Przylecki' },
-  { handle: 'radical', name: 'Ankit Jain' },
   { handle: 'adamint', name: 'Adam Ratzman' },
+  { handle: 'radical', name: 'Ankit Jain' },
+  { handle: 'DamianEdwards', name: 'Damian Edwards' },
+  { handle: 'davidfowl', name: 'David Fowler' },
   { handle: 'danegsta', name: 'David Negstad' },
   { handle: 'IEvangelist', name: 'David Pine' },
+  { handle: 'ellahathaway', name: 'Ella Hathaway' },
+  { handle: 'eerhardt', name: 'Eric Erhardt' },
+  { handle: 'JamesNK', name: 'James Newton-King' },
+  { handle: 'joperezr', name: 'José Pérez' },
+  { handle: 'karolz-ms', name: 'Karol Zadora-Przylecki' },
   { handle: 'maddymontaquila', name: 'Maddy Montaquila' },
+  { handle: 'mitchdenny', name: 'Mitch Denny' },
+  { handle: 'sebastienros', name: 'Sébastien Ros' },
 ];
 
 /** Lower-cased core team handles, for case-insensitive de-duplication. */


### PR DESCRIPTION
## What & why

Follow-up to #1542. Orders the hand-maintained core-team roster in `core-team.ts` alphabetically by **display name** so the Community section renders team members in a predictable order.

## Changes

- Reordered the `coreTeam` array alphabetically by `name` (first-name-first). No members added or removed — 14 before and after.
- Added a note to the doc comment that the roster is ordered by display name, so future additions preserve the convention.

## Notes

- Interpreted "order by name" as alphabetical by the display `name` field as written (e.g. the three `David …` entries stay grouped: Fowler → Negstad → Pine). Happy to switch to last-name ordering if preferred.
- `handle` / avatar / social-link behavior is unchanged; `coreTeamHandles` is derived from the array so de-duplication is unaffected by order.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>