### PR TITLE
Document GitHub Copilot app plugin installation

### DIFF
--- a/src/frontend/src/content/docs/get-started/aspire-skills.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-skills.mdx
@@ -137,6 +137,27 @@ Use this path for terminal workflows where GitHub Copilot needs Aspire-specific 
 </LearnMore>
 
 </TabItem>
+<TabItem id='copilot-app' label='GitHub Copilot app'>
+
+The GitHub Copilot app plugin installs Aspire skills and canvas extensions for the current user.
+
+#### Prerequisites
+
+Before you install, make sure you have:
+
+- [GitHub Copilot app](https://gh.io/app) installed.
+- A GitHub Copilot subscription (paid or free).
+
+#### Install
+
+Install the `microsoft/aspire-skills` marketplace through the GitHub Copilot app:
+
+1. Click [this link](https://github.com/copilot/app/launch?entry_point=aspire_skills_docs&open=ghapp%3A%2F%2Fplugins%2Fmarketplace%2Fadd%3Fsource%3Dmicrosoft%2Faspire-skills) to automatically open the **Settings** > **Plugins** window in the GitHub Copilot app.
+2. In the **Add plugin marketplace?** dialog, select **Allow**.
+3. The **Plugins** window opens with the `microsoft/aspire-skills` marketplace. Select **Add marketplace**.
+4. Expand the `aspire-skills` entry and select **Install** on the `aspire` plugin.
+
+</TabItem>
 <TabItem id='claude-code' label='Claude Code'>
 
 Start Claude Code in your terminal, add the Aspire marketplace, then install the Aspire plugin.
@@ -232,6 +253,14 @@ In that command, `-a github-copilot` selects the target agent, `-g` installs glo
 | `aspireify`            | Completing Aspire initialization in an existing codebase after `aspire init` drops an AppHost skeleton | Scan the repo, propose a resource graph, wire projects and containers into the AppHost, connect resources, configure telemetry when appropriate, and validate the wiring |
 
 Use the top-level `aspire` skill when the request is about an Aspire app and the right workflow isn't obvious. Use a workflow-specific skill directly when the task is clear, such as `aspire-orchestration` for local lifecycle work, `aspire-monitoring` for telemetry investigation, `aspire-deployment` for publish and deploy workflows, or `aspireify` for existing-codebase AppHost wiring.
+
+## GitHub Copilot app canvas extensions
+
+Currently, the Aspire CLI setup flow doesn't install canvas extensions. Install them through the GitHub Copilot app plugin.
+
+| Canvas          | Use it for                              | What it shows                                                                                  |
+| --------------- | --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `aspire-doctor` | Diagnosing your Aspire development setup | Environment checks, suggested fixes, and detected Aspire CLI installations in an app side panel |
 
 ## Companion skills and tools
 


### PR DESCRIPTION
## Summary

- document GitHub Copilot app prerequisites and plugin marketplace installation
- list GitHub Copilot app canvas extensions and clarify that Aspire CLI setup does not install them

## Related

- Closes #1547
- Companion instructions: [microsoft/aspire-skills#52](https://github.com/microsoft/aspire-skills/pull/52)