### PR TITLE
Document dashboard host filtering

### DIFF
--- a/src/frontend/src/content/docs/dashboard/security-considerations.mdx
+++ b/src/frontend/src/content/docs/dashboard/security-considerations.mdx
@@ -51,6 +51,17 @@ During local development on a trusted machine, you might allow anonymous access 
 
 Both settings disable dashboard authentication and have the same security risks.
 
+:::note[Restrict allowed hosts]
+When anonymous access is enabled, consider [configuring host filtering](https://learn.microsoft.com/aspnet/core/fundamentals/servers/kestrel/host-filtering) by setting `AllowedHosts` to the host names used to access the dashboard. Browser token authentication uses a host-scoped authentication cookie, which helps prevent an attacker-controlled host name from accessing dashboard responses in a DNS rebinding attack. Anonymous access removes this protection, so restricting accepted `Host` headers provides additional hardening.
+
+For example, provide a semicolon-delimited list of host names without port numbers:
+
+```bash title="Aspire CLI"
+aspire dashboard run --allow-anonymous --AllowedHosts='localhost;dashboard.example.com'
+```
+
+:::
+
 :::danger
 Anyone who can reach an anonymously accessible dashboard can view potentially sensitive resource and telemetry data without authentication. Untrusted apps can also send telemetry to an unsecured OTLP endpoint. Only allow anonymous access in trusted local development environments, and don't expose an anonymously accessible dashboard or its endpoints to an untrusted network.
 :::


### PR DESCRIPTION
## Summary

- Recommend configuring ASP.NET Core `AllowedHosts` when dashboard anonymous access is enabled.
- Explain how host filtering provides additional protection against DNS rebinding attacks.
- Add an `aspire dashboard run` example with a semicolon-delimited host allowlist.

## Third-party links and affiliations

None. The added link points to Microsoft Learn documentation for ASP.NET Core host filtering.

## Validation

- Verified `aspire dashboard run --allow-anonymous --AllowedHosts=allowed.example` starts successfully.
- Verified an allowed `Host` header reaches the dashboard (`302`) and an unlisted host is rejected (`400 Invalid Hostname`).
- Verified the edited MDX file has no editor diagnostics.
