### PR TITLE
Document Aspire 13.5 package compatibility issue

### DIFF
--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -992,7 +992,7 @@ Affected mixed-version scenarios include:
 - `Aspire.Hosting.Azure.Functions`: `MissingMethodException` involving `WithDebugSupport`.
 - `Aspire.Hosting.Go`, `Aspire.Hosting.JavaScript`, and `Aspire.Hosting.Python`: `TypeLoadException` involving `ExecutableLaunchConfiguration`.
 
-Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use their matching 13.5.0-preview build.
+Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use their full `13.5.0-preview.*` build-qualified version (for example, `13.5.0-preview.1.26417.7`).
 
 ## 🙏 Community
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -994,6 +994,8 @@ Affected mixed-version scenarios include:
 
 Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use the corresponding version from the `13.5.0-preview.*` series.
 
+If you discover an issue, please [report it on GitHub](https://github.com/microsoft/aspire/issues).
+
 ## 🙏 Community
 
 Aspire is built in the open, and this release wouldn't be what it is without you. A huge thank you to everyone who helped make Aspire 13.5 possible.

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -992,7 +992,7 @@ Affected mixed-version scenarios include:
 - `Aspire.Hosting.Azure.Functions`: `MissingMethodException` involving `WithDebugSupport`.
 - `Aspire.Hosting.Go`, `Aspire.Hosting.JavaScript`, and `Aspire.Hosting.Python`: `TypeLoadException` involving `ExecutableLaunchConfiguration`.
 
-Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use their full `13.5.0-preview.*` build-qualified version (for example, `13.5.0-preview.1.26417.7`).
+Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use the corresponding version from the `13.5.0-preview.*` series.
 
 ## 🙏 Community
 

--- a/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
+++ b/src/frontend/src/content/docs/whats-new/aspire-13-5.mdx
@@ -982,7 +982,17 @@ The following breaking changes are included in Aspire 13.5:
 
 ## Known issues
 
-No Aspire 13.5 known issues are documented yet. If you discover an issue, please [report it on GitHub](https://github.com/microsoft/aspire/issues).
+### Mixed Aspire 13.4 and 13.5 packages can fail at runtime
+
+Aspire 13.5 SDK and core packages aren't binary-compatible with some Aspire 13.4.6 hosting integration packages. An AppHost that mixes the 13.4 and 13.5 package families can fail at startup with a `MissingMethodException` or a `TypeLoadException` (sometimes surfaced as multiple `TypeLoadExceptions`).
+
+Affected mixed-version scenarios include:
+
+- `Aspire.Hosting.Kubernetes` and `Aspire.Hosting.Azure.Kubernetes`: `MissingMethodException` involving `ProjectResource.get_DefaultHttpsEndpoint`.
+- `Aspire.Hosting.Azure.Functions`: `MissingMethodException` involving `WithDebugSupport`.
+- `Aspire.Hosting.Go`, `Aspire.Hosting.JavaScript`, and `Aspire.Hosting.Python`: `TypeLoadException` involving `ExecutableLaunchConfiguration`.
+
+Don't mix Aspire 13.4 and 13.5 packages. Either stay wholly on the Aspire 13.4 SDK and integration packages, or upgrade the SDK and every `Aspire.Hosting.*` integration package together to the matching 13.5 series. Stable packages use version 13.5.0; preview integrations use their matching 13.5.0-preview build.
 
 ## 🙏 Community
 


### PR DESCRIPTION
## Summary

- Documents runtime failures caused by mixing Aspire 13.5 SDK/core packages with affected Aspire 13.4.6 hosting integrations.
- Lists the affected packages and their `MissingMethodException` or `TypeLoadException` signatures.
- Directs users to keep the SDK and all hosting integrations in the same 13.4 or 13.5 package family.

## Third-party links and affiliations

None.

## Validation

- `git diff --check`
- `pnpm build:production` and desktop, tablet, and mobile end-to-end tests in [GitHub Actions](https://github.com/microsoft/aspire.dev/actions/runs/32314640809)