### PR TITLE
Keep docs versions current and default to TypeScript AppHosts

### DIFF
--- a/.agents/skills/doc-writer/SKILL.md
+++ b/.agents/skills/doc-writer/SKILL.md
@@ -290,16 +290,16 @@ When a page shows the **On this page** table of contents (the default behavior u
 
 If your opening section is truly introductory, keep it as body copy without an `Overview` heading. If that section has a more specific purpose, use a descriptive heading such as `Key concepts`, `Prerequisites`, or another topic-specific label.
 
-For Aspire AppHost code examples, use synced `Tabs` / `TabItem` blocks with `syncKey='aspire-lang'` at each code snippet. Do **not** add a page-level `PivotSelector` just to switch AppHost code samples between C# and TypeScript. Readers should be able to switch the language at the specific snippet they are reading.
+For Aspire AppHost code examples, use synced `Tabs` / `TabItem` blocks with `syncKey='aspire-lang'` at each code snippet. List TypeScript first so `apphost.mts` is the default experience for readers without a saved preference. Do **not** add a page-level `PivotSelector` just to switch AppHost code samples between TypeScript and C#. Readers should be able to switch the language at the specific snippet they are reading.
 
 ```mdx
 <Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-C# example content here.
-</TabItem>
-
 <TabItem id='typescript' label='TypeScript'>
 TypeScript example content here.
+</TabItem>
+
+<TabItem id='csharp' label='C#'>
+C# example content here.
 </TabItem>
 </Tabs>
 ```
@@ -445,40 +445,26 @@ For client/library packages:
 <InstallDotNetPackage package="Aspire.StackExchange.Redis" />
 ```
 
-## AppHost Language Parity (C# and TypeScript)
+## AppHost Language Parity (TypeScript and C#)
 
-Aspire supports both **C# AppHosts** (`AppHost.cs`) and **TypeScript AppHosts** (`apphost.mts`). Documentation must treat both languages as first-class citizens. **Always show both C# and TypeScript code samples for AppHost code unless the feature is genuinely language-specific or TypeScript support does not exist yet.** Never write AppHost or hosting-integration documentation with a C#-only bias.
+Aspire supports both **TypeScript AppHosts** (`apphost.mts`) and **C# AppHosts** (`AppHost.cs`). Documentation must treat both languages as first-class citizens. **Always show both TypeScript and C# code samples for AppHost code unless the feature is genuinely language-specific or TypeScript support does not exist yet.** Never write AppHost or hosting-integration documentation with a C#-only bias.
 
 ### Core Principles
 
-1. **Always show both languages**: Every AppHost-focused example, walkthrough, and AppHost code sample must include both C# and TypeScript variants unless the feature is genuinely language-specific.
+1. **Always show both languages**: Every AppHost-focused example, walkthrough, and AppHost code sample must include both TypeScript and C# variants unless the feature is genuinely language-specific.
 2. **Show implementations, not availability notes**: When a TypeScript AppHost API exists, demonstrate it in a complete TypeScript tab beside the C# example. A note or callout that only names the available TypeScript methods does not satisfy language parity.
 3. **Use neutral framing**: Write prose that applies to both languages. Say "In your AppHost" not "In your C# project". Say "Add a Redis resource" not "Call `builder.AddRedis()`".
-4. **Neither language is the default**: Don't present C# first as the "real" example and TypeScript as an afterthought. Both tabs are equal peers.
+4. **Default to TypeScript**: Put the TypeScript tab first so `apphost.mts` is on the left and selected for readers without a saved preference. Keep C# as an equal peer and preserve the reader's explicit language selection.
 5. **Verify TypeScript APIs exist**: Before writing a TypeScript example, confirm the API exists in the TypeScript AppHost SDK. Do not invent TypeScript samples — if you are unsure whether an API is available, flag it for review.
 
 ### AppHost tabs pattern for AppHost content
 
-Use synced `Tabs` for AppHost-specific content that changes between C# and TypeScript. Each AppHost code snippet should provide its own language tabs and use `syncKey='aspire-lang'` so the user's language choice stays synchronized across snippets on the page.
+Use synced `Tabs` for AppHost-specific content that changes between TypeScript and C#. Each AppHost code snippet should provide its own language tabs, list TypeScript first, and use `syncKey='aspire-lang'` so the user's language choice stays synchronized across snippets on the page.
 
 ````mdx
 import { Tabs, TabItem } from "@astrojs/starlight/components";
 
 <Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var cache = builder.AddRedis("cache");
-
-builder.AddProject<Projects.Api>("api")
-    .WithReference(cache);
-
-builder.Build().Run();
-```
-
-</TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts"
@@ -495,6 +481,20 @@ await builder.build().run();
 ```
 
 </TabItem>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var cache = builder.AddRedis("cache");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(cache);
+
+builder.Build().Run();
+```
+
+</TabItem>
 </Tabs>
 ````
 
@@ -506,15 +506,15 @@ If a section heading should appear in the **On this page** table of contents, ke
 
 ### Conventions
 
-| Aspect           | C#                                              | TypeScript                                                                                                          |
-| ---------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
-| File title       | `title="AppHost.cs"`                            | `title="apphost.mts"`                                                                                                |
-| Tab wrapper      | Shared `<Tabs syncKey='aspire-lang'>` container | Shared `<Tabs syncKey='aspire-lang'>` container                                                                     |
-| Tab item         | `<TabItem id='csharp' label='C#'>`              | `<TabItem id='typescript' label='TypeScript'>`                                                                      |
-| Builder creation | `DistributedApplication.CreateBuilder(args)`    | `import { createBuilder } from './.aspire/modules/aspire.mjs';` then newline for space followed by `await createBuilder();` |
-| Method casing    | PascalCase (`AddRedis`)                         | camelCase (`addRedis`)                                                                                              |
-| Async pattern    | Synchronous fluent calls                        | `await` each builder call                                                                                           |
-| Build & run      | `builder.Build().Run()`                         | `await builder.build().run()`                                                                                       |
+| Aspect           | TypeScript                                                                                                          | C#                                              |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| File title       | `title="apphost.mts"`                                                                                                | `title="AppHost.cs"`                            |
+| Tab wrapper      | Shared `<Tabs syncKey='aspire-lang'>` container                                                                     | Shared `<Tabs syncKey='aspire-lang'>` container |
+| Tab item         | `<TabItem id='typescript' label='TypeScript'>`                                                                      | `<TabItem id='csharp' label='C#'>`              |
+| Builder creation | `import { createBuilder } from './.aspire/modules/aspire.mjs';` then newline for space followed by `await createBuilder();` | `DistributedApplication.CreateBuilder(args)`    |
+| Method casing    | camelCase (`addRedis`)                                                                                              | PascalCase (`AddRedis`)                         |
+| Async pattern    | `await` each builder call                                                                                           | Synchronous fluent calls                        |
+| Build & run      | `await builder.build().run()`                                                                                       | `builder.Build().Run()`                         |
 
 ### Prose Guidelines
 
@@ -595,18 +595,6 @@ Brief description of the technology and what the integration enables.
 ### Add [Technology] resource
 
 <Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var tech = builder.AddTechnology("tech");
-
-// After adding all resources, run the app...
-builder.Build().Run();
-```
-
-</TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts"
@@ -617,6 +605,18 @@ const builder = await createBuilder();
 const tech = await builder.addTechnology("tech");
 
 await builder.build().run();
+```
+
+</TabItem>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var tech = builder.AddTechnology("tech");
+
+// After adding all resources, run the app...
+builder.Build().Run();
 ```
 
 </TabItem>
@@ -644,20 +644,6 @@ Include both hosting and client sections:
 ### Add [Technology] resource
 
 <Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var tech = builder.AddTechnology("tech");
-
-builder.AddProject<Projects.Api>("api")
-    .WithReference(tech);
-
-builder.Build().Run();
-```
-
-</TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts"
@@ -671,6 +657,20 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withReference(tech);
 
 await builder.build().run();
+```
+
+</TabItem>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var tech = builder.AddTechnology("tech");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(tech);
+
+builder.Build().Run();
 ```
 
 </TabItem>

--- a/.agents/skills/whatsnew/SKILL.md
+++ b/.agents/skills/whatsnew/SKILL.md
@@ -77,7 +77,7 @@ infer from context — e.g. a fresh release with no page → `draft`).
 | What | Path |
 |------|------|
 | What's-new pages | `src/frontend/src/content/docs/whats-new/aspire-N-N.mdx` (JA under `.../ja/whats-new/`) |
-| Version constants | `src/frontend/config/aspire-versions.mjs` (`currentAspireMajorMinorVersion`, `currentAspireVersion`) |
+| Version constants | `src/frontend/config/aspire-versions.mjs` (`currentAspireMajorMinorVersion`, `currentAspireVersion`, `currentAspirePreviewVersion`) |
 | Sidebar | `src/frontend/config/sidebar/docs.topics.ts` (What's-new `items`) |
 | Announcement banner | `banner:` frontmatter on `src/frontend/src/content/docs/index.mdx`, `src/frontend/src/content/docs/docs.mdx`, `src/frontend/src/content/docs/community/index.mdx`, and each `src/frontend/src/content/docs/{locale}/index.mdx` (+ `.../ja/docs.mdx`); rendered by `src/frontend/src/components/starlight/Banner.astro` |
 | Assets | `src/frontend/src/assets/whats-new/aspire-<version>/` |

--- a/.agents/skills/whatsnew/references/01-draft-scaffold.md
+++ b/.agents/skills/whatsnew/references/01-draft-scaffold.md
@@ -35,8 +35,11 @@ duplicating.
    dedicated **"New integrations"** and **"Default container image updates"** sections.
    If the file already exists, reconcile structure without clobbering existing content.
 3. **Version constants.** Update `src/frontend/config/aspire-versions.mjs`:
-   `currentAspireMajorMinorVersion = 'N.N'` and `currentAspireVersion = 'N.N.0'` (only
-   when N.N is the new current release). This drives the `%ASPIRE_VERSION%` remark
+   `currentAspireMajorMinorVersion = 'N.N'`, `currentAspireVersion` to the latest
+   stable `N.N.PATCH`, and `currentAspirePreviewVersion` to the matching full
+   `N.N.PATCH-preview.*` package version. Set both package versions to the initial
+   release patch when N.N becomes current, then keep them aligned with the site
+   AppHost during servicing updates. These drive the Aspire version remark
    placeholders site-wide.
 4. **Site-wide announcement banner.** The banner is **per-page frontmatter**, not a
    global config. Update the `banner.content` string **and its link** to point at

--- a/.agents/skills/whatsnew/references/02-research.md
+++ b/.agents/skills/whatsnew/references/02-research.md
@@ -47,8 +47,8 @@ This is the phase that turns the skeleton into a real, reviewable page.
    the section (next step).
 7. **Author the draft.** Populate the scaffolded MDX from the dossier: write the lede,
    the "This release introduces" bullets (1:1 with the `##` sections, same order), and
-   each section body with impact-first prose, `LearnMore` deep-links, and C#/TypeScript
-   `<Tabs syncKey='aspire-lang'>` where a feature spans AppHost languages. Credit each
+   each section body with impact-first prose, `LearnMore` deep-links, and TypeScript/C#
+   `<Tabs syncKey='aspire-lang'>` with TypeScript first where a feature spans AppHost languages. Credit each
    merged community PR by `@handle`. **Only include sections that apply** — delete any
    standard section with no content. In particular, when the release has **no breaking
    changes**, remove the "⚠️ Breaking changes" section *and* the breaking-changes

--- a/.agents/skills/whatsnew/references/03-critique.md
+++ b/.agents/skills/whatsnew/references/03-critique.md
@@ -28,7 +28,7 @@ actionable, severity-ranked findings report. **Makes no edits** — {polish} act
 - `<Aside>` used **judiciously** (not eye-burning). Breaking-changes caution present
   **only** when the release has breaking changes — when it has none, both the caution
   *and* the "⚠️ Breaking changes" section are omitted (no empty section left behind).
-- C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) wherever a feature spans AppHost languages.
+- TypeScript/C# **tab parity** (`syncKey='aspire-lang'`, TypeScript first) wherever a feature spans AppHost languages.
 - `publishDate` frontmatter set (the `Released MMMM D, YYYY` badge + GitHub release-notes link auto-render; no hand-placed header).
 
 **Content standards (mandated)**

--- a/.agents/skills/whatsnew/references/05-polish.md
+++ b/.agents/skills/whatsnew/references/05-polish.md
@@ -10,7 +10,7 @@ lands *after* the `{validate}` gate and must not ship unchecked.
 - Tighten to **KISS**; smooth flow and voice per the `doc-writer` skill; dedupe.
 - Confirm the "This release introduces" bullets map **1:1** to sections (same order).
 - Right-size `<Aside>` usage (judicious — don't burn the reader's eyes).
-- C#/TypeScript **tab parity** (`syncKey='aspire-lang'`) complete and correct.
+- TypeScript/C# **tab parity** (`syncKey='aspire-lang'`, TypeScript first) complete and correct.
 - Reconcile **"✨ New integrations"**, **"📦 Integration updates"**, and **"🐳 Default
   container image updates"** against the freshly regenerated data (below).
 - Finalize **contributor thanks** (`@handle` + one-line note per merged community PR).

--- a/.agents/skills/whatsnew/references/whats-new-template.mdx
+++ b/.agents/skills/whatsnew/references/whats-new-template.mdx
@@ -17,6 +17,7 @@
 # them at build once this is the current release — see config/aspire-versions.mjs):
 #   %ASPIRE_VERSION_MAJOR_MINOR%   →  currentAspireMajorMinorVersion
 #   %ASPIRE_VERSION%               →  currentAspireVersion
+#   %ASPIRE_VERSION_PREVIEW%       →  currentAspirePreviewVersion
 #
 # Delete this comment block when scaffolding. Keep it STRUCTURE ONLY: headings +
 # placeholders, no researched prose. Content lands in {research}/{polish}.
@@ -105,7 +106,7 @@ The easiest way to upgrade to Aspire {{VERSION_MAJOR_MINOR}} is using the [`aspi
      sections. Order sections by customer impact / DX. Add feature-specific
      sections (e.g. "🌐 TypeScript AppHost", "🧱 Go and Bun") near the top when
      they are the headline. Remove any standard section that doesn't apply.
-     Use <Tabs syncKey='aspire-lang'> for C#/TypeScript parity, `LearnMore` to
+     Use <Tabs syncKey='aspire-lang'> with TypeScript first for TypeScript/C# parity, `LearnMore` to
      deep-link, and <Aside> sparingly for genuinely important call-outs.
    ───────────────────────────────────────────────────────────────────────── */}
 

--- a/.agents/skills/whatsnew/references/writing-guidelines.md
+++ b/.agents/skills/whatsnew/references/writing-guidelines.md
@@ -94,8 +94,9 @@ These are the specific quality gates critique/validate enforce:
   Go) rather than defining any of them in opposition to another.
 - **Second person, active voice, imperative mood.** Concise, professional-approachable.
 - **Dates spelled out:** "August 18, 2025" — never "8/18/25".
-- **C#/TypeScript parity:** when a feature spans AppHost languages, show both with
+- **TypeScript/C# parity:** when a feature spans AppHost languages, show both with
   `<Tabs syncKey='aspire-lang'>` / `<TabItem>` so the tab choice syncs page-wide.
+  Put TypeScript first so `apphost.mts` is the default for readers without a saved preference.
 - **Version tokens:** in prose for the *current* release you may use the build-time
   placeholders `%ASPIRE_VERSION%` / `%ASPIRE_VERSION_MAJOR_MINOR%` (replaced by the
   remark plugin). The article slug, sidebar, and header use the literal version.

--- a/.github/agents/community-toolkit-integration-doc-writer.agent.md
+++ b/.github/agents/community-toolkit-integration-doc-writer.agent.md
@@ -108,7 +108,7 @@ This step ensures that the documentation you've created is properly indexed and 
 
 - Import `Badge` from '@astrojs/starlight/components' and add `<Badge text="⭐ Community Toolkit" variant="tip" size="large" />` at the top
 - Import and use the `Aside` component for notes, tips, cautions, and warnings
-- Import and use synced `Tabs` and `TabItem` from `@astrojs/starlight/components` for AppHost examples when both C# and TypeScript AppHost APIs are available. Use `syncKey='aspire-lang'` and tab IDs `csharp` and `typescript`.
+- Import and use synced `Tabs` and `TabItem` from `@astrojs/starlight/components` for AppHost examples when both TypeScript and C# AppHost APIs are available. Put the `typescript` tab first, followed by `csharp`, and use `syncKey='aspire-lang'`.
 - Import and use `InstallPackage` for hosting packages
 - Import and use `InstallDotNetPackage` for client packages
 - Import `Image` from 'astro:assets' for icons
@@ -171,7 +171,7 @@ prerequisites. Do not present the add-on as a standalone service.
 ### AppHost language parity
 
 - Follow the `doc-writer` skill's AppHost language parity guidance for all AppHost and hosting-integration examples.
-- Always show both C# AppHost (`AppHost.cs`) and TypeScript AppHost (`apphost.mts`) variants inside synced `Tabs` (with `syncKey='aspire-lang'`) unless the feature is genuinely language-specific or TypeScript AppHost support does not exist yet.
+- Always show both TypeScript AppHost (`apphost.mts`) and C# AppHost (`AppHost.cs`) variants inside synced `Tabs` (with `syncKey='aspire-lang'`) unless the feature is genuinely language-specific or TypeScript AppHost support does not exist yet. Put TypeScript first so it is the default.
 - Before writing a TypeScript AppHost example, verify the API exists in the TypeScript AppHost SDK. Do not invent TypeScript samples.
 - If TypeScript AppHost support is not available, show only the C# example without language tabs and add a note that TypeScript AppHost support for the integration is not yet available.
 - Use language-neutral prose around AppHost examples, such as "Add a resource to your AppHost" instead of C#-specific method instructions.

--- a/.github/agents/release-verifier.agent.md
+++ b/.github/agents/release-verifier.agent.md
@@ -177,20 +177,34 @@ version constants match the release being verified:
 | Export | Expected value |
 |--------|----------------|
 | `currentAspireMajorMinorVersion` | `{VERSION}` (for example, `13.2`) |
-| `currentAspireVersion` | `{NUGET_VERSION}` (for example, `13.2.0`) |
+| `currentAspireVersion` | Latest stable `{VERSION}.PATCH` package version |
+| `currentAspirePreviewVersion` | Matching full `{VERSION}.PATCH-preview.*` package version |
 
-These constants drive the `%ASPIRE_VERSION_MAJOR_MINOR%` and
-`%ASPIRE_VERSION%` documentation placeholders. If either value is stale, flag it
-as a **critical** failure because generated docs can show the wrong current
-release version.
+These constants drive the `%ASPIRE_VERSION_MAJOR_MINOR%`, `%ASPIRE_VERSION%`,
+and `%ASPIRE_VERSION_PREVIEW%` documentation placeholders. Verify the stable
+and preview values against published NuGet packages and the versions pinned by
+`src/apphost/Aspire.Dev.AppHost/Aspire.Dev.AppHost.csproj`. If any value is
+stale, flag it as a **critical** failure because generated docs can show a
+nonexistent or outdated current release version.
 
 #### 4c. Scan for stale version references
 
-Search the docs content tree for references to the prior NuGet version that appear **outside** of intentional historical context (e.g., upgrade-from examples that deliberately show the old version).
+Search the docs content tree for every full version-shaped reference outside
+intentional historical context, not only the immediately prior version. A stale
+reference can skip one or more releases, and prerelease package versions include
+additional build segments such as `13.3.0-preview.1.26256.5`.
 
 ```bash
-# Search for prior version references
-grep -rn "{PRIOR_NUGET_VERSION}" src/frontend/src/content/docs/ \
+# Search all stable and prerelease version-shaped references
+grep -rnE '[0-9]+\.[0-9]+\.[0-9]+(-(preview|alpha|beta|rc)(\.[0-9A-Za-z-]+)+)?' src/frontend/src/content/docs/ \
+  --include="*.md" \
+  --include="*.mdx" \
+  --exclude-dir="whats-new"
+
+# A full prerelease must use %ASPIRE_VERSION_PREVIEW%; retaining an old suffix
+# after the stable placeholder can produce a package version that never existed.
+grep -rnE '%ASPIRE_VERSION%-(preview|alpha|beta|rc)(\.[0-9A-Za-z-]+)+' src/frontend/src/content/docs/ \
+  --include="*.md" \
   --include="*.mdx" \
   --exclude-dir="whats-new"
 ```
@@ -199,6 +213,7 @@ Also search for stale SDK version references:
 
 ```bash
 grep -rn 'Aspire.AppHost.Sdk.*Version="{PRIOR_NUGET_VERSION}"' src/frontend/src/content/docs/ \
+  --include="*.md" \
   --include="*.mdx"
 ```
 
@@ -208,8 +223,8 @@ For every match found:
 
 1. **Read the surrounding context** (at least 10 lines before and after).
 2. **Classify the reference**:
-   - **Intentional (old-version example)**: The reference is inside a "before" / upgrade-from code block that deliberately shows the old version to contrast with the new version. These are acceptable — do **not** flag them.
-   - **Stale (should be updated)**: The reference is in current guidance, installation instructions, or sample code that a user would copy today. Flag these for update.
+   - **Intentional fixed version**: The reference is historical, an upgrade-from example, a diagnostic minimum, a versioned schema URL, or an explicit pin where the fixed version is the point of the example. These are acceptable — do **not** flag them.
+   - **Current context**: The reference is in current guidance, installation instructions, output, or sample code that a user would copy today. It should use `%ASPIRE_VERSION_MAJOR_MINOR%`, `%ASPIRE_VERSION%`, or `%ASPIRE_VERSION_PREVIEW%` as appropriate. Flag raw or partially constructed versions for update.
 3. Log each stale reference with file path, line number, and surrounding context.
 
 #### 4e. Verify new version references

--- a/src/frontend/astro.config.mjs
+++ b/src/frontend/astro.config.mjs
@@ -9,6 +9,7 @@ import { headAttrs } from './config/head.attrs.ts';
 import { socialConfig } from './config/socials.config.ts';
 import { aspireVersionPlaceholdersIntegration } from './config/aspire-version-placeholders-integration.mjs';
 import { remarkAspireVersionPlaceholders } from './config/remark-aspire-version-placeholders.mjs';
+import { remarkTypeScriptFirstAppHostTabs } from './config/remark-typescript-first-apphost-tabs.mjs';
 import catppuccin from '@catppuccin/starlight';
 import lunaria from './config/lunaria-starlight.mjs';
 import mermaid from 'astro-mermaid';
@@ -49,7 +50,7 @@ export default defineConfig({
   trailingSlash: 'always',
   markdown: {
     processor: unified({
-      remarkPlugins: [remarkAspireVersionPlaceholders],
+      remarkPlugins: [remarkTypeScriptFirstAppHostTabs, remarkAspireVersionPlaceholders],
     }),
   },
   redirects: redirects,

--- a/src/frontend/config/aspire-version-placeholders-integration.mjs
+++ b/src/frontend/config/aspire-version-placeholders-integration.mjs
@@ -2,12 +2,14 @@ import { readdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { replaceAspireVersionPlaceholders } from './remark-aspire-version-placeholders.mjs';
+import { orderTypeScriptFirstAppHostTabsInMarkdown } from './remark-typescript-first-apphost-tabs.mjs';
 
-// Per-page Markdown copies emitted by `starlight-page-actions` are the only
-// generated artifacts that still contain raw Aspire version placeholders:
+// Per-page Markdown copies emitted by `starlight-page-actions` bypass the
+// remark transforms that replace Aspire version placeholders and order AppHost
+// language tabs:
 // that plugin `viteStaticCopy`s `src/content/docs/**/*.{md,mdx}` straight to
 // `dist/**/*.md` through a regex-only transform, so it never runs through the
-// `remarkAspireVersionPlaceholders` remark plugin.
+// configured remark pipeline.
 //
 // Everything else is already handled before it reaches `dist`:
 //   - `.html` pages   -> rendered via the remark pipeline (placeholders replaced
@@ -19,7 +21,7 @@ import { replaceAspireVersionPlaceholders } from './remark-aspire-version-placeh
 // (instead of walking every `.html`/`.txt` in `dist`) avoids re-reading the bulk
 // of the output — including the large `llms-full.txt` assets — which is what
 // previously exhausted the Node heap.
-const placeholderCopyExtensions = new Set(['.md']);
+const markdownCopyExtensions = new Set(['.md']);
 
 // Process the Markdown copies through a small worker pool rather than a single
 // recursive `Promise.all` over the whole tree, so peak memory stays proportional
@@ -57,7 +59,7 @@ export async function replaceAspireVersionPlaceholdersInDirectory(
   const runWorker = async () => {
     while (cursor < files.length) {
       const filePath = files[cursor++];
-      await replaceAspireVersionPlaceholdersInFile(filePath);
+      await processMarkdownCopy(filePath);
     }
   };
 
@@ -75,15 +77,16 @@ async function collectMarkdownCopies(directory, files) {
       continue;
     }
 
-    if (entry.isFile() && placeholderCopyExtensions.has(path.extname(entry.name))) {
+    if (entry.isFile() && markdownCopyExtensions.has(path.extname(entry.name))) {
       files.push(resolvedPath);
     }
   }
 }
 
-async function replaceAspireVersionPlaceholdersInFile(filePath) {
+async function processMarkdownCopy(filePath) {
   const content = await readFile(filePath, 'utf8');
-  const updated = replaceAspireVersionPlaceholders(content);
+  const ordered = orderTypeScriptFirstAppHostTabsInMarkdown(content);
+  const updated = replaceAspireVersionPlaceholders(ordered);
 
   if (updated !== content) {
     await writeFile(filePath, updated);

--- a/src/frontend/config/aspire-version-placeholders-integration.mjs
+++ b/src/frontend/config/aspire-version-placeholders-integration.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { replaceAspireVersionPlaceholders } from './remark-aspire-version-placeholders.mjs';
 
 // Per-page Markdown copies emitted by `starlight-page-actions` are the only
-// generated artifacts that still contain raw `%ASPIRE_VERSION%` placeholders:
+// generated artifacts that still contain raw Aspire version placeholders:
 // that plugin `viteStaticCopy`s `src/content/docs/**/*.{md,mdx}` straight to
 // `dist/**/*.md` through a regex-only transform, so it never runs through the
 // `remarkAspireVersionPlaceholders` remark plugin.

--- a/src/frontend/config/aspire-versions.mjs
+++ b/src/frontend/config/aspire-versions.mjs
@@ -1,7 +1,9 @@
 export const currentAspireMajorMinorVersion = '13.5';
-export const currentAspireVersion = '13.5.0';
+export const currentAspireVersion = '13.5.3';
+export const currentAspirePreviewVersion = '13.5.3-preview.1.26425.3';
 
 export const aspireVersionPlaceholders = Object.freeze({
   '%ASPIRE_VERSION_MAJOR_MINOR%': currentAspireMajorMinorVersion,
   '%ASPIRE_VERSION%': currentAspireVersion,
+  '%ASPIRE_VERSION_PREVIEW%': currentAspirePreviewVersion,
 });

--- a/src/frontend/config/remark-typescript-first-apphost-tabs.mjs
+++ b/src/frontend/config/remark-typescript-first-apphost-tabs.mjs
@@ -1,0 +1,53 @@
+function getStringAttribute(node, name) {
+  const attribute = node.attributes?.find(
+    (candidate) => candidate?.type === 'mdxJsxAttribute' && candidate.name === name
+  );
+  return typeof attribute?.value === 'string' ? attribute.value : undefined;
+}
+
+function isTabItem(node) {
+  return node?.type === 'mdxJsxFlowElement' && node.name === 'TabItem';
+}
+
+function isTypeScriptTab(node) {
+  if (!isTabItem(node)) {
+    return false;
+  }
+
+  const id = getStringAttribute(node, 'id')?.toLowerCase();
+  const label = getStringAttribute(node, 'label')?.toLowerCase();
+  return id === 'typescript' || label === 'typescript' || label === 'typescript apphost';
+}
+
+function orderAppHostTabs(node) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  if (
+    node.type === 'mdxJsxFlowElement' &&
+    node.name === 'Tabs' &&
+    getStringAttribute(node, 'syncKey') === 'aspire-lang' &&
+    Array.isArray(node.children)
+  ) {
+    const firstTabIndex = node.children.findIndex(isTabItem);
+    const typeScriptIndex = node.children.findIndex(isTypeScriptTab);
+
+    if (firstTabIndex >= 0 && typeScriptIndex > firstTabIndex) {
+      const [typeScriptTab] = node.children.splice(typeScriptIndex, 1);
+      node.children.splice(firstTabIndex, 0, typeScriptTab);
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      orderAppHostTabs(child);
+    }
+  }
+}
+
+export function remarkTypeScriptFirstAppHostTabs() {
+  return (tree) => {
+    orderAppHostTabs(tree);
+  };
+}

--- a/src/frontend/config/remark-typescript-first-apphost-tabs.mjs
+++ b/src/frontend/config/remark-typescript-first-apphost-tabs.mjs
@@ -1,3 +1,8 @@
+import { createProcessor } from '@mdx-js/mdx';
+
+const appHostTabsSourcePattern = /<Tabs\b[^>]*\bsyncKey\s*=\s*(["'])aspire-lang\1[^>]*>/i;
+const markdownParser = createProcessor();
+
 function getStringAttribute(node, name) {
   const attribute = node.attributes?.find(
     (candidate) => candidate?.type === 'mdxJsxAttribute' && candidate.name === name
@@ -44,6 +49,69 @@ function orderAppHostTabs(node) {
       orderAppHostTabs(child);
     }
   }
+}
+
+function collectSourceEdits(node, markdown, edits) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  if (
+    node.type === 'mdxJsxFlowElement' &&
+    node.name === 'Tabs' &&
+    getStringAttribute(node, 'syncKey') === 'aspire-lang' &&
+    Array.isArray(node.children)
+  ) {
+    const tabItems = node.children.filter(isTabItem);
+    const typeScriptIndex = tabItems.findIndex(isTypeScriptTab);
+
+    if (typeScriptIndex > 0) {
+      const firstTab = tabItems[0];
+      const typeScriptTab = tabItems[typeScriptIndex];
+      const nextTab = tabItems[typeScriptIndex + 1];
+      const insertAt = firstTab.position?.start.offset;
+      const moveStart = typeScriptTab.position?.start.offset;
+      const tabsEnd = node.position?.end.offset;
+      const moveEnd =
+        nextTab?.position?.start.offset ??
+        (typeof tabsEnd === 'number' ? markdown.lastIndexOf('</Tabs>', tabsEnd) : -1);
+
+      if (typeof insertAt !== 'number' || typeof moveStart !== 'number' || moveEnd <= moveStart) {
+        throw new Error('Unable to locate an aspire-lang tab group in the Markdown source.');
+      }
+
+      edits.push({ insertAt, moveStart, moveEnd });
+    }
+  }
+
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) {
+      collectSourceEdits(child, markdown, edits);
+    }
+  }
+}
+
+export function orderTypeScriptFirstAppHostTabsInMarkdown(markdown) {
+  if (!appHostTabsSourcePattern.test(markdown)) {
+    return markdown;
+  }
+
+  const tree = markdownParser.parse(markdown);
+  const edits = [];
+  collectSourceEdits(tree, markdown, edits);
+
+  let updated = markdown;
+  for (const { insertAt, moveStart, moveEnd } of edits.sort(
+    (left, right) => right.moveStart - left.moveStart
+  )) {
+    updated =
+      updated.slice(0, insertAt) +
+      updated.slice(moveStart, moveEnd) +
+      updated.slice(insertAt, moveStart) +
+      updated.slice(moveEnd);
+  }
+
+  return updated;
 }
 
 export function remarkTypeScriptFirstAppHostTabs() {

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -75,6 +75,7 @@
     "@fontsource/poppins": "^5.3.0",
     "@lunariajs/core": "^0.1.1",
     "@lunariajs/starlight": "^0.1.1",
+    "@mdx-js/mdx": "^3.1.1",
     "asciinema-player": "^3.17.0",
     "astro": "^7.1.3",
     "astro-contributors": "^0.9.0",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@lunariajs/starlight':
         specifier: ^0.1.1
         version: 0.1.1(@astrojs/starlight@0.41.3(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))(typescript@6.0.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       asciinema-player:
         specifier: ^3.17.0
         version: 3.17.0

--- a/src/frontend/src/components/ContainerImages.astro
+++ b/src/frontend/src/components/ContainerImages.astro
@@ -199,10 +199,10 @@ function registryGlyph(registry: string) {
     }
 
     function apply(lang) {
-      document.documentElement.dataset.aspireLang = lang || 'csharp';
+      document.documentElement.dataset.aspireLang = lang || 'typescript';
     }
 
-    apply(readStored());
+    apply(readStored() || document.documentElement.dataset.apphostLang);
 
     // Starlight persists the choice on tab click; defer a tick so we read the
     // stored value it just wrote rather than the tab we clicked.
@@ -280,7 +280,7 @@ function registryGlyph(registry: string) {
   }
 
   /* Language pivot: mirror the page-wide `syncKey="aspire-lang"` choice. Default
-     to the C# name; swap to the TypeScript name only when TS is selected. The
+     to the TypeScript name while preserving an explicit C# selection. The
      `data-aspire-lang` attribute is set on <html> by the inline script below. */
   .ci-api [data-lang] {
     display: none;
@@ -290,7 +290,7 @@ function registryGlyph(registry: string) {
     display: inline;
   }
 
-  :global(html:not([data-aspire-lang='typescript'])) .ci-api [data-lang='csharp'] {
+  :global(html[data-aspire-lang='csharp']) .ci-api [data-lang='csharp'] {
     display: inline;
   }
 

--- a/src/frontend/src/components/IntegrationCard.astro
+++ b/src/frontend/src/components/IntegrationCard.astro
@@ -165,21 +165,21 @@ const titleIsExternal = !!titleHref && !titleHref.startsWith('/');
             <div class="lang-buttons" role="group" aria-label={Astro.locals.t('integrations.viewLanguageDocs', { title: pkg.title })}>
               <a
                 class="lang-button"
-                href={withLang(pkg.docs!, 'csharp')}
-                aria-label={Astro.locals.t('integrations.viewCsharpDocs', { title: pkg.title })}
-                data-tooltip-placement="top"
-                title={Astro.locals.t('integrations.viewCsharpDocs', { title: pkg.title })}
-              >
-                <Image src={csharpIcon} alt="" width={22} height={22} aria-hidden="true" />
-              </a>
-              <a
-                class="lang-button"
                 href={withLang(pkg.docs!, 'typescript')}
                 aria-label={Astro.locals.t('integrations.viewTypescriptDocs', { title: pkg.title })}
                 data-tooltip-placement="top"
                 title={Astro.locals.t('integrations.viewTypescriptDocs', { title: pkg.title })}
               >
                 <Image src={typescriptIcon} alt="" width={22} height={22} aria-hidden="true" />
+              </a>
+              <a
+                class="lang-button"
+                href={withLang(pkg.docs!, 'csharp')}
+                aria-label={Astro.locals.t('integrations.viewCsharpDocs', { title: pkg.title })}
+                data-tooltip-placement="top"
+                title={Astro.locals.t('integrations.viewCsharpDocs', { title: pkg.title })}
+              >
+                <Image src={csharpIcon} alt="" width={22} height={22} aria-hidden="true" />
               </a>
             </div>
           ) : (

--- a/src/frontend/src/components/PivotSelector.astro
+++ b/src/frontend/src/components/PivotSelector.astro
@@ -13,13 +13,21 @@ type Props = {
 };
 
 const { options, key, title, marginTop } = Astro.props;
+const renderedOptions =
+  key === 'aspire-lang'
+    ? [
+        ...options.filter((option) => option.id === 'typescript'),
+        ...options.filter((option) => option.id === 'csharp'),
+        ...options.filter((option) => option.id !== 'typescript' && option.id !== 'csharp'),
+      ]
+    : options;
 ---
 
 <div class="pivot-container not-content" data-tour-target="pivot-selector" data-tour-step="pivot-selector">
   {title && <div class="pivot-title">{title}</div>}
   <div class="pivot-selector" id=`pivot-selector-${key}`>
     {
-      options.map((o) => (
+      renderedOptions.map((o) => (
         <button type="button" data-pivot-option={o.id} disabled={o.disabled ? true : false}>
           {o.title}
         </button>

--- a/src/frontend/src/components/SimpleAppHostCode.astro
+++ b/src/frontend/src/components/SimpleAppHostCode.astro
@@ -24,7 +24,18 @@ const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
 
 {
   typescriptCode ? (
-    <Tabs syncKey="apphost-implementation-lang">
+    <Tabs syncKey="aspire-lang">
+      <TabItem label="TypeScript AppHost">
+        <Code
+          code={typescriptCode}
+          lang="ts"
+          title="apphost.mts"
+          mark={typescriptMark}
+          collapse={typescriptCollapse}
+          collapseStyle={'collapsible-auto'}
+        />
+        <slot name="typescript-content" />
+      </TabItem>
       <TabItem label="C# AppHost">
         <Code
           code={csharpCode}
@@ -35,17 +46,6 @@ const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
           collapseStyle={'collapsible-auto'}
         />
         <slot name="csharp-content" />
-      </TabItem>
-      <TabItem label="TypeScript AppHost">
-        <Code
-          code={typescriptCode}
-          lang="ts"
-          title="apphost.ts"
-          mark={typescriptMark}
-          collapse={typescriptCollapse}
-          collapseStyle={'collapsible-auto'}
-        />
-        <slot name="typescript-content" />
       </TabItem>
     </Tabs>
   ) : (

--- a/src/frontend/src/components/SimpleAppHostCode.astro
+++ b/src/frontend/src/components/SimpleAppHostCode.astro
@@ -25,7 +25,7 @@ const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
 {
   typescriptCode ? (
     <Tabs syncKey="aspire-lang">
-      <TabItem label="TypeScript AppHost">
+      <TabItem label="TypeScript">
         <Code
           code={typescriptCode}
           lang="ts"
@@ -36,7 +36,7 @@ const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
         />
         <slot name="typescript-content" />
       </TabItem>
-      <TabItem label="C# AppHost">
+      <TabItem label="C#">
         <Code
           code={csharpCode}
           lang="cs"

--- a/src/frontend/src/components/starlight/Head.astro
+++ b/src/frontend/src/components/starlight/Head.astro
@@ -158,7 +158,7 @@ function computeSourceUrl() {
     var qsAppHostLang = persistAppHostLang(
       new URLSearchParams(window.location.search).get('aspire-lang')
     );
-    var rawAppHostLang = qsAppHostLang || 'csharp';
+    var rawAppHostLang = qsAppHostLang || 'typescript';
 
     try {
       rawAppHostLang =
@@ -168,13 +168,10 @@ function computeSourceUrl() {
         localStorage.getItem(appHostLangStorageKey) ||
         localStorage.getItem('starlight-synced-tabs__apphost-lang') ||
         localStorage.getItem('starlight-synced-tabs__apphost-implementation-lang') ||
-        'csharp';
+        'typescript';
     } catch (e) {}
 
-    document.documentElement.setAttribute(
-      'data-apphost-lang',
-      normalizeAppHostLang(rawAppHostLang) || 'csharp'
-    );
+    persistAppHostLang(normalizeAppHostLang(rawAppHostLang) || 'typescript');
 
     try {
       var path = window.location.pathname.replace(/\/$/, '');

--- a/src/frontend/src/content/docs/app-host/eventing.mdx
+++ b/src/frontend/src/content/docs/app-host/eventing.mdx
@@ -128,7 +128,7 @@ When the AppHost is run, by the time the Aspire dashboard is displayed, you shou
 info: Program[0]
       BeforeStartEvent
 info: Aspire.Hosting.DistributedApplication[0]
-      Aspire version: 13.1.0
+      Aspire version: %ASPIRE_VERSION%
 info: Aspire.Hosting.DistributedApplication[0]
       Distributed application starting.
 info: Aspire.Hosting.DistributedApplication[0]
@@ -289,7 +289,7 @@ When the AppHost is run, by the time the Aspire dashboard is displayed, you shou
 
 ```plaintext {8,10,12,14,20} data-disable-copy
 info: Aspire.Hosting.DistributedApplication[0]
-      Aspire version: 13.1.0
+      Aspire version: %ASPIRE_VERSION%
 info: Aspire.Hosting.DistributedApplication[0]
       Distributed application starting.
 info: Aspire.Hosting.DistributedApplication[0]

--- a/src/frontend/src/content/docs/community/contributor-guide.mdx
+++ b/src/frontend/src/content/docs/community/contributor-guide.mdx
@@ -247,9 +247,9 @@ Third-party links are appropriate when they help readers complete a task or unde
 - **Disclose affiliations** - In the **Third-party links and affiliations** section of the pull request description, disclose any material affiliation with a linked organization, such as employment, sponsorship, or ownership. An affiliation doesn't automatically disqualify a link, but the link and surrounding content must meet the same editorial standards as any other contribution.
 - **Review generated content** - Automated updates and generated catalogs aren't exempt. They may reproduce upstream metadata when that's the catalog's explicit purpose, but the reviewing maintainer must apply the same editorial standards to the surrounding content and linked destinations.
 
-### AppHost-specific C# and TypeScript content
+### AppHost-specific TypeScript and C# content
 
-When you are documenting AppHost-specific content that changes between C# and TypeScript, use synced `Tabs` and `TabItem` blocks with `syncKey='aspire-lang'`. Each code snippet should have its own C# and TypeScript selector, and the shared sync key keeps the selected language consistent across the page.
+When you are documenting AppHost-specific content that changes between TypeScript and C#, use synced `Tabs` and `TabItem` blocks with `syncKey='aspire-lang'`. Put TypeScript first so `apphost.mts` is the default for readers without a saved preference. Each code snippet should have its own TypeScript and C# selector, and the shared sync key keeps the selected language consistent across the page.
 
 Use `Tabs` for other choices such as package managers, deployment targets, IDEs, or CLI variants.
 
@@ -799,7 +799,7 @@ Here's an example of using the `LearnMore` component:
 
 ### Aspire language selectors
 
-Use synced `Tabs` and `TabItem` blocks for AppHost content that switches between C# and TypeScript. Each AppHost code snippet should have its own selector, and every AppHost language selector on the page should share `syncKey='aspire-lang'` so a reader's language choice applies to the whole page.
+Use synced `Tabs` and `TabItem` blocks for AppHost content that switches between TypeScript and C#. Put TypeScript first so the `apphost.mts` tab appears on the left and is selected by default. Each AppHost code snippet should have its own selector, and every AppHost language selector on the page should share `syncKey='aspire-lang'` so a reader's language choice applies to the whole page.
 
 Keep shared section headings outside the tabs. For example, write `## Add a Redis resource` before the `Tabs` block, then place the language-specific code inside the `csharp` and `typescript` tab items. This helps the **On this page** navigation stay accurate.
 
@@ -811,20 +811,6 @@ title: Example MDX Page
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 <Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var cache = builder.AddRedis("cache");
-
-builder.AddProject<Projects.Api>("api")
-    .WithReference(cache);
-
-builder.Build().Run();
-```
-
-</TabItem>
 <TabItem id='typescript' label='TypeScript'>
 
 ```typescript title="apphost.mts" twoslash
@@ -838,6 +824,20 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withReference(cache);
 
 await builder.build().run();
+```
+
+</TabItem>
+<TabItem id='csharp' label='C#'>
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var cache = builder.AddRedis("cache");
+
+builder.AddProject<Projects.Api>("api")
+    .WithReference(cache);
+
+builder.Build().Run();
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/get-started/aspire-sdk-templates.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk-templates.mdx
@@ -76,10 +76,10 @@ dotnet new install Aspire.ProjectTemplates
 ```
 
 :::tip
-To install a specific version of the Aspire templates, use the `::{version}` syntax. For example, to install version 13.1.0, run the following command:
+To install a specific version of the Aspire templates, use the `::{version}` syntax. For example, to install version %ASPIRE_VERSION%, run the following command:
 
 ```bash title=".NET CLI"
-dotnet new install Aspire.ProjectTemplates::13.1.0
+dotnet new install Aspire.ProjectTemplates::%ASPIRE_VERSION%
 ```
 
 :::

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
@@ -77,7 +77,7 @@ This updates your `aspire.config.json` with the Azure AI Foundry hosting integra
 ```json title="aspire.config.json" ins={3}
 {
   "packages": {
-    "Aspire.Hosting.Foundry": "13.3.0-preview.1.26256.5"
+    "Aspire.Hosting.Foundry": "%ASPIRE_VERSION_PREVIEW%"
   }
 }
 ```

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
@@ -67,7 +67,7 @@ This updates your `aspire.config.json` with the Azure Data Explorer hosting inte
 ```json title="aspire.config.json" ins={3}
 {
   "packages": {
-    "Aspire.Hosting.Azure.Kusto": "13.3.0-preview.1.26256.5"
+    "Aspire.Hosting.Azure.Kusto": "%ASPIRE_VERSION_PREVIEW%"
   }
 }
 ```

--- a/src/frontend/src/content/docs/integrations/custom-integrations/hosting-integrations.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/hosting-integrations.mdx
@@ -84,7 +84,7 @@ dotnet new aspire -o MailDevResource
 <Steps>
 1. When prompted to select a template, choose the **AppHost and service defaults** template — use the <Kbd windows="↑" mac="↑" /> and <Kbd windows="↓" mac="↓" /> keys to navigate the options. Press <Kbd windows="Enter" mac="Return" /> to select the template.
 1. Enter a project name, in this example use `MailDevResource`, then press <Kbd windows="Enter" mac="Return" /> to continue.
-1. Finally, use the <Kbd windows="↑" mac="↑" /> and <Kbd windows="↓" mac="↓" /> keys to navigate to the desired template version. This example uses 13.5.0.
+1. Finally, use the <Kbd windows="↑" mac="↑" /> and <Kbd windows="↓" mac="↓" /> keys to navigate to the desired template version. This example uses %ASPIRE_VERSION%.
 </Steps>
 
 ```bash title="Change directory"
@@ -144,7 +144,7 @@ Aspire resources are just classes and methods contained within a class library t
 2. Add `Aspire.Hosting` to the class library as a package reference.
 
     ```bash title=".NET CLI"
-    dotnet add ./MailDev.Hosting/MailDev.Hosting.csproj package Aspire.Hosting --version 13.5.0
+    dotnet add ./MailDev.Hosting/MailDev.Hosting.csproj package Aspire.Hosting --version %ASPIRE_VERSION%
     ```
 
     :::note

--- a/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
@@ -235,7 +235,7 @@ To create a service that applies the migrations:
 
     ```bash title=".NET CLI"
     cd SupportTicketApi.MigrationService
-    dotnet add package Aspire.Microsoft.EntityFrameworkCore.SqlServer -v "13.1.0"
+    dotnet add package Aspire.Microsoft.EntityFrameworkCore.SqlServer -v "%ASPIRE_VERSION%"
     ```
 
     :::tip

--- a/src/frontend/src/content/docs/integrations/devtools/browser-logs.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/browser-logs.mdx
@@ -70,7 +70,7 @@ This updates your `aspire.config.json` with the browser logs hosting integration
 ```json title="aspire.config.json" ins={3}
 {
   "packages": {
-    "Aspire.Hosting.Browsers": "13.3.0-preview.1.26256.5"
+    "Aspire.Hosting.Browsers": "%ASPIRE_VERSION_PREVIEW%"
   }
 }
 ```

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-add.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-add.mdx
@@ -77,7 +77,7 @@ The following options are available:
 - Finds an AppHost project and adds the **kafka** (Aspire.Hosting.Kafka) integration package:
 
   ```bash title="Aspire CLI"
-  aspire add kafka --version 13.3.0
+  aspire add kafka --version %ASPIRE_VERSION%
   ```
 
 - Add the **redis** integration to a TypeScript AppHost and regenerate `.aspire/modules/`:

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-doctor.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-doctor.mdx
@@ -153,7 +153,7 @@ When the CLI is out of date, the Aspire section shows a warning with the latest 
 
 ```bash title="Aspire CLI"
 Aspire
-  ⚠️ Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION%-preview.1.26262.10
+  ⚠️ Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION_PREVIEW%
        Run 'aspire update' to update Aspire CLI.
 
 AppHost
@@ -305,11 +305,11 @@ When the CLI is out of date, the `cli-version` check has `"status": "warning"` a
   "category": "aspire",
   "name": "cli-version",
   "status": "warning",
-  "message": "Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION%-preview.1.26262.10",
+  "message": "Aspire CLI version %ASPIRE_VERSION%-dev is out of date. Latest version is %ASPIRE_VERSION_PREVIEW%",
   "fix": "Run 'aspire update' to update Aspire CLI.",
   "metadata": {
     "currentVersion": "%ASPIRE_VERSION%-dev",
-    "latestVersion": "%ASPIRE_VERSION%-preview.1.26262.10"
+    "latestVersion": "%ASPIRE_VERSION_PREVIEW%"
   }
 }
 ```

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-new.mdx
@@ -177,10 +177,10 @@ The `aspire-py-starter` template accepts the following additional options:
   aspire new aspire-starter
   ```
 
-- Create an AppHost project named `aspireapp` from the **13.3.0** templates and place the output in a folder named `dev`.
+- Create an AppHost project named `aspireapp` from the **%ASPIRE_VERSION%** templates and place the output in a folder named `dev`.
 
   ```bash title="Aspire CLI"
-  aspire new aspire-empty --version 13.3.0 --name aspireapp --output ./dev
+  aspire new aspire-empty --version %ASPIRE_VERSION% --name aspireapp --output ./dev
   ```
 
 - Create an Aspire starter app using templates from the `daily` channel to get the latest pre-release templates.

--- a/src/frontend/src/content/docs/reference/cli/commands/aspire-ps.mdx
+++ b/src/frontend/src/content/docs/reference/cli/commands/aspire-ps.mdx
@@ -78,8 +78,8 @@ The following options are available:
 
   ```text title="Output"
   PATH                                                SDK     PID    CLI_PID  DASHBOARD
-  ./src/MyApp.AppHost/MyApp.AppHost.csproj            13.3.0  12345  12340    https://localhost:17244/login?t=abc123
-  /home/user/other/OtherApp.AppHost.csproj            13.3.0  67890  67885    https://localhost:17250/login?t=def456
+  ./src/MyApp.AppHost/MyApp.AppHost.csproj            %ASPIRE_VERSION%  12345  12340    https://localhost:17244/login?t=abc123
+  /home/user/other/OtherApp.AppHost.csproj            %ASPIRE_VERSION%  67890  67885    https://localhost:17250/login?t=def456
   ```
 
 - Output running AppHosts as JSON for scripting:

--- a/src/frontend/tests/e2e/integrations-gallery.spec.ts
+++ b/src/frontend/tests/e2e/integrations-gallery.spec.ts
@@ -83,11 +83,11 @@ test.describe('integrations gallery', () => {
     await dismissCookieConsentIfVisible(page);
 
     const postgresCard = page.locator('.card[data-title="aspire.hosting.postgresql"]');
-    const csharpLink = postgresCard.locator('.lang-button').first();
-    const tsLink = postgresCard.locator('.lang-button').nth(1);
+    const tsLink = postgresCard.locator('.lang-button').first();
+    const csharpLink = postgresCard.locator('.lang-button').nth(1);
 
-    await expect(csharpLink).toHaveAttribute('href', /aspire-lang=csharp/);
     await expect(tsLink).toHaveAttribute('href', /aspire-lang=typescript/);
+    await expect(csharpLink).toHaveAttribute('href', /aspire-lang=csharp/);
 
     // Both links should target the same base docs path — only the lang differs.
     const csharpHref = await csharpLink.getAttribute('href');
@@ -221,7 +221,7 @@ test.describe('integrations gallery', () => {
     await dismissCookieConsentIfVisible(page);
 
     const postgresCard = page.locator('.card[data-title="aspire.hosting.postgresql"]');
-    const csharpLink = postgresCard.locator('.lang-button').first();
+    const csharpLink = postgresCard.locator('.lang-button').nth(1);
     const csharpHref = await csharpLink.getAttribute('href');
     expect(csharpHref).toBeTruthy();
 
@@ -241,7 +241,7 @@ test.describe('integrations gallery', () => {
   });
 });
 
-test('PivotSelector aspire-lang selection bridges to synced-tabs storage', async ({ page }) => {
+test('PivotSelector defaults to TypeScript and bridges to synced-tabs storage', async ({ page }) => {
   await page.goto('/get-started/first-app/');
   await dismissCookieConsentIfVisible(page);
 
@@ -249,7 +249,8 @@ test('PivotSelector aspire-lang selection bridges to synced-tabs storage', async
   await expect(pivotSelector).toBeVisible();
   const typeScriptButton = pivotSelector.getByRole('button', { name: 'TypeScript' });
 
-  await typeScriptButton.click();
+  await expect(pivotSelector.getByRole('button').first()).toHaveText('TypeScript');
+  await expect(typeScriptButton).toHaveClass(/active/);
 
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem('aspire-lang')))

--- a/src/frontend/tests/e2e/pivot-selector.spec.ts
+++ b/src/frontend/tests/e2e/pivot-selector.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test';
 import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
 
-test('prerequisites apphost tabs switch visible content and persist selection', async ({
+test('prerequisites apphost tabs default to TypeScript and persist selection', async ({
   page,
 }) => {
   await page.goto('/get-started/prerequisites/');
@@ -15,27 +15,29 @@ test('prerequisites apphost tabs switch visible content and persist selection', 
   });
   const typeScriptContent = page.getByRole('link', { name: 'Node.js installation instructions' });
 
-  await expect(csharpTab).toHaveAttribute('aria-selected', 'true');
-  await expect(csharpContent).toBeVisible();
-  await expect(typeScriptContent).toBeHidden();
-
-  await typeScriptTab.click();
-
+  await expect(appHostTabs.getByRole('tab').first()).toHaveText('TypeScript');
   await expect(typeScriptTab).toHaveAttribute('aria-selected', 'true');
   await expect(csharpTab).toHaveAttribute('aria-selected', 'false');
   await expect(typeScriptContent).toBeVisible();
   await expect(csharpContent).toBeHidden();
 
+  await csharpTab.click();
+
+  await expect(csharpTab).toHaveAttribute('aria-selected', 'true');
+  await expect(typeScriptTab).toHaveAttribute('aria-selected', 'false');
+  await expect(csharpContent).toBeVisible();
+  await expect(typeScriptContent).toBeHidden();
+
   await expect
     .poll(() => page.evaluate(() => localStorage.getItem('starlight-synced-tabs__aspire-lang')))
-    .toBe('TypeScript');
+    .toBe('C#');
 
   await page.reload();
   await dismissCookieConsentIfVisible(page);
 
-  await expect(typeScriptTab).toHaveAttribute('aria-selected', 'true');
-  await expect(typeScriptContent).toBeVisible();
-  await expect(csharpContent).toBeHidden();
+  await expect(csharpTab).toHaveAttribute('aria-selected', 'true');
+  await expect(csharpContent).toBeVisible();
+  await expect(typeScriptContent).toBeHidden();
 });
 
 test('apphost tabs restore and sync the aspire-lang query string', async ({ page }) => {
@@ -89,8 +91,8 @@ test('postgres apphost tabs use the shared aspire-lang query string', async ({ p
   const appHostTabs = page.locator('starlight-tabs[data-sync-key="aspire-lang"]').first();
   const csharpTab = appHostTabs.getByRole('tab', { name: 'C#' });
   const typeScriptTab = appHostTabs.getByRole('tab', { name: 'TypeScript' });
-  const csharpPanel = appHostTabs.locator(':scope > [role="tabpanel"]').nth(0);
-  const typeScriptPanel = appHostTabs.locator(':scope > [role="tabpanel"]').nth(1);
+  const typeScriptPanel = appHostTabs.locator(':scope > [role="tabpanel"]').nth(0);
+  const csharpPanel = appHostTabs.locator(':scope > [role="tabpanel"]').nth(1);
 
   await expect(typeScriptTab).toHaveAttribute('aria-selected', 'true');
   await expect(csharpTab).toHaveAttribute('aria-selected', 'false');

--- a/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
+++ b/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
@@ -32,6 +32,53 @@ const excludedCurrentDocsDirectories = new Set([
 const aspirePrereleaseVersionPattern =
   /(?:\b\d+\.\d+\.\d+|%ASPIRE_VERSION%)-(?:preview|alpha|beta|rc)(?:\.[0-9A-Za-z-]+)+/gi;
 
+function hasAspireVersionContext(
+  content: string,
+  lines: string[],
+  lineIndex: number,
+  index: number
+) {
+  if (/Aspire/i.test(lines[lineIndex])) {
+    return true;
+  }
+
+  const packageReferenceStart = content.lastIndexOf('<PackageReference', index);
+  const previousTagEnd = content.lastIndexOf('>', index);
+  if (packageReferenceStart > previousTagEnd) {
+    const packageReferenceEnd = content.indexOf('>', index);
+    const packageReference = content.slice(
+      packageReferenceStart,
+      packageReferenceEnd === -1 ? content.length : packageReferenceEnd + 1
+    );
+    if (/\bInclude\s*=\s*(['"])[^'"]*Aspire[^'"]*\1/i.test(packageReference)) {
+      return true;
+    }
+  }
+
+  let commandStartLine = lineIndex;
+  while (commandStartLine > 0 && /[\\`^]\s*$/.test(lines[commandStartLine - 1])) {
+    commandStartLine--;
+  }
+
+  return (
+    commandStartLine < lineIndex &&
+    /Aspire/i.test(lines.slice(commandStartLine, lineIndex + 1).join('\n'))
+  );
+}
+
+function findAspirePrereleaseVersions(content: string) {
+  const lines = content.split(/\r?\n/);
+
+  return [...content.matchAll(aspirePrereleaseVersionPattern)].flatMap((match) => {
+    const index = match.index;
+    const lineIndex = (content.slice(0, index).match(/\n/g) ?? []).length;
+
+    return hasAspireVersionContext(content, lines, lineIndex, index)
+      ? [{ line: lineIndex + 1, value: match[0] }]
+      : [];
+  });
+}
+
 async function collectMarkdownFiles(directory: string): Promise<string[]> {
   const entries = await readdir(directory, { withFileTypes: true });
   const files = await Promise.all(
@@ -111,22 +158,33 @@ describe('Aspire version placeholders', () => {
     expect(previewVersion).toBe(currentAspirePreviewVersion);
   });
 
+  test('finds hard-coded previews in multiline Aspire package examples', () => {
+    const content = [
+      '<PackageReference Include="Aspire.Hosting.Xml"',
+      '                  Version="13.5.3-preview.1.123" />',
+      '',
+      'dotnet add package Aspire.Hosting.Command \\',
+      '  --version 13.5.3-preview.2.456',
+      '',
+      '<PackageReference Include="Contoso.Hosting.Xml"',
+      '                  Version="13.5.3-preview.3.789" />',
+    ].join('\n');
+
+    expect(findAspirePrereleaseVersions(content)).toEqual([
+      { line: 2, value: '13.5.3-preview.1.123' },
+      { line: 5, value: '13.5.3-preview.2.456' },
+    ]);
+  });
+
   test('requires the full preview placeholder in current English Aspire examples', async () => {
     const files = await collectCurrentEnglishMarkdownFiles();
     const findings = (
       await Promise.all(
         files.map(async (filePath) => {
           const content = await readFile(filePath, 'utf8');
-          return content.split(/\r?\n/).flatMap((line, index) => {
-            if (!/Aspire/i.test(line)) {
-              return [];
-            }
-
-            return [...line.matchAll(aspirePrereleaseVersionPattern)].map(
-              (match) =>
-                `${path.relative(docsRoot, filePath)}:${index + 1}: ${match[0]}`
-            );
-          });
+          return findAspirePrereleaseVersions(content).map(
+            ({ line, value }) => `${path.relative(docsRoot, filePath)}:${line}: ${value}`
+          );
         })
       )
     ).flat();
@@ -171,6 +229,38 @@ describe('Aspire version placeholders', () => {
       await expect(readFile(textPath, 'utf8')).resolves.toBe(placeholderContent);
       await expect(readFile(mdxPath, 'utf8')).resolves.toBe(placeholderContent);
       await expect(readFile(jsonPath, 'utf8')).resolves.toBe('{"version":"%ASPIRE_VERSION%"}');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('orders C#-first AppHost tabs in generated Markdown copies', async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), 'aspire-version-placeholders-'));
+
+    try {
+      const markdownPath = path.join(tempDir, 'example.md');
+      const csharp = `<TabItem id='csharp' label='C#'>
+Aspire %ASPIRE_VERSION%
+</TabItem>
+`;
+      const typescript = `<TabItem id='typescript' label='TypeScript'>
+TypeScript content
+</TabItem>
+`;
+      await writeFile(
+        markdownPath,
+        `<Tabs syncKey='aspire-lang'>
+${csharp}${typescript}</Tabs>
+`
+      );
+
+      await replaceAspireVersionPlaceholdersInDirectory(tempDir);
+
+      await expect(readFile(markdownPath, 'utf8')).resolves.toBe(
+        `<Tabs syncKey='aspire-lang'>
+${typescript}${csharp.replace('%ASPIRE_VERSION%', currentAspireVersion)}</Tabs>
+`
+      );
     } finally {
       await rm(tempDir, { recursive: true, force: true });
     }

--- a/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
+++ b/src/frontend/tests/unit/aspire-version-placeholders.vitest.test.ts
@@ -1,10 +1,13 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, test } from 'vitest';
+import { locales } from '../../config/locales.ts';
 import { replaceAspireVersionPlaceholdersInDirectory } from '../../config/aspire-version-placeholders-integration.mjs';
 import {
   currentAspireMajorMinorVersion,
+  currentAspirePreviewVersion,
   currentAspireVersion,
 } from '../../config/aspire-versions.mjs';
 import {
@@ -12,13 +15,62 @@ import {
   replaceAspireVersionPlaceholders,
 } from '../../config/remark-aspire-version-placeholders.mjs';
 
+const testsDir = path.dirname(fileURLToPath(import.meta.url));
+const frontendRoot = path.resolve(testsDir, '..', '..');
+const docsRoot = path.join(frontendRoot, 'src', 'content', 'docs');
+const appHostProjectPath = path.resolve(
+  frontendRoot,
+  '..',
+  'apphost',
+  'Aspire.Dev.AppHost',
+  'Aspire.Dev.AppHost.csproj'
+);
+const excludedCurrentDocsDirectories = new Set([
+  ...Object.keys(locales).filter((locale) => locale !== 'root'),
+  'whats-new',
+]);
+const aspirePrereleaseVersionPattern =
+  /(?:\b\d+\.\d+\.\d+|%ASPIRE_VERSION%)-(?:preview|alpha|beta|rc)(?:\.[0-9A-Za-z-]+)+/gi;
+
+async function collectMarkdownFiles(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const resolvedPath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        return collectMarkdownFiles(resolvedPath);
+      }
+      return entry.isFile() && /\.mdx?$/i.test(entry.name) ? [resolvedPath] : [];
+    })
+  );
+  return files.flat();
+}
+
+async function collectCurrentEnglishMarkdownFiles(): Promise<string[]> {
+  const entries = await readdir(docsRoot, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const resolvedPath = path.join(docsRoot, entry.name);
+      if (entry.isDirectory()) {
+        return excludedCurrentDocsDirectories.has(entry.name)
+          ? []
+          : collectMarkdownFiles(resolvedPath);
+      }
+      return entry.isFile() && /\.mdx?$/i.test(entry.name) ? [resolvedPath] : [];
+    })
+  );
+  return files.flat();
+}
+
 describe('Aspire version placeholders', () => {
-  test('replaces current Aspire major.minor and patch placeholders', () => {
+  test('replaces current Aspire major.minor, stable, and preview placeholders', () => {
     expect(
       replaceAspireVersionPlaceholders(
-        'Aspire %ASPIRE_VERSION_MAJOR_MINOR% ships as %ASPIRE_VERSION%.'
+        'Aspire %ASPIRE_VERSION_MAJOR_MINOR% ships as %ASPIRE_VERSION%; preview packages use %ASPIRE_VERSION_PREVIEW%.'
       )
-    ).toBe(`Aspire ${currentAspireMajorMinorVersion} ships as ${currentAspireVersion}.`);
+    ).toBe(
+      `Aspire ${currentAspireMajorMinorVersion} ships as ${currentAspireVersion}; preview packages use ${currentAspirePreviewVersion}.`
+    );
   });
 
   test('replaces placeholders in markdown text, code fences, and MDX attributes', () => {
@@ -29,7 +81,7 @@ describe('Aspire version placeholders', () => {
           type: 'paragraph',
           children: [{ type: 'text', value: 'Aspire %ASPIRE_VERSION_MAJOR_MINOR%' }],
         },
-        { type: 'code', lang: 'bash', value: 'aspire %ASPIRE_VERSION%' },
+        { type: 'code', lang: 'bash', value: 'aspire %ASPIRE_VERSION_PREVIEW%' },
         {
           type: 'mdxJsxFlowElement',
           name: 'Code',
@@ -44,8 +96,42 @@ describe('Aspire version placeholders', () => {
     expect(tree.children[0].children[0].value).toBe(
       `Aspire ${currentAspireMajorMinorVersion}`
     );
-    expect(tree.children[1].value).toBe(`aspire ${currentAspireVersion}`);
+    expect(tree.children[1].value).toBe(`aspire ${currentAspirePreviewVersion}`);
     expect(tree.children[2].attributes[0].value).toBe(currentAspireVersion);
+  });
+
+  test('matches the stable and preview versions used by the site AppHost', async () => {
+    const project = await readFile(appHostProjectPath, 'utf8');
+    const sdkVersion = project.match(/<Project Sdk="Aspire\.AppHost\.Sdk\/([^"]+)">/)?.[1];
+    const previewVersion = project.match(
+      /<PackageReference Include="Aspire\.Hosting\.Azure\.FrontDoor" Version="([^"]+)" \/>/
+    )?.[1];
+
+    expect(sdkVersion).toBe(currentAspireVersion);
+    expect(previewVersion).toBe(currentAspirePreviewVersion);
+  });
+
+  test('requires the full preview placeholder in current English Aspire examples', async () => {
+    const files = await collectCurrentEnglishMarkdownFiles();
+    const findings = (
+      await Promise.all(
+        files.map(async (filePath) => {
+          const content = await readFile(filePath, 'utf8');
+          return content.split(/\r?\n/).flatMap((line, index) => {
+            if (!/Aspire/i.test(line)) {
+              return [];
+            }
+
+            return [...line.matchAll(aspirePrereleaseVersionPattern)].map(
+              (match) =>
+                `${path.relative(docsRoot, filePath)}:${index + 1}: ${match[0]}`
+            );
+          });
+        })
+      )
+    ).flat();
+
+    expect(findings).toEqual([]);
   });
 
   test('replaces placeholders only in Markdown copies, leaving other assets untouched', async () => {
@@ -58,7 +144,8 @@ describe('Aspire version placeholders', () => {
       const mdxPath = path.join(tempDir, 'example.mdx');
       const jsonPath = path.join(tempDir, 'example.json');
 
-      const placeholderContent = 'Aspire %ASPIRE_VERSION_MAJOR_MINOR%: %ASPIRE_VERSION%';
+      const placeholderContent =
+        'Aspire %ASPIRE_VERSION_MAJOR_MINOR%: %ASPIRE_VERSION% (%ASPIRE_VERSION_PREVIEW%)';
 
       await Promise.all([
         writeFile(markdownPath, placeholderContent),
@@ -72,7 +159,7 @@ describe('Aspire version placeholders', () => {
 
       // Only the `.md` copy (which bypasses the remark pipeline) is rewritten.
       await expect(readFile(markdownPath, 'utf8')).resolves.toBe(
-        `Aspire ${currentAspireMajorMinorVersion}: ${currentAspireVersion}`
+        `Aspire ${currentAspireMajorMinorVersion}: ${currentAspireVersion} (${currentAspirePreviewVersion})`
       );
 
       // The post-build pass intentionally rewrites only `.md` files. In the real

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -881,6 +881,49 @@ describe('custom Astro component render coverage', () => {
     expect(html).toMatch(/data-dark="[^"]*map-darkdots\.svg/);
   });
 
+  it('renders TypeScript first for Aspire language pivots only', async () => {
+    const appHostHtml = normalizeHtml(
+      await renderComponent(PivotSelector, {
+        props: {
+          key: 'aspire-lang',
+          options: [
+            { id: 'csharp', title: 'C#' },
+            { id: 'typescript', title: 'TypeScript' },
+          ],
+        },
+      })
+    );
+    const genericHtml = normalizeHtml(
+      await renderComponent(PivotSelector, {
+        props: {
+          key: 'language',
+          options: [
+            { id: 'csharp', title: 'C#' },
+            { id: 'typescript', title: 'TypeScript' },
+          ],
+        },
+      })
+    );
+
+    expect(appHostHtml.indexOf('data-pivot-option="typescript"')).toBeLessThan(
+      appHostHtml.indexOf('data-pivot-option="csharp"')
+    );
+    expect(genericHtml.indexOf('data-pivot-option="csharp"')).toBeLessThan(
+      genericHtml.indexOf('data-pivot-option="typescript"')
+    );
+  });
+
+  it('renders the TypeScript AppHost tab and apphost.mts before C#', async () => {
+    const html = normalizeHtml(
+      await renderComponent(SimpleAppHostCode, {
+        props: { lang: 'nodejs' },
+      })
+    );
+
+    expect(html.indexOf('TypeScript AppHost')).toBeLessThan(html.indexOf('C# AppHost'));
+    expect(html).toContain('apphost.mts');
+  });
+
   it('AppHostBuilder omits invalid npm package installation APIs from every code variant', async () => {
     const html = normalizeHtml(await renderComponent(AppHostBuilder));
 

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -565,7 +565,7 @@ const basicRenderCases: BasicRenderCase[] = [
     name: 'SimpleAppHostCode renders both AppHost tabs',
     Component: SimpleAppHostCode,
     props: { lang: 'nodejs', mark: '3-5', collapse: '7-8' },
-    includes: ['C# AppHost', 'TypeScript AppHost', 'builder.Build().Run'],
+    includes: ['C#', 'TypeScript', 'builder.Build().Run'],
   },
   {
     name: 'CustomSelect renders a themed combobox and listbox',
@@ -905,22 +905,27 @@ describe('custom Astro component render coverage', () => {
       })
     );
 
-    expect(appHostHtml.indexOf('data-pivot-option="typescript"')).toBeLessThan(
-      appHostHtml.indexOf('data-pivot-option="csharp"')
-    );
-    expect(genericHtml.indexOf('data-pivot-option="csharp"')).toBeLessThan(
-      genericHtml.indexOf('data-pivot-option="typescript"')
-    );
+    const typeScriptOption = 'data-pivot-option="typescript"';
+    const csharpOption = 'data-pivot-option="csharp"';
+
+    expect(appHostHtml).toContain(typeScriptOption);
+    expect(appHostHtml).toContain(csharpOption);
+    expect(genericHtml).toContain(csharpOption);
+    expect(genericHtml).toContain(typeScriptOption);
+    expect(appHostHtml.indexOf(typeScriptOption)).toBeLessThan(appHostHtml.indexOf(csharpOption));
+    expect(genericHtml.indexOf(csharpOption)).toBeLessThan(genericHtml.indexOf(typeScriptOption));
   });
 
-  it('renders the TypeScript AppHost tab and apphost.mts before C#', async () => {
+  it('renders the canonical TypeScript tab and apphost.mts before C#', async () => {
     const html = normalizeHtml(
       await renderComponent(SimpleAppHostCode, {
         props: { lang: 'nodejs' },
       })
     );
 
-    expect(html.indexOf('TypeScript AppHost')).toBeLessThan(html.indexOf('C# AppHost'));
+    expect(html).toContain('TypeScript');
+    expect(html).toContain('C#');
+    expect(html.indexOf('TypeScript')).toBeLessThan(html.indexOf('C#'));
     expect(html).toContain('apphost.mts');
   });
 

--- a/src/frontend/tests/unit/typescript-first-apphost-tabs.vitest.test.ts
+++ b/src/frontend/tests/unit/typescript-first-apphost-tabs.vitest.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'vitest';
+import { remarkTypeScriptFirstAppHostTabs } from '../../config/remark-typescript-first-apphost-tabs.mjs';
+
+function tabItem(id: string, label: string) {
+  return {
+    type: 'mdxJsxFlowElement',
+    name: 'TabItem',
+    attributes: [
+      { type: 'mdxJsxAttribute', name: 'id', value: id },
+      { type: 'mdxJsxAttribute', name: 'label', value: label },
+    ],
+    children: [],
+  };
+}
+
+function tabs(syncKey: string, children: ReturnType<typeof tabItem>[]) {
+  return {
+    type: 'mdxJsxFlowElement',
+    name: 'Tabs',
+    attributes: [{ type: 'mdxJsxAttribute', name: 'syncKey', value: syncKey }],
+    children,
+  };
+}
+
+describe('TypeScript-first AppHost tabs', () => {
+  test('moves TypeScript to the first position in AppHost language tabs', () => {
+    const csharp = tabItem('csharp', 'C#');
+    const typescript = tabItem('typescript', 'TypeScript');
+    const appHostTabs = tabs('aspire-lang', [csharp, typescript]);
+
+    remarkTypeScriptFirstAppHostTabs()({
+      type: 'root',
+      children: [appHostTabs],
+    });
+
+    expect(appHostTabs.children).toEqual([typescript, csharp]);
+  });
+
+  test('preserves author order for unrelated tab groups', () => {
+    const csharp = tabItem('csharp', 'C#');
+    const typescript = tabItem('typescript', 'TypeScript');
+    const unrelatedTabs = tabs('api-language', [csharp, typescript]);
+
+    remarkTypeScriptFirstAppHostTabs()({
+      type: 'root',
+      children: [unrelatedTabs],
+    });
+
+    expect(unrelatedTabs.children).toEqual([csharp, typescript]);
+  });
+});

--- a/src/frontend/tests/unit/typescript-first-apphost-tabs.vitest.test.ts
+++ b/src/frontend/tests/unit/typescript-first-apphost-tabs.vitest.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import { remarkTypeScriptFirstAppHostTabs } from '../../config/remark-typescript-first-apphost-tabs.mjs';
+import {
+  orderTypeScriptFirstAppHostTabsInMarkdown,
+  remarkTypeScriptFirstAppHostTabs,
+} from '../../config/remark-typescript-first-apphost-tabs.mjs';
 
 function tabItem(id: string, label: string) {
   return {
@@ -47,5 +50,35 @@ describe('TypeScript-first AppHost tabs', () => {
     });
 
     expect(unrelatedTabs.children).toEqual([csharp, typescript]);
+  });
+
+  test('moves the TypeScript block first without reformatting copied Markdown', () => {
+    const csharp = `<TabItem id='csharp' label='C#'>
+C# content
+</TabItem>
+`;
+    const typescript = `<TabItem id='typescript' label='TypeScript'>
+TypeScript content
+</TabItem>
+`;
+    const markdown = `<Tabs syncKey='aspire-lang'>
+${csharp}${typescript}</Tabs>
+`;
+
+    expect(orderTypeScriptFirstAppHostTabsInMarkdown(markdown)).toBe(
+      `<Tabs syncKey='aspire-lang'>
+${typescript}${csharp}</Tabs>
+`
+    );
+  });
+
+  test('preserves copied Markdown for unrelated tab groups', () => {
+    const markdown = `<Tabs syncKey='api-language'>
+<TabItem id='csharp' label='C#'>C# content</TabItem>
+<TabItem id='typescript' label='TypeScript'>TypeScript content</TabItem>
+</Tabs>
+`;
+
+    expect(orderTypeScriptFirstAppHostTabsInMarkdown(markdown)).toBe(markdown);
   });
 });


### PR DESCRIPTION
## Why this is needed

Current guidance included hard-coded prerelease package versions such as `13.3.0-preview.1.26256.5`. Aspire prerelease suffixes move independently from the stable version, so `%ASPIRE_VERSION%` cannot safely represent them and combining it with an older suffix can produce a package version that never existed. The release audit also searched only the immediately prior version, allowing older stale examples to survive multiple releases.

AppHost language tabs were also authored C# first, which made C# the default for first-time readers even though TypeScript AppHosts are now the intended default documentation experience.

## What changed

- add `%ASPIRE_VERSION_PREVIEW%` as a complete prerelease value and align stable and preview placeholders with the current site AppHost packages
- migrate copy-ready stable and preview examples to contextual placeholders
- broaden release auditing and regression coverage to catch all version-shaped references, including full prerelease build suffixes
- render every `aspire-lang` tab group TypeScript-first through a central remark transform, avoiding a fragile rewrite of more than 1,000 existing tab groups
- make TypeScript the first/default choice in pivots, integration cards, container API labels, and shared AppHost examples while preserving saved C# choices and query-string overrides
- update contributor and agent guidance so new AppHost examples are authored TypeScript-first with `apphost.mts`

## Validation

- `pnpm --dir ./src/frontend exec vitest run --config vitest.config.ts tests/unit/aspire-version-placeholders.vitest.test.ts`
- `pnpm --dir ./src/frontend exec vitest run --config vitest.config.ts tests/unit/typescript-first-apphost-tabs.vitest.test.ts`
- targeted custom-component render coverage for TypeScript-first pivots and `apphost.mts`
- six targeted desktop Playwright scenarios covering default selection, leftmost order, persistence, query overrides, and integration-gallery links
- focused ESLint and `git diff --check`