### PR TITLE
Document GitHub Models retirement

### DIFF
--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
@@ -19,8 +19,8 @@ import githubIcon from '@assets/icons/github-icon.png';
   data-zoom-off
 />
 
-:::caution[Integration deprecated]
-The GitHub Models service is **no longer available to new customers**. The `Aspire.Hosting.GitHub.Models` integration is sunset as of Aspire 13.5. All public APIs are marked `[Obsolete]` and the package no longer appears in `aspire add` output. The package will ship one final obsolete release on NuGet and will be removed entirely in a future version. For new and existing apps, use the [Azure AI Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/) instead, which provides access to a broad catalog of models — including OpenAI's GPT models — and supports local development with `RunAsFoundryLocal()`. See [microsoft/aspire#18402](https://github.com/microsoft/aspire/issues/18402) for details.
+:::caution[GitHub Models retired]
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
 This page describes how consuming apps connect to a GitHub Model resource that's already modeled in your AppHost. For the AppHost API surface — adding a model resource, API key parameters, organization configuration, and health checks — see [GitHub Models hosting integration](../github-models-host/).

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-connect.mdx
@@ -20,7 +20,7 @@ import githubIcon from '@assets/icons/github-icon.png';
 />
 
 :::caution[GitHub Models retired]
-[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration will be removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
 This page describes how consuming apps connect to a GitHub Model resource that's already modeled in your AppHost. For the AppHost API surface — adding a model resource, API key parameters, organization configuration, and health checks — see [GitHub Models hosting integration](../github-models-host/).
@@ -361,7 +361,7 @@ console.log(response.choices[0].message.content);
 
 ## See also
 
-- [Get started with the GitHub Models integrations](/integrations/ai/github-models/github-models-get-started/)
+- [Migrate Aspire apps from GitHub Models](/integrations/ai/github-models/github-models-get-started/)
 - [GitHub Models hosting integration](/integrations/ai/github-models/github-models-host/)
 - [GitHub Models Marketplace](https://github.com/marketplace/models)
 - [GitHub Models documentation](https://docs.github.com/github-models)

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
@@ -17,8 +17,8 @@ import githubIcon from '@assets/icons/github-icon.png';
   data-zoom-off
 />
 
-:::caution[Integration deprecated]
-The GitHub Models service is **no longer available to new customers**. The `Aspire.Hosting.GitHub.Models` integration is sunset as of Aspire 13.5. All public APIs are marked `[Obsolete]` and the package no longer appears in `aspire add` output. The package will ship one final obsolete release on NuGet and will be removed entirely in a future version. For new and existing apps, use the [Azure AI Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/) instead, which provides access to a broad catalog of models — including OpenAI's GPT models — and supports local development with `RunAsFoundryLocal()`. See [microsoft/aspire#18402](https://github.com/microsoft/aspire/issues/18402) for details.
+:::caution[GitHub Models retired]
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
 [GitHub Models](https://github.com/marketplace/models) provides access to a broad catalog of AI models — including OpenAI's GPT models, DeepSeek, Microsoft's Phi models, and more — through GitHub's infrastructure and your existing GitHub token. The Aspire GitHub Models integration lets you model a GitHub Model resource as a first-class resource in your AppHost, then hand the connection information to any consuming app — regardless of language.

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
@@ -1,11 +1,10 @@
 ---
-title: Get started with the GitHub Models integrations
-description: Learn how the Aspire GitHub Models integrations register a GitHub Models resource and wire the .NET client to call models hosted on GitHub.
+title: Migrate Aspire apps from GitHub Models
+description: Learn how to migrate Aspire apps from the discontinued GitHub Models integration to Microsoft Foundry for continued AI model access.
 prev: false
 ---
 
 import { Image } from 'astro:assets';
-import { LinkButton, Steps } from '@astrojs/starlight/components';
 import githubIcon from '@assets/icons/github-icon.png';
 
 <Image
@@ -18,77 +17,29 @@ import githubIcon from '@assets/icons/github-icon.png';
 />
 
 :::caution[GitHub Models retired]
-[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration will be removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
-[GitHub Models](https://github.com/marketplace/models) provides access to a broad catalog of AI models — including OpenAI's GPT models, DeepSeek, Microsoft's Phi models, and more — through GitHub's infrastructure and your existing GitHub token. The Aspire GitHub Models integration lets you model a GitHub Model resource as a first-class resource in your AppHost, then hand the connection information to any consuming app — regardless of language.
+The GitHub Models playground, model catalog, inference API, and bring your own key (BYOK) capabilities are no longer available. Existing apps that use the Aspire GitHub Models integration can't send inference requests to the retired service.
 
-## Why use GitHub Models with Aspire
+## Migrate to Microsoft Foundry
 
-Adding GitHub Models through Aspire — rather than hard-coding API keys and endpoints in each service — gives you:
+Microsoft Foundry provides a broad model catalog and supports both cloud-hosted deployments and local development. To migrate:
 
-- **Centralized credential management.** The GitHub token is stored once as a secret parameter in the AppHost and injected into each consuming app automatically.
-- **Typed model resources with connection strings.** Each GitHub Model resource composes a connection string from the endpoint, API key, and model identifier, giving consuming apps a single named connection.
-- **Consistent connection info across languages.** Once you reference a model resource from a consuming app, Aspire injects connection properties as environment variables in a predictable format that works from C#, TypeScript, Python, Go, or any other language.
-- **Automatic `GITHUB_TOKEN` fallback.** In Codespaces and GitHub Actions the ambient `GITHUB_TOKEN` is used automatically — no extra secrets to configure.
-- **A first-class C# client integration.** C# apps can use `Aspire.Azure.AI.Inference` or `Aspire.OpenAI` for dependency injection, health checks, and OpenTelemetry, all wired up from the same resource name.
+1. Remove the `Aspire.Hosting.GitHub.Models` package from your AppHost and remove GitHub Models resources, API key parameters, and `GITHUB_TOKEN` configuration.
+1. Follow the [Microsoft Foundry hosting integration guide](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host/) to add a Foundry resource and model deployment. For local development, you can configure the resource to run with Foundry Local.
+1. Reference the Foundry deployment from each consuming app that needs model access.
+1. Follow [Connect to Microsoft Foundry](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-connect/) to update client configuration and environment-variable handling. Don't reuse retired GitHub Models endpoints, tokens, or model identifiers.
 
-## How the pieces fit together
+## Aspire 13.5 historical reference
 
-The GitHub Models integration has two sides: a **hosting integration** that you use in your AppHost to model the GitHub Model resource, and a **connection story** for consuming apps that reference it.
+The following articles document the final Aspire 13.5 integration surface for migration and historical reference. Their examples don't restore access to the retired GitHub Models service:
 
-```mermaid
-architecture-beta
-
-  group apphost(server)[AppHost]
-  group consumer(server)[Consuming app]
-
-  service hosting(server)[Hosting integration] in apphost
-  service githubmodels(internet)[GitHub Models API] in apphost
-  service model(database)[chat model] in apphost
-
-  service client(iconoir:server-connection)[Client integration] in consumer
-  service app(server)[App] in consumer
-
-  hosting:R --> L:githubmodels
-  githubmodels:R --> L:model
-  model:R --> L:client
-  client:R --> L:app
-```
-
-The **hosting integration** lives in your AppHost project and models the GitHub Model resource. The **client integration** lives in each consuming app and uses the connection information Aspire injects to call the GitHub Models API.
-
-Getting there is a two-step process: model the GitHub Model resource in your AppHost, then connect to the API from each app that needs it.
-
-<Steps>
-
-1. ### Model GitHub Models in your AppHost
-
-    Add the GitHub Models hosting integration to your AppHost, then declare a model resource and reference it from the apps that need to call the API. The [GitHub Models hosting integration](/integrations/ai/github-models/github-models-host/) article walks through every capability — adding model resources, API key parameters, organization configuration, and health checks — with side-by-side C# and TypeScript examples.
-
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/github-models/github-models-host/'>
-        Set up GitHub Models in the AppHost
-    </LinkButton>
-
-2. ### Connect from your consuming app
-
-    When you reference a GitHub Model resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
-
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/github-models/github-models-connect/'>
-        Connect to GitHub Models
-    </LinkButton>
-
-</Steps>
+- [GitHub Models hosting integration](/integrations/ai/github-models/github-models-host/)
+- [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/)
 
 ## See also
 
-- [GitHub Models on GitHub Marketplace](https://github.com/marketplace/models)
+- [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/)
+- [GitHub Models retirement notice](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/)
 - [GitHub Models documentation](https://docs.github.com/github-models)

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
@@ -5,6 +5,7 @@ prev: false
 ---
 
 import { Image } from 'astro:assets';
+import { Steps } from '@astrojs/starlight/components';
 import githubIcon from '@assets/icons/github-icon.png';
 
 <Image
@@ -26,10 +27,14 @@ The GitHub Models playground, model catalog, inference API, and bring your own k
 
 Microsoft Foundry provides a broad model catalog and supports both cloud-hosted deployments and local development. To migrate:
 
+<Steps>
+
 1. Remove the `Aspire.Hosting.GitHub.Models` package from your AppHost and remove GitHub Models resources, API key parameters, and `GITHUB_TOKEN` configuration.
-1. Follow the [Microsoft Foundry hosting integration guide](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host/) to add a Foundry resource and model deployment. For local development, you can configure the resource to run with Foundry Local.
-1. Reference the Foundry deployment from each consuming app that needs model access.
-1. Follow [Connect to Microsoft Foundry](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-connect/) to update client configuration and environment-variable handling. Don't reuse retired GitHub Models endpoints, tokens, or model identifiers.
+2. Follow the [Microsoft Foundry hosting integration guide](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host/) to add a Foundry resource and model deployment. For local development, you can configure the resource to run with Foundry Local.
+3. Reference the Foundry deployment from each consuming app that needs model access.
+4. Follow [Connect to Microsoft Foundry](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-connect/) to update client configuration and environment-variable handling. Don't reuse retired GitHub Models endpoints, tokens, or model identifiers.
+
+</Steps>
 
 ## Aspire 13.5 historical reference
 

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
@@ -17,8 +17,8 @@ import githubIcon from '@assets/icons/github-icon.png';
   data-zoom-off
 />
 
-:::caution[Integration deprecated]
-The GitHub Models service is **no longer available to new customers**. The `Aspire.Hosting.GitHub.Models` integration is sunset as of Aspire 13.5. All public APIs are marked `[Obsolete]` and the package no longer appears in `aspire add` output. The package will ship one final obsolete release on NuGet and will be removed entirely in a future version. For new and existing apps, use the [Azure AI Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/) instead, which provides access to a broad catalog of models — including OpenAI's GPT models — and supports local development with `RunAsFoundryLocal()`. See [microsoft/aspire#18402](https://github.com/microsoft/aspire/issues/18402) for details.
+:::caution[GitHub Models retired]
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
 This article is the reference for the Aspire GitHub Models hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model GitHub Model resources in your [`AppHost`](/get-started/app-host/) project.

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
@@ -5,7 +5,6 @@ description: Learn how to use the Aspire GitHub Models hosting integration to or
 
 import { Image } from 'astro:assets';
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
-import LearnMore from '@components/LearnMore.astro';
 import githubIcon from '@assets/icons/github-icon.png';
 
 <Image
@@ -18,55 +17,35 @@ import githubIcon from '@assets/icons/github-icon.png';
 />
 
 :::caution[GitHub Models retired]
-[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration was removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
+[GitHub Models was retired for all customers on July 30, 2026](https://github.blog/changelog/2026-07-30-github-models-is-now-retired/). The `Aspire.Hosting.GitHub.Models` integration is discontinued. Its final release shipped with Aspire 13.5, and the integration will be removed after that release. Migrate new and existing apps to the [Microsoft Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/). The rest of this article is retained as a historical reference. For more information about the retired service, see the [GitHub Models documentation](https://docs.github.com/github-models).
 :::
 
 This article is the reference for the Aspire GitHub Models hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model GitHub Model resources in your [`AppHost`](/get-started/app-host/) project.
 
-If you're new to the GitHub Models integration, start with the [Get started with GitHub Models integrations](/integrations/ai/github-models/github-models-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to GitHub Models](../github-models-connect/).
+For migration guidance, see [Migrate Aspire apps from GitHub Models](/integrations/ai/github-models/github-models-get-started/). For how consuming apps read the connection information this page exposes, see [Connect to GitHub Models](../github-models-connect/).
 
 ## Installation
 
-To start building an Aspire app that uses GitHub Models, install the [📦 Aspire.Hosting.GitHub.Models](https://www.nuget.org/packages/Aspire.Hosting.GitHub.Models) NuGet package:
+The following examples pin the final [📦 Aspire.Hosting.GitHub.Models 13.5.1](https://www.nuget.org/packages/Aspire.Hosting.GitHub.Models/13.5.1) package for historical reference. The package is hidden from `aspire add` because the integration is discontinued.
 
 <Tabs syncKey="aspire-lang">
 <TabItem id="csharp" label="C#">
 
-```bash title="Terminal"
-aspire add github-models
-```
-
-<LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
-</LearnMore>
-
-Or, choose a manual installation approach:
-
 ```csharp title="AppHost.cs"
-#:package Aspire.Hosting.GitHub.Models@*
+#:package Aspire.Hosting.GitHub.Models@13.5.1
 ```
 
 ```xml title="AppHost.csproj"
-<PackageReference Include="Aspire.Hosting.GitHub.Models" Version="*" />
+<PackageReference Include="Aspire.Hosting.GitHub.Models" Version="13.5.1" />
 ```
 
 </TabItem>
 <TabItem id="typescript" label="TypeScript">
 
-```bash title="Terminal"
-aspire add github-models
-```
-
-<LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
-</LearnMore>
-
-This updates your `aspire.config.json` with the GitHub Models hosting integration package:
-
-```json title="aspire.config.json" ins={3}
+```json title="aspire.config.json"
 {
   "packages": {
-    "Aspire.Hosting.GitHub.Models": "%ASPIRE_VERSION%"
+    "Aspire.Hosting.GitHub.Models": "13.5.1"
   }
 }
 ```
@@ -325,7 +304,7 @@ For the full reference of GitHub Models connection properties — and how consum
 
 ## See also
 
-- [Get started with the GitHub Models integrations](/integrations/ai/github-models/github-models-get-started/)
+- [Migrate Aspire apps from GitHub Models](/integrations/ai/github-models/github-models-get-started/)
 - [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/)
 - [GitHub Models Marketplace](https://github.com/marketplace/models)
 - [GitHub Models documentation](https://docs.github.com/github-models)

--- a/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
@@ -27,7 +27,6 @@ The following table shows the compatibility between Aspire AI hosting and client
 | `Aspire.Hosting.Foundry` | ❌ No | ⚠️ Partial | ✅ Yes (preferred) |
 | `Aspire.Hosting.Azure.CognitiveServices` | ❌ No | ✅ Yes (preferred) | ❌ No |
 | `Aspire.Hosting.OpenAI` | ✅ Yes (preferred) | ✅ Yes | ❌ No |
-| `Aspire.Hosting.GitHub.Models` | ⚠️ Partial | ❌ No | ✅ Yes (preferred) |
 
 <Aside type="note" title="Legend">
 
@@ -165,47 +164,6 @@ The [Aspire.OpenAI](https://www.nuget.org/packages/Aspire.OpenAI) package provid
 builder.AddOpenAIClient("openai");
 ```
 
-### GitHub Models
-
-For GitHub Models, use the **Aspire.Azure.AI.Inference** client integration for the best compatibility with the GitHub Models API. For more information, see [Aspire GitHub Models integration (Preview)](/integrations/ai/github-models/github-models-get-started/).
-
-#### Hosting integration
-
-The [Aspire.Hosting.GitHub.Models](https://www.nuget.org/packages/Aspire.Hosting.GitHub.Models) package provides the hosting integration. In your app host project:
-
-<Tabs syncKey="aspire-lang">
-<TabItem id="csharp" label="C#">
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini");
-
-builder.AddProject<Projects.ExampleProject>()
-    .WithReference(chat);
-```
-</TabItem>
-<TabItem id="typescript" label="TypeScript">
-```typescript title="apphost.mts" twoslash
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-
-const builder = await createBuilder();
-
-const chat = await builder.addGitHubModelById("chat", "openai/gpt-4o-mini");
-
-await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(chat);
-```
-</TabItem>
-</Tabs>
-
-#### Client integration
-
-The [Aspire.Azure.AI.Inference](https://www.nuget.org/packages/Aspire.Azure.AI.Inference) package provides the client integration. In your service project:
-
-```csharp title="Program.cs"
-builder.AddAzureChatCompletionsClient("chat");
-```
-
 ## Connection string formats
 
 Understanding how hosting and client integrations communicate through connection strings can help you troubleshoot connectivity issues and understand the underlying mechanics.
@@ -248,12 +206,6 @@ Endpoint={EmulatorServiceUri};Key={ApiKey}
 Endpoint={Endpoint};Key={Key};Model={Model}
 ```
 
-#### Aspire.Hosting.GitHub.Models
-
-```
-Endpoint=https://models.github.ai/inference;Key={Key};Model={ModelName}
-```
-
 ### Client integration connection string requirements
 
 #### Aspire.OpenAI
@@ -286,7 +238,7 @@ Expects connection strings in the format:
 Endpoint={Endpoint};EndpointAIInference={EndpointAIInference};Key={Key};Deployment={DeploymentName};Model={ModelName}
 ```
 
-Uses either `Deployment` or `Model` (in that order). `Deployment` is set by `Aspire.Hosting.Azure.CognitiveServices` while `Model` is set by `Aspire.Hosting.GitHub.Models`.
+Uses either `Deployment` or `Model` (in that order).
 
 Uses `EndpointAIInference` if available, otherwise `Endpoint`.
 


### PR DESCRIPTION
## Summary

- Mark GitHub Models as retired for all customers and the `Aspire.Hosting.GitHub.Models` integration as discontinued and removed after its final Aspire 13.5 release.
- Direct users to migrate to Microsoft Foundry while retaining the existing integration pages as historical reference.
- Remove the discontinued integration from the current AI compatibility matrix.

Related to microsoft/aspire#18953 and the product removal in microsoft/aspire#19848.

## Third-party links and affiliations

Adds GitHub's official retirement notice and GitHub Models documentation. GitHub is a Microsoft subsidiary.

## Validation

- `pnpm --dir .\src\frontend run test:unit:twoslash-blocks`
- `git diff --check`
- Verified the official GitHub retirement notice and GitHub Models documentation links.