### PR TITLE
Add SoftwareApplication + SoftwareSourceCode JSON-LD to the homepage

### DIFF
--- a/src/frontend/src/utils/structured-data.ts
+++ b/src/frontend/src/utils/structured-data.ts
@@ -35,6 +35,7 @@ const sameAsLinks = [
   'https://www.youtube.com/@aspiredotdev',
   'https://www.twitch.tv/aspiredotdev',
 ] as const;
+const codeRepositoryUrl = 'https://github.com/microsoft/aspire';
 const aspireConfName = 'Aspire Conf 2026';
 const aspireConfReplayUrl =
   'https://www.youtube.com/playlist?list=PLSi5JsxQ5oNvRCeQj5v6ZYUe1gwzTSUfR';
@@ -80,6 +81,8 @@ function isCommunityPagePath(contentBasePath: string): boolean {
 
 function buildHomePageSchema(siteUrl: string, language: string, description: string): JsonObject {
   const organizationId = `${siteUrl}/#org`;
+  const applicationId = `${siteUrl}/#app`;
+  const sourceCodeId = `${siteUrl}/#source`;
 
   return {
     '@context': 'https://schema.org',
@@ -101,6 +104,23 @@ function buildHomePageSchema(siteUrl: string, language: string, description: str
         name: organizationName,
         publisher: { '@id': organizationId },
         inLanguage: language,
+      },
+      {
+        ...buildSoftwareApplication(siteUrl),
+        '@id': applicationId,
+        author: { '@id': organizationId },
+        publisher: { '@id': organizationId },
+        sameAs: codeRepositoryUrl,
+      },
+      {
+        '@type': 'SoftwareSourceCode',
+        '@id': sourceCodeId,
+        name: organizationName,
+        description: softwareDescription,
+        codeRepository: codeRepositoryUrl,
+        author: { '@id': organizationId },
+        isAccessibleForFree: true,
+        targetProduct: { '@id': applicationId },
       },
     ],
   };
@@ -316,6 +336,12 @@ function buildSoftwareApplication(siteUrl: string): JsonObject {
     applicationCategory: 'DeveloperApplication',
     operatingSystem: 'Windows, macOS, Linux',
     url: `${siteUrl}/`,
+    isAccessibleForFree: true,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    },
   };
 }
 

--- a/src/frontend/tests/unit/structured-data.vitest.test.ts
+++ b/src/frontend/tests/unit/structured-data.vitest.test.ts
@@ -97,6 +97,34 @@ describe('getStructuredData', () => {
       expect(website?.inLanguage).toBe('en');
     });
 
+    it('includes a SoftwareApplication + SoftwareSourceCode wired to the organization', () => {
+      const route = createRoute({
+        entryId: 'index.mdx',
+        title: 'Aspire',
+        description: 'Your stack, streamlined.',
+      });
+
+      const json = parse(getStructuredData(route, new URL('https://aspire.dev/'), site));
+      const graph = json['@graph'] as Array<Record<string, unknown>>;
+
+      const app = graph.find((node) => node['@type'] === 'SoftwareApplication');
+      expect(app).toBeDefined();
+      expect(app?.['@id']).toBe('https://aspire.dev/#app');
+      expect(app?.applicationCategory).toBe('DeveloperApplication');
+      expect(app?.isAccessibleForFree).toBe(true);
+      expect(app?.offers).toEqual({ '@type': 'Offer', price: '0', priceCurrency: 'USD' });
+      expect(app?.author).toEqual({ '@id': 'https://aspire.dev/#org' });
+      expect(app?.publisher).toEqual({ '@id': 'https://aspire.dev/#org' });
+      expect(app?.sameAs).toBe('https://github.com/microsoft/aspire');
+
+      const source = graph.find((node) => node['@type'] === 'SoftwareSourceCode');
+      expect(source).toBeDefined();
+      expect(source?.['@id']).toBe('https://aspire.dev/#source');
+      expect(source?.codeRepository).toBe('https://github.com/microsoft/aspire');
+      expect(source?.author).toEqual({ '@id': 'https://aspire.dev/#org' });
+      expect(source?.targetProduct).toEqual({ '@id': 'https://aspire.dev/#app' });
+    });
+
     it('detects localized home pages', () => {
       const route = createRoute({
         entryId: 'de/index.mdx',


### PR DESCRIPTION
## Summary

Adds `SoftwareApplication` and `SoftwareSourceCode` nodes to the homepage JSON-LD `@graph`, which previously emitted only `Organization` + `WebSite`. These are high-leverage schema types for developer products (consumed by Google Rich Results and AI engines).

## Changes

- **`buildHomePageSchema()`** now adds two nodes to the homepage `@graph`:
  - `SoftwareApplication` (`@id: <site>/#app`) wired to the org via `author` + `publisher` (`<site>/#org`), with `offers`, `isAccessibleForFree`, and `sameAs` → the Aspire GitHub repos.
  - `SoftwareSourceCode` (`@id: <site>/#source`) with `codeRepository` → the Aspire GitHub repos, `author` → `#org`, and `targetProduct` → `#app`.
- **`buildSoftwareApplication()`** enriched with a free `Offer` (`price: "0"`, `priceCurrency: "USD"`) + `isAccessibleForFree: true`, so every schema that references it advertises Aspire as free/OSS.
- Added a `codeRepositoryLinks` constant for `https://github.com/microsoft/aspire` and `https://github.com/dotnet/aspire`.

## Testing

- Extended `structured-data.vitest.test.ts` (home page block) to assert the new `SoftwareApplication`/`SoftwareSourceCode` nodes and their `@id` wiring to `#org`/`#app`.
- `pnpm test:unit:structured-data` → **26 passed**.
- `eslint` clean on the changed files.

Fixes #1417
