### PR TITLE
fix(home): align closing CTA button heights with hero CTAs

### DIFF
--- a/src/frontend/src/components/home/HomePage.astro
+++ b/src/frontend/src/components/home/HomePage.astro
@@ -2913,7 +2913,7 @@ const localizedPrinciples = principles.map((principle) => ({
   }
 
   .closing-action {
-    min-height: 3.25rem;
+    min-height: 3.15rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -2924,6 +2924,7 @@ const localizedPrinciples = principles.map((principle) => ({
     color: var(--home-text);
     font-size: 0.94rem;
     font-weight: 750;
+    line-height: 1;
     text-decoration: none;
   }
 


### PR DESCRIPTION
## What

The homepage **closing** CTAs ("Install Aspire", "Build your first app", "View on GitHub") rendered ~3px taller than the **hero** CTAs. This aligns every CTA to a uniform height.

## Why

`.closing-action` used `min-height: 3.25rem` and inherited the body `line-height` (~1.75) rather than resetting it, so the closing group rendered taller than the hero's `.home-hero-action` group.

## Change

In `src/frontend/src/components/home/HomePage.astro`:

- `min-height: 3.25rem` -> `3.15rem`
- add `line-height: 1`

This matches the hero CTA sizing exactly. No markup or color changes -- the recently added dark-mode grey `.closing-action.tertiary` background is untouched.

## Verification

Measured on the latest `main` at the top of the page, in **both light and dark themes** -- all five CTAs (2 hero + 3 closing, including the dark-mode grey tertiary) render at exactly **50.4px**.
