### PR TITLE
Fix misaligned code line highlights in secure communications docs

### DIFF
--- a/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
@@ -46,7 +46,7 @@ To flow authentication credentials from the MailDev resource to the MailKit inte
 
 The MailDev container supports basic authentication for both incoming and outgoing simple mail transfer protocol (SMTP). To configure the credentials for incoming, you need to set the `MAILDEV_INCOMING_USER` and `MAILDEV_INCOMING_PASS` environment variables. For more information, see [MailDev: Usage](https://maildev.github.io/maildev/#usage). Update the `MailDevResource.cs` file in the `MailDev.Hosting` project, by replacing its contents with the following C# code:
 
-```csharp {10-11,26-29,31-34,36-39,49} title="MailDev.Hosting/MailDevResource.cs"
+```csharp {10-11,26-29,31-34,36-39,50} title="MailDev.Hosting/MailDevResource.cs"
 // For ease of discovery, resource types should be placed in
 // the Aspire.Hosting.ApplicationModel namespace. If there is
 // likelihood of a conflict on the resource name consider using

--- a/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
@@ -46,7 +46,7 @@ To flow authentication credentials from the MailDev resource to the MailKit inte
 
 The MailDev container supports basic authentication for both incoming and outgoing simple mail transfer protocol (SMTP). To configure the credentials for incoming, you need to set the `MAILDEV_INCOMING_USER` and `MAILDEV_INCOMING_PASS` environment variables. For more information, see [MailDev: Usage](https://maildev.github.io/maildev/#usage). Update the `MailDevResource.cs` file in the `MailDev.Hosting` project, by replacing its contents with the following C# code:
 
-```csharp {9-10,25-28,30-33,35-38,48} title="MailDev.Hosting/MailDevResource.cs"
+```csharp {10-11,26-29,31-34,36-39,49} title="MailDev.Hosting/MailDevResource.cs"
 // For ease of discovery, resource types should be placed in
 // the Aspire.Hosting.ApplicationModel namespace. If there is
 // likelihood of a conflict on the resource name consider using
@@ -102,7 +102,7 @@ public sealed class MailDevResource(
 
 These updates add a `UsernameParameter` and `PasswordParameter` property. These properties are used to store the parameters for the MailDev username and password. The `ConnectionStringExpression` property is updated to include the username and password parameters in the connection string. Next, update the `MailDevResourceBuilderExtensions.cs` file in the `MailDev.Hosting` project with the following C# code:
 
-```csharp {9-10,29-30,32-34,40-41,55-59} title="MailDev.Hosting/MailDevResourceBuilderExtensions.cs"
+```csharp {9-10,30-31,33-35,41-42,56-60} title="MailDev.Hosting/MailDevResourceBuilderExtensions.cs"
 using Aspire.Hosting.ApplicationModel;
 
 // Put extensions in the Aspire.Hosting namespace to ease discovery as referencing


### PR DESCRIPTION
## Summary

The Expressive Code line-highlight ranges in the **Secure communication between integrations** article were shifted up by one line in two snippets. As a result they highlighted blank lines and XML doc comments instead of the members they describe, and cut off multi-line statements partway through.

This realigns each range to cover the complete, intended member.

### `MailDev.Hosting/MailDevResource.cs`

`{9-10,25-28,30-33,35-38,48}` → `{10-11,26-29,31-34,36-39,49}`

- ctor params `username`/`password`, the `UsernameParameter`/`PasswordParameter` properties (with their doc comments), the full `UserNameReference` expression, and the connection-string line referencing `{UserNameReference}`.

### `MailDev.Hosting/MailDevResourceBuilderExtensions.cs`

`{9-10,29-30,32-34,40-41,55-59}` → `{9-10,30-31,33-35,41-42,56-60}`

- the new `username`/`password` method params, the full `passwordParameter` statement, the `new MailDevResource(...)` statement, and the complete `.WithEnvironment(...)` block.

The other two code blocks on the page (`MailKitClientSettings.cs`, `MailKitClientFactory.cs`) were already aligned and are left unchanged.

## Verification

Scanned all 89 highlighted code fences across the docs; no remaining ranges start on a blank line or end on a doc-comment line.
