### PR TITLE
Skip no-op merges in the update-release-branch workflow

### DIFF
--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -77,12 +77,29 @@ jobs:
         if: ${{ steps.find-branch.outputs.branch != '' }}
         shell: bash
         run: |
+          branch="${{ steps.find-branch.outputs.branch }}"
           git fetch origin main
+
+          # Nothing to integrate: main is already contained in the release branch.
+          if git merge-base --is-ancestor origin/main HEAD; then
+            echo "$branch already contains origin/main. Nothing to merge."
+            exit 0
+          fi
+
+          # Prefer a fast-forward when the release branch has not diverged from
+          # main, so no merge commit is created.
+          if git merge --ff-only origin/main; then
+            echo "Fast-forwarded $branch to origin/main."
+            git push
+            exit 0
+          fi
+
+          # The branches have genuinely diverged; create a merge commit.
           if git merge origin/main --no-edit; then
-            echo "Merged main into ${{ steps.find-branch.outputs.branch }} successfully."
+            echo "Merged main into $branch successfully."
             git push
           else
-            echo "::error::Merge conflict detected between main and ${{ steps.find-branch.outputs.branch }}. Manual intervention required."
+            echo "::error::Merge conflict detected between main and $branch. Manual intervention required."
             git merge --abort
             exit 1
           fi


### PR DESCRIPTION
## Summary

The **Update Release Branch** workflow (`.github/workflows/update-release-branch.yml`) triggers on every push to `main` and runs `git merge origin/main --no-edit` + `git push` on the latest `release/{major}.{minor}` branch. This hardens the merge step so it does nothing when there is nothing to integrate, and fast-forwards instead of creating a merge commit when the branch has not diverged.

## Root cause of the history noise

Comparing `release/13.6` to `main` (at time of investigation): **34 commits ahead / 0 behind**, of which only **4 are real content** and **30 are merge commits** (13 `into release/13.6`, 17 inherited `into release/17.0`).

- `git merge origin/main` **does not fabricate empty commits** — it prints "Already up to date" when `main` is already contained, and fast-forwards when the branch has no unique commits. The merge commits it creates each integrate real `main` content.
- Once the release branch carries **any** unique commit (the release-notes docs) plus its own accumulated merge commits, it **can never fast-forward** to `main` again. So every push-to-`main` wave produces a merge commit, accumulating indefinitely and burying the handful of real release commits.
- ~Half the current noise is **inherited cross-release history**: `release/13.6` descends from the previous `release/17.0` branch tip (a 17.0 merge and its real commit are ancestors of 13.6), not from `main`. That is a branch-*creation* choice, not something this workflow does.

## What this change does

In the "Merge main into release branch" step:

1. **Guard** — if `origin/main` is already an ancestor of the release branch (`git merge-base --is-ancestor origin/main HEAD`), log and exit `0`. No merge, no push. This makes `workflow_dispatch` and duplicate/queued runs clean no-ops.
2. **Fast-forward path** — try `git merge --ff-only origin/main`; on success push and exit, so no merge commit is created when the branch has not diverged (e.g. right after a release branch is cut).
3. **Diverged path** — otherwise `git merge origin/main --no-edit`; on success push, on conflict keep today's behavior (`::error::` + `git merge --abort` + `exit 1`).

All branch decisions use `if` conditions, so they remain safe under the Actions default `bash -eo pipefail`. **No force-push or history rewrite.**

> [!NOTE]
> This is robustness/idempotency hardening. It intentionally does **not** shrink the existing history and does **not** stop the structural one-merge-per-wave accumulation on an already-diverged release branch — on a real push, `main` is not yet contained, so the guard does not skip. Reducing that accumulation would require a different trigger cadence or branch strategy (see below), or a history rewrite (out of scope).

## Validation

- YAML parses; bash `-n` syntax check passes.
- Local git simulation of the exact logic (push replaced with an echo) — all cases pass:
  - `main` already contained → skip, no push;
  - no unique commits → fast-forward, `HEAD == origin/main`, not a merge;
  - genuinely diverged → a single merge commit;
  - conflicting change → `git merge --abort`, non-zero exit, working tree clean, `HEAD` unchanged.

## Out of scope (for human follow-up)

- **Existing merge-bubble history** on `release/13.6` — removing it needs a force-push/rewrite, which is deliberately avoided here.
- **Cross-release inheritance** — cutting future `release/*` branches from `main` (not from the prior release tip) would stop inheriting the previous release's merge history.
- **Trigger cadence** — if the intent is "nightly", a `schedule:` trigger would reduce future merge frequency; the every-push trigger is kept here per review.
- **AzDO pipelines** (`azure-pipelines.yml` on the `deploy` / `deploy-vnext-release` branches of the mirror) are not in this repo; note that the `deploy` pipeline force-pushes GitHub `main` → AzDO `main`.
