### PR TITLE
Redirect static paths to canonical casing

### DIFF
--- a/src/statichost/StaticHost/GlobalUsings.cs
+++ b/src/statichost/StaticHost/GlobalUsings.cs
@@ -2,6 +2,7 @@ global using System.Diagnostics;
 
 global using StaticHost;
 global using StaticHost.AgentReadiness;
+global using StaticHost.Routing;
 global using StaticHost.Telemetry;
 
 global using OpenTelemetry;

--- a/src/statichost/StaticHost/Program.cs
+++ b/src/statichost/StaticHost/Program.cs
@@ -19,6 +19,9 @@ if (!app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
+// Resolve request casing before any middleware rewrites or matches the static path.
+app.UseCanonicalPathRedirects();
+
 // Agent-readiness middlewares MUST run before UseDefaultFiles + UseRouting:
 //   * UseDefaultFiles rewrites /foo/ -> /foo/index.html, breaking .md-companion mapping.
 //   * MapStaticAssets registers endpoints during UseRouting, so a path rewrite

--- a/src/statichost/StaticHost/Routing/CanonicalPathRedirectExtensions.cs
+++ b/src/statichost/StaticHost/Routing/CanonicalPathRedirectExtensions.cs
@@ -1,0 +1,16 @@
+namespace StaticHost.Routing;
+
+public static class CanonicalPathRedirectExtensions
+{
+    /// <summary>
+    /// Redirects case-insensitive static path matches to their exact on-disk casing.
+    /// Call before middleware that rewrites or resolves the request path.
+    /// </summary>
+    public static IApplicationBuilder UseCanonicalPathRedirects(this IApplicationBuilder app)
+    {
+        ArgumentNullException.ThrowIfNull(app);
+
+        app.UseMiddleware<CanonicalPathRedirectMiddleware>();
+        return app;
+    }
+}

--- a/src/statichost/StaticHost/Routing/CanonicalPathRedirectMiddleware.cs
+++ b/src/statichost/StaticHost/Routing/CanonicalPathRedirectMiddleware.cs
@@ -1,0 +1,32 @@
+namespace StaticHost.Routing;
+
+internal sealed class CanonicalPathRedirectMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly CanonicalPathResolver _resolver;
+
+    public CanonicalPathRedirectMiddleware(
+        RequestDelegate next,
+        IWebHostEnvironment environment)
+    {
+        _next = next;
+        _resolver = new CanonicalPathResolver(
+            environment.WebRootPath ??
+            throw new InvalidOperationException("The static web root is not configured."));
+    }
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        if (!_resolver.TryResolve(context.Request.Path, out var canonicalPath))
+        {
+            return _next(context);
+        }
+
+        var location =
+            context.Request.PathBase.Add(canonicalPath).ToUriComponent() +
+            context.Request.QueryString.ToUriComponent();
+
+        context.Response.Redirect(location, permanent: true, preserveMethod: true);
+        return Task.CompletedTask;
+    }
+}

--- a/src/statichost/StaticHost/Routing/CanonicalPathRedirectMiddleware.cs
+++ b/src/statichost/StaticHost/Routing/CanonicalPathRedirectMiddleware.cs
@@ -1,32 +1,29 @@
+using Microsoft.AspNetCore.Http.Extensions;
+
 namespace StaticHost.Routing;
 
-internal sealed class CanonicalPathRedirectMiddleware
+internal sealed class CanonicalPathRedirectMiddleware(
+    RequestDelegate next,
+    IWebHostEnvironment environment)
 {
-    private readonly RequestDelegate _next;
-    private readonly CanonicalPathResolver _resolver;
-
-    public CanonicalPathRedirectMiddleware(
-        RequestDelegate next,
-        IWebHostEnvironment environment)
-    {
-        _next = next;
-        _resolver = new CanonicalPathResolver(
-            environment.WebRootPath ??
-            throw new InvalidOperationException("The static web root is not configured."));
-    }
+    private readonly CanonicalPathResolver _resolver = new(
+        environment.WebRootPath ??
+        throw new InvalidOperationException("The static web root is not configured."));
 
     public Task InvokeAsync(HttpContext context)
     {
         if (!_resolver.TryResolve(context.Request.Path, out var canonicalPath))
         {
-            return _next(context);
+            return next(context);
         }
 
-        var location =
-            context.Request.PathBase.Add(canonicalPath).ToUriComponent() +
-            context.Request.QueryString.ToUriComponent();
-
-        context.Response.Redirect(location, permanent: true, preserveMethod: true);
+        context.Response.Redirect(
+            UriHelper.BuildRelative(
+                context.Request.PathBase,
+                canonicalPath,
+                context.Request.QueryString),
+            permanent: true,
+            preserveMethod: true);
         return Task.CompletedTask;
     }
 }

--- a/src/statichost/StaticHost/Routing/CanonicalPathResolver.cs
+++ b/src/statichost/StaticHost/Routing/CanonicalPathResolver.cs
@@ -1,6 +1,6 @@
 namespace StaticHost.Routing;
 
-internal sealed class CanonicalPathResolver
+internal sealed class CanonicalPathResolver(IEnumerable<string> canonicalPaths)
 {
     private static readonly HashSet<string> DefaultFileNames =
     [
@@ -16,29 +16,11 @@ internal sealed class CanonicalPathResolver
         RecurseSubdirectories = true,
     };
 
-    private readonly Dictionary<string, string?> _canonicalPaths;
+    private readonly Dictionary<string, string?> _canonicalPaths = CreateLookup(canonicalPaths);
 
     public CanonicalPathResolver(string webRootPath)
         : this(EnumerateCanonicalPaths(webRootPath))
     {
-    }
-
-    internal CanonicalPathResolver(IEnumerable<string> canonicalPaths)
-    {
-        ArgumentNullException.ThrowIfNull(canonicalPaths);
-
-        _canonicalPaths = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
-        foreach (var canonicalPath in canonicalPaths)
-        {
-            if (string.IsNullOrEmpty(canonicalPath) || canonicalPath[0] != '/')
-            {
-                throw new ArgumentException(
-                    "Canonical paths must be non-empty and start with '/'.",
-                    nameof(canonicalPaths));
-            }
-
-            Add(canonicalPath);
-        }
     }
 
     public bool TryResolve(PathString requestPath, out PathString canonicalPath)
@@ -58,20 +40,34 @@ internal sealed class CanonicalPathResolver
         return true;
     }
 
-    private void Add(string canonicalPath)
+    private static Dictionary<string, string?> CreateLookup(
+        IEnumerable<string> canonicalPaths)
     {
-        if (!_canonicalPaths.TryGetValue(canonicalPath, out var existingPath))
+        ArgumentNullException.ThrowIfNull(canonicalPaths);
+
+        var lookup = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var canonicalPath in canonicalPaths)
         {
-            _canonicalPaths.Add(canonicalPath, canonicalPath);
-            return;
+            if (string.IsNullOrEmpty(canonicalPath) || canonicalPath[0] != '/')
+            {
+                throw new ArgumentException(
+                    "Canonical paths must be non-empty and start with '/'.",
+                    nameof(canonicalPaths));
+            }
+
+            if (!lookup.TryGetValue(canonicalPath, out var existingPath))
+            {
+                lookup.Add(canonicalPath, canonicalPath);
+            }
+            else if (existingPath is not null &&
+                     !string.Equals(existingPath, canonicalPath, StringComparison.Ordinal))
+            {
+                // A case-insensitive request cannot uniquely identify either path.
+                lookup[canonicalPath] = null;
+            }
         }
 
-        if (existingPath is not null &&
-            !string.Equals(existingPath, canonicalPath, StringComparison.Ordinal))
-        {
-            // A case-insensitive request cannot uniquely identify either path.
-            _canonicalPaths[canonicalPath] = null;
-        }
+        return lookup;
     }
 
     private static IEnumerable<string> EnumerateCanonicalPaths(string webRootPath)

--- a/src/statichost/StaticHost/Routing/CanonicalPathResolver.cs
+++ b/src/statichost/StaticHost/Routing/CanonicalPathResolver.cs
@@ -1,0 +1,117 @@
+namespace StaticHost.Routing;
+
+internal sealed class CanonicalPathResolver
+{
+    private static readonly HashSet<string> DefaultFileNames =
+    [
+        "default.htm",
+        "default.html",
+        "index.htm",
+        "index.html",
+    ];
+
+    private static readonly EnumerationOptions StaticFileEnumerationOptions = new()
+    {
+        AttributesToSkip = FileAttributes.ReparsePoint,
+        RecurseSubdirectories = true,
+    };
+
+    private readonly Dictionary<string, string?> _canonicalPaths;
+
+    public CanonicalPathResolver(string webRootPath)
+        : this(EnumerateCanonicalPaths(webRootPath))
+    {
+    }
+
+    internal CanonicalPathResolver(IEnumerable<string> canonicalPaths)
+    {
+        ArgumentNullException.ThrowIfNull(canonicalPaths);
+
+        _canonicalPaths = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var canonicalPath in canonicalPaths)
+        {
+            if (string.IsNullOrEmpty(canonicalPath) || canonicalPath[0] != '/')
+            {
+                throw new ArgumentException(
+                    "Canonical paths must be non-empty and start with '/'.",
+                    nameof(canonicalPaths));
+            }
+
+            Add(canonicalPath);
+        }
+    }
+
+    public bool TryResolve(PathString requestPath, out PathString canonicalPath)
+    {
+        canonicalPath = default;
+
+        var requestedPath = requestPath.Value;
+        if (requestedPath is null ||
+            !_canonicalPaths.TryGetValue(requestedPath, out var resolvedPath) ||
+            resolvedPath is null ||
+            string.Equals(requestedPath, resolvedPath, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        canonicalPath = new PathString(resolvedPath);
+        return true;
+    }
+
+    private void Add(string canonicalPath)
+    {
+        if (!_canonicalPaths.TryGetValue(canonicalPath, out var existingPath))
+        {
+            _canonicalPaths.Add(canonicalPath, canonicalPath);
+            return;
+        }
+
+        if (existingPath is not null &&
+            !string.Equals(existingPath, canonicalPath, StringComparison.Ordinal))
+        {
+            // A case-insensitive request cannot uniquely identify either path.
+            _canonicalPaths[canonicalPath] = null;
+        }
+    }
+
+    private static IEnumerable<string> EnumerateCanonicalPaths(string webRootPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(webRootPath);
+        if (!Directory.Exists(webRootPath))
+        {
+            throw new DirectoryNotFoundException(
+                $"The static web root '{webRootPath}' does not exist.");
+        }
+
+        // Enumerate the physical root so dot-prefixed paths such as /.well-known/
+        // are included; some IFileProvider implementations hide them from listings.
+        foreach (var filePath in Directory.EnumerateFiles(
+            webRootPath,
+            "*",
+            StaticFileEnumerationOptions))
+        {
+            var relativePath = Path.GetRelativePath(webRootPath, filePath)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            var requestPath = $"/{relativePath}";
+
+            yield return requestPath;
+
+            if (!DefaultFileNames.Contains(Path.GetFileName(relativePath)))
+            {
+                continue;
+            }
+
+            var relativeDirectory = Path.GetDirectoryName(relativePath)?
+                .Replace(Path.DirectorySeparatorChar, '/');
+            var directoryRequestPath = string.IsNullOrEmpty(relativeDirectory)
+                ? "/"
+                : $"/{relativeDirectory}";
+
+            yield return directoryRequestPath;
+            if (directoryRequestPath != "/")
+            {
+                yield return $"{directoryRequestPath}/";
+            }
+        }
+    }
+}

--- a/tests/StaticHost.Tests/AgentReadinessTestServer.cs
+++ b/tests/StaticHost.Tests/AgentReadinessTestServer.cs
@@ -6,13 +6,14 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using StaticHost.AgentReadiness;
+using StaticHost.Routing;
 
 namespace StaticHost.Tests;
 
 /// <summary>
 /// Builds an in-process ASP.NET Core test server that mirrors the production
-/// pipeline order for the agent-readiness middlewares (markdown negotiation
-/// and Link headers) without depending on the frontend build.
+/// pipeline order for path canonicalization and the agent-readiness middlewares
+/// without depending on the frontend build.
 /// </summary>
 internal sealed class AgentReadinessTestServer : IAsyncDisposable
 {
@@ -47,8 +48,9 @@ internal sealed class AgentReadinessTestServer : IAsyncDisposable
                     web.UseWebRoot(wwwroot.Path);
                     web.Configure(app =>
                     {
-                        // Match production order: agent-readiness BEFORE
-                        // UseDefaultFiles + UseRouting (see Program.cs).
+                        // Match production order: canonical redirects and
+                        // agent-readiness BEFORE default files (see Program.cs).
+                        app.UseCanonicalPathRedirects();
                         app.UseAgentReadiness();
                         app.UseDefaultFiles();
                         app.UseStaticFiles();

--- a/tests/StaticHost.Tests/AgentReadinessTestServer.cs
+++ b/tests/StaticHost.Tests/AgentReadinessTestServer.cs
@@ -33,7 +33,9 @@ internal sealed class AgentReadinessTestServer : IAsyncDisposable
         Client = testServer.CreateClient();
     }
 
-    public static async Task<AgentReadinessTestServer> StartAsync(Action<TempWebRoot>? seed = null)
+    public static async Task<AgentReadinessTestServer> StartAsync(
+        Action<TempWebRoot>? seed = null,
+        PathString pathBase = default)
     {
         var wwwroot = new TempWebRoot();
         try
@@ -48,6 +50,11 @@ internal sealed class AgentReadinessTestServer : IAsyncDisposable
                     web.UseWebRoot(wwwroot.Path);
                     web.Configure(app =>
                     {
+                        if (pathBase.HasValue)
+                        {
+                            app.UsePathBase(pathBase);
+                        }
+
                         // Match production order: canonical redirects and
                         // agent-readiness BEFORE default files (see Program.cs).
                         app.UseCanonicalPathRedirects();

--- a/tests/StaticHost.Tests/CanonicalPathRedirectTests.cs
+++ b/tests/StaticHost.Tests/CanonicalPathRedirectTests.cs
@@ -1,0 +1,94 @@
+using StaticHost.Routing;
+
+namespace StaticHost.Tests;
+
+public sealed class CanonicalPathRedirectTests
+{
+    [Theory]
+    [InlineData(
+        "/diagnostics/ASPIRE001/?source=compiler",
+        "/diagnostics/aspire001/?source=compiler")]
+    [InlineData(
+        "/DiAgNoStIcS/ASPIRE001",
+        "/diagnostics/aspire001")]
+    public async Task Case_mismatched_page_route_redirects_to_canonical_path(
+        string requestPath,
+        string expectedLocation)
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync(
+            root => root.WriteFile("diagnostics/aspire001/index.html", SamplePages.Html));
+
+        using var response = await server.Client.GetAsync(requestPath);
+
+        Assert.Equal(HttpStatusCode.PermanentRedirect, response.StatusCode);
+        Assert.Equal(expectedLocation, response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Case_mismatched_static_file_redirects_to_canonical_path()
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync(
+            root => root.WriteFile("scripts/site.js", "console.log('Aspire');"));
+
+        using var response = await server.Client.GetAsync("/SCRIPTS/SITE.JS");
+
+        Assert.Equal(HttpStatusCode.PermanentRedirect, response.StatusCode);
+        Assert.Equal("/scripts/site.js", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Canonically_uppercase_file_redirects_to_its_exact_casing()
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync(
+            root => root.WriteFile(
+                ".well-known/agent-skills/getting-started/SKILL.md",
+                "# Getting started"));
+
+        using var response = await server.Client.GetAsync(
+            "/.WELL-KNOWN/AGENT-SKILLS/GETTING-STARTED/skill.md");
+
+        Assert.Equal(HttpStatusCode.PermanentRedirect, response.StatusCode);
+        Assert.Equal(
+            "/.well-known/agent-skills/getting-started/SKILL.md",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Canonical_request_passes_through_unchanged()
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync(
+            root => root.WriteFile("diagnostics/aspire001/index.html", SamplePages.Html));
+
+        using var response = await server.Client.GetAsync("/diagnostics/aspire001/");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+    }
+
+    [Fact]
+    public async Task Missing_path_remains_not_found()
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync();
+
+        using var response = await server.Client.GetAsync("/MISSING/PAGE/");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        Assert.Null(response.Headers.Location);
+    }
+
+    [Fact]
+    public void Ambiguous_case_only_paths_are_not_redirected()
+    {
+        var resolver = new CanonicalPathResolver(
+        [
+            "/assets/logo.svg",
+            "/assets/LOGO.svg",
+        ]);
+
+        var resolved = resolver.TryResolve(
+            new PathString("/assets/Logo.svg"),
+            out _);
+
+        Assert.False(resolved);
+    }
+}

--- a/tests/StaticHost.Tests/CanonicalPathRedirectTests.cs
+++ b/tests/StaticHost.Tests/CanonicalPathRedirectTests.cs
@@ -25,6 +25,22 @@ public sealed class CanonicalPathRedirectTests
     }
 
     [Fact]
+    public async Task Redirect_preserves_path_base_and_query_string()
+    {
+        await using var server = await AgentReadinessTestServer.StartAsync(
+            root => root.WriteFile("diagnostics/aspire001/index.html", SamplePages.Html),
+            pathBase: new PathString("/docs"));
+
+        using var response = await server.Client.GetAsync(
+            "/docs/DIAGNOSTICS/ASPIRE001/?source=compiler");
+
+        Assert.Equal(HttpStatusCode.PermanentRedirect, response.StatusCode);
+        Assert.Equal(
+            "/docs/diagnostics/aspire001/?source=compiler",
+            response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Case_mismatched_static_file_redirects_to_canonical_path()
     {
         await using var server = await AgentReadinessTestServer.StartAsync(


### PR DESCRIPTION
## Summary

- redirect case-insensitive matches for every deployed static page and file to its exact canonical casing
- preserve query strings with method-preserving permanent (`308`) redirects
- keep canonical requests, missing paths, and ambiguous case-only collisions unchanged
- fix natural diagnostic URLs such as `/diagnostics/ASPIRE001/`

Fixes #1579

## Third-party links and affiliations

None.

## Validation

- `dotnet test .\tests\StaticHost.Tests\StaticHost.Tests.csproj --no-restore --filter FullyQualifiedName~CanonicalPathRedirectTests --nologo`
- `dotnet test .\tests\StaticHost.Tests\StaticHost.Tests.csproj --no-restore --nologo`