### PR TITLE
Add six-language AppHost integration documentation

### DIFF
--- a/src/frontend/src/content/docs/app-host/go-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/go-apphost.mdx
@@ -136,6 +136,6 @@ Add `.aspire/` to `.gitignore`. The generated Go module can be recreated from `a
 
 ## See also
 
-- [Build your first Aspire app](/get-started/first-app/?lang=go)
+- [Build your first Aspire app](/get-started/first-app/?aspire-lang=go)
 - [Multi-language architecture](/architecture/multi-language-architecture/)
 - [Author multi-language integrations](/extensibility/multi-language-integration-authoring/)

--- a/src/frontend/src/content/docs/app-host/java-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/java-apphost.mdx
@@ -122,6 +122,6 @@ Keep the scaffolded `.gitignore`. Generated `.aspire` content and compiled AppHo
 
 ## See also
 
-- [Build your first Aspire app](/get-started/first-app/?lang=java)
+- [Build your first Aspire app](/get-started/first-app/?aspire-lang=java)
 - [Multi-language architecture](/architecture/multi-language-architecture/)
 - [Author multi-language integrations](/extensibility/multi-language-integration-authoring/)

--- a/src/frontend/src/content/docs/app-host/python-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/python-apphost.mdx
@@ -118,6 +118,6 @@ Add `.aspire/` and the AppHost virtual environment to `.gitignore`. Both can be 
 
 ## See also
 
-- [Build your first Aspire app](/get-started/first-app/?lang=python)
+- [Build your first Aspire app](/get-started/first-app/?aspire-lang=python)
 - [Multi-language architecture](/architecture/multi-language-architecture/)
 - [Author multi-language integrations](/extensibility/multi-language-integration-authoring/)

--- a/src/frontend/src/content/docs/app-host/rust-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/rust-apphost.mdx
@@ -128,6 +128,6 @@ Add `.aspire/` and Cargo build output to `.gitignore`. The generated module can 
 
 ## See also
 
-- [Build your first Aspire app](/get-started/first-app/?lang=rust)
+- [Build your first Aspire app](/get-started/first-app/?aspire-lang=rust)
 - [Multi-language architecture](/architecture/multi-language-architecture/)
 - [Author multi-language integrations](/extensibility/multi-language-integration-authoring/)

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-get-started.mdx
@@ -64,27 +64,29 @@ Getting there is a two-step process: model the GitHub Model resource in your App
 
 1. ### Model GitHub Models in your AppHost
 
-    Add the GitHub Models hosting integration to your AppHost, then declare a model resource and reference it from the apps that need to call the API. The [GitHub Models hosting integration](/integrations/ai/github-models/github-models-host/) article walks through every capability — adding model resources, API key parameters, organization configuration, and health checks — with side-by-side C# and TypeScript examples.
+   Add the GitHub Models hosting integration to your AppHost, then declare a model resource and reference it from the apps that need to call the API. The [GitHub Models hosting integration](/integrations/ai/github-models/github-models-host/) article walks through every capability — adding model resources, API key parameters, organization configuration, and health checks — with examples for C#, TypeScript, Python, Go, Java, and Rust.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/github-models/github-models-host/'>
-        Set up GitHub Models in the AppHost
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/ai/github-models/github-models-host/"
+   >
+     Set up GitHub Models in the AppHost
+   </LinkButton>
 
 2. ### Connect from your consuming app
 
-    When you reference a GitHub Model resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
+   When you reference a GitHub Model resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to GitHub Models](/integrations/ai/github-models/github-models-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/github-models/github-models-connect/'>
-        Connect to GitHub Models
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/ai/github-models/github-models-connect/"
+   >
+     Connect to GitHub Models
+   </LinkButton>
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
@@ -23,7 +23,7 @@ import githubIcon from '@assets/icons/github-icon.png';
 The GitHub Models service is **no longer available to new customers**. The `Aspire.Hosting.GitHub.Models` integration is sunset as of Aspire 13.5. All public APIs are marked `[Obsolete]` and the package no longer appears in `aspire add` output. The package will ship one final obsolete release on NuGet and will be removed entirely in a future version. For new and existing apps, use the [Azure AI Foundry integration](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/) instead, which provides access to a broad catalog of models — including OpenAI's GPT models — and supports local development with `RunAsFoundryLocal()`. See [microsoft/aspire#18402](https://github.com/microsoft/aspire/issues/18402) for details.
 :::
 
-This article is the reference for the Aspire GitHub Models hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model GitHub Model resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire GitHub Models hosting integration. It shows the generated AppHost APIs for C#, TypeScript, Python, Go, Java, and Rust that model GitHub Model resources.
 
 If you're new to the GitHub Models integration, start with the [Get started with GitHub Models integrations](/integrations/ai/github-models/github-models-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to GitHub Models](../github-models-connect/).
 
@@ -39,7 +39,8 @@ aspire add github-models
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -60,10 +61,63 @@ aspire add github-models
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the GitHub Models hosting integration package:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "Aspire.Hosting.GitHub.Models": "%ASPIRE_VERSION%"
+  }
+}
+```
+
+</Fragment>
+<Fragment slot="python">
+
+The package is obsolete and no longer appears in `aspire add` results. Add it directly to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "Aspire.Hosting.GitHub.Models": "%ASPIRE_VERSION%"
+  }
+}
+```
+
+</Fragment>
+<Fragment slot="go">
+
+The package is obsolete and no longer appears in `aspire add` results. Add it directly to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "Aspire.Hosting.GitHub.Models": "%ASPIRE_VERSION%"
+  }
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+The package is obsolete and no longer appears in `aspire add` results. Add it directly to `aspire.config.json`:
+
+```json title="aspire.config.json" ins={3}
+{
+  "packages": {
+    "Aspire.Hosting.GitHub.Models": "%ASPIRE_VERSION%"
+  }
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The package is obsolete and no longer appears in `aspire add` results. Add it directly to `aspire.config.json`:
 
 ```json title="aspire.config.json" ins={3}
 {
@@ -88,10 +142,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 var chat = builder.AddGitHubModel("chat", GitHubModel.OpenAI.OpenAIGpt4oMini);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -105,22 +160,112 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+chat = builder.add_git_hub_model("chat", "OpenAIGpt4oMini")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	chat := builder.AddGitHubModel(
+		"chat",
+		aspire.GitHubModelNameOpenAIGpt4oMini,
+	)
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var chat = builder.addGitHubModel(
+        "chat",
+        GitHubModelName.OPEN_AIGPT4O_MINI);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let chat = builder.add_git_hub_model(
+        "chat",
+        GitHubModelName::OpenAIGpt4oMini,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Steps>
 
-1. Calling `AddGitHubModel` (or `addGitHubModel`) creates a `GitHubModelResource`. It registers a secret parameter for the API key that defaults to the `GITHUB_TOKEN` environment variable.
+1. Adding a GitHub Model creates a `GitHubModelResource`. It registers a secret parameter for the API key that defaults to the `GITHUB_TOKEN` environment variable.
 
-1. The model identifier selects which GitHub-hosted model to target. In C#, use the strongly-typed `GitHubModel` constants grouped by publisher; in TypeScript, use the `GitHubModelName` enum.
+1. The model identifier selects which GitHub-hosted model to target. C# uses publisher-grouped `GitHubModel` constants. TypeScript, Python, Go, Java, and Rust use generated `GitHubModelName` values in each language's naming convention.
 
-1. The AppHost reference call configures a connection in the consuming project named after the resource (for example, `chat` in the preceding example).
+1. When a consuming resource references the model, Aspire configures a connection named after that resource, such as `chat`.
 
 </Steps>
 
 <Aside type="note">
-    When you reference a GitHub Model resource from the AppHost, Aspire makes several properties available to the consuming project, such as the endpoint URI, API key, and model name. For a complete list of these properties and per-language connection examples, see [Connect to GitHub Models](../github-models-connect/).
+  When you reference a GitHub Model resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the endpoint
+  URI, API key, and model name. For a complete list of these properties and
+  per-language connection examples, see [Connect to GitHub
+  Models](../github-models-connect/).
 </Aside>
 
 ## Use a model identifier string
@@ -135,10 +280,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -152,21 +298,105 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+chat = builder.add_git_hub_model_by_id("chat", "openai/gpt-4o-mini")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	chat := builder.AddGitHubModelById("chat", "openai/gpt-4o-mini")
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var chat = builder.addGitHubModelById(
+        "chat",
+        "openai/gpt-4o-mini");
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let chat = builder.add_git_hub_model_by_id(
+        "chat",
+        "openai/gpt-4o-mini",
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="tip">
   In C#, use the strongly-typed `GitHubModel` constants to avoid typos — they're
   grouped by publisher (for example, `GitHubModel.OpenAI.OpenAIGpt4oMini`,
-  `GitHubModel.Microsoft.Phi4MiniInstruct`, `GitHubModel.DeepSeek.DeepSeekV30324`).
-  In TypeScript, use the `GitHubModelName` enum (for example,
-  `GitHubModelName.OpenAIGpt4oMini`, `GitHubModelName.DeepSeekV30324`).
+  `GitHubModel.Microsoft.Phi4MiniInstruct`,
+  `GitHubModel.DeepSeek.DeepSeekV30324`). In TypeScript, use the
+  `GitHubModelName` enum (for example, `GitHubModelName.OpenAIGpt4oMini`,
+  `GitHubModelName.DeepSeekV30324`).
 </Aside>
 
 ## Use default API key parameter
 
-Calling `AddGitHubModel("chat", ...)` (or `addGitHubModel("chat", ...)`) automatically creates a secret parameter named `chat-gh-apikey`. Aspire resolves its value in this order:
+Adding a GitHub Model named `chat` automatically creates a secret parameter named `chat-gh-apikey`. Aspire resolves its value in this order:
 
 1. The `Parameters:chat-gh-apikey` configuration key (user secrets, `appsettings.*`, or environment variables).
 2. The `GITHUB_TOKEN` environment variable.
@@ -179,7 +409,7 @@ aspire secret set Parameters:chat-gh-apikey github_pat_YOUR_TOKEN_HERE
 
 ## Use a custom API key parameter
 
-Replace the default parameter by creating your own secret parameter and passing it to `WithApiKey` (or `withApiKey`):
+Replace the default parameter by creating your own secret parameter and passing it to the generated API-key method:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -189,13 +419,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 var apiKey = builder.AddParameter("my-gh-token", secret: true);
 
 var chat = builder.AddGitHubModel("chat", GitHubModel.OpenAI.OpenAIGpt4oMini)
-                  .WithApiKey(apiKey);
+.WithApiKey(apiKey);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -212,11 +443,115 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+api_key = builder.add_parameter("my-gh-token", secret=True)
+chat = builder.add_git_hub_model(
+"chat",
+"OpenAIGpt4oMini",
+).with_api_key(api_key)
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secret := true
+	apiKey := builder.AddParameter(
+		"my-gh-token",
+		&aspire.AddParameterOptions{Secret: &secret},
+	)
+	chat := builder.AddGitHubModel(
+		"chat",
+		aspire.GitHubModelNameOpenAIGpt4oMini,
+	).WithApiKey(apiKey)
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var apiKey = builder.addParameter(
+        "my-gh-token",
+        new AddParameterOptions().secret(true));
+    var chat = builder.addGitHubModel(
+        "chat",
+        GitHubModelName.OPEN_AIGPT4O_MINI).withApiKey(apiKey);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api_key = builder.add_parameter("my-gh-token", None, None, Some(true))?;
+    let chat = builder
+        .add_git_hub_model(
+            "chat",
+            GitHubModelName::OpenAIGpt4oMini,
+            None,
+        )?
+        .with_api_key(&api_key)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
-<Aside type="note">Parameters marked <code>secret: true</code> are stored in the user secrets store and never appear in plain text in logs or the dashboard.</Aside>
+<Aside type="note">
+  Parameters marked <code>secret: true</code> are stored in the user secrets
+  store and never appear in plain text in logs or the dashboard.
+</Aside>
 
 ## Specify an organization
 
@@ -232,10 +567,11 @@ var organization = builder.AddParameter("github-org");
 var chat = builder.AddGitHubModel("chat", GitHubModel.OpenAI.OpenAIGpt4oMini, organization);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -253,7 +589,103 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+organization = builder.add_parameter("github-org")
+chat = builder.add_git_hub_model(
+"chat",
+"OpenAIGpt4oMini",
+organization=organization,
+)
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	organization := builder.AddParameter("github-org")
+	chat := builder.AddGitHubModel(
+		"chat",
+		aspire.GitHubModelNameOpenAIGpt4oMini,
+		&aspire.AddGitHubModelOptions{Organization: &organization},
+	)
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var organization = builder.addParameter("github-org");
+    var chat = builder.addGitHubModel(
+        "chat",
+        GitHubModelName.OPEN_AIGPT4O_MINI,
+        organization);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let organization = builder.add_parameter("github-org", None, None, None)?;
+    let chat = builder.add_git_hub_model(
+        "chat",
+        GitHubModelName::OpenAIGpt4oMini,
+        Some(&organization),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -269,13 +701,14 @@ Add an optional health check to verify endpoint reachability and API key validit
 var builder = DistributedApplication.CreateBuilder(args);
 
 var chat = builder.AddGitHubModel("chat", GitHubModel.OpenAI.OpenAIGpt4oMini)
-                  .WithHealthCheck();
+.WithHealthCheck();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -290,7 +723,98 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+chat = builder.add_git_hub_model(
+"chat",
+"OpenAIGpt4oMini",
+).enable_health_check()
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	chat := builder.AddGitHubModel(
+		"chat",
+		aspire.GitHubModelNameOpenAIGpt4oMini,
+	).EnableHealthCheck()
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var chat = builder.addGitHubModel(
+        "chat",
+        GitHubModelName.OPEN_AIGPT4O_MINI).enableHealthCheck();
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let chat = builder
+        .add_git_hub_model(
+            "chat",
+            GitHubModelName::OpenAIGpt4oMini,
+            None,
+        )?
+        .enable_health_check()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -302,21 +826,22 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 ## Available models
 
-GitHub Models supports a broad and growing catalog of models. Use the strongly-typed constants for the most accurate list:
+GitHub Models supports a broad and growing catalog of models. Use the strongly typed constants for the most accurate list. The table shows the C# and TypeScript spellings; Python, Go, Java, and Rust generate the same `GitHubModelName` values using each language's enum or literal conventions.
 
-| Publisher  | C# constant (examples)                             | TypeScript enum (examples)                          |
-| ---------- | --------------------------------------------------- | --------------------------------------------------- |
-| OpenAI     | `GitHubModel.OpenAI.OpenAIGpt4oMini`               | `GitHubModelName.OpenAIGpt4oMini`                   |
-| OpenAI     | `GitHubModel.OpenAI.OpenAIGpt41Mini`               | `GitHubModelName.OpenAIGpt41Mini`                   |
-| DeepSeek   | `GitHubModel.DeepSeek.DeepSeekV30324`              | `GitHubModelName.DeepSeekV30324`                    |
-| DeepSeek   | `GitHubModel.DeepSeek.DeepSeekR1`                  | `GitHubModelName.DeepSeekR1`                        |
-| Microsoft  | `GitHubModel.Microsoft.Phi4MiniInstruct`           | `GitHubModelName.Phi4MiniInstruct` *(see note)*     |
-| Meta       | `GitHubModel.Meta.MetaLlama318BInstruct`           | `GitHubModelName.MetaLlama318BInstruct`             |
+| Publisher | C# constant (examples)                   | TypeScript enum (examples)                      |
+| --------- | ---------------------------------------- | ----------------------------------------------- |
+| OpenAI    | `GitHubModel.OpenAI.OpenAIGpt4oMini`     | `GitHubModelName.OpenAIGpt4oMini`               |
+| OpenAI    | `GitHubModel.OpenAI.OpenAIGpt41Mini`     | `GitHubModelName.OpenAIGpt41Mini`               |
+| DeepSeek  | `GitHubModel.DeepSeek.DeepSeekV30324`    | `GitHubModelName.DeepSeekV30324`                |
+| DeepSeek  | `GitHubModel.DeepSeek.DeepSeekR1`        | `GitHubModelName.DeepSeekR1`                    |
+| Microsoft | `GitHubModel.Microsoft.Phi4MiniInstruct` | `GitHubModelName.Phi4MiniInstruct` _(see note)_ |
+| Meta      | `GitHubModel.Meta.MetaLlama318BInstruct` | `GitHubModelName.MetaLlama318BInstruct`         |
 
 <Aside type="note">
   In TypeScript, the `GitHubModelName` enum is a single flat list and does not
   use publisher-grouped sub-namespaces. This is a known gap compared to the C#
-  API. Check the enum values in `.aspire/modules/aspire.mjs` for the complete list.
+  API. Check the enum values in `.aspire/modules/aspire.mjs` for the complete
+  list.
 </Aside>
 
 For the full catalogue, visit the [GitHub Models Marketplace](https://github.com/marketplace/models).

--- a/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/github-models/github-models-host.mdx
@@ -481,6 +481,10 @@ func main() {
 		"my-gh-token",
 		&aspire.AddParameterOptions{Secret: &secret},
 	)
+	if err := apiKey.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := builder.AddGitHubModel(
 		"chat",
 		aspire.GitHubModelNameOpenAIGpt4oMini,
@@ -624,6 +628,10 @@ func main() {
 	}
 
 	organization := builder.AddParameter("github-org")
+	if err := organization.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := builder.AddGitHubModel(
 		"chat",
 		aspire.GitHubModelNameOpenAIGpt4oMini,

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -172,6 +172,10 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama")
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	llama3 := ollama.AddModel("llama3")
 	if err := llama3.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -291,6 +295,9 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama")
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	// Add by model name - resource name is generated automatically
 	phi35 := ollama.AddModel("phi3.5")
@@ -397,6 +404,10 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama").WithDataVolume()
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	llama3 := ollama.AddModel("llama3")
 	if err := llama3.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -538,6 +549,10 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama").WithGPUSupport()
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	model := ollama.AddModel("llama3")
 	if err := model.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -574,6 +589,10 @@ func main() {
 	ollama := builder.AddOllama("ollama").WithGPUSupport(
 		&aspire.WithGPUSupportOptions{Vendor: &vendor},
 	)
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	model := ollama.AddModel("llama3")
 	if err := model.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -669,6 +688,10 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama")
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	llama := ollama.AddHuggingFaceModel(
 		"llama",
 		"bartowski/Llama-3.2-1B-Instruct-GGUF:IQ4_XS",
@@ -758,6 +781,10 @@ func main() {
 		"ollama",
 		&aspire.AddOllamaOptions{Port: &port},
 	)
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	model := ollama.AddModel("llama3")
 	if err := model.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -840,6 +867,10 @@ func main() {
 	}
 
 	ollama := builder.AddOllama("ollama").WithOpenWebUI()
+	if err := ollama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	model := ollama.AddModel("llama3")
 	if err := model.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))

--- a/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/ollama/ollama-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Ollama in the AppHost
-seoTitle: "Set up Ollama in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Ollama in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Ollama hosting integration to orchestrate and configure Ollama models in an Aspire solution.
 ---
 
@@ -23,7 +23,7 @@ import ollamaIcon from '@assets/icons/ollama-icon.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire Ollama hosting integration from the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire). It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model an Ollama server and its model resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Ollama hosting integration from the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire). It shows the generated AppHost APIs for C#, TypeScript, Python, and Go that model an Ollama server and its model resources. The daily Java and Rust generators currently have package-level output conflicts, documented with each example.
 
 If you're new to the Ollama integration, start with the [Get started with Ollama integrations](/integrations/ai/ollama/ollama-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Ollama](../ollama-connect/).
 
@@ -31,7 +31,10 @@ If you're new to the Ollama integration, start with the [Get started with Ollama
 
 To start building an Aspire app that uses Ollama, install the [📦 CommunityToolkit.Aspire.Hosting.Ollama](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Ollama) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -39,7 +42,8 @@ aspire add ollama --source CommunityToolkit
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -60,7 +64,8 @@ aspire add ollama --source CommunityToolkit
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Ollama hosting integration package:
@@ -74,8 +79,29 @@ This updates your `aspire.config.json` with the Ollama hosting integration packa
 ```
 
 <Aside type="note">
-  The TypeScript AppHost bindings for Ollama are provided by the Community Toolkit package and are not part of the core Aspire TypeScript SDK. The `.aspire/modules/aspire.mjs` file in your project will include `addOllama` and related APIs after installation.
+  The generated Ollama AppHost bindings come from the Community Toolkit package
+  rather than the core Aspire SDK. After installation, TypeScript, Python, and
+  Go AppHosts include `addOllama` or its language-specific equivalent in
+  `.aspire/modules`.
 </Aside>
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add ollama --source CommunityToolkit
+```
+
+This updates `aspire.config.json` with the Ollama hosting integration package.
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add ollama --source CommunityToolkit
+```
+
+This updates `aspire.config.json` with the Ollama hosting integration package.
 
 </Fragment>
 </AppHostTabs>
@@ -84,7 +110,10 @@ This updates your `aspire.config.json` with the Ollama hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add an Ollama server resource and then add model resources as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -93,10 +122,11 @@ var ollama = builder.AddOllama("ollama");
 var llama3 = ollama.AddModel("llama3");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(llama3);
+.WithReference(llama3);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -111,7 +141,52 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(llama3);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama")
+llama3 = ollama.add_model("llama3")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama")
+	llama3 := ollama.AddModel("llama3")
+	if err := llama3.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -121,19 +196,25 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 1. The resource name passed to `AddOllama` is used as the connection string name when referenced in a dependency. Model sub-resources are named by sanitizing the model name (for example, `"llama3"` produces the resource name `"ollama-llama3"`).
 
-1. The AppHost reference call configures a connection in the consuming project named after the referenced model resource.
+1. When a consuming resource references the model, Aspire configures a connection named after that model resource.
 
 </Steps>
 
 <Aside type="note">
-    When you reference an Ollama model resource from the AppHost, Aspire makes several properties available to the consuming project, such as the HTTP endpoint, host, and port. For a complete list of these properties and per-language connection examples, see [Connect to Ollama](../ollama-connect/).
+  When you reference an Ollama model resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the HTTP
+  endpoint, host, and port. For a complete list of these properties and
+  per-language connection examples, see [Connect to Ollama](../ollama-connect/).
 </Aside>
 
 ## Add Ollama model resource
 
-Models are sub-resources of an Ollama server resource. You add them with the `AddModel` (or `addModel`) method. Each model is downloaded when the Ollama container first starts.
+Models are sub-resources of an Ollama server resource. Add them with the generated model methods. Each model is downloaded when the Ollama container first starts.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -147,11 +228,12 @@ var phi35 = ollama.AddModel("phi3.5");
 var llama3 = ollama.AddModel("ollama-llama3", "llama3");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(phi35)
-    .WithReference(llama3);
+.WithReference(phi35)
+.WithReference(llama3);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -172,7 +254,67 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(llama3);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama")
+
+    # Add by model name - resource name is generated automatically
+    phi35 = ollama.add_model("phi3.5")
+
+    # Add with an explicit resource name
+    llama3 = ollama.add_model("llama3", name="ollama-llama3")
+
+    builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama")
+
+	// Add by model name - resource name is generated automatically
+	phi35 := ollama.AddModel("phi3.5")
+
+	// Add with an explicit resource name
+	llama3 := ollama.AddNamedModel("ollama-llama3", "llama3")
+
+	if err := phi35.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := llama3.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -189,21 +331,25 @@ When the Ollama container for this integration first spins up, it downloads the 
 
 Add a data volume to the Ollama resource to persist downloaded models across container restarts:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var ollama = builder.AddOllama("ollama")
-    .WithDataVolume();
+.WithDataVolume();
 
 var llama3 = ollama.AddModel("llama3");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(llama3);
+.WithReference(llama3);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -220,7 +366,52 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(llama3);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama").with_data_volume()
+llama3 = ollama.add_model("llama3")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama").WithDataVolume()
+	llama3 := ollama.AddModel("llama3")
+	if err := llama3.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -228,9 +419,12 @@ The data volume is mounted at `/root/.ollama` in the Ollama container. When a `n
 
 ## Use GPUs when available
 
-By default, the Ollama container runs on CPU. To enable GPU acceleration, use the `WithGPUSupport` (or `withGPUSupport`) extension method:
+By default, the Ollama container runs on CPU. To enable GPU acceleration, use the generated GPU-support method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 
 **Nvidia:**
@@ -269,10 +463,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ollama = await builder.addOllama("ollama");
+const ollama = await builder.addOllama('ollama');
 await ollama.withGPUSupport();
 
-await ollama.addModel("llama3");
+await ollama.addModel('llama3');
 
 // After adding all resources, run the app...
 ```
@@ -284,17 +478,116 @@ import { createBuilder, OllamaGpuVendor } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ollama = await builder.addOllama("ollama");
+const ollama = await builder.addOllama('ollama');
 await ollama.withGPUSupport({ vendor: OllamaGpuVendor.AMD });
 
-await ollama.addModel("llama3");
+await ollama.addModel('llama3');
 
 // After adding all resources, run the app...
 ```
 
 <Aside type="note">
-  In TypeScript, select the GPU vendor with the `OllamaGpuVendor` enum imported from the generated `.aspire/modules/aspire.mjs` — for example, `OllamaGpuVendor.AMD` or `OllamaGpuVendor.Nvidia`.
+  In TypeScript, select the GPU vendor with the `OllamaGpuVendor` enum imported
+  from the generated `.aspire/modules/aspire.mjs` — for example,
+  `OllamaGpuVendor.AMD` or `OllamaGpuVendor.Nvidia`.
 </Aside>
+
+</Fragment>
+<Fragment slot="python">
+
+**Nvidia:**
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ollama = builder.add_ollama("ollama").with_gpu_support()
+    ollama.add_model("llama3")
+    builder.run()
+```
+
+**AMD:**
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ollama = builder.add_ollama("ollama").with_gpu_support(vendor="AMD")
+    ollama.add_model("llama3")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+**Nvidia:**
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama").WithGPUSupport()
+	model := ollama.AddModel("llama3")
+	if err := model.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+**AMD:**
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	vendor := aspire.OllamaGpuVendorAMD
+	ollama := builder.AddOllama("ollama").WithGPUSupport(
+		&aspire.WithGPUSupportOptions{Vendor: &vendor},
+	)
+	model := ollama.AddModel("llama3")
+	if err := model.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
 
 </Fragment>
 </AppHostTabs>
@@ -303,9 +596,12 @@ For more information, see [GPU support in Docker Desktop](https://docs.docker.co
 
 ## Add a model from Hugging Face
 
-To use a model in GGUF format from [Hugging Face](https://huggingface.co/), use the `AddHuggingFaceModel` (or `addHuggingFaceModel`) extension method:
+To use a model in GGUF format from [Hugging Face](https://huggingface.co/), use the generated Hugging Face model method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -313,14 +609,15 @@ var builder = DistributedApplication.CreateBuilder(args);
 var ollama = builder.AddOllama("ollama");
 
 var llama = ollama.AddHuggingFaceModel(
-    "llama",
-    "bartowski/Llama-3.2-1B-Instruct-GGUF:IQ4_XS");
+"llama",
+"bartowski/Llama-3.2-1B-Instruct-GGUF:IQ4_XS");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(llama);
+.WithReference(llama);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -338,7 +635,58 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(llama);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama")
+llama = ollama.add_hugging_face_model(
+"llama",
+"bartowski/Llama-3.2-1B-Instruct-GGUF:IQ4_XS",
+)
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama")
+	llama := ollama.AddHuggingFaceModel(
+		"llama",
+		"bartowski/Llama-3.2-1B-Instruct-GGUF:IQ4_XS",
+	)
+	if err := llama.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -348,7 +696,10 @@ Only models in GGUF format are supported. The integration automatically prefixes
 
 To use a fixed port for the Ollama container, pass it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -358,7 +709,8 @@ var ollama = builder.AddOllama("ollama", port: 11434);
 ollama.AddModel("llama3");
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -371,7 +723,56 @@ const ollama = await builder.addOllama("ollama", { port: 11434 });
 await ollama.addModel("llama3");
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama", port=11434)
+ollama.add_model("llama3")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	port := float64(11434)
+	ollama := builder.AddOllama(
+		"ollama",
+		&aspire.AddOllamaOptions{Port: &port},
+	)
+	model := ollama.AddModel("llama3")
+	if err := model.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -379,18 +780,22 @@ await ollama.addModel("llama3");
 
 The Ollama integration also provides support for running [Open WebUI](https://openwebui.com/) alongside the Ollama container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  java: 'The daily Java generator cannot emit this Community Toolkit package because it produces duplicate OllamaGpuVendor.java outputs.',
+  rust: 'The daily Rust generator emits conflicting OllamaGpuVendor types for this package, so the generated SDK does not compile.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var ollama = builder.AddOllama("ollama")
-    .WithOpenWebUI();
+.WithOpenWebUI();
 
 ollama.AddModel("llama3");
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -404,7 +809,51 @@ await ollama.withOpenWebUI();
 await ollama.addModel("llama3");
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+ollama = builder.add_ollama("ollama").with_open_web_ui()
+ollama.add_model("llama3")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	ollama := builder.AddOllama("ollama").WithOpenWebUI()
+	model := ollama.AddModel("llama3")
+	if err := model.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
 
 </Fragment>
 </AppHostTabs>

--- a/src/frontend/src/content/docs/integrations/ai/openai/openai-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/openai/openai-get-started.mdx
@@ -61,27 +61,29 @@ Getting there is a two-step process: model the OpenAI resources in your AppHost,
 
 1. ### Model OpenAI in your AppHost
 
-    Add the OpenAI hosting integration to your AppHost, then declare an OpenAI parent resource and one or more model resources, and reference them from the apps that need to call the API. The [OpenAI hosting integration](/integrations/ai/openai/openai-host/) article walks through every capability — adding models, API key parameters, endpoint overrides, and health checks — with side-by-side C# and TypeScript examples.
+   Add the OpenAI hosting integration to your AppHost, then declare an OpenAI parent resource and one or more model resources, and reference them from the apps that need to call the API. The [OpenAI hosting integration](/integrations/ai/openai/openai-host/) article walks through every capability — adding models, API key parameters, endpoint overrides, and health checks — with examples for C#, TypeScript, Python, Go, Java, and Rust.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/openai/openai-host/'>
-        Set up OpenAI in the AppHost
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/ai/openai/openai-host/"
+   >
+     Set up OpenAI in the AppHost
+   </LinkButton>
 
 2. ### Connect from your consuming app
 
-    When you reference an OpenAI model resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to OpenAI](/integrations/ai/openai/openai-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
+   When you reference an OpenAI model resource from a consuming app, Aspire injects its connection information as environment variables. See [Connect to OpenAI](/integrations/ai/openai/openai-connect/) for the connection properties reference and per-language examples for C#, Go, Python, and TypeScript — including the full C# client integration.
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/ai/openai/openai-connect/'>
-        Connect to OpenAI
-    </LinkButton>
+   <LinkButton
+     variant="secondary"
+     iconPlacement="end"
+     icon="right-arrow"
+     href="/integrations/ai/openai/openai-connect/"
+   >
+     Connect to OpenAI
+   </LinkButton>
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/ai/openai/openai-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/openai/openai-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up OpenAI in the AppHost
-seoTitle: "Set up OpenAI in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up OpenAI in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire OpenAI hosting integration to orchestrate and configure OpenAI resources in an Aspire solution.
 ---
 
@@ -20,7 +20,7 @@ import openaiIcon from '@assets/icons/openai-icon.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire OpenAI hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model an OpenAI parent resource and model resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire OpenAI hosting integration. It shows the generated AppHost APIs for C#, TypeScript, Python, Go, Java, and Rust that model an OpenAI parent resource and its model resources.
 
 If you're new to the OpenAI integration, start with the [Get started with OpenAI integrations](/integrations/ai/openai/openai-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to OpenAI](../openai-connect/).
 
@@ -36,7 +36,8 @@ aspire add openai
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -57,7 +58,8 @@ aspire add openai
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the OpenAI hosting integration package:
@@ -69,6 +71,42 @@ This updates your `aspire.config.json` with the OpenAI hosting integration packa
   }
 }
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add openai
+```
+
+This updates `aspire.config.json` with the OpenAI hosting integration package.
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add openai
+```
+
+This updates `aspire.config.json` with the OpenAI hosting integration package.
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add openai
+```
+
+This updates `aspire.config.json` with the OpenAI hosting integration package.
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add openai
+```
+
+This updates `aspire.config.json` with the OpenAI hosting integration package.
 
 </Fragment>
 </AppHostTabs>
@@ -87,10 +125,11 @@ var openai = builder.AddOpenAI("openai");
 var chat = openai.AddModel("chat", "gpt-4o-mini");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -106,22 +145,106 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+openai = builder.add_open_ai("openai")
+chat = openai.add_model("chat", "gpt-4o-mini")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	openai := builder.AddOpenAI("openai")
+	chat := openai.AddModel("chat", "gpt-4o-mini")
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var openai = builder.addOpenAI("openai");
+    var chat = openai.addModel("chat", "gpt-4o-mini");
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let openai = builder.add_open_ai("openai")?;
+    let chat = openai.add_model("chat", "gpt-4o-mini")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Steps>
 
-1. Calling `AddOpenAI` (or `addOpenAI`) creates an `OpenAIResource` that models the OpenAI account. It registers a secret parameter for the API key that defaults to the `OPENAI_API_KEY` environment variable.
+1. Adding the OpenAI parent creates an `OpenAIResource` that models the OpenAI account. It registers a secret parameter for the API key that defaults to the `OPENAI_API_KEY` environment variable.
 
-1. Calling `AddModel` (or `addModel`) creates an `OpenAIModelResource` child whose connection string is composed from the parent endpoint, API key, and the model name you supply.
+1. Adding a model creates an `OpenAIModelResource` child whose connection string is composed from the parent endpoint, API key, and the model name you supply.
 
-1. The AppHost reference call configures a connection in the consuming project named after the referenced model resource, such as `chat` in the preceding example. Multiple models can share the single API key and endpoint from the parent resource.
+1. When a consuming resource references a model, Aspire configures a connection named after that model resource, such as `chat`. Multiple models can share the single API key and endpoint from the parent resource.
 
 </Steps>
 
 <Aside type="note">
-    When you reference an OpenAI model resource from the AppHost, Aspire makes several properties available to the consuming project, such as the endpoint URI, API key, and model name. For a complete list of these properties and per-language connection examples, see [Connect to OpenAI](../openai-connect/).
+  When you reference an OpenAI model resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the endpoint
+  URI, API key, and model name. For a complete list of these properties and
+  per-language connection examples, see [Connect to OpenAI](../openai-connect/).
 </Aside>
 
 ## Add multiple OpenAI model resources
@@ -139,11 +262,12 @@ var chat = openai.AddModel("chat", "gpt-4o-mini");
 var embeddings = openai.AddModel("embeddings", "text-embedding-3-small");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat)
-    .WithReference(embeddings);
+.WithReference(chat)
+.WithReference(embeddings);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -161,7 +285,95 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(embeddings);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+openai = builder.add_open_ai("openai")
+chat = openai.add_model("chat", "gpt-4o-mini")
+embeddings = openai.add_model("embeddings", "text-embedding-3-small")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	openai := builder.AddOpenAI("openai")
+	chat := openai.AddModel("chat", "gpt-4o-mini")
+	embeddings := openai.AddModel("embeddings", "text-embedding-3-small")
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := embeddings.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var openai = builder.addOpenAI("openai");
+    var chat = openai.addModel("chat", "gpt-4o-mini");
+    var embeddings = openai.addModel("embeddings", "text-embedding-3-small");
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let openai = builder.add_open_ai("openai")?;
+    let chat = openai.add_model("chat", "gpt-4o-mini")?;
+    let embeddings = openai.add_model("embeddings", "text-embedding-3-small")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -169,7 +381,7 @@ Referencing `chat` passes a connection string named `chat` to the project, and r
 
 ## Use default API key parameter
 
-Calling `AddOpenAI("openai")` (or `addOpenAI("openai")`) automatically creates a secret parameter named `openai-openai-apikey`. Aspire resolves its value in this order:
+Adding an OpenAI parent named `openai` automatically creates a secret parameter named `openai-openai-apikey`. Aspire resolves its value in this order:
 
 1. The `Parameters:openai-openai-apikey` configuration key (user secrets, `appsettings.*`, or environment variables).
 2. The `OPENAI_API_KEY` environment variable.
@@ -182,7 +394,7 @@ aspire secret set Parameters:openai-openai-apikey sk-your-api-key
 
 ## Use custom API key parameter
 
-Replace the default parameter by creating your own secret parameter and passing it to `WithApiKey` (or `withApiKey`) on the parent:
+Replace the default parameter by creating your own secret parameter and passing it to the generated API-key method on the parent:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -192,15 +404,16 @@ var builder = DistributedApplication.CreateBuilder(args);
 var apiKey = builder.AddParameter("my-api-key", secret: true);
 
 var openai = builder.AddOpenAI("openai")
-                    .WithApiKey(apiKey);
+.WithApiKey(apiKey);
 
 var chat = openai.AddModel("chat", "gpt-4o-mini");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -219,15 +432,109 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+api_key = builder.add_parameter("my-api-key", secret=True)
+openai = builder.add_open_ai("openai").with_api_key(api_key)
+chat = openai.add_model("chat", "gpt-4o-mini")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secret := true
+	apiKey := builder.AddParameter(
+		"my-api-key",
+		&aspire.AddParameterOptions{Secret: &secret},
+	)
+	openai := builder.AddOpenAI("openai").WithApiKey(apiKey)
+	chat := openai.AddModel("chat", "gpt-4o-mini")
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var apiKey = builder.addParameter(
+        "my-api-key",
+        new AddParameterOptions().secret(true));
+    var openai = builder.addOpenAI("openai").withApiKey(apiKey);
+    var chat = openai.addModel("chat", "gpt-4o-mini");
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api_key = builder.add_parameter("my-api-key", None, None, Some(true))?;
+    let openai = builder.add_open_ai("openai")?.with_api_key(&api_key)?;
+    let chat = openai.add_model("chat", "gpt-4o-mini")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
-<Aside type="note">Parameters marked <code>secret: true</code> are stored in the user secrets store and never appear in plain text in logs or the dashboard.</Aside>
+<Aside type="note">
+  Parameters marked <code>secret: true</code> are stored in the user secrets
+  store and never appear in plain text in logs or the dashboard.
+</Aside>
 
 ## Add a custom endpoint
 
-Override the default `https://api.openai.com/v1` endpoint to use a proxy, an Azure OpenAI endpoint, or any OpenAI-compatible gateway. Call `WithEndpoint` (or `withEndpoint`) on the parent resource:
+Override the default `https://api.openai.com/v1` endpoint to use a proxy, an Azure OpenAI endpoint, or any OpenAI-compatible gateway. Use the generated endpoint method on the parent resource:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -235,15 +542,16 @@ Override the default `https://api.openai.com/v1` endpoint to use a proxy, an Azu
 var builder = DistributedApplication.CreateBuilder(args);
 
 var openai = builder.AddOpenAI("openai")
-                    .WithEndpoint("https://my-gateway.example.com/v1");
+.WithEndpoint("https://my-gateway.example.com/v1");
 
 var chat = openai.AddModel("chat", "gpt-4o-mini");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -260,7 +568,93 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+openai = builder.add_open_ai("openai")
+openai.with_endpoint("https://my-gateway.example.com/v1")
+chat = openai.add_model("chat", "gpt-4o-mini")
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	openai := builder.AddOpenAI("openai").
+		WithEndpoint("https://my-gateway.example.com/v1")
+	chat := openai.AddModel("chat", "gpt-4o-mini")
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var openai = builder.addOpenAI("openai")
+        .withEndpoint("https://my-gateway.example.com/v1");
+    var chat = openai.addModel("chat", "gpt-4o-mini");
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let openai = builder
+        .add_open_ai("openai")?
+        .with_endpoint("https://my-gateway.example.com/v1")?;
+    let chat = openai.add_model("chat", "gpt-4o-mini")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -278,13 +672,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 var openai = builder.AddOpenAI("openai");
 
 var chat = openai.AddModel("chat", "gpt-4o-mini")
-                 .WithHealthCheck();
+.WithHealthCheck();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat);
+.WithReference(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -301,28 +696,115 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
 
 // After adding all resources, run the app...
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+openai = builder.add_open_ai("openai")
+chat = openai.add_model("chat", "gpt-4o-mini").with_health_check()
+builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	openai := builder.AddOpenAI("openai")
+	chat := openai.AddModel("chat", "gpt-4o-mini").WithHealthCheck()
+	if err := chat.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var openai = builder.addOpenAI("openai");
+    var chat = openai.addModel("chat", "gpt-4o-mini")
+        .withHealthCheck();
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let openai = builder.add_open_ai("openai")?;
+    let chat = openai
+        .add_model("chat", "gpt-4o-mini")?
+        .with_health_check()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
 The model health check validates endpoint reachability, API key validity (401), and model existence (404). It executes only once per application instance to limit rate-limit implications.
 
 <Aside type="note">
-In C#, each OpenAI parent resource also automatically registers a status-page health check against `https://status.openai.com/api/v2/status.json`. This status-page check is not currently exposed in the TypeScript AppHost.
+  In C#, each OpenAI parent resource also automatically registers a status-page
+  health check against `https://status.openai.com/api/v2/status.json`. This
+  status-page check is not generated for TypeScript, Python, Go, Java, or Rust
+  AppHosts.
 </Aside>
 
 ## Available models
 
 Common model identifiers for the OpenAI API:
 
-| Category   | Model identifiers |
-| ---------- | ----------------- |
-| Chat       | `gpt-5`, `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo` |
-| Reasoning  | `o3`, `o3-mini`, `o4-mini` |
-| Realtime   | `gpt-realtime` |
+| Category   | Model identifiers                                  |
+| ---------- | -------------------------------------------------- |
+| Chat       | `gpt-5`, `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`    |
+| Reasoning  | `o3`, `o3-mini`, `o4-mini`                         |
+| Realtime   | `gpt-realtime`                                     |
 | Embeddings | `text-embedding-3-small`, `text-embedding-3-large` |
-| Images     | `dall-e-3` |
-| Audio      | `whisper-1` |
+| Images     | `dall-e-3`                                         |
+| Audio      | `whisper-1`                                        |
 
 For the full and up-to-date list, see the [OpenAI models documentation](https://platform.openai.com/docs/models).
 

--- a/src/frontend/src/content/docs/integrations/ai/openai/openai-host.mdx
+++ b/src/frontend/src/content/docs/integrations/ai/openai/openai-host.mdx
@@ -176,6 +176,10 @@ func main() {
 	}
 
 	openai := builder.AddOpenAI("openai")
+	if err := openai.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := openai.AddModel("chat", "gpt-4o-mini")
 	if err := chat.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -317,6 +321,10 @@ func main() {
 	}
 
 	openai := builder.AddOpenAI("openai")
+	if err := openai.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := openai.AddModel("chat", "gpt-4o-mini")
 	embeddings := openai.AddModel("embeddings", "text-embedding-3-small")
 	if err := chat.Err(); err != nil {
@@ -468,7 +476,15 @@ func main() {
 		"my-api-key",
 		&aspire.AddParameterOptions{Secret: &secret},
 	)
+	if err := apiKey.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	openai := builder.AddOpenAI("openai").WithApiKey(apiKey)
+	if err := openai.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := openai.AddModel("chat", "gpt-4o-mini")
 	if err := chat.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -601,6 +617,10 @@ func main() {
 
 	openai := builder.AddOpenAI("openai").
 		WithEndpoint("https://my-gateway.example.com/v1")
+	if err := openai.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := openai.AddModel("chat", "gpt-4o-mini")
 	if err := chat.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
@@ -727,6 +747,10 @@ func main() {
 	}
 
 	openai := builder.AddOpenAI("openai")
+	if err := openai.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	chat := openai.AddModel("chat", "gpt-4o-mini").WithHealthCheck()
 	if err := chat.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Garnet in the AppHost
-seoTitle: "Set up Garnet in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Garnet in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Garnet Hosting integration to orchestrate and configure a Garnet resource in an Aspire solution.
 ---
 
@@ -21,7 +21,7 @@ import garnetIcon from '@assets/icons/garnet-icon.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire Garnet Hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model a Garnet resource in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Garnet Hosting integration. It enumerates the AppHost APIs — with examples across all six supported AppHost languages (C#, TypeScript, Python, Go, Java, and Rust) — that you use to model a Garnet resource in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the Garnet integration, start with the [Get started with Garnet integrations](/integrations/caching/garnet/garnet-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Garnet](../garnet-connect/).
 
@@ -29,7 +29,12 @@ If you're new to the Garnet integration, start with the [Get started with Garnet
 
 To start building an Aspire app that uses Garnet, install the [📦 Aspire.Hosting.Garnet](https://www.nuget.org/packages/Aspire.Hosting.Garnet) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add garnet
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add garnet
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Garnet hosting integration package:
@@ -78,20 +85,29 @@ This updates your `aspire.config.json` with the Garnet hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add a Garnet resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddGarnet("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -104,6 +120,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,7 +135,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a Garnet resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and the password. For a complete list of these properties and per-language connection examples, see [Connect to Garnet](../garnet-connect/).
+  When you reference a Garnet resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and the password. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  Garnet](../garnet-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Garnet" />
@@ -127,21 +148,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the Garnet resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddGarnet("cache")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -155,6 +185,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -164,23 +195,32 @@ The data volume is used to persist Garnet data outside the lifecycle of its cont
 
 Add a data bind mount to the Garnet resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddGarnet("cache")
-    .WithDataBindMount(
-        source: "/Garnet/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/Garnet/Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -194,11 +234,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Garnet data across container restarts. The data bind mount is mounted at the `C:\Garnet\Data` on Windows (or `/Garnet/Data` on Unix) path on the host machine in the Garnet container. As with `WithDataVolume`, this call also enables persistence. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -207,24 +254,33 @@ Data bind mounts rely on the host machine's filesystem to persist Garnet data ac
 
 To configure Garnet snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddGarnet("cache")
-    .WithDataVolume()
-    .WithPersistence(
-        interval: TimeSpan.FromMinutes(5),
-        keysChangedThreshold: 100);
+.WithDataVolume()
+.WithPersistence(
+interval: TimeSpan.FromMinutes(5),
+keysChangedThreshold: 100);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -241,21 +297,28 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
-The preceding code adds explicit persistence to the Garnet resource by snapshotting data at the configured interval. The C# AppHost accepts a `TimeSpan` for `interval` and a `keysChangedThreshold` to also trigger snapshots when a minimum number of keys change; the TypeScript AppHost accepts the interval as milliseconds.
+The preceding code adds explicit persistence to the Garnet resource by snapshotting data at the configured interval. The C# AppHost accepts a `TimeSpan` for `interval` and a `keysChangedThreshold` to also trigger snapshots when a minimum number of keys change; every other AppHost language accepts the interval as milliseconds and doesn't expose `keysChangedThreshold`.
 
 :::note
-The TypeScript `WithPersistenceOptions` does not currently expose `keysChangedThreshold`. If you need threshold-based snapshotting, use the C# AppHost.
+`keysChangedThreshold`-based snapshotting for Garnet is only available from the C# AppHost. TypeScript, Python, Go, Java, and Rust all generate a `WithPersistence` overload that accepts only `interval`.
 :::
 
 ## Add Garnet resource with parameters
 
 When you want to explicitly provide the port and password used by the Garnet container, you can pass them as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -264,12 +327,15 @@ var password = builder.AddParameter("password", secret: true);
 var cache = builder.AddGarnet("cache", port: 6379, password: password);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -284,6 +350,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -293,26 +360,35 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 By default, Aspire injects the Garnet connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddGarnet("cache");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(cache)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["GARNET_HOST"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["GARNET_PORT"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["GARNET_PASSWORD"] = cache.Resource.PasswordParameter;
-    });
+.WithReference(cache)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["GARNET_HOST"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["GARNET_PORT"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["GARNET_PASSWORD"] = cache.Resource.PasswordParameter;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -331,6 +407,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -338,20 +415,29 @@ await builder.build().run();
 
 To reference an externally managed Garnet instance instead of running one as a container, use `AddConnectionString`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddConnectionString("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -365,6 +451,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -372,7 +459,7 @@ With `AddConnectionString` and `addConnectionString`, Aspire resolves `cache` fr
 
 ## Connection properties
 
-For the full reference of Garnet resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to Garnet](../garnet-connect/).
+For the full reference of Garnet resource connection properties — and how consuming apps in C#, TypeScript, Python, Go, Java, and Rust read them — see [Connect to Garnet](../garnet-connect/).
 
 ## Hosting integration health checks
 

--- a/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/garnet/garnet-host.mdx
@@ -30,10 +30,10 @@ If you're new to the Garnet integration, start with the [Get started with Garnet
 To start building an Aspire app that uses Garnet, install the [📦 Aspire.Hosting.Garnet](https://www.nuget.org/packages/Aspire.Hosting.Garnet) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the Garnet hosting integration packa
 Once you've installed the hosting integration in your AppHost project, you can add a Garnet resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -149,10 +149,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the Garnet resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -196,10 +196,10 @@ The data volume is used to persist Garnet data outside the lifecycle of its cont
 Add a data bind mount to the Garnet resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -255,10 +255,10 @@ Data bind mounts rely on the host machine's filesystem to persist Garnet data ac
 To configure Garnet snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -312,10 +312,10 @@ The preceding code adds explicit persistence to the Garnet resource by snapshott
 When you want to explicitly provide the port and password used by the Garnet container, you can pass them as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -361,10 +361,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 By default, Aspire injects the Garnet connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -416,10 +416,10 @@ await builder.build().run();
 To reference an externally managed Garnet instance instead of running one as a container, use `AddConnectionString`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/caching/redis-distributed/redis-distributed-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis-distributed/redis-distributed-host.mdx
@@ -35,7 +35,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +57,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Redis hosting integration package:
@@ -70,6 +72,34 @@ This updates your `aspire.config.json` with the Redis hosting integration packag
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add Redis resource
@@ -78,30 +108,129 @@ Once the hosting integration is installed, add a Redis resource in your AppHost 
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis("cache");
+const cache = await builder.addRedis('cache');
 
-await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(cache);
+await builder.addNodeApp('api', './api', 'index.js').withReference(cache);
 
 // After adding all resources, run the app...
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+
+    builder.add_project(
+        "apiservice",
+        "../ExampleProject/ExampleProject.csproj",
+    ).with_reference(cache)
+
+    builder.run()
+
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddRedis("cache")
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject(
+		"apiservice",
+		"../ExampleProject/ExampleProject.csproj",
+	).WithReference(cache)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var cache = builder.addRedis("cache");
+    builder.addProject(
+        "apiservice",
+        "../ExampleProject/ExampleProject.csproj")
+        .withReference(cache);
+
+}
+
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_redis("cache", None, None)?;
+    builder
+        .add_project(
+            "apiservice",
+            "../ExampleProject/ExampleProject.csproj",
+            None,
+        )?
+        .with_reference(cache.handle().to_json(), None, None, None)?;
+
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -116,7 +245,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-  When you reference a Redis resource from the AppHost, Aspire makes the connection URI, hostname, port, and password available to the consuming project as environment variables. For a complete list of these properties, see [Connect to Redis distributed caching](../redis-distributed-connect/#connection-properties).
+  When you reference a Redis resource from the AppHost, Aspire makes the
+  connection URI, hostname, port, and password available to the consuming
+  project as environment variables. For a complete list of these properties, see
+  [Connect to Redis distributed
+  caching](../redis-distributed-connect/#connection-properties).
 </Aside>
 
 ## Full AppHost API reference

--- a/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis-extensions.mdx
@@ -57,6 +57,34 @@ This updates your `aspire.config.json` with the Redis extensions package:
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Redis.Extensions
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Redis.Extensions
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Redis.Extensions
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add CommunityToolkit.Aspire.Hosting.Redis.Extensions
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add management UI
@@ -101,6 +129,112 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_redis("redis").with_db_gate()
+
+    builder.add_project(
+        "example-project",
+        "../ExampleProject/ExampleProject.csproj",
+    ).with_reference(redis)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.AddRedis("redis").WithDbGate()
+	if err := redis.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	project := builder.
+		AddProject("example-project", "../ExampleProject/ExampleProject.csproj").
+		WithReference(redis)
+	if err := project.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var redis = builder.addRedis("redis").withDbGate();
+    builder.addProject(
+        "example-project",
+        "../ExampleProject/ExampleProject.csproj")
+        .withReference(redis);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let redis = builder
+        .add_redis("redis", None, None)?
+        .with_db_gate(|_| Value::Null, None)?;
+    builder
+        .add_project(
+            "example-project",
+            "../ExampleProject/ExampleProject.csproj",
+            None,
+        )?
+        .with_reference(redis.handle().to_json(), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 This adds a new DbGate resource to the app host which is available from the Aspire dashboard. DbGate is a comprehensive database management tool that provides a web-based interface for managing your Redis databases.
@@ -139,9 +273,90 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_redis("redis").with_dbx()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.AddRedis("redis").WithDbx()
+	if err := redis.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    builder.addRedis("redis").withDbx();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder
+        .add_redis("redis", None, None)?
+        .with_dbx(None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
-The C# overload accepts an optional container configuration callback and `containerName`. The TypeScript binding accepts optional `containerName` and `imageTag` values.
+The C# overload accepts an optional container configuration callback and `containerName`. The generated AppHost bindings accept optional container-name and image-tag values using each language's options shape.
 
 ## See also
 

--- a/src/frontend/src/content/docs/integrations/caching/redis-output/redis-output-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis-output/redis-output-host.mdx
@@ -35,7 +35,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +57,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Redis hosting integration package:
@@ -67,6 +69,34 @@ This updates your `aspire.config.json` with the Redis hosting integration packag
     "Aspire.Hosting.Redis": "*"
   }
 }
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add redis
 ```
 
 </Fragment>
@@ -98,19 +128,110 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis("cache");
+const cache = await builder.addRedis('cache');
 
-await builder.addProject("apiservice", "../ApiService/ApiService.csproj")
-    .withReference(cache);
+await builder
+  .addProject('apiservice', '../ApiService/ApiService.csproj')
+  .withReference(cache);
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+
+    builder.add_project(
+        "apiservice",
+        "../ApiService/ApiService.csproj",
+    ).with_reference(cache)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddRedis("cache")
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject(
+		"apiservice",
+		"../ApiService/ApiService.csproj",
+	).WithReference(cache)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var cache = builder.addRedis("cache");
+    builder.addProject(
+        "apiservice",
+        "../ApiService/ApiService.csproj")
+        .withReference(cache);
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_redis("cache", None, None)?;
+    builder
+        .add_project("apiservice", "../ApiService/ApiService.csproj", None)?
+        .with_reference(cache.handle().to_json(), None, None, None)?;
+
+    Ok(())
+}
 ```
 
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-  When you reference the Redis resource from the AppHost, Aspire injects connection properties — host, port, password, and URI — as environment variables into the consuming project. For the full list and how to read them in C#, see [Connect to Redis output caching](../redis-output-connect/#connection-properties).
+  When you reference the Redis resource from the AppHost, Aspire injects
+  connection properties — host, port, password, and URI — as environment
+  variables into the consuming project. For the full list and how to read them
+  in C#, see [Connect to Redis output
+  caching](../redis-output-connect/#connection-properties).
 </Aside>
 
 ## More AppHost options

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -604,8 +604,6 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 
 </Fragment>
 </AppHostTabs>
-</Fragment>
-</AppHostTabs>
 
 ## Pass custom environment variables
 

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -109,10 +109,10 @@ aspire add redis
 Once you've installed the hosting integration in your AppHost project, you can add a Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -172,10 +172,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -219,10 +219,10 @@ The data volume is used to persist Redis data outside the lifecycle of its conta
 Add a data bind mount to the Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -278,10 +278,10 @@ Data bind mounts rely on the host machine's filesystem to persist Redis data acr
 To configure Redis snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -332,10 +332,10 @@ The preceding code adds explicit persistence to the Redis resource by snapshotti
 When you want to explicitly provide the port and password used by the Redis container, you can pass them as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -381,10 +381,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 [Redis Insight](https://redis.io/insight/) is a free graphical interface for analyzing Redis data. Add it to the Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -430,10 +430,10 @@ The preceding code adds a container based on the `docker.io/redis/redisinsight` 
 To configure the host port for the Redis Insight container, use the `configureContainer` callback as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -481,10 +481,10 @@ The preceding code adds and configures the host port for the Redis Insight conta
 [Redis Commander](https://joeferner.github.io/redis-commander/) is a Node.js web application for viewing, editing, and managing a Redis database. Add it to the Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -530,10 +530,10 @@ The preceding code adds a container based on the `ghcr.io/joeferner/redis-comman
 To configure the host port for the Redis Commander container, use the `configureContainer` callback as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -581,11 +581,11 @@ The preceding code adds and configures the host port for the Redis Commander con
 The `WithClearCommand` method adds a **CLEAR** command button to the Aspire dashboard for the Redis resource. When clicked, it flushes all keys from the Redis database, which is useful during development to reset cache state without restarting the container.
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -612,10 +612,10 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 By default, Aspire injects the Redis connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -667,10 +667,10 @@ await builder.build().run();
 To reference an externally managed Redis instance instead of running one as a container, use `AddConnectionString`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/redis/redis-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Redis in the AppHost
-seoTitle: "Set up Redis in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Redis in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Redis Hosting integration to orchestrate and configure a Redis resource in an Aspire solution.
 ---
 
@@ -37,7 +37,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +59,8 @@ aspire add redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Redis hosting integration package:
@@ -72,26 +74,63 @@ This updates your `aspire.config.json` with the Redis hosting integration packag
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add redis
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add Redis resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -104,6 +143,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,7 +158,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a Redis resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and the password. For a complete list of these properties and per-language connection examples, see [Connect to Redis](../redis-connect/).
+  When you reference a Redis resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and the password. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  Redis](../redis-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Redis" only="Redis" />
@@ -127,21 +171,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -155,6 +208,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -164,23 +218,32 @@ The data volume is used to persist Redis data outside the lifecycle of its conta
 
 Add a data bind mount to the Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithDataBindMount(
-        source: @"C:\Redis\Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: @"C:\Redis\Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -194,11 +257,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Redis data across container restarts. The data bind mount is mounted at the `C:\Redis\Data` on Windows (or `/Redis/Data` on Unix) path on the host machine in the Redis container. As with `WithDataVolume`, this call also enables persistence. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -207,24 +277,33 @@ Data bind mounts rely on the host machine's filesystem to persist Redis data acr
 
 To configure Redis snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithDataVolume()
-    .WithPersistence(
-        interval: TimeSpan.FromMinutes(5),
-        keysChangedThreshold: 100);
+.WithDataVolume()
+.WithPersistence(
+interval: TimeSpan.FromMinutes(5),
+keysChangedThreshold: 100);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -242,6 +321,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -251,8 +331,14 @@ The preceding code adds explicit persistence to the Redis resource by snapshotti
 
 When you want to explicitly provide the port and password used by the Redis container, you can pass them as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -261,12 +347,15 @@ var password = builder.AddParameter("password", secret: true);
 var cache = builder.AddRedis("cache", port: 6379, password: password);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -281,6 +370,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -290,21 +380,30 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 [Redis Insight](https://redis.io/insight/) is a free graphical interface for analyzing Redis data. Add it to the Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithRedisInsight();
+.WithRedisInsight();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -318,6 +417,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -329,21 +429,30 @@ The preceding code adds a container based on the `docker.io/redis/redisinsight` 
 
 To configure the host port for the Redis Insight container, use the `configureContainer` callback as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithRedisInsight(redisInsight => redisInsight.WithHostPort(8001));
+.WithRedisInsight(redisInsight => redisInsight.WithHostPort(8001));
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -361,6 +470,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -370,21 +480,30 @@ The preceding code adds and configures the host port for the Redis Insight conta
 
 [Redis Commander](https://joeferner.github.io/redis-commander/) is a Node.js web application for viewing, editing, and managing a Redis database. Add it to the Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithRedisCommander();
+.WithRedisCommander();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -398,6 +517,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -409,21 +529,30 @@ The preceding code adds a container based on the `ghcr.io/joeferner/redis-comman
 
 To configure the host port for the Redis Commander container, use the `configureContainer` callback as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithRedisCommander(redisCommander => redisCommander.WithHostPort(8081));
+.WithRedisCommander(redisCommander => redisCommander.WithHostPort(8081));
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -441,6 +570,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -450,28 +580,45 @@ The preceding code adds and configures the host port for the Redis Commander con
 
 The `WithClearCommand` method adds a **CLEAR** command button to the Aspire dashboard for the Redis resource. When clicked, it flushes all keys from the Redis database, which is useful during development to reset cache state without restarting the container.
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddRedis("cache")
-    .WithClearCommand();
+.WithClearCommand();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
 
-<Aside type="note">
-    The TypeScript AppHost doesn't currently expose a `withClearCommand()` API for Redis. This feature is only available in the C# AppHost.
-</Aside>
+</Fragment>
+</AppHostTabs>
+</Fragment>
+</AppHostTabs>
 
 ## Pass custom environment variables
 
 By default, Aspire injects the Redis connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -488,8 +635,10 @@ var app = builder.AddExecutable("my-app", "node", "app.js", ".")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -501,13 +650,15 @@ const cacheHost = await cacheEndpoint.property(EndpointProperty.Host);
 const cachePort = await cacheEndpoint.property(EndpointProperty.Port);
 
 await builder.addNodeApp("my-app", "./app", "index.js")
-    .withReference(cache)
-    .withEnvironment("REDIS_HOST", cacheHost)
-    .withEnvironment("REDIS_PORT", cachePort)
-    .withEnvironment("REDIS_PASSWORD", await cache.passwordParameter());
+.withReference(cache)
+.withEnvironment("REDIS_HOST", cacheHost)
+.withEnvironment("REDIS_PORT", cachePort)
+.withEnvironment("REDIS_PASSWORD", await cache.passwordParameter());
 
 await builder.build().run();
+
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -515,8 +666,14 @@ await builder.build().run();
 
 To reference an externally managed Redis instance instead of running one as a container, use `AddConnectionString`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -527,8 +684,10 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -537,11 +696,13 @@ const builder = await createBuilder();
 const cache = await builder.addConnectionString("cache");
 
 await builder.addNodeApp("my-app", "./app", "index.js")
-    .withReference(cache);
+.withReference(cache);
 
 // After adding all resources, run the app...
 await builder.build().run();
+
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -556,3 +717,4 @@ For the full reference of Redis resource connection properties — and how consu
 The Redis hosting integration automatically adds a health check for the Redis resource. The health check verifies that the Redis instance is running and that a connection can be established to it.
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.Redis](https://www.nuget.org/packages/AspNetCore.HealthChecks.Redis) NuGet package.
+```

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
@@ -30,10 +30,10 @@ If you're new to the Valkey integration, start with the [Get started with Valkey
 To start building an Aspire app that uses Valkey, install the [📦 Aspire.Hosting.Valkey](https://www.nuget.org/packages/Aspire.Hosting.Valkey) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the Valkey hosting integration packa
 Once you've installed the hosting integration in your AppHost project, you can add a Valkey resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -149,10 +149,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the Valkey resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -196,10 +196,10 @@ The data volume is used to persist Valkey data outside the lifecycle of its cont
 Add a data bind mount to the Valkey resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -255,10 +255,10 @@ Data bind mounts rely on the host machine's filesystem to persist Valkey data ac
 To configure Valkey snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -309,10 +309,10 @@ The preceding code adds explicit persistence to the Valkey resource by snapshott
 When you want to explicitly provide the port and password used by the Valkey container, you can pass them as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -358,10 +358,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 By default, Aspire injects the Valkey connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -413,10 +413,10 @@ await builder.build().run();
 To reference an externally managed Valkey instance instead of running one as a container, use `AddConnectionString`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
+++ b/src/frontend/src/content/docs/integrations/caching/valkey/valkey-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Valkey in the AppHost
-seoTitle: "Set up Valkey in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Valkey in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Valkey Hosting integration to orchestrate and configure a Valkey resource in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the Valkey integration, start with the [Get started with Valkey
 
 To start building an Aspire app that uses Valkey, install the [📦 Aspire.Hosting.Valkey](https://www.nuget.org/packages/Aspire.Hosting.Valkey) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add valkey
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add valkey
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Valkey hosting integration package:
@@ -78,20 +85,29 @@ This updates your `aspire.config.json` with the Valkey hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add a Valkey resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddValkey("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -104,6 +120,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,7 +135,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a Valkey resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and the password. For a complete list of these properties and per-language connection examples, see [Connect to Valkey](../valkey-connect/).
+  When you reference a Valkey resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and the password. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  Valkey](../valkey-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Valkey" />
@@ -127,21 +148,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the Valkey resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddValkey("cache")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -155,6 +185,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -164,23 +195,32 @@ The data volume is used to persist Valkey data outside the lifecycle of its cont
 
 Add a data bind mount to the Valkey resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddValkey("cache")
-    .WithDataBindMount(
-        source: "/Valkey/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/Valkey/Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -194,11 +234,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Valkey data across container restarts. The data bind mount is mounted at the `C:\Valkey\Data` on Windows (or `/Valkey/Data` on Unix) path on the host machine in the Valkey container. As with `WithDataVolume`, this call also enables persistence. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -207,24 +254,33 @@ Data bind mounts rely on the host machine's filesystem to persist Valkey data ac
 
 To configure Valkey snapshot persistence explicitly, call `WithPersistence` (or `withPersistence`) alongside a data volume or bind mount:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddValkey("cache")
-    .WithDataVolume()
-    .WithPersistence(
-        interval: TimeSpan.FromMinutes(5),
-        keysChangedThreshold: 100);
+.WithDataVolume()
+.WithPersistence(
+interval: TimeSpan.FromMinutes(5),
+keysChangedThreshold: 100);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -242,6 +298,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -251,8 +308,14 @@ The preceding code adds explicit persistence to the Valkey resource by snapshott
 
 When you want to explicitly provide the port and password used by the Valkey container, you can pass them as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -261,12 +324,15 @@ var password = builder.AddParameter("password", secret: true);
 var cache = builder.AddValkey("cache", port: 6379, password: password);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -281,6 +347,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -290,26 +357,35 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 By default, Aspire injects the Valkey connection information using variable names derived from the resource name (for example, `CACHE_URI`, `CACHE_HOST`, `CACHE_PORT`, `CACHE_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddValkey("cache");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(cache)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["VALKEY_HOST"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["VALKEY_PORT"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["VALKEY_PASSWORD"] = cache.Resource.PasswordParameter;
-    });
+.WithReference(cache)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["VALKEY_HOST"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["VALKEY_PORT"] = cache.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["VALKEY_PASSWORD"] = cache.Resource.PasswordParameter;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -328,6 +404,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -335,20 +412,29 @@ await builder.build().run();
 
 To reference an externally managed Valkey instance instead of running one as a container, use `AddConnectionString`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddConnectionString("cache");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -362,6 +448,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
@@ -24,12 +24,12 @@ Aspire provides several AI hosting and client integrations that enable you to wo
 
 The following table shows the compatibility between Aspire AI hosting and client integrations:
 
-| **Hosting Integration** | **Aspire.OpenAI** | **Aspire.Azure.AI.OpenAI** | **Aspire.Azure.AI.Inference** |
-|--|--|--|--|
-| `Aspire.Hosting.Foundry` | ❌ No | ⚠️ Partial | ✅ Yes (preferred) |
-| `Aspire.Hosting.Azure.CognitiveServices` | ❌ No | ✅ Yes (preferred) | ❌ No |
-| `Aspire.Hosting.OpenAI` | ✅ Yes (preferred) | ✅ Yes | ❌ No |
-| `Aspire.Hosting.GitHub.Models` | ⚠️ Partial | ❌ No | ✅ Yes (preferred) |
+| **Hosting Integration**                  | **Aspire.OpenAI**  | **Aspire.Azure.AI.OpenAI** | **Aspire.Azure.AI.Inference** |
+| ---------------------------------------- | ------------------ | -------------------------- | ----------------------------- |
+| `Aspire.Hosting.Foundry`                 | ❌ No              | ⚠️ Partial                 | ✅ Yes (preferred)            |
+| `Aspire.Hosting.Azure.CognitiveServices` | ❌ No              | ✅ Yes (preferred)         | ❌ No                         |
+| `Aspire.Hosting.OpenAI`                  | ✅ Yes (preferred) | ✅ Yes                     | ❌ No                         |
+| `Aspire.Hosting.GitHub.Models`           | ⚠️ Partial         | ❌ No                      | ✅ Yes (preferred)            |
 
 <Aside type="note" title="Legend">
 
@@ -52,7 +52,12 @@ For Microsoft Foundry resources, use the **Aspire.Azure.AI.Inference** client in
 
 The [Aspire.Hosting.Foundry](https://www.nuget.org/packages/Aspire.Hosting.Foundry) package provides the hosting integration. In your app host project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -60,8 +65,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 var foundry = builder.AddFoundry("foundry");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(foundry);
-```
+.WithReference(foundry);
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -73,7 +79,8 @@ const foundry = await builder.addFoundry("foundry");
 
 await builder.addNodeApp("api", "./api", "index.js")
     .withReference(foundry);
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -93,7 +100,12 @@ For Azure OpenAI resources, use the **Aspire.Azure.AI.OpenAI** client integratio
 
 The [Aspire.Hosting.Azure.CognitiveServices](https://www.nuget.org/packages/Aspire.Hosting.Azure.CognitiveServices) package provides the hosting integration. In your app host project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -101,8 +113,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 var openai = builder.AddAzureOpenAI("openai");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(openai);
-```
+.WithReference(openai);
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -114,7 +127,8 @@ const openai = await builder.addAzureOpenAI("openai");
 
 await builder.addNodeApp("api", "./api", "index.js")
     .withReference(openai);
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -134,7 +148,12 @@ For direct OpenAI API access, use the **Aspire.OpenAI** client integration. For 
 
 The [Aspire.Hosting.OpenAI](https://www.nuget.org/packages/Aspire.Hosting.OpenAI) package provides the hosting integration. In your app host project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -142,8 +161,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 var openai = builder.AddOpenAI("openai");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(openai);
-```
+.WithReference(openai);
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -155,7 +175,8 @@ const openai = await builder.addOpenAI("openai");
 
 await builder.addNodeApp("api", "./api", "index.js")
     .withReference(openai);
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -175,7 +196,12 @@ For GitHub Models, use the **Aspire.Azure.AI.Inference** client integration for 
 
 The [Aspire.Hosting.GitHub.Models](https://www.nuget.org/packages/Aspire.Hosting.GitHub.Models) package provides the hosting integration. In your app host project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -183,8 +209,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 var chat = builder.AddGitHubModel("chat", "openai/gpt-4o-mini");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(chat);
-```
+.WithReference(chat);
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -196,7 +223,8 @@ const chat = await builder.addGitHubModelById("chat", "openai/gpt-4o-mini");
 
 await builder.addNodeApp("api", "./api", "index.js")
     .withReference(chat);
-```
+````
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/ai-compatibility-matrix.mdx
@@ -53,10 +53,10 @@ For Microsoft Foundry resources, use the **Aspire.Azure.AI.Inference** client in
 The [Aspire.Hosting.Foundry](https://www.nuget.org/packages/Aspire.Hosting.Foundry) package provides the hosting integration. In your app host project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -101,10 +101,10 @@ For Azure OpenAI resources, use the **Aspire.Azure.AI.OpenAI** client integratio
 The [Aspire.Hosting.Azure.CognitiveServices](https://www.nuget.org/packages/Aspire.Hosting.Azure.CognitiveServices) package provides the hosting integration. In your app host project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -149,10 +149,10 @@ For direct OpenAI API access, use the **Aspire.OpenAI** client integration. For 
 The [Aspire.Hosting.OpenAI](https://www.nuget.org/packages/Aspire.Hosting.OpenAI) package provides the hosting integration. In your app host project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -197,10 +197,10 @@ For GitHub Models, use the **Aspire.Azure.AI.Inference** client integration for 
 The [Aspire.Hosting.GitHub.Models](https://www.nuget.org/packages/Aspire.Hosting.GitHub.Models) package provides the hosting integration. In your app host project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
@@ -35,10 +35,10 @@ To get started with the Aspire AKS hosting integration, install the [📦 Aspire
 After installing the package, add an AKS environment to your AppHost using `AddAzureKubernetesEnvironment`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -80,10 +80,10 @@ Customize the system node pool VM size and scaling using `WithSystemNodePool`:
 <AppHostTabs
   limitations={{
     python:
-      'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-    go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-    java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-    rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+      'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+    go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+    java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+    rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
   }}
 >
   <Fragment slot="csharp">
@@ -102,10 +102,10 @@ Customize the system node pool VM size and scaling using `WithSystemNodePool`:
 Add additional node pools for workload isolation, GPU workloads, or specialized hardware requirements using `AddNodePool`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -139,10 +139,10 @@ await worker.withNodePool(gpuPool);
 Call `AddPersistentVolume` directly on the AKS environment to model durable storage without reaching through to the underlying Kubernetes integration. The call forwards to the AKS environment's Kubernetes publisher, so the same configuration methods and workload-binding APIs described in [Persistent volumes on Kubernetes](/deployment/kubernetes/persistent-volumes/) apply:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
@@ -50,7 +50,7 @@ var api = builder.AddProject<Projects.MyApi>("api");
 
 builder.Build().Run();
 
-````
+```
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -66,7 +66,7 @@ const api = await builder
     .withExternalHttpEndpoints();
 
 await builder.build().run();
-````
+```
 
 </Fragment>
 </AppHostTabs>
@@ -87,13 +87,17 @@ Customize the system node pool VM size and scaling using `WithSystemNodePool`:
   }}
 >
   <Fragment slot="csharp">
-    ```csharp title="AppHost.cs" builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5); ```
+```csharp title="AppHost.cs"
+builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5);
+```
   </Fragment>
   <Fragment slot="typescript">
-    ```typescript title="apphost.mts" const aks = await
-    builder.addAzureKubernetesEnvironment('aks'); await
-    aks.withSystemNodePool('Standard_D4s_v5', 1, 5); ```
+```typescript title="apphost.mts"
+const aks = await builder.addAzureKubernetesEnvironment('aks');
+
+await aks.withSystemNodePool('Standard_D4s_v5', 1, 5);
+```
   </Fragment>
 </AppHostTabs>
 
@@ -115,7 +119,7 @@ var gpuPool = aks.AddNodePool("gpupool", "Standard_NC6s_v3", minCount: 0, maxCou
 builder.AddContainer("ml-worker", "my-ml-image")
 .WithNodePool(gpuPool);
 
-````
+```
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -124,7 +128,7 @@ const gpuPool = await aks.addNodePool('gpupool', 'Standard_NC6s_v3', 0, 5);
 
 const worker = await builder.addContainer('ml-worker', 'my-ml-image');
 await worker.withNodePool(gpuPool);
-````
+```
 
 </Fragment>
 </AppHostTabs>
@@ -154,7 +158,7 @@ var data = aks.AddPersistentVolume("data")
 builder.AddProject<Projects.Api>("api")
 .WithPersistentVolume(data, "/data");
 
-````
+```
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -168,7 +172,7 @@ const api = await builder
     .withHttpEndpoint({ env: 'PORT' })
     .withExternalHttpEndpoints()
     .withKubernetesPersistentVolumeMount(data, "/data");
-````
+```
 
 </Fragment>
 </AppHostTabs>

--- a/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/aks/index.mdx
@@ -34,7 +34,12 @@ To get started with the Aspire AKS hosting integration, install the [📦 Aspire
 
 After installing the package, add an AKS environment to your AppHost using `AddAzureKubernetesEnvironment`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -44,7 +49,8 @@ var aks = builder.AddAzureKubernetesEnvironment("aks");
 var api = builder.AddProject<Projects.MyApi>("api");
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -60,7 +66,8 @@ const api = await builder
     .withExternalHttpEndpoints();
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -70,34 +77,45 @@ When an AKS environment is present, all compute resources are automatically depl
 
 Customize the system node pool VM size and scaling using `WithSystemNodePool`:
 
-<AppHostTabs>
-<Fragment slot="csharp">
-```csharp title="AppHost.cs"
-builder.AddAzureKubernetesEnvironment("aks")
-    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5);
-```
-</Fragment>
-<Fragment slot="typescript">
-```typescript title="apphost.mts"
-const aks = await builder.addAzureKubernetesEnvironment('aks');
-await aks.withSystemNodePool('Standard_D4s_v5', 1, 5);
-```
-</Fragment>
+<AppHostTabs
+  limitations={{
+    python:
+      'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+    go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+    java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+    rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  }}
+>
+  <Fragment slot="csharp">
+    ```csharp title="AppHost.cs" builder.AddAzureKubernetesEnvironment("aks")
+    .WithSystemNodePool("Standard_D4s_v5", minCount: 1, maxCount: 5); ```
+  </Fragment>
+  <Fragment slot="typescript">
+    ```typescript title="apphost.mts" const aks = await
+    builder.addAzureKubernetesEnvironment('aks'); await
+    aks.withSystemNodePool('Standard_D4s_v5', 1, 5); ```
+  </Fragment>
 </AppHostTabs>
 
 ## Add node pools
 
 Add additional node pools for workload isolation, GPU workloads, or specialized hardware requirements using `AddNodePool`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var aks = builder.AddAzureKubernetesEnvironment("aks");
 var gpuPool = aks.AddNodePool("gpupool", "Standard_NC6s_v3", minCount: 0, maxCount: 5);
 
 builder.AddContainer("ml-worker", "my-ml-image")
-    .WithNodePool(gpuPool);
-```
+.WithNodePool(gpuPool);
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -106,29 +124,37 @@ const gpuPool = await aks.addNodePool('gpupool', 'Standard_NC6s_v3', 0, 5);
 
 const worker = await builder.addContainer('ml-worker', 'my-ml-image');
 await worker.withNodePool(gpuPool);
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 ## Add a persistent volume
 
 <Aside type="note">
-  Persistent volume APIs are experimental. In C#, suppress the `ASPIRECOMPUTE002` diagnostic to use them.
+  Persistent volume APIs are experimental. In C#, suppress the
+  `ASPIRECOMPUTE002` diagnostic to use them.
 </Aside>
 
 Call `AddPersistentVolume` directly on the AKS environment to model durable storage without reaching through to the underlying Kubernetes integration. The call forwards to the AKS environment's Kubernetes publisher, so the same configuration methods and workload-binding APIs described in [Persistent volumes on Kubernetes](/deployment/kubernetes/persistent-volumes/) apply:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var aks = builder.AddAzureKubernetesEnvironment("aks");
 
 var data = aks.AddPersistentVolume("data")
-    .WithCapacity("20Gi");
+.WithCapacity("20Gi");
 
 builder.AddProject<Projects.Api>("api")
-    .WithPersistentVolume(data, "/data");
-```
+.WithPersistentVolume(data, "/data");
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -142,18 +168,22 @@ const api = await builder
     .withHttpEndpoint({ env: 'PORT' })
     .withExternalHttpEndpoints()
     .withKubernetesPersistentVolumeMount(data, "/data");
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 When you don't set a storage class, the generated claim omits `spec.storageClassName` so the cluster's default storage class provisions the disk. A standard AKS cluster dynamically provisions an Azure managed disk for such claims. To request Premium SSD storage explicitly, call `WithStorageClass("managed-csi-premium")` in C# or `withStorageClass('managed-csi-premium')` in TypeScript.
 
 <Aside type="note">
-  The APIs that are specific to Azure Files are intentionally deferred until managed-identity mounting can be modeled securely.
+  The APIs that are specific to Azure Files are intentionally deferred until
+  managed-identity mounting can be modeled securely.
 </Aside>
 
 <LearnMore>
-  For the full set of configuration methods (storage class, capacity, access modes, annotations) and how to bind volumes to workloads, see [Persistent volumes on Kubernetes](/deployment/kubernetes/persistent-volumes/).
+  For the full set of configuration methods (storage class, capacity, access
+  modes, annotations) and how to bind volumes to workloads, see [Persistent
+  volumes on Kubernetes](/deployment/kubernetes/persistent-volumes/).
 </LearnMore>
 
 ## Publishing and deployment

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
@@ -32,7 +32,12 @@ If you're new to the Azure AI Foundry integration, start with the [Get started w
 
 To start building an Aspire app that uses Azure AI Foundry, install the [📦 Aspire.Hosting.Foundry](https://www.nuget.org/packages/Aspire.Hosting.Foundry) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -93,7 +98,12 @@ For an introduction to working with the Azure AI Foundry hosting integration, se
 
 To add an Azure AI Foundry resource to your AppHost project, call the `AddFoundry` method providing a name:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -141,7 +151,12 @@ The preceding code adds an Azure AI Foundry resource named `foundry` to the AppH
 
 To add a Foundry deployment resource, call the `AddDeployment` method with one of the generated `FoundryModel` entries:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -192,7 +207,12 @@ The preceding code:
 
 If you need a different generated model descriptor, use the corresponding nested type. The `FoundryModel` class organizes models by provider family: `FoundryModel.Microsoft`, `FoundryModel.OpenAI`, `FoundryModel.Cohere`, `FoundryModel.MistralAI`, and others. For example, to use `FoundryModel.Microsoft.Phi4Reasoning`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -255,7 +275,12 @@ The preceding code sets the SKU name to `Standard` and capacity to `10` for the 
 
 Use the `AddProject` method to create an Azure AI Foundry project for agents, project-scoped connections, and related Azure resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -309,7 +334,12 @@ The preceding code creates a Foundry project and adds a deployment through `AddM
 
 You can customize the Azure resources associated with a Foundry project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -355,7 +385,12 @@ await foundry
 
 Use `AsHostedAgent` in C# or `asHostedAgent` in TypeScript to configure an executable or containerized app as a hosted agent in a Foundry project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -425,7 +460,12 @@ builder.WebHost.UseUrls($"http://+:{port}");
 
 If your hosted agent listens on a different port, declare the endpoint before calling `AsHostedAgent(...)`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -470,7 +510,12 @@ For C# AppHosts, the parameterless `AsHostedAgent()` overload reuses an existing
 
 `AsHostedAgent` defaults to the Responses protocol version `2.0.0`. If your hosted agent implements a different protocol or protocol version, use the C# `AsHostedAgent(project, protocol, version)` overload or the polyglot/TypeScript `asHostedAgentWithProtocol` export. For example, some Microsoft Agent Framework (MAF) agents use the Invocations protocol:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -500,7 +545,12 @@ The defaulted `asHostedAgent` entry point and the explicit `asHostedAgentWithPro
 
 For prompt-only scenarios, use `AddPromptAgent` on a Foundry project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -540,16 +590,12 @@ const chat = await project.addModelDeployment('chat', 'gpt-5-mini', {
 const webSearch = await project.addWebSearchTool('web-search');
 
 await project
-  .addPromptAgent(
-    'web-researcher',
-    chat,
-    {
-      instructions: `
+  .addPromptAgent('web-researcher', chat, {
+    instructions: `
     You are the Web Researcher. Use web search for current information,
     cite sources, summarize tradeoffs, and keep answers concise and practical.
   `,
-    }
-  )
+  })
   .withTool(webSearch);
 
 await builder.build().run();
@@ -589,7 +635,12 @@ Aspire also makes the declared agents easy to try from the dashboard. Prompt age
 
 You might have an existing Azure AI Foundry service that you want to connect to. You can chain a call to annotate that your `FoundryResource` is an existing resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -650,7 +701,12 @@ await builder.build().run();
 
 Aspire supports the usage of Foundry Local for local development. Add the following to your AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -711,7 +767,12 @@ The `RunAsFoundryLocal` method configures the resource to use the local service.
 
 You can assign specific roles to resources that need to access the Azure AI Foundry service. Use the `WithRoleAssignments` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -863,7 +924,8 @@ builder.AddFoundry("foundry")
   TypeScript AppHosts can use curated provisioning helper APIs when an
   integration exposes them. This example directly customizes Azure.Provisioning
   objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a [polyglot](/get-started/glossary/#polyglot)-friendly helper.
+  the integration wraps the scenario in a
+  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
 </Aside>
 
 The preceding code:

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
@@ -904,6 +904,15 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resources—using the `ConfigureInfrastructure` API:
 
+<AppHostTabs limitations={{
+  typescript: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not available to TypeScript AppHosts.',
+  python: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Python generated SDK.',
+  go: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Go generated SDK.',
+  java: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Java generated SDK.',
+  rust: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Rust generated SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 builder.AddFoundry("foundry")
   .ConfigureInfrastructure(infra =>
@@ -920,13 +929,8 @@ builder.AddFoundry("foundry")
   });
 ```
 
-<Aside type="note">
-  TypeScript AppHosts can use curated provisioning helper APIs when an
-  integration exposes them. This example directly customizes Azure.Provisioning
-  objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a
-  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 The preceding code:
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-host.mdx
@@ -33,10 +33,10 @@ If you're new to the Azure AI Foundry integration, start with the [Get started w
 To start building an Aspire app that uses Azure AI Foundry, install the [📦 Aspire.Hosting.Foundry](https://www.nuget.org/packages/Aspire.Hosting.Foundry) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -99,10 +99,10 @@ For an introduction to working with the Azure AI Foundry hosting integration, se
 To add an Azure AI Foundry resource to your AppHost project, call the `AddFoundry` method providing a name:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -152,10 +152,10 @@ The preceding code adds an Azure AI Foundry resource named `foundry` to the AppH
 To add a Foundry deployment resource, call the `AddDeployment` method with one of the generated `FoundryModel` entries:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -208,10 +208,10 @@ The preceding code:
 If you need a different generated model descriptor, use the corresponding nested type. The `FoundryModel` class organizes models by provider family: `FoundryModel.Microsoft`, `FoundryModel.OpenAI`, `FoundryModel.Cohere`, `FoundryModel.MistralAI`, and others. For example, to use `FoundryModel.Microsoft.Phi4Reasoning`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -276,10 +276,10 @@ The preceding code sets the SKU name to `Standard` and capacity to `10` for the 
 Use the `AddProject` method to create an Azure AI Foundry project for agents, project-scoped connections, and related Azure resources:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -335,10 +335,10 @@ The preceding code creates a Foundry project and adds a deployment through `AddM
 You can customize the Azure resources associated with a Foundry project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -386,10 +386,10 @@ await foundry
 Use `AsHostedAgent` in C# or `asHostedAgent` in TypeScript to configure an executable or containerized app as a hosted agent in a Foundry project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -461,10 +461,10 @@ builder.WebHost.UseUrls($"http://+:{port}");
 If your hosted agent listens on a different port, declare the endpoint before calling `AsHostedAgent(...)`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -511,10 +511,10 @@ For C# AppHosts, the parameterless `AsHostedAgent()` overload reuses an existing
 `AsHostedAgent` defaults to the Responses protocol version `2.0.0`. If your hosted agent implements a different protocol or protocol version, use the C# `AsHostedAgent(project, protocol, version)` overload or the polyglot/TypeScript `asHostedAgentWithProtocol` export. For example, some Microsoft Agent Framework (MAF) agents use the Invocations protocol:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -546,10 +546,10 @@ The defaulted `asHostedAgent` entry point and the explicit `asHostedAgentWithPro
 For prompt-only scenarios, use `AddPromptAgent` on a Foundry project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -636,10 +636,10 @@ Aspire also makes the declared agents easy to try from the dashboard. Prompt age
 You might have an existing Azure AI Foundry service that you want to connect to. You can chain a call to annotate that your `FoundryResource` is an existing resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -702,10 +702,10 @@ await builder.build().run();
 Aspire supports the usage of Foundry Local for local development. Add the following to your AppHost project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -768,10 +768,10 @@ The `RunAsFoundryLocal` method configures the resource to use the local service.
 You can assign specific roles to resources that need to access the Azure AI Foundry service. Use the `WithRoleAssignments` method:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started.mdx
@@ -3,8 +3,10 @@ title: Get started with the Azure AI Inference integrations
 description: Understand why you use the Aspire Azure AI Inference integrations and how they fit together in your Aspire AppHost.
 ---
 
+import AppHostTabs from '@components/AppHostTabs.astro';
+
 import { Image } from 'astro:assets';
-import { Badge, LinkButton, Steps } from '@astrojs/starlight/components';
+import { Badge, LinkButton } from '@astrojs/starlight/components';
 import aiFoundryIcon from '@assets/icons/azure-ai-foundry-icon.png';
 
 <Image
@@ -49,47 +51,56 @@ architecture-beta
 
 Getting there is a two-step process: register the connection string in your AppHost, then connect to the endpoint from each app that needs it.
 
-<Steps>
+### 1. Register the Azure AI Inference connection in your AppHost
 
-1. ### Register the Azure AI Inference connection in your AppHost
+Add a named connection string to your AppHost that points to your existing Azure AI Inference endpoint. Aspire injects the connection information into each consuming app that references it.
 
-    Add a named connection string to your AppHost that points to your existing Azure AI Inference endpoint. Aspire injects the connection information into each consuming app that references it.
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
-    ```csharp title="AppHost.cs"
-    var builder = DistributedApplication.CreateBuilder(args);
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
 
-    var aiInference = builder.AddConnectionString("ai-foundry");
+var aiInference = builder.AddConnectionString("ai-foundry");
 
-    builder.AddProject<Projects.ExampleProject>("myapp")
-        .WithReference(aiInference);
+builder.AddProject<Projects.ExampleProject>("myapp")
+    .WithReference(aiInference);
 
-    // After adding all resources, run the app...
-    builder.Build().Run();
-    ```
+// After adding all resources, run the app...
+builder.Build().Run();
+```
 
-    Store the connection string in your AppHost's configuration — typically in User Secrets during local development — under the `ConnectionStrings` key:
+</Fragment>
+</AppHostTabs>
 
-    ```json title="User Secrets"
-    {
-      "ConnectionStrings": {
-        "ai-foundry": "Endpoint=https://{endpoint}/;Key={apikey};DeploymentId={deploymentName}"
-      }
-    }
-    ```
+Store the connection string in your AppHost's configuration — typically in User Secrets during local development — under the `ConnectionStrings` key:
 
-2. ### Connect from your consuming app
+```json title="User Secrets"
+{
+  "ConnectionStrings": {
+    "ai-foundry": "Endpoint=https://{endpoint}/;Key={apikey};DeploymentId={deploymentName}"
+  }
+}
+```
 
-    When you reference the connection from a consuming app, Aspire injects the connection string as an environment variable. See [Connect to Azure AI Inference](/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-connect/) for the connection string format, per-language examples for C#, Go, Python, and TypeScript, and the full C# client integration reference.
+### 2. Connect from your consuming app
 
-    <LinkButton
-        variant='secondary'
-        iconPlacement='end'
-        icon='right-arrow'
-        href='/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-connect/'>
-        Connect to Azure AI Inference
-    </LinkButton>
+When you reference the connection from a consuming app, Aspire injects the connection string as an environment variable. See [Connect to Azure AI Inference](/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-connect/) for the connection string format, per-language examples for C#, Go, Python, and TypeScript, and the full C# client integration reference.
 
-</Steps>
+<LinkButton
+  variant="secondary"
+  iconPlacement="end"
+  icon="right-arrow"
+  href="/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-connect/"
+>
+  Connect to Azure AI Inference
+</LinkButton>
 
 ## See also
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-get-started.mdx
@@ -56,11 +56,11 @@ Getting there is a two-step process: register the connection string in your AppH
 Add a named connection string to your AppHost that points to your existing Azure AI Inference endpoint. Aspire injects the connection information into each consuming app that references it.
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-host.mdx
@@ -28,7 +28,12 @@ If you're new to Azure AI Inference, start with [Get started with the Azure AI I
 
 Use `AddConnectionString` to register an existing Azure AI Inference endpoint with your AppHost, then reference it from any consuming app:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -47,13 +52,16 @@ builder.Build().Run();
 <Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
-import { createBuilder } from "./.aspire/modules/aspire.mjs";
+import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const aiInference = await builder.addConnectionString("ai-foundry");
+const aiInference = await builder.addConnectionString('ai-foundry');
 
-const myapp = await builder.addProject("myapp", "../ExampleProject/ExampleProject.csproj");
+const myapp = await builder.addProject(
+  'myapp',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await myapp.withReference(aiInference);
 
 await builder.build().run();
@@ -76,14 +84,17 @@ Store the Azure AI Inference connection string in your AppHost's configuration. 
 
 The connection string supports the following segments:
 
-| Segment | Description |
-| --- | --- |
-| `Endpoint` | The Azure AI Inference endpoint URL — for example, `https://{your-foundry-resource}.services.ai.azure.com/models`. |
-| `Key` | The API key for the Azure AI Inference endpoint. Omit when the consuming app authenticates with `DefaultAzureCredential`. |
-| `DeploymentId` | The name of the deployed model (for example, `gpt-4o`). |
+| Segment        | Description                                                                                                               |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `Endpoint`     | The Azure AI Inference endpoint URL — for example, `https://{your-foundry-resource}.services.ai.azure.com/models`.        |
+| `Key`          | The API key for the Azure AI Inference endpoint. Omit when the consuming app authenticates with `DefaultAzureCredential`. |
+| `DeploymentId` | The name of the deployed model (for example, `gpt-4o`).                                                                   |
 
 <Aside type="note">
-Connection strings represent any connection information — database connections, message brokers, endpoint URIs, and other services. For more information, see [Add existing Azure resources with connection strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
+  Connection strings represent any connection information — database
+  connections, message brokers, endpoint URIs, and other services. For more
+  information, see [Add existing Azure resources with connection
+  strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
 </Aside>
 
 ## Connection properties

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-inference/azure-ai-inference-host.mdx
@@ -29,10 +29,10 @@ If you're new to Azure AI Inference, start with [Get started with the Azure AI I
 Use `AddConnectionString` to register an existing Azure AI Inference endpoint with your AppHost, then reference it from any consuming app:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-search/azure-ai-search-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-search/azure-ai-search-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure AI Search integration, start with the [Get started wi
 To start building an Aspire app that uses Azure AI Search, install the [📦 Aspire.Hosting.Azure.Search](https://www.nuget.org/packages/Aspire.Hosting.Azure.Search) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure AI Search hosting integrat
 Once you've installed the hosting integration in your AppHost project, you can add an Azure AI Search resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -143,10 +143,10 @@ await builder.build().run();
 You might have an existing Azure AI Search service that you want to connect to. Chain a call to mark the resource as existing rather than provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -263,10 +263,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -324,10 +324,10 @@ For more information, see [Azure.Provisioning customization](/integrations/cloud
 By default, the Azure AI Search hosting integration generates role assignments for `SearchIndexDataContributor` and `SearchServiceContributor` in the provisioned Bicep. You can customize the roles assigned to a resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-search/azure-ai-search-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-ai-search/azure-ai-search-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure AI Search integration, start with the [Get started wi
 
 To start building an Aspire app that uses Azure AI Search, install the [📦 Aspire.Hosting.Azure.Search](https://www.nuget.org/packages/Aspire.Hosting.Azure.Search) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add azure-search
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add azure-search
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure AI Search hosting integration package:
@@ -76,7 +83,12 @@ This updates your `aspire.config.json` with the Azure AI Search hosting integrat
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure AI Search resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -84,11 +96,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var search = builder.AddAzureSearch("search");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(search);
+.WithReference(search);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -103,7 +116,8 @@ await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj"
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,14 +132,22 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    When you reference an Azure AI Search resource from the AppHost, Aspire makes connection properties available to the consuming project. For a complete list of these properties and per-language connection examples, see [Connect to Azure AI Search](../azure-ai-search-connect/).
+  When you reference an Azure AI Search resource from the AppHost, Aspire makes
+  connection properties available to the consuming project. For a complete list
+  of these properties and per-language connection examples, see [Connect to
+  Azure AI Search](../azure-ai-search-connect/).
 </Aside>
 
 ## Connect to an existing Azure AI Search instance
 
 You might have an existing Azure AI Search service that you want to connect to. Chain a call to mark the resource as existing rather than provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -134,14 +156,15 @@ var existingSearchName = builder.AddParameter("existingSearchName");
 var existingSearchResourceGroup = builder.AddParameter("existingSearchResourceGroup");
 
 var search = builder.AddAzureSearch("search")
-    .AsExisting(existingSearchName, existingSearchResourceGroup);
+.AsExisting(existingSearchName, existingSearchResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(search);
+.WithReference(search);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -159,7 +182,8 @@ await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj"
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -238,24 +262,30 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureSearch("search")
-    .ConfigureInfrastructure(infra =>
-    {
-        var searchService = infra.GetProvisionableResources()
-                                  .OfType<SearchService>()
-                                  .Single();
+.ConfigureInfrastructure(infra =>
+{
+var searchService = infra.GetProvisionableResources()
+.OfType<SearchService>()
+.Single();
 
         searchService.PartitionCount = 6;
         searchService.ReplicaCount = 3;
         searchService.SearchSkuName = SearchServiceSkuName.Standard3;
         searchService.Tags.Add("ExampleKey", "Example value");
     });
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -271,7 +301,8 @@ await search.configureInfrastructure(async (infra) => {
 });
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -292,7 +323,12 @@ For more information, see [Azure.Provisioning customization](/integrations/cloud
 
 By default, the Azure AI Search hosting integration generates role assignments for `SearchIndexDataContributor` and `SearchServiceContributor` in the provisioned Bicep. You can customize the roles assigned to a resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Role assignments are generated automatically in the provisioned Bicep. To clear the default role assignments and assign custom ones, use `ClearDefaultRoleAssignments` and then configure via `ConfigureInfrastructure`:
@@ -317,10 +353,11 @@ import { createBuilder, AzureSearchRole } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const search = await builder.addAzureSearch("search");
+const search = await builder.addAzureSearch('search');
 
-const api = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(search);
+const api = await builder
+  .addProject('apiservice', '../ExampleProject/ExampleProject.csproj')
+  .withReference(search);
 
 // Assign only the data-reader role to the api project
 await search.withRoleAssignments(api, [AzureSearchRole.SearchIndexDataReader]);
@@ -333,11 +370,11 @@ await builder.build().run();
 
 The available roles are defined in the `AzureSearchRole` enum:
 
-| Role                          | Description                                                           |
-| ----------------------------- | --------------------------------------------------------------------- |
-| `SearchIndexDataContributor`  | Full access to Azure AI Search index data (read, write, and delete). |
-| `SearchIndexDataReader`       | Read-only access to Azure AI Search index data.                      |
-| `SearchServiceContributor`    | Manage search service resources (not data).                          |
+| Role                         | Description                                                          |
+| ---------------------------- | -------------------------------------------------------------------- |
+| `SearchIndexDataContributor` | Full access to Azure AI Search index data (read, write, and delete). |
+| `SearchIndexDataReader`      | Read-only access to Azure AI Search index data.                      |
+| `SearchServiceContributor`   | Manage search service resources (not data).                          |
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-host.mdx
@@ -27,7 +27,13 @@ If you're new to the Azure App Configuration integration, start with the [Get st
 ## Installation
 
 To start building an Aspire app that uses Azure App Configuration, install the [📦 Aspire.Hosting.Azure.AppConfiguration](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppConfiguration) NuGet package:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +41,8 @@ aspire add azure-app-configuration
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +63,8 @@ aspire add azure-app-configuration
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure App Configuration hosting integration package:
@@ -75,7 +83,13 @@ This updates your `aspire.config.json` with the Azure App Configuration hosting 
 ## Add Azure App Configuration resource
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure App Configuration resource as shown in the following examples:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -99,10 +113,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config");
+const appConfig = await builder.addAzureAppConfiguration('config');
 
-await builder.addProject("web", "../WebApplication/WebApplication.csproj")
-    .withReference(appConfig);
+await builder
+  .addProject('web', '../WebApplication/WebApplication.csproj')
+  .withReference(appConfig);
 
 // After adding all resources, run the app...
 
@@ -113,15 +128,19 @@ await builder.build().run();
 </AppHostTabs>
 
 <Aside type="caution">
-  When you call `AddAzureAppConfiguration` (or `addAzureAppConfiguration`), it implicitly calls
-  `AddAzureProvisioning`—which adds support for generating Azure resources
-  dynamically during app startup. The app must configure the appropriate
-  subscription and location. For more information, see [Local provisioning:
+  When you call `AddAzureAppConfiguration` (or `addAzureAppConfiguration`), it
+  implicitly calls `AddAzureProvisioning`—which adds support for generating
+  Azure resources dynamically during app startup. The app must configure the
+  appropriate subscription and location. For more information, see [Local
+  provisioning:
   Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure App Configuration resource from the AppHost, Aspire makes the store endpoint available to the consuming project. For a complete list of these properties and per-language connection examples, see [Connect to Azure App Configuration](../azure-app-configuration-connect/).
+  When you reference an Azure App Configuration resource from the AppHost,
+  Aspire makes the store endpoint available to the consuming project. For a
+  complete list of these properties and per-language connection examples, see
+  [Connect to Azure App Configuration](../azure-app-configuration-connect/).
 </Aside>
 
 ## Provisioning-generated Bicep
@@ -183,7 +202,13 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 ## Customize provisioning infrastructure
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources — using the `ConfigureInfrastructure` API (or `configureInfrastructure` in TypeScript). For example, you can configure the SKU, enable purge protection, add tags, and more:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -210,16 +235,17 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addAzureAppConfiguration("config")
-    .configureInfrastructure(async infra => {
-        const resources = await infra.getProvisionableResources();
-        const store = resources.find(r => r.$type === 'AppConfigurationStore');
-        if (store) {
-            store.skuName = "Free";
-            store.enablePurgeProtection = true;
-            store.tags = { ...store.tags, ExampleKey: "Example value" };
-        }
-    });
+await builder
+  .addAzureAppConfiguration('config')
+  .configureInfrastructure(async (infra) => {
+    const resources = await infra.getProvisionableResources();
+    const store = resources.find((r) => r.$type === 'AppConfigurationStore');
+    if (store) {
+      store.skuName = 'Free';
+      store.enablePurgeProtection = true;
+      store.tags = { ...store.tags, ExampleKey: 'Example value' };
+    }
+  });
 ```
 
 </Fragment>
@@ -239,7 +265,13 @@ There are many more configuration options available to customize the Azure App C
 ## Add Azure App Configuration emulator resource
 
 Microsoft provides the Azure App Configuration emulator for developers who want a local, lightweight implementation of the Azure App Configuration service to code and test against. In Aspire, you can use this emulator by calling the `RunAsEmulator` method (or `runAsEmulator`) when you add your resource:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -261,8 +293,9 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .runAsEmulator();
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .runAsEmulator();
 
 // After adding all resources, run the app...
 
@@ -283,7 +316,13 @@ There are various configurations available to container resources. For example, 
 #### Configure Azure App Configuration emulator host port
 
 By default, Aspire assigns a random host port for the emulator container. If you want to use a specific port, chain calls on the container resource builder provided by the `RunAsEmulator` method as shown in the following example:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -306,12 +345,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .runAsEmulator({
-        configureEmulator: async emulator => {
-            await emulator.withHostPort({ port: 28000 });
-        }
-    });
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .runAsEmulator({
+    configureEmulator: async (emulator) => {
+      await emulator.withHostPort({ port: 28000 });
+    },
+  });
 
 // After adding all resources, run the app...
 ```
@@ -324,7 +364,13 @@ The preceding code configures the emulator container's endpoint to listen on por
 #### Configure Azure App Configuration emulator with persistent lifetime
 
 To configure the emulator container with a persistent lifetime, call the `WithLifetime` method (or `withLifetime`) on the emulator container resource and pass `ContainerLifetime.Persistent`:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -347,12 +393,13 @@ import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .runAsEmulator({
-        configureEmulator: async emulator => {
-            await emulator.withLifetime(ContainerLifetime.Persistent);
-        }
-    });
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .runAsEmulator({
+    configureEmulator: async (emulator) => {
+      await emulator.withLifetime(ContainerLifetime.Persistent);
+    },
+  });
 
 // After adding all resources, run the app...
 ```
@@ -363,7 +410,13 @@ const appConfig = await builder.addAzureAppConfiguration("config")
 #### Configure Azure App Configuration emulator with data volume
 
 By default, the Azure App Configuration emulator doesn't persist data between container restarts. To enable persistent storage using a Docker volume, call the `WithDataVolume` method (or `withDataVolume`) on the emulator resource:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -386,12 +439,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .runAsEmulator({
-        configureEmulator: async emulator => {
-            await emulator.withDataVolume();
-        }
-    });
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .runAsEmulator({
+    configureEmulator: async (emulator) => {
+      await emulator.withDataVolume();
+    },
+  });
 
 // After adding all resources, run the app...
 ```
@@ -404,7 +458,13 @@ The data volume is used to persist the emulator data outside the lifecycle of it
 #### Configure Azure App Configuration emulator with data bind mount
 
 To persist emulator data to a specific directory on your host machine, call the `WithDataBindMount` method (or `withDataBindMount`). This is useful when you want direct access to the data files on your host system:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -427,12 +487,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .runAsEmulator({
-        configureEmulator: async emulator => {
-            await emulator.withDataBindMount({ path: "../Emulator/Data" });
-        }
-    });
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .runAsEmulator({
+    configureEmulator: async (emulator) => {
+      await emulator.withDataBindMount({ path: '../Emulator/Data' });
+    },
+  });
 
 // After adding all resources, run the app...
 ```
@@ -449,7 +510,13 @@ Data bind mounts rely on the host machine's filesystem to persist the emulator d
 ## Use existing Azure App Configuration resource
 
 You might have an existing Azure App Configuration store that you want to connect to. Call the `AsExisting` method (or `asExisting`) with the config store name and resource group parameters to connect to an existing store:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -474,11 +541,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const configName = await builder.addParameter("configName");
-const configResourceGroupName = await builder.addParameter("configResourceGroupName");
+const configName = await builder.addParameter('configName');
+const configResourceGroupName = await builder.addParameter(
+  'configResourceGroupName'
+);
 
-const appConfig = await builder.addAzureAppConfiguration("config")
-    .asExisting(configName, { resourceGroup: configResourceGroupName });
+const appConfig = await builder
+  .addAzureAppConfiguration('config')
+  .asExisting(configName, { resourceGroup: configResourceGroupName });
 
 // After adding all resources, run the app...
 
@@ -493,7 +563,13 @@ For more information, see [Use existing Azure resources](/integrations/cloud/azu
 ## Connect to existing Azure App Configuration store
 
 An alternative approach to using the `AsExisting` API enables the addition of a connection string instead, where the AppHost uses configuration to resolve the connection information. To add a connection to an existing Azure App Configuration store, call the `AddConnectionString` method:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -517,10 +593,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const config = await builder.addConnectionString("config");
+const config = await builder.addConnectionString('config');
 
-await builder.addProject("web", "../WebApplication/WebApplication.csproj")
-    .withReference(config);
+await builder
+  .addProject('web', '../WebApplication/WebApplication.csproj')
+  .withReference(config);
 
 // After adding all resources, run the app...
 
@@ -547,7 +624,13 @@ The connection string is configured in the AppHost's configuration, typically un
 ## Role-based access control
 
 By default, Aspire provisions the `AppConfigurationDataOwner` role so your app can read and write configuration values. You can customize the roles assigned using the `WithRoleAssignments` method (or `withRoleAssignments`) to grant least-privilege access. For example, to grant read-only access:
-<AppHostTabs>
+
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -568,14 +651,17 @@ builder.Build().Run();
 <Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
-import { createBuilder, AzureAppConfigurationRole } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  AzureAppConfigurationRole,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const appConfig = await builder.addAzureAppConfiguration("config");
+const appConfig = await builder.addAzureAppConfiguration('config');
 
 await appConfig.withRoleAssignments(appConfig, [
-    AzureAppConfigurationRole.AppConfigurationDataReader
+  AzureAppConfigurationRole.AppConfigurationDataReader,
 ]);
 
 // After adding all resources, run the app...
@@ -588,10 +674,10 @@ await builder.build().run();
 
 The available roles are defined in the `AzureAppConfigurationRole` enum:
 
-| Role | Description |
-| ---- | ----------- |
-| `AppConfigurationDataOwner` | Full access to App Configuration data, including read, write, and delete operations |
-| `AppConfigurationDataReader` | Read-only access to App Configuration data |
+| Role                         | Description                                                                         |
+| ---------------------------- | ----------------------------------------------------------------------------------- |
+| `AppConfigurationDataOwner`  | Full access to App Configuration data, including read, write, and delete operations |
+| `AppConfigurationDataReader` | Read-only access to App Configuration data                                          |
 
 ## Connection properties
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-host.mdx
@@ -1,4 +1,4 @@
-﻿---
+---
 title: Set up Azure App Configuration in the AppHost
 description: Learn how to use the Aspire Azure App Configuration Hosting integration to orchestrate and configure an App Configuration store in an Aspire solution.
 ---
@@ -29,10 +29,10 @@ If you're new to the Azure App Configuration integration, start with the [Get st
 To start building an Aspire app that uses Azure App Configuration, install the [📦 Aspire.Hosting.Azure.AppConfiguration](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppConfiguration) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -85,10 +85,10 @@ This updates your `aspire.config.json` with the Azure App Configuration hosting 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure App Configuration resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -204,10 +204,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources — using the `ConfigureInfrastructure` API (or `configureInfrastructure` in TypeScript). For example, you can configure the SKU, enable purge protection, add tags, and more:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -267,10 +267,10 @@ There are many more configuration options available to customize the Azure App C
 Microsoft provides the Azure App Configuration emulator for developers who want a local, lightweight implementation of the Azure App Configuration service to code and test against. In Aspire, you can use this emulator by calling the `RunAsEmulator` method (or `runAsEmulator`) when you add your resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -318,10 +318,10 @@ There are various configurations available to container resources. For example, 
 By default, Aspire assigns a random host port for the emulator container. If you want to use a specific port, chain calls on the container resource builder provided by the `RunAsEmulator` method as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -366,10 +366,10 @@ The preceding code configures the emulator container's endpoint to listen on por
 To configure the emulator container with a persistent lifetime, call the `WithLifetime` method (or `withLifetime`) on the emulator container resource and pass `ContainerLifetime.Persistent`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -412,10 +412,10 @@ const appConfig = await builder
 By default, the Azure App Configuration emulator doesn't persist data between container restarts. To enable persistent storage using a Docker volume, call the `WithDataVolume` method (or `withDataVolume`) on the emulator resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -460,10 +460,10 @@ The data volume is used to persist the emulator data outside the lifecycle of it
 To persist emulator data to a specific directory on your host machine, call the `WithDataBindMount` method (or `withDataBindMount`). This is useful when you want direct access to the data files on your host system:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -512,10 +512,10 @@ Data bind mounts rely on the host machine's filesystem to persist the emulator d
 You might have an existing Azure App Configuration store that you want to connect to. Call the `AsExisting` method (or `asExisting`) with the config store name and resource group parameters to connect to an existing store:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -565,10 +565,10 @@ For more information, see [Use existing Azure resources](/integrations/cloud/azu
 An alternative approach to using the `AsExisting` API enables the addition of a connection string instead, where the AppHost uses configuration to resolve the connection information. To add a connection to an existing Azure App Configuration store, call the `AddConnectionString` method:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -626,10 +626,10 @@ The connection string is configured in the AppHost's configuration, typically un
 By default, Aspire provisions the `AppConfigurationDataOwner` role so your app can read and write configuration values. You can customize the roles assigned using the `WithRoleAssignments` method (or `withRoleAssignments`) to grant least-privilege access. For example, to grant read-only access:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-service/azure-app-service-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-service/azure-app-service-host.mdx
@@ -6,8 +6,7 @@ description: Learn how to use the Aspire Azure App Service Hosting integration t
 import AppHostTabs from '@components/AppHostTabs.astro';
 
 import { Image } from 'astro:assets';
-import {
-  Aside, Badge, Steps } from '@astrojs/starlight/components';
+import { Aside, Badge, Steps } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
 import InstallPackage from '@components/InstallPackage.astro';
 import appServiceIcon from '@assets/icons/azure-app-services.svg';
@@ -31,7 +30,12 @@ If you're new to the Azure App Service integration, start with the [Get started 
 
 To start building an Aspire app that targets Azure App Service, install the [📦 Aspire.Hosting.Azure.AppService](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppService) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -82,7 +86,12 @@ This updates your `aspire.config.json` with the hosting integration package:
 
 To deploy compute resources to Azure App Service, first add an App Service environment to your AppHost. The environment represents the hosting infrastructure (App Service Plan) into which Aspire deploys your project and container resources.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -152,7 +161,12 @@ When the App Service environment is provisioned in Azure, the following resource
 
 If you already have an App Service plan in Azure, annotate your environment resource as existing to use it instead of provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -206,7 +220,12 @@ For more information on treating Azure resources as existing resources, see [Use
 
 By default, Aspire generates an App Service website for each eligible resource without additional configuration. Use `PublishAsAzureAppServiceWebsite` (C#) or `publishAsAzureAppServiceWebsite` (TypeScript) when you need to customize the generated website — for example to add application settings or tags:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -274,7 +293,12 @@ The preceding code:
 
 [Deployment slots](https://learn.microsoft.com/azure/app-service/deploy-staging-slots) let you deploy your app to a staging environment for testing before swapping it into production. The `WithDeploymentSlot` extension method (or `withDeploymentSlot` in TypeScript) configures a deployment slot for the App Service environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -337,7 +361,12 @@ When you deploy to a slot, the deployment behavior depends on whether the produc
 
 Specify the deployment slot name as a parameter so that it can be provided at deployment time:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -387,7 +416,12 @@ With this configuration, provide a value for the `deploymentSlot` parameter when
 
 When you customize App Service resources using `PublishAsAzureAppServiceWebsite` (or `publishAsAzureAppServiceWebsite`) or `ConfigureInfrastructure`, those customizations apply to the production slot by default. Apply them separately to each slot when needed using the `configureSlot` option:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -420,7 +454,12 @@ await api.publishAsAzureAppServiceWebsite({
 
 To configure [regional virtual network integration](https://learn.microsoft.com/azure/app-service/overview-vnet-integration) for the websites in an App Service environment, add the [📦 Aspire.Hosting.Azure.Network](https://www.nuget.org/packages/Aspire.Hosting.Azure.Network) integration and delegate a subnet to the environment with `WithDelegatedSubnet` (or `withDelegatedSubnet` in TypeScript):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -467,10 +506,10 @@ await builder.build().run();
 `WithDelegatedSubnet` delegates the subnet to `Microsoft.Web/serverFarms` and configures every generated website, deployment slot, and the default Aspire Dashboard to use it for regional virtual network integration. The subnet must meet the [Azure App Service regional virtual network integration requirements](https://learn.microsoft.com/azure/app-service/overview-vnet-integration).
 
 <Aside type="note">
-  Regional virtual network integration affects outbound traffic only. It
-  doesn't make website or dashboard ingress private, and it doesn't enable
-  Route All. Configure private endpoints or access restrictions, and Route
-  All, separately when those behaviors are required.
+  Regional virtual network integration affects outbound traffic only. It doesn't
+  make website or dashboard ingress private, and it doesn't enable Route All.
+  Configure private endpoints or access restrictions, and Route All, separately
+  when those behaviors are required.
 </Aside>
 
 For more information on configuring virtual networks and subnets, see [Azure Virtual Network](/integrations/cloud/azure/azure-virtual-network/).
@@ -479,7 +518,12 @@ For more information on configuring virtual networks and subnets, see [Azure Vir
 
 All Aspire Azure resources expose a `ConfigureInfrastructure` API (or `configureInfrastructure` in TypeScript) that lets you customize the generated Bicep through the [Azure.Provisioning](https://learn.microsoft.com/dotnet/api/azure.provisioning) APIs. For example, you can change the App Service Plan SKU:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-service/azure-app-service-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-app-service/azure-app-service-host.mdx
@@ -31,10 +31,10 @@ If you're new to the Azure App Service integration, start with the [Get started 
 To start building an Aspire app that targets Azure App Service, install the [📦 Aspire.Hosting.Azure.AppService](https://www.nuget.org/packages/Aspire.Hosting.Azure.AppService) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -87,10 +87,10 @@ This updates your `aspire.config.json` with the hosting integration package:
 To deploy compute resources to Azure App Service, first add an App Service environment to your AppHost. The environment represents the hosting infrastructure (App Service Plan) into which Aspire deploys your project and container resources.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -162,10 +162,10 @@ When the App Service environment is provisioned in Azure, the following resource
 If you already have an App Service plan in Azure, annotate your environment resource as existing to use it instead of provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -221,10 +221,10 @@ For more information on treating Azure resources as existing resources, see [Use
 By default, Aspire generates an App Service website for each eligible resource without additional configuration. Use `PublishAsAzureAppServiceWebsite` (C#) or `publishAsAzureAppServiceWebsite` (TypeScript) when you need to customize the generated website — for example to add application settings or tags:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -294,10 +294,10 @@ The preceding code:
 [Deployment slots](https://learn.microsoft.com/azure/app-service/deploy-staging-slots) let you deploy your app to a staging environment for testing before swapping it into production. The `WithDeploymentSlot` extension method (or `withDeploymentSlot` in TypeScript) configures a deployment slot for the App Service environment:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -362,10 +362,10 @@ When you deploy to a slot, the deployment behavior depends on whether the produc
 Specify the deployment slot name as a parameter so that it can be provided at deployment time:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -417,10 +417,10 @@ With this configuration, provide a value for the `deploymentSlot` parameter when
 When you customize App Service resources using `PublishAsAzureAppServiceWebsite` (or `publishAsAzureAppServiceWebsite`) or `ConfigureInfrastructure`, those customizations apply to the production slot by default. Apply them separately to each slot when needed using the `configureSlot` option:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -455,10 +455,10 @@ await api.publishAsAzureAppServiceWebsite({
 To configure [regional virtual network integration](https://learn.microsoft.com/azure/app-service/overview-vnet-integration) for the websites in an App Service environment, add the [📦 Aspire.Hosting.Azure.Network](https://www.nuget.org/packages/Aspire.Hosting.Azure.Network) integration and delegate a subnet to the environment with `WithDelegatedSubnet` (or `withDelegatedSubnet` in TypeScript):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -519,10 +519,10 @@ For more information on configuring virtual networks and subnets, see [Azure Vir
 All Aspire Azure resources expose a `ConfigureInfrastructure` API (or `configureInfrastructure` in TypeScript) that lets you customize the generated Bicep through the [Azure.Provisioning](https://learn.microsoft.com/dotnet/api/azure.provisioning) APIs. For example, you can change the App Service Plan SKU:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-application-insights.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-application-insights.mdx
@@ -34,10 +34,10 @@ The Aspire Azure Application Insights hosting integration models the Application
 To start building an Aspire app that uses Azure Application Insights, install the [📦 Aspire.Hosting.Azure.ApplicationInsights](https://www.nuget.org/packages/Aspire.Hosting.Azure.ApplicationInsights) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -90,10 +90,10 @@ This updates your `aspire.config.json` with the Azure Application Insights hosti
 Once you've installed the hosting integration in your AppHost project, call `AddAzureApplicationInsights` (or `addAzureApplicationInsights`) to add and return an Azure Application Insights resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -151,10 +151,10 @@ await builder.build().run();
 If you have an existing Log Analytics workspace that you want to use, you can link Application Insights to it:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -201,10 +201,10 @@ The preceding code:
 You can also configure the Log Analytics workspace using the fluent API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -291,10 +291,10 @@ The generated Bicep is a starting point that reflects the provisioning infrastru
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-application-insights.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-application-insights.mdx
@@ -33,7 +33,12 @@ The Aspire Azure Application Insights hosting integration models the Application
 
 To start building an Aspire app that uses Azure Application Insights, install the [📦 Aspire.Hosting.Azure.ApplicationInsights](https://www.nuget.org/packages/Aspire.Hosting.Azure.ApplicationInsights) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -41,7 +46,8 @@ aspire add azure-application-insights
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -62,7 +68,8 @@ aspire add azure-application-insights
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Application Insights hosting integration package:
@@ -82,7 +89,12 @@ This updates your `aspire.config.json` with the Azure Application Insights hosti
 
 Once you've installed the hosting integration in your AppHost project, call `AddAzureApplicationInsights` (or `addAzureApplicationInsights`) to add and return an Azure Application Insights resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -90,11 +102,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var appInsights = builder.AddAzureApplicationInsights("app-insights");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(appInsights);
+.WithReference(appInsights);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -109,7 +122,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -124,10 +138,11 @@ await builder.build().run();
 </Steps>
 
 <Aside type="caution">
-  When you call `AddAzureApplicationInsights` (or `addAzureApplicationInsights`), it implicitly calls
-  `AddAzureProvisioning` — which adds support for generating Azure resources
-  dynamically during app startup. The app must configure the appropriate
-  subscription and location. For more information, see [Local provisioning:
+  When you call `AddAzureApplicationInsights` (or
+  `addAzureApplicationInsights`), it implicitly calls `AddAzureProvisioning` —
+  which adds support for generating Azure resources dynamically during app
+  startup. The app must configure the appropriate subscription and location. For
+  more information, see [Local provisioning:
   Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
@@ -135,7 +150,12 @@ await builder.build().run();
 
 If you have an existing Log Analytics workspace that you want to use, you can link Application Insights to it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -144,11 +164,12 @@ var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("log-analytics");
 var appInsights = builder.AddAzureApplicationInsights("app-insights", logAnalytics);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(appInsights);
+.WithReference(appInsights);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -164,7 +185,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -178,21 +200,27 @@ The preceding code:
 
 You can also configure the Log Analytics workspace using the fluent API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("log-analytics");
 var appInsights = builder.AddAzureApplicationInsights("app-insights")
-    .WithLogAnalyticsWorkspace(logAnalytics);
+.WithLogAnalyticsWorkspace(logAnalytics);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(appInsights);
+.WithReference(appInsights);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -209,7 +237,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -217,8 +246,8 @@ await builder.build().run();
 
 The Azure Application Insights resource exposes the following connection property:
 
-| Property name | Description |
-|---------------|-------------|
+| Property name                 | Description                                     |
+| ----------------------------- | ----------------------------------------------- |
 | `appInsightsConnectionString` | The connection string for Application Insights. |
 
 This connection string is automatically made available to referencing projects as an environment variable named `APPLICATIONINSIGHTS_CONNECTION_STRING` (or based on the resource name).
@@ -261,17 +290,22 @@ The generated Bicep is a starting point that reflects the provisioning infrastru
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var appInsights = builder.AddAzureApplicationInsights("app-insights")
-    .ConfigureInfrastructure(infra =>
-    {
-        var insights = infra.GetProvisionableResources()
-            .OfType<ApplicationInsightsComponent>()
-            .Single();
+.ConfigureInfrastructure(infra =>
+{
+var insights = infra.GetProvisionableResources()
+.OfType<ApplicationInsightsComponent>()
+.Single();
 
         insights.RetentionInDays = 90;
         insights.IngestionMode = ComponentIngestionMode.LogAnalytics;
@@ -279,11 +313,12 @@ var appInsights = builder.AddAzureApplicationInsights("app-insights")
     });
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(appInsights);
+.WithReference(appInsights);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -302,7 +337,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -318,7 +354,9 @@ For more information, see [Customize Azure resources](/integrations/cloud/azure/
 ## Client integration
 
 <Aside type="note">
-  The Azure Application Insights hosting integration works with the standard Application Insights SDK and OpenTelemetry exporters. No separate Aspire client integration package is required.
+  The Azure Application Insights hosting integration works with the standard
+  Application Insights SDK and OpenTelemetry exporters. No separate Aspire
+  client integration package is required.
 </Aside>
 
 ### Configure Application Insights in your application

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure Cache for Redis integration, start with the [Get star
 To start building an Aspire app that uses Azure Cache for Redis, install the [📦 Aspire.Hosting.Azure.Redis](https://www.nuget.org/packages/Aspire.Hosting.Azure.Redis) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure Cache for Redis hosting in
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Managed Redis resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -155,10 +155,10 @@ The Azure Cache for Redis hosting integration supports running a local Redis con
 To run the resource as a container, chain a call to `RunAsContainer` (or `runAsContainer`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -205,10 +205,10 @@ The `RunAsContainer` method accepts an optional delegate that lets you customize
 If you already have an Azure Cache for Redis instance you want to use, call `AsExisting` (or `asExisting`) to annotate that the resource already exists rather than being provisioned:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -257,10 +257,10 @@ For more information on treating Azure resources as existing resources, see [Use
 By default, the Azure Managed Redis resource uses Microsoft Entra ID authentication. To switch to access key authentication (not recommended for production), call `WithAccessKeyAuthentication` (or `withAccessKeyAuthentication`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -374,10 +374,10 @@ The generated Bicep provisions the Azure Cache for Redis instance and creates an
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables Bicep customization through the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure Cache for Redis integration, start with the [Get star
 
 To start building an Aspire app that uses Azure Cache for Redis, install the [📦 Aspire.Hosting.Azure.Redis](https://www.nuget.org/packages/Aspire.Hosting.Azure.Redis) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add azure-redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add azure-redis
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Cache for Redis hosting integration package:
@@ -76,7 +83,12 @@ This updates your `aspire.config.json` with the Azure Cache for Redis hosting in
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Managed Redis resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -84,11 +96,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var cache = builder.AddAzureManagedRedis("cache");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -103,7 +116,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,11 +132,20 @@ await builder.build().run();
 </Steps>
 
 <Aside type="caution">
-  When you call `AddAzureManagedRedis` (or `addAzureManagedRedis`), it implicitly calls `AddAzureProvisioning` — which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureManagedRedis` (or `addAzureManagedRedis`), it
+  implicitly calls `AddAzureProvisioning` — which adds support for generating
+  Azure resources dynamically during app startup. The app must configure the
+  appropriate subscription and location. For more information, see [Local
+  provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-  When you reference an Azure Cache for Redis resource from the AppHost, Aspire makes several properties available to the consuming project, such as the hostname, port, and connection URI. For a complete list of these properties and per-language connection examples, see [Connect to Azure Cache for Redis](../azure-cache-redis-connect/).
+  When you reference an Azure Cache for Redis resource from the AppHost, Aspire
+  makes several properties available to the consuming project, such as the
+  hostname, port, and connection URI. For a complete list of these properties
+  and per-language connection examples, see [Connect to Azure Cache for
+  Redis](../azure-cache-redis-connect/).
 </Aside>
 
 ## Run as a local Redis container
@@ -131,20 +154,26 @@ The Azure Cache for Redis hosting integration supports running a local Redis con
 
 To run the resource as a container, chain a call to `RunAsContainer` (or `runAsContainer`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddAzureManagedRedis("cache")
-    .RunAsContainer();
+.RunAsContainer();
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -160,7 +189,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -174,7 +204,12 @@ The `RunAsContainer` method accepts an optional delegate that lets you customize
 
 If you already have an Azure Cache for Redis instance you want to use, call `AsExisting` (or `asExisting`) to annotate that the resource already exists rather than being provisioned:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -183,14 +218,15 @@ var existingRedisName = builder.AddParameter("existingRedisName");
 var existingRedisResourceGroup = builder.AddParameter("existingRedisResourceGroup");
 
 var cache = builder.AddAzureManagedRedis("cache")
-    .AsExisting(existingRedisName, existingRedisResourceGroup);
+.AsExisting(existingRedisName, existingRedisResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -209,7 +245,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -219,20 +256,26 @@ For more information on treating Azure resources as existing resources, see [Use
 
 By default, the Azure Managed Redis resource uses Microsoft Entra ID authentication. To switch to access key authentication (not recommended for production), call `WithAccessKeyAuthentication` (or `withAccessKeyAuthentication`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cache = builder.AddAzureManagedRedis("cache")
-    .WithAccessKeyAuthentication();
+.WithAccessKeyAuthentication();
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cache);
+.WithReference(cache);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -248,7 +291,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -329,17 +373,22 @@ The generated Bicep provisions the Azure Cache for Redis instance and creates an
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables Bicep customization through the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureManagedRedis("cache")
-    .ConfigureInfrastructure(infra =>
-    {
-        var redisCache = infra.GetProvisionableResources()
-                              .OfType<RedisEnterpriseCluster>()
-                              .Single();
+.ConfigureInfrastructure(infra =>
+{
+var redisCache = infra.GetProvisionableResources()
+.OfType<RedisEnterpriseCluster>()
+.Single();
 
         redisCache.Sku = new RedisEnterpriseSku
         {
@@ -351,7 +400,8 @@ builder.AddAzureManagedRedis("cache")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -368,7 +418,8 @@ await builder.addAzureManagedRedis("cache")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-connect.mdx
@@ -3,6 +3,7 @@ title: Use Azure Container Registry at deploy time
 description: Learn how Azure Container Registry is consumed as a publish target during deployment, including registry outputs and integration with your deployment pipeline.
 ---
 
+import AppHostTabs from '@components/AppHostTabs.astro';
 import { Image } from 'astro:assets';
 import { Aside } from '@astrojs/starlight/components';
 import containerRegistryIcon from '@assets/icons/azure-container-registry-icon.svg';
@@ -25,16 +26,20 @@ Unlike database or cache integrations, Azure Container Registry is not accessed 
 There is no client library to install in consuming apps. Your services do not open a connection to ACR, send commands to it, or read environment variables from it at startup.
 
 <Aside type="note">
-  If your app needs to interact with ACR programmatically at runtime — for example, to list or delete images — use the [Azure Container Registry client library for .NET](https://learn.microsoft.com/dotnet/api/overview/azure/Containers.ContainerRegistry-readme) directly, and supply credentials through standard Azure identity mechanisms.
+  If your app needs to interact with ACR programmatically at runtime — for
+  example, to list or delete images — use the [Azure Container Registry client
+  library for
+  .NET](https://learn.microsoft.com/dotnet/api/overview/azure/Containers.ContainerRegistry-readme)
+  directly, and supply credentials through standard Azure identity mechanisms.
 </Aside>
 
 ## Registry outputs
 
 When Aspire provisions an Azure Container Registry resource, the generated Bicep module exposes the following outputs:
 
-| Output name   | Description |
-| ------------- | ----------- |
-| `name`        | The provisioned name of the registry (used to reference the registry from other Bicep modules). |
+| Output name   | Description                                                                                                                                                                           |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | The provisioned name of the registry (used to reference the registry from other Bicep modules).                                                                                       |
 | `loginServer` | The registry login server hostname, for example `myacr1234abcd.azurecr.io`. This is the endpoint used to tag and push images during CI/CD and to pull images in compute environments. |
 
 These outputs are automatically wired into the compute environment's Bicep when you call `WithAzureContainerRegistry` (or `withAzureContainerRegistry`) from your AppHost.
@@ -43,17 +48,62 @@ These outputs are automatically wired into the compute environment's Bicep when 
 
 If you need to pass the registry's `loginServer` value to another resource in your AppHost — for example, to tag images before pushing — use `GetOutput` (or `getOutput`) to retrieve it as a Bicep output reference:
 
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+const acr = await builder.addAzureContainerRegistry('my-acr');
+
+const loginServer = await acr.getOutput('loginServer');
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var acr = builder.AddAzureContainerRegistry("my-acr");
 
 var loginServer = acr.GetOutput("loginServer");
 ```
 
-```typescript title="apphost.mts"
-const acr = await builder.addAzureContainerRegistry("my-acr");
+</Fragment>
+<Fragment slot="python">
 
-const loginServer = await acr.getOutput("loginServer");
+```python title="apphost.py"
+acr = builder.add_azure_container_registry("my-acr")
+
+login_server = acr.get_output("loginServer")
 ```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+acr := builder.AddAzureContainerRegistry("my-acr")
+
+loginServer := acr.GetOutput("loginServer")
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var acr = builder.addAzureContainerRegistry("my-acr");
+
+var loginServer = acr.getOutput("loginServer");
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let acr = builder.add_azure_container_registry("my-acr")?;
+
+let login_server = acr.get_output("loginServer")?;
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Push images from your CI/CD pipeline
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-connect.mdx
@@ -80,6 +80,9 @@ login_server = acr.get_output("loginServer")
 
 ```go title="apphost.go"
 acr := builder.AddAzureContainerRegistry("my-acr")
+if err := acr.Err(); err != nil {
+	panic(err)
+}
 
 loginServer := acr.GetOutput("loginServer")
 ```

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started.mdx
@@ -142,10 +142,10 @@ To begin, install the Aspire Azure Container Registry Hosting integration in you
 Next, in the AppHost project, create an Azure Container Registry resource and wire it to a compute environment:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started.mdx
@@ -7,7 +7,12 @@ import AppHostTabs from '@components/AppHostTabs.astro';
 
 import { Image } from 'astro:assets';
 import {
-  Aside, CardGrid, LinkButton, LinkCard, Steps } from '@astrojs/starlight/components';
+  Aside,
+  CardGrid,
+  LinkButton,
+  LinkCard,
+  Steps,
+} from '@astrojs/starlight/components';
 import InstallPackage from '@components/InstallPackage.astro';
 import containerRegistryIcon from '@assets/icons/azure-container-registry-icon.svg';
 
@@ -136,7 +141,12 @@ To begin, install the Aspire Azure Container Registry Hosting integration in you
 
 Next, in the AppHost project, create an Azure Container Registry resource and wire it to a compute environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure Container Registry integration, start with the [Get s
 To start building an Aspire app that uses Azure Container Registry, install the [📦 Aspire.Hosting.Azure.ContainerRegistry](https://www.nuget.org/packages/Aspire.Hosting.Azure.ContainerRegistry) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -93,10 +93,10 @@ This updates your `aspire.config.json` with the Azure Container Registry hosting
 Once you've installed the hosting integration in your AppHost project, add an Azure Container Registry resource and wire it to a compute environment:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -152,10 +152,10 @@ await builder.build().run();
 To retrieve the registry that is associated with a compute environment — for example, to add purge tasks to the auto-provisioned default registry — use `GetAzureContainerRegistry` (or `getAzureContainerRegistry`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -200,10 +200,10 @@ This returns an `AzureContainerRegistryResource` builder that you can use for fu
 To reference a registry your team already manages rather than provisioning a new one, use `publishAsExisting`, `runAsExisting`, or `asExisting`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -269,10 +269,10 @@ await acr.asExisting(registryName, { resourceGroup: rgName });
 Use `WithRoleAssignments` (or `withRoleAssignments`) to grant an Azure resource fine-grained access to the registry. The `ContainerRegistryBuiltInRole` enum (TypeScript: `AzureContainerRegistryRole`) covers the standard ACR roles:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -318,10 +318,10 @@ Available roles include: `AcrPull`, `AcrPush`, `AcrDelete`, `AcrImageSigner`, `A
 Over time, container registries accumulate old images that consume storage. Use `WithPurgeTask` (or `withPurgeTask`) to add a scheduled [ACR purge task](https://learn.microsoft.com/azure/container-registry/container-registry-auto-purge) that automatically removes old or unused images:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -361,10 +361,10 @@ The preceding code creates a purge task that runs daily at 1:00 AM, removing ima
 Add multiple purge tasks to target different repositories with different schedules:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -397,10 +397,10 @@ Each purge task is given a unique name automatically. Use the `taskName` option 
 To make changes that go beyond what the built-in APIs expose, configure the underlying Bicep infrastructure directly via `ConfigureInfrastructure` (or `configureInfrastructure`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-container-registry/azure-container-registry-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure Container Registry integration, start with the [Get s
 
 To start building an Aspire app that uses Azure Container Registry, install the [📦 Aspire.Hosting.Azure.ContainerRegistry](https://www.nuget.org/packages/Aspire.Hosting.Azure.ContainerRegistry) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add Aspire.Hosting.Azure.ContainerRegistry
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add Aspire.Hosting.Azure.ContainerRegistry
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Container Registry hosting integration package:
@@ -73,17 +80,24 @@ This updates your `aspire.config.json` with the Azure Container Registry hosting
 </AppHostTabs>
 
 <Aside type="caution">
-  When you call `AddAzureContainerRegistry` (or `addAzureContainerRegistry`), it implicitly calls
-  `AddAzureProvisioning` — which adds support for generating Azure resources dynamically during app
-  startup. The app must configure the appropriate subscription and location. For more information,
-  see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureContainerRegistry` (or `addAzureContainerRegistry`), it
+  implicitly calls `AddAzureProvisioning` — which adds support for generating
+  Azure resources dynamically during app startup. The app must configure the
+  appropriate subscription and location. For more information, see [Local
+  provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 ## Add Azure Container Registry resource
 
 Once you've installed the hosting integration in your AppHost project, add an Azure Container Registry resource and wire it to a compute environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -105,9 +119,9 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const acr = await builder.addAzureContainerRegistry("my-acr");
+const acr = await builder.addAzureContainerRegistry('my-acr');
 
-const env = await builder.addAzureContainerAppEnvironment("env");
+const env = await builder.addAzureContainerAppEnvironment('env');
 await env.withAzureContainerRegistry(acr);
 
 await builder.build().run();
@@ -127,14 +141,22 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-  Compute environments such as `AzureContainerAppEnvironment` automatically provision a default Azure Container Registry when none is specified. You only need to call `WithAzureContainerRegistry` when you want to use a specific registry.
+  Compute environments such as `AzureContainerAppEnvironment` automatically
+  provision a default Azure Container Registry when none is specified. You only
+  need to call `WithAzureContainerRegistry` when you want to use a specific
+  registry.
 </Aside>
 
 ## Get the registry from a compute environment
 
 To retrieve the registry that is associated with a compute environment — for example, to add purge tasks to the auto-provisioned default registry — use `GetAzureContainerRegistry` (or `getAzureContainerRegistry`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -154,7 +176,7 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const env = await builder.addAzureContainerAppEnvironment("env");
+const env = await builder.addAzureContainerAppEnvironment('env');
 
 // Retrieve the default auto-provisioned registry
 const registry = await env.getAzureContainerRegistry();
@@ -166,14 +188,23 @@ const registry = await env.getAzureContainerRegistry();
 This returns an `AzureContainerRegistryResource` builder that you can use for further configuration, such as [scheduling image cleanup with purge tasks](#schedule-image-cleanup-with-purge-tasks).
 
 <Aside type="caution">
-  The `IAzureContainerRegistry` interface is obsolete as of Aspire 13.2. If your code casts a compute environment to `IAzureContainerRegistry`, migrate to the `ContainerRegistry` property on `IAzureComputeEnvironmentResource` instead. For more information, see [What's new in Aspire 13.2](/whats-new/aspire-13-2/#breaking-changes).
+  The `IAzureContainerRegistry` interface is obsolete as of Aspire 13.2. If your
+  code casts a compute environment to `IAzureContainerRegistry`, migrate to the
+  `ContainerRegistry` property on `IAzureComputeEnvironmentResource` instead.
+  For more information, see [What's new in Aspire
+  13.2](/whats-new/aspire-13-2/#breaking-changes).
 </Aside>
 
 ## Reference an existing container registry
 
 To reference a registry your team already manages rather than provisioning a new one, use `publishAsExisting`, `runAsExisting`, or `asExisting`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Use `PublishAsExisting` to reference an existing registry only in publish (deployment) mode:
@@ -211,13 +242,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const registryName = await builder.addParameter("registryName");
-const rgName = await builder.addParameter("rgName");
+const registryName = await builder.addParameter('registryName');
+const rgName = await builder.addParameter('rgName');
 
-const acr = await builder.addAzureContainerRegistry("my-acr");
+const acr = await builder.addAzureContainerRegistry('my-acr');
 await acr.publishAsExisting(registryName, { resourceGroup: rgName });
 
-const env = await builder.addAzureContainerAppEnvironment("env");
+const env = await builder.addAzureContainerAppEnvironment('env');
 await env.withAzureContainerRegistry(acr);
 
 await builder.build().run();
@@ -226,7 +257,7 @@ await builder.build().run();
 Use `asExisting` to reference an existing registry in both run and publish modes:
 
 ```typescript title="apphost.mts"
-const acr = await builder.addAzureContainerRegistry("my-acr");
+const acr = await builder.addAzureContainerRegistry('my-acr');
 await acr.asExisting(registryName, { resourceGroup: rgName });
 ```
 
@@ -237,7 +268,12 @@ await acr.asExisting(registryName, { resourceGroup: rgName });
 
 Use `WithRoleAssignments` (or `withRoleAssignments`) to grant an Azure resource fine-grained access to the registry. The `ContainerRegistryBuiltInRole` enum (TypeScript: `AzureContainerRegistryRole`) covers the standard ACR roles:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -256,14 +292,17 @@ builder.Build().Run();
 <Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
-import { createBuilder, AzureContainerRegistryRole } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  AzureContainerRegistryRole,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const acr = await builder.addAzureContainerRegistry("my-acr");
+const acr = await builder.addAzureContainerRegistry('my-acr');
 
 // Grant the 'api' project permission to push images
-const api = await builder.addProject("api", "../Api/Api.csproj");
+const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withRoleAssignments(acr, [AzureContainerRegistryRole.AcrPush]);
 
 await builder.build().run();
@@ -278,7 +317,12 @@ Available roles include: `AcrPull`, `AcrPush`, `AcrDelete`, `AcrImageSigner`, `A
 
 Over time, container registries accumulate old images that consume storage. Use `WithPurgeTask` (or `withPurgeTask`) to add a scheduled [ACR purge task](https://learn.microsoft.com/azure/container-registry/container-registry-auto-purge) that automatically removes old or unused images:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -298,10 +342,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const acr = await builder.addAzureContainerRegistry("my-acr");
-await acr.withPurgeTask("0 1 * * *", {
-    ago: 7 * 24 * 60 * 60 * 1000,  // 7 days in milliseconds
-    keep: 5,
+const acr = await builder.addAzureContainerRegistry('my-acr');
+await acr.withPurgeTask('0 1 * * *', {
+  ago: 7 * 24 * 60 * 60 * 1000, // 7 days in milliseconds
+  keep: 5,
 });
 
 await builder.build().run();
@@ -316,7 +360,12 @@ The preceding code creates a purge task that runs daily at 1:00 AM, removing ima
 
 Add multiple purge tasks to target different repositories with different schedules:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="Multiple purge tasks"
@@ -329,12 +378,12 @@ var acr = builder.AddAzureContainerRegistry("my-acr")
 <Fragment slot="typescript">
 
 ```typescript title="Multiple purge tasks"
-const acr = await builder.addAzureContainerRegistry("my-acr");
-await acr.withPurgeTask("0 1 * * *", { filter: "app1:.*", keep: 3 });
-await acr.withPurgeTask("0 2 * * 0", {
-    filter: "app2:.*",
-    ago: 30 * 24 * 60 * 60 * 1000,
-    keep: 10,
+const acr = await builder.addAzureContainerRegistry('my-acr');
+await acr.withPurgeTask('0 1 * * *', { filter: 'app1:.*', keep: 3 });
+await acr.withPurgeTask('0 2 * * 0', {
+  filter: 'app2:.*',
+  ago: 30 * 24 * 60 * 60 * 1000,
+  keep: 10,
 });
 ```
 
@@ -347,7 +396,12 @@ Each purge task is given a unique name automatically. Use the `taskName` option 
 
 To make changes that go beyond what the built-in APIs expose, configure the underlying Bicep infrastructure directly via `ConfigureInfrastructure` (or `configureInfrastructure`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -366,9 +420,9 @@ var acr = builder.AddAzureContainerRegistry("my-acr")
 <Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
-const acr = await builder.addAzureContainerRegistry("my-acr");
+const acr = await builder.addAzureContainerRegistry('my-acr');
 await acr.configureInfrastructure(async (infra) => {
-    // Use the Bicep infrastructure object to customize the registry
+  // Use the Bicep infrastructure object to customize the registry
 });
 ```
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host.mdx
@@ -31,7 +31,12 @@ If you're new to the Azure Cosmos DB integration, start with the [Get started wi
 
 To start building an Aspire app that uses Azure Cosmos DB, install the [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -39,7 +44,8 @@ aspire add azure-cosmosdb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -60,7 +66,8 @@ aspire add azure-cosmosdb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Cosmos DB hosting integration package:
@@ -80,7 +87,12 @@ This updates your `aspire.config.json` with the Azure Cosmos DB hosting integrat
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Cosmos DB resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -88,10 +100,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 var cosmos = builder.AddAzureCosmosDB("cosmos-db");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(cosmos);
+.WithReference(cosmos);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -105,32 +118,47 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(cosmos);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="caution">
-  When you call `AddAzureCosmosDB` (or `addAzureCosmosDB`), it implicitly calls `AddAzureProvisioning` — which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureCosmosDB` (or `addAzureCosmosDB`), it implicitly calls
+  `AddAzureProvisioning` — which adds support for generating Azure resources
+  dynamically during app startup. The app must configure the appropriate
+  subscription and location. For more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure Cosmos DB resource from the AppHost, Aspire makes several properties available to the consuming project, such as the endpoint URI, account key, and connection string. For a complete list of these properties and per-language connection examples, see [Connect to Azure Cosmos DB](../azure-cosmos-db-connect/).
+  When you reference an Azure Cosmos DB resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the endpoint
+  URI, account key, and connection string. For a complete list of these
+  properties and per-language connection examples, see [Connect to Azure Cosmos
+  DB](../azure-cosmos-db-connect/).
 </Aside>
 
 ## Run as emulator
 
 For local development, use the Azure Cosmos DB Emulator instead of a live Azure account. Chain `RunAsEmulator` (or `runAsEmulator`) on the resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -142,7 +170,8 @@ const cosmos = await builder.addAzureCosmosDB("cosmos-db");
 await cosmos.runAsEmulator();
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -160,19 +189,25 @@ By default, the Cosmos DB emulator container exposes the following endpoint:
 
 To configure a fixed host port, call `WithGatewayPort` (or `withGatewayPort`) inside the emulator callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithGatewayPort(7777);
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithGatewayPort(7777);
+});
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -188,7 +223,8 @@ await cosmos.runAsEmulator({
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -202,19 +238,25 @@ The Cosmos DB emulator container's port is mapped to the host port as shown in t
 
 To configure the partition count for the Cosmos DB emulator container, call `WithPartitionCount` (or `withPartitionCount`) inside the emulator callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithPartitionCount(100); // Defaults to 25
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithPartitionCount(100); // Defaults to 25
+});
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -230,7 +272,8 @@ await cosmos.runAsEmulator({
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -240,19 +283,25 @@ This is a shorthand for setting the `AZURE_COSMOS_EMULATOR_PARTITION_COUNT` envi
 
 To persist the emulator data across container restarts, attach a named volume:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithDataVolume();
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithDataVolume();
+});
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -268,7 +317,8 @@ await cosmos.runAsEmulator({
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -277,6 +327,15 @@ The data volume is mounted at `/tmp/cosmos/appdata` in the emulator container. W
 ### Configure emulator with persistent lifetime
 
 To configure the Cosmos DB emulator container with a persistent lifetime, call the `WithLifetime` method with `ContainerLifetime.Persistent`:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -290,15 +349,24 @@ var cosmos = builder.AddAzureCosmosDB("cosmos-db")
 // After adding all resources, run the app...
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
-    The TypeScript AppHost doesn't currently expose a `withLifetime` API for the Cosmos DB emulator container.
+  The TypeScript AppHost doesn't currently expose a `withLifetime` API for the
+  Cosmos DB emulator container.
 </Aside>
 
 ## Run as preview emulator (Linux-based)
 
 The [next generation of the Azure Cosmos DB emulator](https://learn.microsoft.com/azure/cosmos-db/emulator-linux) is Linux-based, supports a wide variety of processors and operating systems, and includes a built-in **Data Explorer** web UI. To use it, call `RunAsPreviewEmulator` (or `runAsPreviewEmulator`).
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Since the preview emulator is an experimental feature, you must suppress the `ASPIRECOSMOSDB001` diagnostic to opt in:
@@ -325,11 +393,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cosmos = await builder.addAzureCosmosDB("cosmos-db");
+const cosmos = await builder.addAzureCosmosDB('cosmos-db');
 await cosmos.runAsPreviewEmulator({
-    configureContainer: async emulator => {
-        await emulator.withDataExplorer();
-    }
+  configureContainer: async (emulator) => {
+    await emulator.withDataExplorer();
+  },
 });
 
 // After adding all resources, run the app...
@@ -344,7 +412,12 @@ await cosmos.runAsPreviewEmulator({
 
 You might have an existing Azure Cosmos DB account you want to connect to. Chain a call to `AsExisting` (or `asExisting`) on the resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -353,13 +426,14 @@ var existingCosmosName = builder.AddParameter("existingCosmosName");
 var existingCosmosResourceGroup = builder.AddParameter("existingCosmosResourceGroup");
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .AsExisting(existingCosmosName, existingCosmosResourceGroup);
+.AsExisting(existingCosmosName, existingCosmosResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cosmos);
+.WithReference(cosmos);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -377,14 +451,17 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(cosmos);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 For more information on treating Azure Cosmos DB resources as existing resources, see [Use existing Azure resources](/integrations/cloud/azure/overview/#use-existing-azure-resources).
 
 <Aside type="note">
-    Alternatively, instead of representing an Azure Cosmos DB account resource, you can add a connection string to the AppHost. This approach is weakly-typed and doesn't work with role assignments or infrastructure customizations.
+  Alternatively, instead of representing an Azure Cosmos DB account resource,
+  you can add a connection string to the AppHost. This approach is weakly-typed
+  and doesn't work with role assignments or infrastructure customizations.
 </Aside>
 
 ## Add Azure Cosmos DB database and container resources
@@ -395,7 +472,12 @@ Aspire models parent-child relationships between Azure Cosmos DB resources. An A
 
 To add an Azure Cosmos DB database resource, call `AddCosmosDatabase` (or `addCosmosDatabase`) on the Cosmos DB account resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -404,7 +486,8 @@ var cosmos = builder.AddAzureCosmosDB("cosmos-db");
 var db = cosmos.AddCosmosDatabase("db");
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -416,7 +499,8 @@ const cosmos = await builder.addAzureCosmosDB("cosmos-db");
 const db = await cosmos.addCosmosDatabase("db");
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -426,7 +510,12 @@ The `AddCosmosDatabase` call adds a logical database named `db` to your Cosmos D
 
 An Azure Cosmos DB container is where data is stored. When you create a container, you must supply a partition key path. To add an Azure Cosmos DB container resource, call `AddContainer` (or `addContainer`) on the database resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -436,7 +525,8 @@ var db = cosmos.AddCosmosDatabase("db");
 var container = db.AddContainer("entries", "/id");
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -449,7 +539,8 @@ const db = await cosmos.addCosmosDatabase("db");
 const container = await db.addContainer("entries", "/id");
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -459,7 +550,12 @@ The second argument to `AddContainer` (or `addContainer`) is the partition key p
 
 The following example demonstrates a full parent-child hierarchy — a single Cosmos DB account with two databases, each containing multiple containers:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -474,12 +570,13 @@ var details = orders.AddContainer("details", "/id");
 var history = orders.AddContainer("history", "/id");
 
 builder.AddProject<Projects.Api>("api")
-    .WithReference(profiles)
-    .WithReference(details)
-    .WithReference(history);
+.WithReference(profiles)
+.WithReference(details)
+.WithReference(history);
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -502,7 +599,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(history);
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -523,16 +621,22 @@ When your AppHost code expresses parent-child relationships, consuming apps can 
 
 By default, the Azure Cosmos DB hosting integration uses Microsoft Entra ID (role-based access). To enable access key authentication instead, call `WithAccessKeyAuthentication` (or `withAccessKeyAuthentication`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .WithAccessKeyAuthentication();
+.WithAccessKeyAuthentication();
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -544,7 +648,8 @@ const cosmos = await builder.addAzureCosmosDB("cosmos-db");
 await cosmos.withAccessKeyAuthentication();
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -626,17 +731,22 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables fluent customization of the generated Bicep using the `ConfigureInfrastructure` (or `configureInfrastructure`) API. For example, you can configure the `kind`, `consistencyPolicy`, `locations`, and more:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureCosmosDB("cosmos-db")
-    .ConfigureInfrastructure(infra =>
-    {
-        var cosmosDbAccount = infra.GetProvisionableResources()
-                                    .OfType<CosmosDBAccount>()
-                                    .Single();
+.ConfigureInfrastructure(infra =>
+{
+var cosmosDbAccount = infra.GetProvisionableResources()
+.OfType<CosmosDBAccount>()
+.Single();
 
         cosmosDbAccount.Kind = CosmosDBAccountKind.MongoDB;
         cosmosDbAccount.ConsistencyPolicy = new()
@@ -645,7 +755,8 @@ builder.AddAzureCosmosDB("cosmos-db")
         };
         cosmosDbAccount.Tags.Add("ExampleKey", "Example value");
     });
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -661,10 +772,12 @@ await cosmos.configureInfrastructure(async infra => {
         account.tags = { ...account.tags, ExampleKey: 'Example value' };
     }
 });
-```
+````
 
 <Aside type="note">
-    The TypeScript `configureInfrastructure` API provides access to raw Bicep resource objects. Strongly-typed resource properties (such as `CosmosDBAccountKind`) are only available in the C# provisioning SDK.
+  The TypeScript `configureInfrastructure` API provides access to raw Bicep
+  resource objects. Strongly-typed resource properties (such as
+  `CosmosDBAccountKind`) are only available in the C# provisioning SDK.
 </Aside>
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host.mdx
@@ -32,10 +32,10 @@ If you're new to the Azure Cosmos DB integration, start with the [Get started wi
 To start building an Aspire app that uses Azure Cosmos DB, install the [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -88,10 +88,10 @@ This updates your `aspire.config.json` with the Azure Cosmos DB hosting integrat
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Cosmos DB resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -144,10 +144,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 For local development, use the Azure Cosmos DB Emulator instead of a live Azure account. Chain `RunAsEmulator` (or `runAsEmulator`) on the resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -190,10 +190,10 @@ By default, the Cosmos DB emulator container exposes the following endpoint:
 To configure a fixed host port, call `WithGatewayPort` (or `withGatewayPort`) inside the emulator callback:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -239,10 +239,10 @@ The Cosmos DB emulator container's port is mapped to the host port as shown in t
 To configure the partition count for the Cosmos DB emulator container, call `WithPartitionCount` (or `withPartitionCount`) inside the emulator callback:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -284,10 +284,10 @@ This is a shorthand for setting the `AZURE_COSMOS_EMULATOR_PARTITION_COUNT` envi
 To persist the emulator data across container restarts, attach a named volume:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -329,11 +329,11 @@ The data volume is mounted at `/tmp/cosmos/appdata` in the emulator container. W
 To configure the Cosmos DB emulator container with a persistent lifetime, call the `WithLifetime` method with `ContainerLifetime.Persistent`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -362,10 +362,10 @@ var cosmos = builder.AddAzureCosmosDB("cosmos-db")
 The [next generation of the Azure Cosmos DB emulator](https://learn.microsoft.com/azure/cosmos-db/emulator-linux) is Linux-based, supports a wide variety of processors and operating systems, and includes a built-in **Data Explorer** web UI. To use it, call `RunAsPreviewEmulator` (or `runAsPreviewEmulator`).
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -413,10 +413,10 @@ await cosmos.runAsPreviewEmulator({
 You might have an existing Azure Cosmos DB account you want to connect to. Chain a call to `AsExisting` (or `asExisting`) on the resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -473,10 +473,10 @@ Aspire models parent-child relationships between Azure Cosmos DB resources. An A
 To add an Azure Cosmos DB database resource, call `AddCosmosDatabase` (or `addCosmosDatabase`) on the Cosmos DB account resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -511,10 +511,10 @@ The `AddCosmosDatabase` call adds a logical database named `db` to your Cosmos D
 An Azure Cosmos DB container is where data is stored. When you create a container, you must supply a partition key path. To add an Azure Cosmos DB container resource, call `AddContainer` (or `addContainer`) on the database resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -551,10 +551,10 @@ The second argument to `AddContainer` (or `addContainer`) is the partition key p
 The following example demonstrates a full parent-child hierarchy — a single Cosmos DB account with two databases, each containing multiple containers:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -622,10 +622,10 @@ When your AppHost code expresses parent-child relationships, consuming apps can 
 By default, the Azure Cosmos DB hosting integration uses Microsoft Entra ID (role-based access). To enable access key authentication instead, call `WithAccessKeyAuthentication` (or `withAccessKeyAuthentication`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -732,10 +732,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables fluent customization of the generated Bicep using the `ConfigureInfrastructure` (or `configureInfrastructure`) API. For example, you can configure the `kind`, `consistencyPolicy`, `locations`, and more:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
@@ -33,10 +33,10 @@ This article is the reference for the Aspire Azure Data Explorer (Kusto) hosting
 To start building an Aspire app that uses Azure Data Explorer, install the [📦 Aspire.Hosting.Azure.Kusto](https://www.nuget.org/packages/Aspire.Hosting.Azure.Kusto) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -89,10 +89,10 @@ This updates your `aspire.config.json` with the Azure Data Explorer hosting inte
 Once you've installed the hosting integration, call `AddAzureKustoCluster` (or `addAzureKustoCluster`) to declare a cluster, then call `AddReadWriteDatabase` (or `addReadWriteDatabase`) to declare one or more databases inside it:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -143,10 +143,10 @@ The preceding code adds an Azure Data Explorer cluster named `kusto` with a read
 The hosting integration supports running Azure Data Explorer locally using the Kustainer container image. This lets you develop and test without an Azure subscription or an existing cluster.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -195,10 +195,10 @@ When running as an emulator, databases are automatically created when the contai
 By default, the emulator uses a dynamic host port. To fix the host port, pass a `configureContainer` callback and call `WithHostPort` (or `withHostPort`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -238,10 +238,10 @@ const kusto = await builder.addAzureKustoCluster("kusto")
 When running as an emulator, you can provide a KQL script to initialize the database with tables and data:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -359,10 +359,10 @@ The generated Bicep is a starting point — customise it through the C# provisio
 All Aspire Azure resources subclass `AzureProvisioningResource`. The `ConfigureInfrastructure` (or `configureInfrastructure`) API lets you customise the generated Bicep with a fluent callback:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-data-explorer.mdx
@@ -32,7 +32,12 @@ This article is the reference for the Aspire Azure Data Explorer (Kusto) hosting
 
 To start building an Aspire app that uses Azure Data Explorer, install the [📦 Aspire.Hosting.Azure.Kusto](https://www.nuget.org/packages/Aspire.Hosting.Azure.Kusto) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -40,7 +45,8 @@ aspire add azure-kusto
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -61,7 +67,8 @@ aspire add azure-kusto
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Data Explorer hosting integration package:
@@ -81,7 +88,12 @@ This updates your `aspire.config.json` with the Azure Data Explorer hosting inte
 
 Once you've installed the hosting integration, call `AddAzureKustoCluster` (or `addAzureKustoCluster`) to declare a cluster, then call `AddReadWriteDatabase` (or `addReadWriteDatabase`) to declare one or more databases inside it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -90,11 +102,12 @@ var kusto = builder.AddAzureKustoCluster("kusto");
 var database = kusto.AddReadWriteDatabase("analytics");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(database)
-    .WaitFor(database);
+.WithReference(database)
+.WaitFor(database);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -110,39 +123,47 @@ await builder.addNodeApp("api", "./api", "index.js")
     .waitFor(database);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The preceding code adds an Azure Data Explorer cluster named `kusto` with a read-write database named `analytics`. The `WithReference` (or `withReference`) method injects the connection information into the consuming project.
 
 <Aside type="caution">
-  When you call `AddAzureKustoCluster`, it implicitly calls `AddAzureProvisioning` —
-  which adds support for generating Azure resources dynamically during app startup.
-  The app must configure the appropriate subscription and location. For more
-  information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureKustoCluster`, it implicitly calls
+  `AddAzureProvisioning` — which adds support for generating Azure resources
+  dynamically during app startup. The app must configure the appropriate
+  subscription and location. For more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 ## Run as emulator
 
 The hosting integration supports running Azure Data Explorer locally using the Kustainer container image. This lets you develop and test without an Azure subscription or an existing cluster.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kusto = builder.AddAzureKustoCluster("kusto")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 var database = kusto.AddReadWriteDatabase("analytics");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(database)
-    .WaitFor(database);
+.WithReference(database)
+.WaitFor(database);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -160,7 +181,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .waitFor(database);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -172,19 +194,25 @@ When running as an emulator, databases are automatically created when the contai
 
 By default, the emulator uses a dynamic host port. To fix the host port, pass a `configureContainer` callback and call `WithHostPort` (or `withHostPort`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kusto = builder.AddAzureKustoCluster("kusto")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithHostPort(8080);
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithHostPort(8080);
+});
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -200,7 +228,8 @@ const kusto = await builder.addAzureKustoCluster("kusto")
     });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -208,29 +237,35 @@ const kusto = await builder.addAzureKustoCluster("kusto")
 
 When running as an emulator, you can provide a KQL script to initialize the database with tables and data:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kusto = builder.AddAzureKustoCluster("kusto")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 var database = kusto.AddReadWriteDatabase("analytics")
-    .WithCreationScript("""
-        .create table Events (
-            Timestamp: datetime,
-            EventType: string,
-            Message: string
-        )
-        """);
+.WithCreationScript("""
+.create table Events (
+Timestamp: datetime,
+EventType: string,
+Message: string
+)
+""");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(database)
-    .WaitFor(database);
+.WithReference(database)
+.WaitFor(database);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -256,12 +291,15 @@ await exampleProject
     .waitFor(database);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-  The creation script is only executed when running as an emulator. In production scenarios, database schema should be managed through your deployment and provisioning process.
+  The creation script is only executed when running as an emulator. In
+  production scenarios, database schema should be managed through your
+  deployment and provisioning process.
 </Aside>
 
 ## Provisioning-generated Bicep
@@ -320,17 +358,22 @@ The generated Bicep is a starting point — customise it through the C# provisio
 
 All Aspire Azure resources subclass `AzureProvisioningResource`. The `ConfigureInfrastructure` (or `configureInfrastructure`) API lets you customise the generated Bicep with a fluent callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kusto = builder.AddAzureKustoCluster("kusto")
-    .ConfigureInfrastructure(infra =>
-    {
-        var cluster = infra.GetProvisionableResources()
-            .OfType<KustoCluster>()
-            .Single();
+.ConfigureInfrastructure(infra =>
+{
+var cluster = infra.GetProvisionableResources()
+.OfType<KustoCluster>()
+.Single();
 
         cluster.Sku = new KustoSku
         {
@@ -343,7 +386,8 @@ var kusto = builder.AddAzureKustoCluster("kusto")
     });
 
 kusto.AddReadWriteDatabase("analytics");
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -359,7 +403,8 @@ await kusto.configureInfrastructure(async (infra) => {
 await kusto.addReadWriteDatabase("analytics");
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -378,21 +423,24 @@ When you add an Azure Data Explorer resource to your application, the connection
 
 ### Cluster resource
 
-| Property | Description |
-|----------|-------------|
-| `Uri` | The URI of the Azure Data Explorer cluster endpoint. |
+| Property | Description                                          |
+| -------- | ---------------------------------------------------- |
+| `Uri`    | The URI of the Azure Data Explorer cluster endpoint. |
 
 ### Database resource
 
-| Property | Description |
-|----------|-------------|
-| `Uri` | The URI of the parent cluster endpoint (inherited from cluster). |
-| `DatabaseName` | The name of the database. |
+| Property       | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| `Uri`          | The URI of the parent cluster endpoint (inherited from cluster). |
+| `DatabaseName` | The name of the database.                                        |
 
 The connection string format is: `Data Source=https://{cluster-uri};Initial Catalog={database-name}`
 
 <Aside type="note">
-  The Azure Data Explorer hosting integration does not include a corresponding client integration package. Use the [Kusto .NET SDK](https://learn.microsoft.com/azure/data-explorer/kusto/api/netfx/about-the-sdk) directly in your application to query data.
+  The Azure Data Explorer hosting integration does not include a corresponding
+  client integration package. Use the [Kusto .NET
+  SDK](https://learn.microsoft.com/azure/data-explorer/kusto/api/netfx/about-the-sdk)
+  directly in your application to query data.
 </Aside>
 
 ## Hosting integration health checks

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-default-credential.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-default-credential.mdx
@@ -29,14 +29,23 @@ Starting in Aspire 13.2, the default credential behavior was updated to follow [
 - **Local development**: When no Azure environment is detected, a `DefaultAzureCredential` configured for development is used. This credential excludes `EnvironmentCredential`, `WorkloadIdentityCredential`, and `ManagedIdentityCredential`—leaving only credentials applicable to developer machines, such as the Azure CLI, Visual Studio, or Azure Developer CLI credentials.
 
 <Aside type="caution" title="Breaking change in Aspire 13.2">
-  This is a breaking change for anyone depending on credentials other than `ManagedIdentityCredential` working in an Azure service. For example, if your application relies on `EnvironmentCredential` or `WorkloadIdentityCredential` in an Azure-hosted environment, you need to explicitly configure the credential.
+  This is a breaking change for anyone depending on credentials other than
+  `ManagedIdentityCredential` working in an Azure service. For example, if your
+  application relies on `EnvironmentCredential` or `WorkloadIdentityCredential`
+  in an Azure-hosted environment, you need to explicitly configure the
+  credential.
 </Aside>
 
 ## Override the default credential
 
 If you need to use a different credential in your application, you can provide your own by configuring the integration's settings. For example, to use `EnvironmentCredential` with Azure Blob Storage:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="Program.cs"
@@ -54,7 +63,11 @@ Each Aspire Azure client integration exposes a `Credential` property in its sett
 <Fragment slot="typescript">
 
 <Aside type="note">
-  Credential overrides apply to .NET client integrations running in consuming apps. TypeScript consuming apps that need a non-default Azure credential should configure authentication directly using the Azure SDK for their language; the `AZURE_TOKEN_CREDENTIALS` environment variable set by the AppHost still governs the default credential chain for all runtimes.
+  Credential overrides apply to .NET client integrations running in consuming
+  apps. TypeScript consuming apps that need a non-default Azure credential
+  should configure authentication directly using the Azure SDK for their
+  language; the `AZURE_TOKEN_CREDENTIALS` environment variable set by the
+  AppHost still governs the default credential chain for all runtimes.
 </Aside>
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-default-credential.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-default-credential.mdx
@@ -41,10 +41,10 @@ Starting in Aspire 13.2, the default credential behavior was updated to follow [
 If you need to use a different credential in your application, you can provide your own by configuring the integration's settings. For example, to use `EnvironmentCredential` with Azure Blob Storage:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-host.mdx
@@ -36,10 +36,10 @@ The hosting integration models the following types:
 To start building an Aspire app that uses Azure Event Hubs, install the [📦 Aspire.Hosting.Azure.EventHubs](https://www.nuget.org/packages/Aspire.Hosting.Azure.EventHubs) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -92,10 +92,10 @@ This updates your `aspire.config.json` with the Azure Event Hubs hosting integra
 Once you've installed the hosting integration, call `AddAzureEventHubs` to declare a namespace, then call `AddHub` to declare one or more hubs inside it:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -152,10 +152,10 @@ The preceding code adds an Azure Event Hubs namespace named `event-hubs` with an
 To add a consumer group to a hub, call `AddConsumerGroup` (or `addConsumerGroup`) on the hub resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -198,10 +198,10 @@ The `AddConsumerGroup` call registers a consumer group named `messagesConsumer` 
 The hosting integration supports running Event Hubs locally using the `mcr.microsoft.com/azure-messaging/eventhubs-emulator` container image. This lets you develop and test without an Azure subscription or an existing Event Hubs namespace.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -254,10 +254,10 @@ By default, the emulator container exposes port `5672` mapped to a random host p
 To fix the host port, pass a `configureContainer` callback and call `WithHostPort` (or `withHostPort`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -311,10 +311,10 @@ The emulator container's port mapping is then fixed:
 ### Add a data volume to the emulator
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -345,10 +345,10 @@ The data volume persists emulator state outside the container's lifecycle. The v
 ### Add a data bind mount to the emulator
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -381,10 +381,10 @@ Data bind mounts rely on the host machine's filesystem. For more information, se
 The Event Hubs emulator starts with a default [_Config.json_](https://github.com/Azure/azure-event-hubs-emulator-installer/blob/main/EventHub-Emulator/Config/Config.json). To replace it entirely, call `WithConfigurationFile` (or `withConfigurationFile`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -436,11 +436,11 @@ The file is mounted at `/Eventhubs_Emulator/ConfigFiles/Config.json` in the cont
 To update individual properties in the default configuration rather than replacing the entire file, call `WithConfiguration` in C#:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -483,10 +483,10 @@ builder.AddProject<Projects.ExampleService>()
 If you already have an Azure Event Hubs namespace, call `AsExisting` (or `asExisting`) instead of provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -542,10 +542,10 @@ Azure Event Hubs uses role-based access control (RBAC). The hosting integration 
 To customise role assignments, call `withRoleAssignments`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -657,10 +657,10 @@ The generated Bicep is a starting point — customise it through the C# provisio
 All Aspire Azure resources subclass `AzureProvisioningResource`. The `ConfigureInfrastructure` (or `configureInfrastructure`) API lets you customise the generated Bicep with a fluent callback:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-host.mdx
@@ -35,7 +35,12 @@ The hosting integration models the following types:
 
 To start building an Aspire app that uses Azure Event Hubs, install the [📦 Aspire.Hosting.Azure.EventHubs](https://www.nuget.org/packages/Aspire.Hosting.Azure.EventHubs) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -43,7 +48,8 @@ aspire add azure-event-hubs
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -64,7 +70,8 @@ aspire add azure-event-hubs
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Event Hubs hosting integration package:
@@ -84,7 +91,12 @@ This updates your `aspire.config.json` with the Azure Event Hubs hosting integra
 
 Once you've installed the hosting integration, call `AddAzureEventHubs` to declare a namespace, then call `AddHub` to declare one or more hubs inside it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -93,10 +105,11 @@ var eventHubs = builder.AddAzureEventHubs("event-hubs");
 eventHubs.AddHub("messages");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -111,31 +124,39 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The preceding code adds an Azure Event Hubs namespace named `event-hubs` with an Event Hub named `messages`. The `WithReference` (or `withReference`) method injects the connection information into the consuming project.
 
 <Aside type="caution">
-  When you call `AddAzureEventHubs`, it implicitly calls `AddAzureProvisioning` —
-  which adds support for generating Azure resources dynamically during app startup.
-  The app must configure the appropriate subscription and location. For more
-  information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureEventHubs`, it implicitly calls `AddAzureProvisioning`
+  — which adds support for generating Azure resources dynamically during app
+  startup. The app must configure the appropriate subscription and location. For
+  more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
   When you reference an Azure Event Hubs resource from the AppHost, Aspire makes
   several properties available to the consuming project, such as connection URIs
   and hub names. For a complete list of these properties and per-language
-  connection examples, see [Connect to Azure Event Hubs](../azure-event-hubs-connect/).
+  connection examples, see [Connect to Azure Event
+  Hubs](../azure-event-hubs-connect/).
 </Aside>
 
 ## Add an Event Hub consumer group
 
 To add a consumer group to a hub, call `AddConsumerGroup` (or `addConsumerGroup`) on the hub resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -145,10 +166,11 @@ var messages = eventHubs.AddHub("messages");
 messages.AddConsumerGroup("messagesConsumer");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -164,7 +186,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -174,21 +197,27 @@ The `AddConsumerGroup` call registers a consumer group named `messagesConsumer` 
 
 The hosting integration supports running Event Hubs locally using the `mcr.microsoft.com/azure-messaging/eventhubs-emulator` container image. This lets you develop and test without an Azure subscription or an existing Event Hubs namespace.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var eventHubs = builder.AddAzureEventHubs("event-hubs")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 eventHubs.AddHub("messages");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -205,7 +234,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -217,30 +247,36 @@ For more information, see [Azure Event Hubs Emulator](https://learn.microsoft.co
 
 By default, the emulator container exposes port `5672` mapped to a random host port:
 
-| Endpoint   | Container image                                                | Container port | Host port |
-| ---------- | -------------------------------------------------------------- | -------------- | --------- |
-| `emulator` | `mcr.microsoft.com/azure-messaging/eventhubs-emulator`         | 5672           | dynamic   |
+| Endpoint   | Container image                                        | Container port | Host port |
+| ---------- | ------------------------------------------------------ | -------------- | --------- |
+| `emulator` | `mcr.microsoft.com/azure-messaging/eventhubs-emulator` | 5672           | dynamic   |
 
 To fix the host port, pass a `configureContainer` callback and call `WithHostPort` (or `withHostPort`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var eventHubs = builder.AddAzureEventHubs("event-hubs")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithHostPort(7777);
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithHostPort(7777);
+});
 
 eventHubs.AddHub("messages");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -261,7 +297,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -273,24 +310,30 @@ The emulator container's port mapping is then fixed:
 
 ### Add a data volume to the emulator
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var eventHubs = builder.AddAzureEventHubs("event-hubs")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithDataVolume();
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithDataVolume();
+});
 
 eventHubs.AddHub("messages");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose `withDataVolume` on the Event Hubs emulator resource. To persist emulator state across restarts from a TypeScript AppHost, use `withConfigurationFile` to pre-configure hubs or run the C# AppHost instead.
@@ -301,7 +344,12 @@ The data volume persists emulator state outside the container's lifecycle. The v
 
 ### Add a data bind mount to the emulator
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -318,7 +366,8 @@ builder.AddProject<Projects.ExampleService>()
     .WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose `withDataBindMount` on the Event Hubs emulator resource. Use a data volume via the C# AppHost or pre-configure hubs with `withConfigurationFile` instead.
@@ -331,24 +380,30 @@ Data bind mounts rely on the host machine's filesystem. For more information, se
 
 The Event Hubs emulator starts with a default [_Config.json_](https://github.com/Azure/azure-event-hubs-emulator-installer/blob/main/EventHub-Emulator/Config/Config.json). To replace it entirely, call `WithConfigurationFile` (or `withConfigurationFile`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var eventHubs = builder.AddAzureEventHubs("event-hubs")
-    .RunAsEmulator(emulator =>
-    {
-        emulator.WithConfigurationFile("./messaging/custom-config.json");
-    });
+.RunAsEmulator(emulator =>
+{
+emulator.WithConfigurationFile("./messaging/custom-config.json");
+});
 
 eventHubs.AddHub("messages");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -369,7 +424,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -378,6 +434,15 @@ The file is mounted at `/Eventhubs_Emulator/ConfigFiles/Config.json` in the cont
 ### Override specific emulator configuration properties
 
 To update individual properties in the default configuration rather than replacing the entire file, call `WithConfiguration` in C#:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -404,15 +469,25 @@ builder.AddProject<Projects.ExampleService>()
 // After adding all resources, run the app...
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
-  `WithConfiguration` is not available in the TypeScript AppHost. Use `withConfigurationFile` to supply a fully customized configuration file instead.
+  `WithConfiguration` is not available in the TypeScript AppHost. Use
+  `withConfigurationFile` to supply a fully customized configuration file
+  instead.
 </Aside>
 
 ## Connect to an existing Azure Event Hubs namespace
 
 If you already have an Azure Event Hubs namespace, call `AsExisting` (or `asExisting`) instead of provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -421,13 +496,14 @@ var existingName = builder.AddParameter("existingEventHubsName");
 var existingResourceGroup = builder.AddParameter("existingEventHubsResourceGroup");
 
 var eventHubs = builder.AddAzureEventHubs("event-hubs")
-    .AsExisting(existingName, existingResourceGroup);
+.AsExisting(existingName, existingResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(eventHubs);
+.WithReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -444,7 +520,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(eventHubs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -454,7 +531,8 @@ For more information, see [Use existing Azure resources](/integrations/cloud/azu
   Alternatively, you can add a connection string to the AppHost directly. This
   approach is weakly-typed and doesn't work with role assignments or
   infrastructure customizations. For more information, see [Add existing Azure
-  resources with connection strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
+  resources with connection
+  strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
 </Aside>
 
 ## Role-based access
@@ -463,7 +541,12 @@ Azure Event Hubs uses role-based access control (RBAC). The hosting integration 
 
 To customise role assignments, call `withRoleAssignments`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -471,11 +554,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 var eventHubs = builder.AddAzureEventHubs("event-hubs");
 
 builder.AddProject<Projects.ExampleService>()
-    .WithReference(eventHubs)
-    .WithRoleAssignments(eventHubs, AzureEventHubsRole.AzureEventHubsDataSender);
+.WithReference(eventHubs)
+.WithRoleAssignments(eventHubs, AzureEventHubsRole.AzureEventHubsDataSender);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -492,17 +576,18 @@ const api = await builder.addNodeApp("api", "./api", "index.js")
 await eventHubs.withRoleAssignments(api, [AzureEventHubsRole.AzureEventHubsDataSender]);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The available roles are:
 
-| Role                          | Description |
-| ----------------------------- | ----------- |
-| `AzureEventHubsDataOwner`     | Full access to Azure Event Hubs resources |
-| `AzureEventHubsDataReceiver`  | Receive access to Azure Event Hubs resources |
-| `AzureEventHubsDataSender`    | Send access to Azure Event Hubs resources |
+| Role                         | Description                                  |
+| ---------------------------- | -------------------------------------------- |
+| `AzureEventHubsDataOwner`    | Full access to Azure Event Hubs resources    |
+| `AzureEventHubsDataReceiver` | Receive access to Azure Event Hubs resources |
+| `AzureEventHubsDataSender`   | Send access to Azure Event Hubs resources    |
 
 ## Provisioning-generated Bicep
 
@@ -571,17 +656,22 @@ The generated Bicep is a starting point — customise it through the C# provisio
 
 All Aspire Azure resources subclass `AzureProvisioningResource`. The `ConfigureInfrastructure` (or `configureInfrastructure`) API lets you customise the generated Bicep with a fluent callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureEventHubs("event-hubs")
-    .ConfigureInfrastructure(infra =>
-    {
-        var eventHubs = infra.GetProvisionableResources()
-                              .OfType<EventHubsNamespace>()
-                              .Single();
+.ConfigureInfrastructure(infra =>
+{
+var eventHubs = infra.GetProvisionableResources()
+.OfType<EventHubsNamespace>()
+.Single();
 
         eventHubs.Sku = new EventHubsSku()
         {
@@ -592,7 +682,8 @@ builder.AddAzureEventHubs("event-hubs")
         eventHubs.PublicNetworkAccess = EventHubsPublicNetworkAccess.SecuredByPerimeter;
         eventHubs.Tags.Add("ExampleKey", "Example value");
     });
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -606,7 +697,8 @@ await eventHubs.configureInfrastructure(async (infra) => {
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -628,4 +720,3 @@ For the full reference of Azure Event Hubs connection properties — and how con
 The Azure Event Hubs hosting integration automatically adds a health check for the Event Hubs resource. The health check verifies that the Event Hubs namespace is running and that a connection can be established to it.
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.Azure.Messaging.EventHubs](https://www.nuget.org/packages/AspNetCore.HealthChecks.Azure.Messaging.EventHubs) NuGet package.
-

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-front-door.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-front-door.mdx
@@ -36,7 +36,12 @@ To access this type and APIs, add the [📦 Aspire.Hosting.Azure.FrontDoor](http
 
 In your AppHost, call `addAzureFrontDoor` to add a Front Door profile, then call `withOrigin` to attach a backend resource as an origin:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -62,12 +67,12 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addAzureAppServiceEnvironment("production");
+await builder.addAzureAppServiceEnvironment('production');
 
-const api = await builder.addProject("api", "../Api/Api.csproj");
+const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withExternalHttpEndpoints();
 
-const frontdoor = await builder.addAzureFrontDoor("frontdoor");
+const frontdoor = await builder.addAzureFrontDoor('frontdoor');
 await frontdoor.withOrigin(api);
 
 // After adding all resources, run the app...
@@ -97,7 +102,12 @@ Each call to `withOrigin` creates a separate Front Door endpoint, origin group, 
 
 You can add multiple backends to the same Front Door profile. Each origin gets its own Front Door endpoint and route:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -126,15 +136,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addAzureAppServiceEnvironment("production");
+await builder.addAzureAppServiceEnvironment('production');
 
-const api = await builder.addProject("api", "../Api/Api.csproj");
+const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withExternalHttpEndpoints();
 
-const web = await builder.addProject("web", "../Web/Web.csproj");
+const web = await builder.addProject('web', '../Web/Web.csproj');
 await web.withExternalHttpEndpoints();
 
-const frontdoor = await builder.addAzureFrontDoor("frontdoor");
+const frontdoor = await builder.addAzureFrontDoor('frontdoor');
 await frontdoor.withOrigin(api);
 await frontdoor.withOrigin(web);
 
@@ -155,7 +165,12 @@ Front Door uses health probes to determine which origins are healthy. By default
 When you publish your app, Aspire generates Bicep alongside the manifest. A Front Door resource with a single origin generates Bicep similar to the following:
 
 <Aside type="caution">
-  **Upgrading from Aspire 13.3.0-preview:** The resource names generated for Front Door profiles, endpoints, origin groups, origins, and routes changed in Aspire 13.4. This can result in duplicate Azure resources (profiles, endpoints, origin groups, routes, and origins) during an upgrade. To avoid duplicates, either remove the existing Azure resources before redeploying, or set resource names explicitly using `ConfigureInfrastructure`.
+  **Upgrading from Aspire 13.3.0-preview:** The resource names generated for
+  Front Door profiles, endpoints, origin groups, origins, and routes changed in
+  Aspire 13.4. This can result in duplicate Azure resources (profiles,
+  endpoints, origin groups, routes, and origins) during an upgrade. To avoid
+  duplicates, either remove the existing Azure resources before redeploying, or
+  set resource names explicitly using `ConfigureInfrastructure`.
 </Aside>
 
 ```bicep title="Generated Bicep — frontdoor.bicep"
@@ -236,7 +251,12 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 For advanced scenarios such as upgrading to the Premium SKU, attaching a Web Application Firewall (WAF) policy, configuring caching, or tuning routes, use `ConfigureInfrastructure` (`configureInfrastructure` in TypeScript) to modify the generated Bicep model directly:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -269,17 +289,17 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addAzureAppServiceEnvironment("production");
+await builder.addAzureAppServiceEnvironment('production');
 
-const api = await builder.addProject("api", "../Api/Api.csproj");
+const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withExternalHttpEndpoints();
 
-const frontdoor = await builder.addAzureFrontDoor("frontdoor");
+const frontdoor = await builder.addAzureFrontDoor('frontdoor');
 await frontdoor.withOrigin(api);
 await frontdoor.configureInfrastructure(async (infra) => {
-    // Use the AzureResourceInfrastructure API to customize Bicep
-    // parameters or resources directly.
-    await infra.addParameter("skuName", "Premium_AzureFrontDoor");
+  // Use the AzureResourceInfrastructure API to customize Bicep
+  // parameters or resources directly.
+  await infra.addParameter('skuName', 'Premium_AzureFrontDoor');
 });
 
 await builder.build().run();

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-front-door.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-front-door.mdx
@@ -37,10 +37,10 @@ To access this type and APIs, add the [📦 Aspire.Hosting.Azure.FrontDoor](http
 In your AppHost, call `addAzureFrontDoor` to add a Front Door profile, then call `withOrigin` to attach a backend resource as an origin:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -103,10 +103,10 @@ Each call to `withOrigin` creates a separate Front Door endpoint, origin group, 
 You can add multiple backends to the same Front Door profile. Each origin gets its own Front Door endpoint and route:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -252,10 +252,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 For advanced scenarios such as upgrading to the Premium SKU, attaching a Web Application Firewall (WAF) policy, configuring caching, or tuning routes, use `ConfigureInfrastructure` (`configureInfrastructure` in TypeScript) to modify the generated Bicep model directly:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions/azure-functions-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions/azure-functions-host.mdx
@@ -51,10 +51,10 @@ If you encounter the error **"There is no Functions runtime available that match
 To start building an Aspire app that uses Azure Functions, install the [📦 Aspire.Hosting.Azure.Functions](https://www.nuget.org/packages/Aspire.Hosting.Azure.Functions) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -113,11 +113,11 @@ There are two ways to add an Azure Functions project in C#, depending on whether
 If the Azure Functions project is referenced in your C# AppHost project, use the generic overload of `AddAzureFunctionsProject`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -143,10 +143,10 @@ builder.Build().Run();
 If the Azure Functions project is not referenced in your AppHost project (or you are using a TypeScript AppHost), specify the path to the project file:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -212,10 +212,10 @@ await builder
 Azure Functions requires an Azure Storage account as host storage for checkpoints, leases, and other internal state. By default, Aspire creates an implicit host storage resource automatically. To use a specific storage account, call `WithHostStorage` (or `withHostStorage`) on the Azure Functions resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -272,11 +272,11 @@ If you are not using implicit host storage, you must manually assign the `Storag
 For production, register the storage account explicitly and assign a minimal set of roles:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -305,10 +305,10 @@ builder.AddAzureFunctionsProject<Projects.ExampleFunctions>("functions")
 To connect Azure Functions triggers and bindings to other Azure resources, chain `WithReference` (or `withReference`) on the Azure Functions project resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -357,10 +357,10 @@ The connection information required to connect to the `blobs` resource is automa
 To make HTTP triggers publicly accessible when deployed, call `WithExternalHttpEndpoints` (or `withExternalHttpEndpoints`) on the Azure Functions resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -408,10 +408,10 @@ The `Aspire.Hosting.Azure.Functions` package includes support for [Azure Durable
 Call `AddDurableTaskScheduler` on the `builder` instance to add a scheduler resource, then call `AddTaskHub` to create a task hub and pass its reference to the Azure Functions project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -489,11 +489,11 @@ When using `RunAsEmulator()`, Aspire starts a local container running the DTS em
 To connect to an already-deployed Durable Task Scheduler instance instead of provisioning a new one, use `RunAsExisting`. The overload accepts either a plain `string` connection string or an `IResourceBuilder<ParameterResource>` for securely supplying the value at runtime:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions/azure-functions-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-functions/azure-functions-host.mdx
@@ -42,14 +42,20 @@ If you encounter the error **"There is no Functions runtime available that match
 
 <Image
   src={vsAzureFunctionsOptions}
-  alt="Visual Studio: Options / Projects and Solutions / Azure Functions." />
+  alt="Visual Studio: Options / Projects and Solutions / Azure Functions."
+/>
 :::
 
 ## Installation
 
 To start building an Aspire app that uses Azure Functions, install the [📦 Aspire.Hosting.Azure.Functions](https://www.nuget.org/packages/Aspire.Hosting.Azure.Functions) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -57,7 +63,8 @@ aspire add azure-functions
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -78,7 +85,8 @@ aspire add azure-functions
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Functions hosting integration package:
@@ -104,6 +112,15 @@ There are two ways to add an Azure Functions project in C#, depending on whether
 
 If the Azure Functions project is referenced in your C# AppHost project, use the generic overload of `AddAzureFunctionsProject`:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -118,11 +135,19 @@ builder.AddProject<Projects.ExampleProject>()
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### Add a Functions project by file path
 
 If the Azure Functions project is not referenced in your AppHost project (or you are using a TypeScript AppHost), specify the path to the project file:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -148,14 +173,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const functions = await builder.addAzureFunctionsProject(
-    "functions",
-    "../MyFunctions/MyFunctions.csproj"
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
 );
 await functions.withExternalHttpEndpoints();
 
-await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(functions)
-    .waitFor(functions);
+await builder
+  .addNodeApp('api', './api', 'index.js')
+  .withReference(functions)
+  .waitFor(functions);
 
 // After adding all resources, run the app...
 ```
@@ -174,14 +200,23 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference an Azure Functions resource from the AppHost, Aspire injects connection information for all referenced Azure resources as environment variables into the Functions host. For details on how your function code reads those values, see [Azure Functions runtime configuration](../azure-functions-connect/).
+  When you reference an Azure Functions resource from the AppHost, Aspire
+  injects connection information for all referenced Azure resources as
+  environment variables into the Functions host. For details on how your
+  function code reads those values, see [Azure Functions runtime
+  configuration](../azure-functions-connect/).
 </Aside>
 
 ## Add Azure Functions resource with host storage
 
 Azure Functions requires an Azure Storage account as host storage for checkpoints, leases, and other internal state. By default, Aspire creates an implicit host storage resource automatically. To use a specific storage account, call `WithHostStorage` (or `withHostStorage`) on the Azure Functions resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -209,12 +244,12 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage");
+const storage = await builder.addAzureStorage('storage');
 await storage.runAsEmulator();
 
 const functions = await builder.addAzureFunctionsProject(
-    "functions",
-    "../MyFunctions/MyFunctions.csproj"
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
 );
 await functions.withHostStorage(storage);
 
@@ -236,6 +271,15 @@ If you are not using implicit host storage, you must manually assign the `Storag
 
 For production, register the storage account explicitly and assign a minimal set of roles:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -247,16 +291,25 @@ builder.AddAzureFunctionsProject<Projects.ExampleFunctions>("functions")
                                     StorageBuiltInRole.StorageQueueDataReader);
 ```
 
+</Fragment>
+</AppHostTabs>
+
 :::caution[TypeScript gap]
 `WithRoleAssignments` is available in the C# AppHost only. The TypeScript AppHost does not currently expose an equivalent API for scoped role assignments on Azure Functions resources.
 :::
+
 </Aside>
 
 ## Reference resources in Azure Functions
 
 To connect Azure Functions triggers and bindings to other Azure resources, chain `WithReference` (or `withReference`) on the Azure Functions project resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -280,13 +333,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage");
+const storage = await builder.addAzureStorage('storage');
 await storage.runAsEmulator();
-const blobs = await storage.addBlobs("blobs");
+const blobs = await storage.addBlobs('blobs');
 
 const functions = await builder.addAzureFunctionsProject(
-    "functions",
-    "../MyFunctions/MyFunctions.csproj"
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
 );
 await functions.withHostStorage(storage);
 await functions.withReference(blobs);
@@ -303,7 +356,12 @@ The connection information required to connect to the `blobs` resource is automa
 
 To make HTTP triggers publicly accessible when deployed, call `WithExternalHttpEndpoints` (or `withExternalHttpEndpoints`) on the Azure Functions resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -324,8 +382,8 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const functions = await builder.addAzureFunctionsProject(
-    "functions",
-    "../MyFunctions/MyFunctions.csproj"
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
 );
 await functions.withExternalHttpEndpoints();
 
@@ -349,7 +407,12 @@ The `Aspire.Hosting.Azure.Functions` package includes support for [Azure Durable
 
 Call `AddDurableTaskScheduler` on the `builder` instance to add a scheduler resource, then call `AddTaskHub` to create a task hub and pass its reference to the Azure Functions project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -382,17 +445,17 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage");
+const storage = await builder.addAzureStorage('storage');
 await storage.runAsEmulator();
 
-const scheduler = await builder.addDurableTaskScheduler("scheduler");
+const scheduler = await builder.addDurableTaskScheduler('scheduler');
 await scheduler.runAsEmulator();
 
-const taskHub = await scheduler.addTaskHub("taskhub");
+const taskHub = await scheduler.addTaskHub('taskhub');
 
 const functions = await builder.addAzureFunctionsProject(
-    "functions",
-    "../MyFunctions/MyFunctions.csproj"
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
 );
 await functions.withHostStorage(storage);
 await functions.withReference(taskHub);
@@ -416,11 +479,23 @@ When using `RunAsEmulator()`, Aspire starts a local container running the DTS em
 - A **Task Hub Dashboard** URL on each task hub resource.
 - A `DTS_TASK_HUB_NAMES` environment variable on the emulator container listing the associated task hub names.
 
-<ContainerImages package="Aspire.Hosting.Azure.Functions" title="Durable Task Scheduler emulator image" />
+<ContainerImages
+  package="Aspire.Hosting.Azure.Functions"
+  title="Durable Task Scheduler emulator image"
+/>
 
 ### Use an existing scheduler
 
 To connect to an already-deployed Durable Task Scheduler instance instead of provisioning a new one, use `RunAsExisting`. The overload accepts either a plain `string` connection string or an `IResourceBuilder<ParameterResource>` for securely supplying the value at runtime:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREDURABLETASK001
@@ -443,8 +518,13 @@ builder.Build().Run();
 #pragma warning restore ASPIREDURABLETASK001
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
-  Durable Task Scheduler deployment support (manifest and deployment) is not yet included. Only local development with the emulator or an existing scheduler instance is currently supported.
+  Durable Task Scheduler deployment support (manifest and deployment) is not yet
+  included. Only local development with the emulator or an existing scheduler
+  instance is currently supported.
 </Aside>
 
 ## Deployment

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure Key Vault integration, start with the [Get started wi
 To start building an Aspire app that uses Azure Key Vault, install the [📦 Aspire.Hosting.Azure.KeyVault](https://www.nuget.org/packages/Aspire.Hosting.Azure.KeyVault) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure Key Vault hosting integrat
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Key Vault resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -145,10 +145,10 @@ The `WithReference` (or `withReference`) method configures a connection in the c
 You might have an existing Azure Key Vault instance that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -209,10 +209,10 @@ await builder.build().run();
 By default, `AddAzureKeyVault` configures a [Key Vault Administrator built-in role](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/security#key-vault-administrator) for the consuming project. To assign a more restrictive role — such as `KeyVaultSecretsUser` — use `WithRoleAssignments` (or `withRoleAssignments`) on the consuming resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -262,10 +262,10 @@ You can reference secrets stored in an Azure Key Vault directly from your AppHos
 To add a secret to the Key Vault resource from the AppHost, call `AddSecret` (or `addSecret`) providing a name and a parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -305,10 +305,10 @@ await builder.build().run();
 To reference an existing secret in the vault and pass it to a consuming resource, use `GetSecret` (or `getSecret`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -418,10 +418,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` (or `configureInfrastructure`) API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-key-vault/azure-key-vault-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure Key Vault integration, start with the [Get started wi
 
 To start building an Aspire app that uses Azure Key Vault, install the [📦 Aspire.Hosting.Azure.KeyVault](https://www.nuget.org/packages/Aspire.Hosting.Azure.KeyVault) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add azure-key-vault
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add azure-key-vault
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Key Vault hosting integration package:
@@ -76,7 +83,12 @@ This updates your `aspire.config.json` with the Azure Key Vault hosting integrat
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Key Vault resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -99,10 +111,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 
-await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(keyVault);
+await builder
+  .addProject('apiservice', '../ExampleProject/ExampleProject.csproj')
+  .withReference(keyVault);
 
 await builder.build().run();
 ```
@@ -131,7 +144,12 @@ The `WithReference` (or `withReference`) method configures a connection in the c
 
 You might have an existing Azure Key Vault instance that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -158,19 +176,22 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const existingKeyVaultName = await builder.addParameter("existingKeyVaultName");
+const existingKeyVaultName = await builder.addParameter('existingKeyVaultName');
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 await keyVault.asExisting(existingKeyVaultName);
 
-await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(keyVault);
+await builder
+  .addProject('apiservice', '../ExampleProject/ExampleProject.csproj')
+  .withReference(keyVault);
 
 await builder.build().run();
 ```
 
 <Aside type="note">
-  The TypeScript AppHost `asExisting` method accepts a vault name parameter, but does not accept a resource group parameter. Use `runAsExisting` or `publishAsExisting` for mode-specific control.
+  The TypeScript AppHost `asExisting` method accepts a vault name parameter, but
+  does not accept a resource group parameter. Use `runAsExisting` or
+  `publishAsExisting` for mode-specific control.
 </Aside>
 
 </Fragment>
@@ -187,7 +208,12 @@ await builder.build().run();
 
 By default, `AddAzureKeyVault` configures a [Key Vault Administrator built-in role](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/security#key-vault-administrator) for the consuming project. To assign a more restrictive role — such as `KeyVaultSecretsUser` — use `WithRoleAssignments` (or `withRoleAssignments`) on the consuming resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -209,10 +235,15 @@ import { createBuilder, AzureKeyVaultRole } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 
-const api = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
-await api.withRoleAssignments(keyVault, [AzureKeyVaultRole.KeyVaultSecretsUser]);
+const api = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withRoleAssignments(keyVault, [
+  AzureKeyVaultRole.KeyVaultSecretsUser,
+]);
 
 await builder.build().run();
 ```
@@ -230,7 +261,12 @@ You can reference secrets stored in an Azure Key Vault directly from your AppHos
 
 To add a secret to the Key Vault resource from the AppHost, call `AddSecret` (or `addSecret`) providing a name and a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -253,10 +289,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 
-const apiKey = await builder.addParameter("api-key", { secret: true });
-await keyVault.addSecret("my-api-key", apiKey);
+const apiKey = await builder.addParameter('api-key', { secret: true });
+await keyVault.addSecret('my-api-key', apiKey);
 
 await builder.build().run();
 ```
@@ -268,7 +304,12 @@ await builder.build().run();
 
 To reference an existing secret in the vault and pass it to a consuming resource, use `GetSecret` (or `getSecret`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -296,16 +337,17 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const existingKeyVaultName = await builder.addParameter("existingKeyVaultName");
+const existingKeyVaultName = await builder.addParameter('existingKeyVaultName');
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 await keyVault.asExisting(existingKeyVaultName);
 
-const secretRef = await keyVault.getSecret("my-api-key");
+const secretRef = await keyVault.getSecret('my-api-key');
 
-await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(keyVault)
-    .withEnvironment("API_KEY", secretRef);
+await builder
+  .addProject('apiservice', '../ExampleProject/ExampleProject.csproj')
+  .withReference(keyVault)
+  .withEnvironment('API_KEY', secretRef);
 
 await builder.build().run();
 ```
@@ -375,7 +417,12 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` (or `configureInfrastructure`) API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -409,15 +456,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const keyVault = await builder.addAzureKeyVault("key-vault");
+const keyVault = await builder.addAzureKeyVault('key-vault');
 await keyVault.configureInfrastructure(async (infra) => {
-    const kv = (await infra.getProvisionableResources())
-        .filter(r => r.resourceType === 'Microsoft.KeyVault/vaults')[0];
+  const kv = (await infra.getProvisionableResources()).filter(
+    (r) => r.resourceType === 'Microsoft.KeyVault/vaults'
+  )[0];
 
-    if (kv) {
-        kv.properties.sku = { family: 'A', name: 'premium' };
-        kv.tags['ExampleKey'] = 'Example value';
-    }
+  if (kv) {
+    kv.properties.sku = { family: 'A', name: 'premium' };
+    kv.tags['ExampleKey'] = 'Example value';
+  }
 });
 
 await builder.build().run();

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-log-analytics.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-log-analytics.mdx
@@ -28,7 +28,12 @@ This article is the reference for the Aspire Azure Log Analytics Hosting integra
 
 To start building an Aspire app that uses Azure Log Analytics, install the [📦 Aspire.Hosting.Azure.OperationalInsights](https://www.nuget.org/packages/Aspire.Hosting.Azure.OperationalInsights) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -79,7 +84,12 @@ This updates your `aspire.config.json` with the Azure Log Analytics hosting inte
 
 The Aspire Azure Log Analytics hosting integration models the Log Analytics workspace as the `AzureLogAnalyticsWorkspaceResource` type. To add a Log Analytics workspace resource to your app host, call `AddAzureLogAnalyticsWorkspace` (or `addAzureLogAnalyticsWorkspace`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -124,7 +134,12 @@ The preceding code adds an Azure Log Analytics workspace resource named `log-ana
 
 A common pattern is to use a Log Analytics workspace with Application Insights for centralized telemetry collection. You can link an Application Insights resource to a Log Analytics workspace:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -211,6 +226,15 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API. For example, you can configure the SKU, retention period, and more. The following example demonstrates how to customize the Azure Log Analytics workspace:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -230,11 +254,15 @@ var logAnalytics = builder.AddAzureLogAnalyticsWorkspace("log-analytics")
 var appInsights = builder.AddAzureApplicationInsights("app-insights", logAnalytics);
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
   TypeScript AppHosts can use curated provisioning helper APIs when an
   integration exposes them. This example directly customizes Azure.Provisioning
   objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a [polyglot](/get-started/glossary/#polyglot)-friendly helper.
+  the integration wraps the scenario in a
+  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
 </Aside>
 
 The preceding code:

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-log-analytics.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-log-analytics.mdx
@@ -29,10 +29,10 @@ This article is the reference for the Aspire Azure Log Analytics Hosting integra
 To start building an Aspire app that uses Azure Log Analytics, install the [📦 Aspire.Hosting.Azure.OperationalInsights](https://www.nuget.org/packages/Aspire.Hosting.Azure.OperationalInsights) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -85,10 +85,10 @@ This updates your `aspire.config.json` with the Azure Log Analytics hosting inte
 The Aspire Azure Log Analytics hosting integration models the Log Analytics workspace as the `AzureLogAnalyticsWorkspaceResource` type. To add a Log Analytics workspace resource to your app host, call `AddAzureLogAnalyticsWorkspace` (or `addAzureLogAnalyticsWorkspace`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -135,10 +135,10 @@ The preceding code adds an Azure Log Analytics workspace resource named `log-ana
 A common pattern is to use a Log Analytics workspace with Application Insights for centralized telemetry collection. You can link an Application Insights resource to a Log Analytics workspace:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -227,11 +227,11 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API. For example, you can configure the SKU, retention period, and more. The following example demonstrates how to customize the Azure Log Analytics workspace:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-openai/azure-openai-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-openai/azure-openai-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure OpenAI integration, start with the [Get started with 
 
 To start building an Aspire app that uses Azure OpenAI, install the [📦 Aspire.Hosting.Azure.CognitiveServices](https://www.nuget.org/packages/Aspire.Hosting.Azure.CognitiveServices) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add azure-cognitive-services
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add azure-cognitive-services
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure OpenAI hosting integration package:
@@ -76,7 +83,12 @@ This updates your `aspire.config.json` with the Azure OpenAI hosting integration
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure OpenAI account resource and then add one or more deployment resources beneath it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -84,16 +96,17 @@ var builder = DistributedApplication.CreateBuilder(args);
 var openai = builder.AddAzureOpenAI("openai");
 
 var chat = openai.AddDeployment(
-    name: "chat",
-    modelName: "gpt-4o",
-    modelVersion: "2024-08-06");
+name: "chat",
+modelName: "gpt-4o",
+modelVersion: "2024-08-06");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat)
-    .WaitFor(chat);
+.WithReference(chat)
+.WaitFor(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -110,7 +123,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .waitFor(chat);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -133,14 +147,23 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure OpenAI deployment from the AppHost, Aspire makes the endpoint URI and model name available to the consuming project as environment variables. For a complete list of these properties and per-language connection examples, see [Connect to Azure OpenAI](../azure-openai-connect/).
+  When you reference an Azure OpenAI deployment from the AppHost, Aspire makes
+  the endpoint URI and model name available to the consuming project as
+  environment variables. For a complete list of these properties and
+  per-language connection examples, see [Connect to Azure
+  OpenAI](../azure-openai-connect/).
 </Aside>
 
 ## Add multiple Azure OpenAI deployments
 
 Add multiple deployment children beneath the same account to share a single Azure OpenAI resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -151,13 +174,14 @@ var chat = openai.AddDeployment("chat", "gpt-4o", "2024-08-06");
 var embeddings = openai.AddDeployment("embeddings", "text-embedding-3-small", "1");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat)
-    .WithReference(embeddings)
-    .WaitFor(chat)
-    .WaitFor(embeddings);
+.WithReference(chat)
+.WithReference(embeddings)
+.WaitFor(chat)
+.WaitFor(embeddings);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -177,7 +201,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .waitFor(embeddings);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -189,7 +214,12 @@ By default, Aspire provisions Azure OpenAI with `disableLocalAuth: true` and aut
 
 To explicitly assign roles to a consuming app (for example, to grant contributor access for fine-tuning scenarios), call `WithRoleAssignments` in C# or `withCognitiveServicesRoleAssignments` in TypeScript on the consuming resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Azure;
@@ -201,12 +231,13 @@ var openai = builder.AddAzureOpenAI("openai");
 var chat = openai.AddDeployment("chat", "gpt-4o", "2024-08-06");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(chat)
-    .WaitFor(chat)
-    .WithRoleAssignments(openai, AzureOpenAIRole.CognitiveServicesOpenAIContributor);
+.WithReference(chat)
+.WaitFor(chat)
+.WithRoleAssignments(openai, AzureOpenAIRole.CognitiveServicesOpenAIContributor);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -224,21 +255,27 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withCognitiveServicesRoleAssignments(openai, [AzureOpenAIRole.CognitiveServicesOpenAIContributor]);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The available `AzureOpenAIRole` values are:
 
-| Role | Description |
-| ---- | ----------- |
-| `CognitiveServicesOpenAIUser` | Read access to models, deployments, and completions. Default when using `WithReference`. |
-| `CognitiveServicesOpenAIContributor` | Create and delete deployments in addition to user permissions. |
-| `CognitiveServicesUser` | Broader Cognitive Services access. |
+| Role                                 | Description                                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------------------------- |
+| `CognitiveServicesOpenAIUser`        | Read access to models, deployments, and completions. Default when using `WithReference`. |
+| `CognitiveServicesOpenAIContributor` | Create and delete deployments in addition to user permissions.                           |
+| `CognitiveServicesUser`              | Broader Cognitive Services access.                                                       |
 
 To remove the default automatic role assignments and manage them entirely yourself, call `ClearDefaultRoleAssignments` (or `clearDefaultRoleAssignments`) on the Azure OpenAI resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var openai = builder.AddAzureOpenAI("openai")
@@ -253,7 +290,8 @@ const builder = await createBuilder();
 
 const openai = await builder.addAzureOpenAI("openai");
 await openai.clearDefaultRoleAssignments();
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -261,7 +299,12 @@ await openai.clearDefaultRoleAssignments();
 
 You might have an already-deployed Azure OpenAI account in your Azure subscription that you want to connect to. Use `AsExisting` (or `asExisting`) to point the resource at an existing account instead of provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -279,7 +322,8 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
     .WaitFor(chat);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -296,11 +340,12 @@ await openai.asExisting(existingOpenAIName, existingOpenAIResourceGroup);
 const chat = await openai.addDeployment("chat", "gpt-4o", "2024-08-06");
 
 await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(chat)
-    .waitFor(chat);
+.withReference(chat)
+.waitFor(chat);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -354,7 +399,7 @@ resource chat 'Microsoft.CognitiveServices/accounts/deployments@2024-10-01' = {
 output connectionString string = 'Endpoint=${openai.properties.endpoint}'
 
 output name string = openai.name
-```
+````
 
 Role assignments are created in a companion module:
 
@@ -389,7 +434,12 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of `AzureProvisioningResource`. This enables customization of the generated Bicep by providing a fluent API to configure Azure resources using the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Azure.Provisioning.CognitiveServices;
@@ -397,10 +447,10 @@ using Azure.Provisioning.CognitiveServices;
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureOpenAI("openai")
-    .ConfigureInfrastructure(infra =>
-    {
-        var resources = infra.GetProvisionableResources();
-        var account = resources.OfType<CognitiveServicesAccount>().Single();
+.ConfigureInfrastructure(infra =>
+{
+var resources = infra.GetProvisionableResources();
+var account = resources.OfType<CognitiveServicesAccount>().Single();
 
         account.Sku = new CognitiveServicesSku
         {
@@ -411,7 +461,8 @@ builder.AddAzureOpenAI("openai")
     });
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -427,7 +478,8 @@ await openai.configureInfrastructure(async infra => {
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -443,13 +495,13 @@ The preceding C# code:
 
 Common model identifiers for Azure OpenAI:
 
-| Category   | Model identifiers |
-| ---------- | ----------------- |
-| Chat       | `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo` |
-| Reasoning  | `o3`, `o3-mini`, `o4-mini` |
+| Category   | Model identifiers                                  |
+| ---------- | -------------------------------------------------- |
+| Chat       | `gpt-4o`, `gpt-4o-mini`, `gpt-4-turbo`             |
+| Reasoning  | `o3`, `o3-mini`, `o4-mini`                         |
 | Embeddings | `text-embedding-3-small`, `text-embedding-3-large` |
-| Images     | `dall-e-3` |
-| Audio      | `whisper` |
+| Images     | `dall-e-3`                                         |
+| Audio      | `whisper`                                          |
 
 For the full list and current model versions, see the [Azure OpenAI models documentation](https://learn.microsoft.com/azure/ai-services/openai/concepts/models).
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-openai/azure-openai-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-openai/azure-openai-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure OpenAI integration, start with the [Get started with 
 To start building an Aspire app that uses Azure OpenAI, install the [📦 Aspire.Hosting.Azure.CognitiveServices](https://www.nuget.org/packages/Aspire.Hosting.Azure.CognitiveServices) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure OpenAI hosting integration
 Once you've installed the hosting integration in your AppHost project, you can add an Azure OpenAI account resource and then add one or more deployment resources beneath it:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -159,10 +159,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add multiple deployment children beneath the same account to share a single Azure OpenAI resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -215,10 +215,10 @@ By default, Aspire provisions Azure OpenAI with `disableLocalAuth: true` and aut
 To explicitly assign roles to a consuming app (for example, to grant contributor access for fine-tuning scenarios), call `WithRoleAssignments` in C# or `withCognitiveServicesRoleAssignments` in TypeScript on the consuming resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -271,10 +271,10 @@ The available `AzureOpenAIRole` values are:
 To remove the default automatic role assignments and manage them entirely yourself, call `ClearDefaultRoleAssignments` (or `clearDefaultRoleAssignments`) on the Azure OpenAI resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -300,10 +300,10 @@ await openai.clearDefaultRoleAssignments();
 You might have an already-deployed Azure OpenAI account in your Azure subscription that you want to connect to. Use `AsExisting` (or `asExisting`) to point the resource at an existing account instead of provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -435,10 +435,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of `AzureProvisioningResource`. This enables customization of the generated Bicep by providing a fluent API to configure Azure resources using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-postgresql/azure-postgresql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-postgresql/azure-postgresql-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure PostgreSQL integration, start with the [Get started w
 
 To start building an Aspire app that uses Azure Database for PostgreSQL, install the [📦 Aspire.Hosting.Azure.PostgreSQL](https://www.nuget.org/packages/Aspire.Hosting.Azure.PostgreSQL) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -78,7 +83,12 @@ This updates your `aspire.config.json` with the Azure PostgreSQL hosting integra
 
 Once you've installed the hosting integration in your AppHost project, you can add a PostgreSQL flexible server resource and then add a database resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -138,7 +148,12 @@ The preceding code adds an Azure PostgreSQL flexible server resource named `post
 
 You can add multiple named databases to the same flexible server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -185,7 +200,12 @@ await builder.addNodeApp("orders", "./orders", "index.js")
 
 You can also customize the underlying database name (as distinct from the Aspire resource name) by passing `databaseName` in the options:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var postgresdb = postgres.AddDatabase("postgresdb", databaseName: "app_catalog");
@@ -202,7 +222,12 @@ const postgresdb = await postgres.addDatabase("postgresdb", { databaseName: "app
 
 The Azure PostgreSQL hosting integration supports running the PostgreSQL server as a local Docker container. This is beneficial for local development and testing — you get a real PostgreSQL server without needing an Azure subscription or connection to an existing Azure PostgreSQL instance.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -264,7 +289,12 @@ For a comparison of the two hosting integrations, see [PostgreSQL Hosting integr
 
 If you have an existing Azure Database for PostgreSQL Flexible Server that you want to connect to rather than provisioning a new one, use `AsExisting` / `asExisting`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -311,7 +341,12 @@ For more information on treating Azure resources as existing, see [Use existing 
 
 By default, the Azure PostgreSQL flexible server is configured to use [Microsoft Entra ID](https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-azure-ad-authentication) authentication — no username or password is stored in your app configuration. If you need password authentication (for example, to connect with a legacy client that doesn't support Entra tokens), call `WithPasswordAuthentication` / `withPasswordAuthentication`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -454,6 +489,15 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -481,11 +525,15 @@ builder.AddAzurePostgresFlexibleServer("postgres")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
   TypeScript AppHosts can use curated provisioning helper APIs when an
   integration exposes them. This example directly customizes Azure.Provisioning
   objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a [polyglot](/get-started/glossary/#polyglot)-friendly helper.
+  the integration wraps the scenario in a
+  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
 </Aside>
 
 The preceding code:

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-postgresql/azure-postgresql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-postgresql/azure-postgresql-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure PostgreSQL integration, start with the [Get started w
 To start building an Aspire app that uses Azure Database for PostgreSQL, install the [📦 Aspire.Hosting.Azure.PostgreSQL](https://www.nuget.org/packages/Aspire.Hosting.Azure.PostgreSQL) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure PostgreSQL hosting integra
 Once you've installed the hosting integration in your AppHost project, you can add a PostgreSQL flexible server resource and then add a database resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -149,10 +149,10 @@ The preceding code adds an Azure PostgreSQL flexible server resource named `post
 You can add multiple named databases to the same flexible server resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -201,10 +201,10 @@ await builder.addNodeApp("orders", "./orders", "index.js")
 You can also customize the underlying database name (as distinct from the Aspire resource name) by passing `databaseName` in the options:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -223,10 +223,10 @@ const postgresdb = await postgres.addDatabase("postgresdb", { databaseName: "app
 The Azure PostgreSQL hosting integration supports running the PostgreSQL server as a local Docker container. This is beneficial for local development and testing — you get a real PostgreSQL server without needing an Azure subscription or connection to an existing Azure PostgreSQL instance.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -290,10 +290,10 @@ For a comparison of the two hosting integrations, see [PostgreSQL Hosting integr
 If you have an existing Azure Database for PostgreSQL Flexible Server that you want to connect to rather than provisioning a new one, use `AsExisting` / `asExisting`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -342,10 +342,10 @@ For more information on treating Azure resources as existing, see [Use existing 
 By default, the Azure PostgreSQL flexible server is configured to use [Microsoft Entra ID](https://learn.microsoft.com/azure/postgresql/flexible-server/concepts-azure-ad-authentication) authentication — no username or password is stored in your app configuration. If you need password authentication (for example, to connect with a legacy client that doesn't support Entra tokens), call `WithPasswordAuthentication` / `withPasswordAuthentication`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -490,11 +490,11 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
@@ -37,10 +37,10 @@ The following resource types are available in the hosting integration:
 To start building an Aspire app that uses Azure Service Bus, install the [📦 Aspire.Hosting.Azure.ServiceBus](https://www.nuget.org/packages/Aspire.Hosting.Azure.ServiceBus) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -93,10 +93,10 @@ This updates your `aspire.config.json` with the Azure Service Bus hosting integr
 Once you've installed the hosting integration in your AppHost project, add an Azure Service Bus namespace resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -147,10 +147,10 @@ await builder.build().run();
 If you have an existing Azure Service Bus namespace, chain a call to `AsExisting` (C#) or `asExisting` (TypeScript) to connect to it instead of provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -215,10 +215,10 @@ For more information on treating Azure resources as existing resources, see [Use
 To add a queue to an Azure Service Bus namespace, call `AddServiceBusQueue` (C#) or `addServiceBusQueue` (TypeScript) on the Service Bus resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -261,10 +261,10 @@ This expresses an explicit parent-child relationship between the `messaging` Ser
 To add a topic, call `AddServiceBusTopic` (C#) or `addServiceBusTopic` (TypeScript) on the Service Bus resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -302,10 +302,10 @@ The topic is created in the namespace that the `AzureServiceBusResource` represe
 To add a subscription for a topic, call `AddServiceBusSubscription` (C#) or `addServiceBusSubscription` (TypeScript) on the topic resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -345,11 +345,11 @@ For more information, see [Queues, topics, and subscriptions in Azure Service Bu
 In C# AppHosts, you can configure advanced subscription properties — such as maximum delivery count and correlation filter rules — using the `WithProperties` method:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -399,10 +399,10 @@ builder.Build().Run();
 For local development, Aspire can run the [Azure Service Bus Emulator](https://learn.microsoft.com/azure/service-bus-messaging/overview-emulator) as a container. Chain a call to `RunAsEmulator` (C#) or `runAsEmulator` (TypeScript) on the Service Bus resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -450,10 +450,10 @@ By default, the Service Bus emulator container exposes the following endpoints:
 By default, the host port is assigned dynamically. To pin it to a specific port, pass the `configureContainer` callback and call `withHostPort`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -501,10 +501,10 @@ The preceding code maps the `emulator` endpoint to host port `7777`:
 The Service Bus emulator generates its configuration automatically from the resources you've added. To provide a fully custom configuration file instead, call `WithConfigurationFile` (C#) or `withConfigurationFile` (TypeScript):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -547,11 +547,11 @@ await builder.build().run();
 In C# AppHosts, you can also update specific properties in the auto-generated configuration using a `JsonNode` callback, without replacing the entire file:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -651,11 +651,11 @@ For more information on the assigned role, see [Azure Service Bus Data Owner](ht
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep using the fluent `ConfigureInfrastructure` API. For example, you can configure the SKU, location, tags, and more:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-service-bus/azure-service-bus-host.mdx
@@ -36,7 +36,12 @@ The following resource types are available in the hosting integration:
 
 To start building an Aspire app that uses Azure Service Bus, install the [📦 Aspire.Hosting.Azure.ServiceBus](https://www.nuget.org/packages/Aspire.Hosting.Azure.ServiceBus) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -44,7 +49,8 @@ aspire add azure-service-bus
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -65,7 +71,8 @@ aspire add azure-service-bus
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Service Bus hosting integration package:
@@ -85,7 +92,12 @@ This updates your `aspire.config.json` with the Azure Service Bus hosting integr
 
 Once you've installed the hosting integration in your AppHost project, add an Azure Service Bus namespace resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -105,7 +117,7 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging");
+const serviceBus = await builder.addAzureServiceBus('messaging');
 
 await builder.build().run();
 ```
@@ -118,14 +130,15 @@ await builder.build().run();
   it implicitly calls `AddAzureProvisioning`—which adds support for generating
   Azure resources dynamically during app startup. The app must configure the
   appropriate subscription and location. For more information, see [Local
-  provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-  When you reference an Azure Service Bus resource from the AppHost, Aspire makes
-  several properties available to the consuming project, such as the namespace
-  endpoint and connection strings. For a complete list of these properties and
-  per-language connection examples, see [Connect to Azure Service
+  When you reference an Azure Service Bus resource from the AppHost, Aspire
+  makes several properties available to the consuming project, such as the
+  namespace endpoint and connection strings. For a complete list of these
+  properties and per-language connection examples, see [Connect to Azure Service
   Bus](../azure-service-bus-connect/).
 </Aside>
 
@@ -133,7 +146,12 @@ await builder.build().run();
 
 If you have an existing Azure Service Bus namespace, chain a call to `AsExisting` (C#) or `asExisting` (TypeScript) to connect to it instead of provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -160,14 +178,20 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const existingServiceBusName = await builder.addParameter("existingServiceBusName");
-const existingServiceBusResourceGroup = await builder.addParameter("existingServiceBusResourceGroup");
+const existingServiceBusName = await builder.addParameter(
+  'existingServiceBusName'
+);
+const existingServiceBusResourceGroup = await builder.addParameter(
+  'existingServiceBusResourceGroup'
+);
 
-const serviceBus = await builder.addAzureServiceBus("messaging")
-    .asExisting(existingServiceBusName, { resourceGroup: existingServiceBusResourceGroup });
+const serviceBus = await builder
+  .addAzureServiceBus('messaging')
+  .asExisting(existingServiceBusName, {
+    resourceGroup: existingServiceBusResourceGroup,
+  });
 
-await builder.addNodeApp("web", "./web", "index.js")
-    .withReference(serviceBus);
+await builder.addNodeApp('web', './web', 'index.js').withReference(serviceBus);
 
 await builder.build().run();
 ```
@@ -182,14 +206,20 @@ For more information on treating Azure resources as existing resources, see [Use
   you can add a connection string directly to the AppHost. This approach is
   weakly-typed and doesn't work with role assignments or infrastructure
   customizations. For more information, see [Add existing Azure resources with
-  connection strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
+  connection
+  strings](/integrations/cloud/azure/overview/#add-existing-azure-resources-with-connection-strings).
 </Aside>
 
 ## Add Azure Service Bus queue
 
 To add a queue to an Azure Service Bus namespace, call `AddServiceBusQueue` (C#) or `addServiceBusQueue` (TypeScript) on the Service Bus resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -213,11 +243,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging");
-const queue = await serviceBus.addServiceBusQueue("queue");
+const serviceBus = await builder.addAzureServiceBus('messaging');
+const queue = await serviceBus.addServiceBusQueue('queue');
 
-await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(queue);
+await builder.addNodeApp('api', './api', 'index.js').withReference(queue);
 
 await builder.build().run();
 ```
@@ -231,7 +260,12 @@ This expresses an explicit parent-child relationship between the `messaging` Ser
 
 To add a topic, call `AddServiceBusTopic` (C#) or `addServiceBusTopic` (TypeScript) on the Service Bus resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -252,8 +286,8 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging");
-const topic = await serviceBus.addServiceBusTopic("topic");
+const serviceBus = await builder.addAzureServiceBus('messaging');
+const topic = await serviceBus.addServiceBusTopic('topic');
 
 await builder.build().run();
 ```
@@ -267,7 +301,12 @@ The topic is created in the namespace that the `AzureServiceBusResource` represe
 
 To add a subscription for a topic, call `AddServiceBusSubscription` (C#) or `addServiceBusSubscription` (TypeScript) on the topic resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -289,9 +328,9 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging");
-const topic = await serviceBus.addServiceBusTopic("topic");
-await topic.addServiceBusSubscription("sub1");
+const serviceBus = await builder.addAzureServiceBus('messaging');
+const topic = await serviceBus.addServiceBusTopic('topic');
+await topic.addServiceBusSubscription('sub1');
 
 await builder.build().run();
 ```
@@ -304,6 +343,15 @@ For more information, see [Queues, topics, and subscriptions in Azure Service Bu
 ### Configure subscription properties
 
 In C# AppHosts, you can configure advanced subscription properties — such as maximum delivery count and correlation filter rules — using the `WithProperties` method:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Azure;
@@ -337,6 +385,9 @@ topic.AddServiceBusSubscription("sub1")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
   `WithProperties` for advanced subscription configuration is only available in
   C# AppHosts. TypeScript AppHosts support creating subscriptions by name but
@@ -347,7 +398,12 @@ builder.Build().Run();
 
 For local development, Aspire can run the [Azure Service Bus Emulator](https://learn.microsoft.com/azure/service-bus-messaging/overview-emulator) as a container. Chain a call to `RunAsEmulator` (C#) or `runAsEmulator` (TypeScript) on the Service Bus resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -368,8 +424,9 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging")
-    .runAsEmulator();
+const serviceBus = await builder
+  .addAzureServiceBus('messaging')
+  .runAsEmulator();
 
 await builder.build().run();
 ```
@@ -392,7 +449,12 @@ By default, the Service Bus emulator container exposes the following endpoints:
 
 By default, the host port is assigned dynamically. To pin it to a specific port, pass the `configureContainer` callback and call `withHostPort`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -416,12 +478,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging")
-    .runAsEmulator({
-        configureContainer: async (emulator) => {
-            await emulator.withHostPort({ port: 7777 });
-        }
-    });
+const serviceBus = await builder.addAzureServiceBus('messaging').runAsEmulator({
+  configureContainer: async (emulator) => {
+    await emulator.withHostPort({ port: 7777 });
+  },
+});
 
 await builder.build().run();
 ```
@@ -439,7 +500,12 @@ The preceding code maps the `emulator` endpoint to host port `7777`:
 
 The Service Bus emulator generates its configuration automatically from the resources you've added. To provide a fully custom configuration file instead, call `WithConfigurationFile` (C#) or `withConfigurationFile` (TypeScript):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -464,12 +530,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const serviceBus = await builder.addAzureServiceBus("messaging")
-    .runAsEmulator({
-        configureContainer: async (emulator) => {
-            await emulator.withConfigurationFile("./messaging/custom-config.json");
-        }
-    });
+const serviceBus = await builder.addAzureServiceBus('messaging').runAsEmulator({
+  configureContainer: async (emulator) => {
+    await emulator.withConfigurationFile('./messaging/custom-config.json');
+  },
+});
 
 await builder.build().run();
 ```
@@ -480,6 +545,15 @@ await builder.build().run();
 ### Patch the emulator configuration with `WithConfiguration`
 
 In C# AppHosts, you can also update specific properties in the auto-generated configuration using a `JsonNode` callback, without replacing the entire file:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -504,6 +578,9 @@ var serviceBus = builder.AddAzureServiceBus("messaging")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 <Aside type="note">
   `WithConfiguration` (JSON node mutation) is only available in C# AppHosts.
@@ -573,6 +650,15 @@ For more information on the assigned role, see [Azure Service Bus Data Owner](ht
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep using the fluent `ConfigureInfrastructure` API. For example, you can configure the SKU, location, tags, and more:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -594,6 +680,9 @@ builder.AddAzureServiceBus("service-bus")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
   `ConfigureInfrastructure` is only available in C# AppHosts. For more
   information, see [Azure.Provisioning
@@ -605,4 +694,3 @@ builder.Build().Run();
 The Azure Service Bus hosting integration automatically adds a health check for the Service Bus resource. The health check verifies that the Service Bus is running and that a connection can be established.
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.AzureServiceBus](https://www.nuget.org/packages/AspNetCore.HealthChecks.AzureServiceBus) NuGet package.
-

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-signalr/azure-signalr-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-signalr/azure-signalr-host.mdx
@@ -28,7 +28,12 @@ If you're new to the Azure SignalR Service integration, start with the [Get star
 
 To start building an Aspire app that uses Azure SignalR Service, install the [📦 Aspire.Hosting.Azure.SignalR](https://www.nuget.org/packages/Aspire.Hosting.Azure.SignalR) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -36,7 +41,8 @@ aspire add azure-signalr
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -57,7 +63,8 @@ aspire add azure-signalr
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure SignalR Service hosting integration package:
@@ -77,7 +84,12 @@ This updates your `aspire.config.json` with the Azure SignalR Service hosting in
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure SignalR Service resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -85,12 +97,13 @@ var builder = DistributedApplication.CreateBuilder(args);
 var signalR = builder.AddAzureSignalR("signalr");
 
 var api = builder.AddProject<Projects.ApiService>("api")
-    .WithReference(signalR)
-    .WaitFor(signalR);
+.WithReference(signalR)
+.WaitFor(signalR);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -106,7 +119,8 @@ await builder.addProject("api", "../ApiService/ApiService.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -136,7 +150,12 @@ For more information, see [Azure SignalR Service modes](https://learn.microsoft.
 
 ### Set service mode
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Pass the `AzureSignalRServiceMode` enum value when adding the resource:
@@ -173,10 +192,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const signalR = await builder.addAzureSignalR("signalr");
+const signalR = await builder.addAzureSignalR('signalr');
 await signalR.configureInfrastructure(async (infra) => {
-    // Use infra.getProvisionableResources() to access the SignalRService object
-    // and set features[ServiceMode] = 'Serverless' on the Bicep resource.
+  // Use infra.getProvisionableResources() to access the SignalRService object
+  // and set features[ServiceMode] = 'Serverless' on the Bicep resource.
 });
 
 await builder.build().run();
@@ -202,7 +221,12 @@ The Azure SignalR Service emulator allows local development and testing without 
 
 To use the emulator, chain a call to `RunAsEmulator` (or `runAsEmulator`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Azure;
@@ -210,15 +234,16 @@ using Aspire.Hosting.Azure;
 var builder = DistributedApplication.CreateBuilder(args);
 
 var signalR = builder.AddAzureSignalR("signalr", AzureSignalRServiceMode.Serverless)
-    .RunAsEmulator();
+.RunAsEmulator();
 
 builder.AddProject<Projects.ApiService>("api")
-    .WithReference(signalR)
-    .WaitFor(signalR);
+.WithReference(signalR)
+.WaitFor(signalR);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -235,7 +260,8 @@ await builder.addProject("api", "../ApiService/ApiService.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -247,7 +273,12 @@ The `RunAsEmulator` call configures the Azure SignalR Service resource to use th
 
 You might have an existing Azure SignalR Service that you want to connect to. Use `AsExisting` (or `asExisting`) to annotate that your `AzureSignalRResource` is an existing resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -256,14 +287,15 @@ var existingSignalRName = builder.AddParameter("existingSignalRName");
 var existingSignalRResourceGroup = builder.AddParameter("existingSignalRResourceGroup");
 
 var signalR = builder.AddAzureSignalR("signalr")
-    .AsExisting(existingSignalRName, existingSignalRResourceGroup);
+.AsExisting(existingSignalRName, existingSignalRResourceGroup);
 
 builder.AddProject<Projects.ApiService>("api")
-    .WithReference(signalR);
+.WithReference(signalR);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -281,7 +313,8 @@ await builder.addProject("api", "../ApiService/ApiService.csproj")
     .withReference(signalR);
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -366,17 +399,22 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep through the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureSignalR("signalr")
-    .ConfigureInfrastructure(infra =>
-    {
-        var signalRService = infra.GetProvisionableResources()
-                                  .OfType<SignalRService>()
-                                  .Single();
+.ConfigureInfrastructure(infra =>
+{
+var signalRService = infra.GetProvisionableResources()
+.OfType<SignalRService>()
+.Single();
 
         signalRService.Sku.Name = "Premium_P1";
         signalRService.Sku.Capacity = 10;
@@ -386,7 +424,8 @@ builder.AddAzureSignalR("signalr")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -400,7 +439,8 @@ await builder.addAzureSignalR("signalr")
     });
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -417,8 +457,8 @@ For more information, see [Azure.Provisioning customization](/integrations/cloud
 
 When you reference an Azure SignalR Service resource using `WithReference` (or `withReference`), the following connection property is made available to the consuming project:
 
-| Property Name | Description |
-| ------------- | ----------- |
+| Property Name | Description                                                                                                                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Uri`         | The endpoint URI for the SignalR service, with the format `https://{host}` in Azure (typically `https://<resource-name>.service.signalr.net`) or the emulator-provided endpoint when running locally |
 
 Aspire exposes each property as an environment variable named `[RESOURCE]_[PROPERTY]`. For instance, the `Uri` property of a resource called `signalr` becomes `SIGNALR_URI`.
@@ -430,4 +470,3 @@ For the full reference of connection properties and per-language connection exam
 ## Hosting integration health checks
 
 The Azure SignalR Service hosting integration doesn't register a container-based health check when connecting to the cloud service. When running the emulator locally, Aspire monitors the container lifecycle to determine readiness.
-

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-signalr/azure-signalr-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-signalr/azure-signalr-host.mdx
@@ -29,10 +29,10 @@ If you're new to the Azure SignalR Service integration, start with the [Get star
 To start building an Aspire app that uses Azure SignalR Service, install the [📦 Aspire.Hosting.Azure.SignalR](https://www.nuget.org/packages/Aspire.Hosting.Azure.SignalR) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -85,10 +85,10 @@ This updates your `aspire.config.json` with the Azure SignalR Service hosting in
 Once you've installed the hosting integration in your AppHost project, you can add an Azure SignalR Service resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -151,10 +151,10 @@ For more information, see [Azure SignalR Service modes](https://learn.microsoft.
 ### Set service mode
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -222,10 +222,10 @@ The Azure SignalR Service emulator allows local development and testing without 
 To use the emulator, chain a call to `RunAsEmulator` (or `runAsEmulator`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -274,10 +274,10 @@ The `RunAsEmulator` call configures the Azure SignalR Service resource to use th
 You might have an existing Azure SignalR Service that you want to connect to. Use `AsExisting` (or `asExisting`) to annotate that your `AzureSignalRResource` is an existing resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -400,10 +400,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep through the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-sql-database/azure-sql-database-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-sql-database/azure-sql-database-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure SQL Database integration, start with the [Get started
 
 To start building an Aspire app that uses Azure SQL Database, install the [📦 Aspire.Hosting.Azure.Sql](https://www.nuget.org/packages/Aspire.Hosting.Azure.Sql) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -78,7 +83,12 @@ This updates your `aspire.config.json` with the Azure SQL Database hosting integ
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure SQL server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -143,7 +153,12 @@ await builder.build().run();
 
 During local development and testing, you can run an Azure SQL server as a local SQL Server container instead of provisioning an actual Azure resource. Call `RunAsContainer` (or `runAsContainer`) to switch to a local container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -196,7 +211,12 @@ When `RunAsContainer` is active, Aspire pulls a SQL Server container image and r
 
 You might have an existing Azure SQL Database service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -315,6 +335,15 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API. For example, you can configure the `sku`, `version`, and more. The following example demonstrates how to customize the Azure SQL Database resource:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -338,11 +367,15 @@ var sql = builder.AddAzureSqlServer("sql")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
   TypeScript AppHosts can use curated provisioning helper APIs when an
   integration exposes them. This example directly customizes Azure.Provisioning
   objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a [polyglot](/get-started/glossary/#polyglot)-friendly helper.
+  the integration wraps the scenario in a
+  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
 </Aside>
 
 The preceding code:
@@ -375,7 +408,12 @@ You can modify the default behavior in the following ways:
 
 Call `ClearDefaultRoleAssignments` (or `clearDefaultRoleAssignments`) to disable the deployment script entirely:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -412,7 +450,12 @@ await builder.build().run();
 
 Call `WithAdminDeploymentScriptSubnet` (or `withAdminDeploymentScriptSubnet`) to provide your own subnet for the deployment script container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -457,7 +500,12 @@ await builder.build().run();
 
 Call `WithAdminDeploymentScriptStorage` (or `withAdminDeploymentScriptStorage`) to provide your own storage account for the deployment script:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-sql-database/azure-sql-database-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-sql-database/azure-sql-database-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure SQL Database integration, start with the [Get started
 To start building an Aspire app that uses Azure SQL Database, install the [📦 Aspire.Hosting.Azure.Sql](https://www.nuget.org/packages/Aspire.Hosting.Azure.Sql) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure SQL Database hosting integ
 Once you've installed the hosting integration in your AppHost project, you can add an Azure SQL server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -154,10 +154,10 @@ await builder.build().run();
 During local development and testing, you can run an Azure SQL server as a local SQL Server container instead of provisioning an actual Azure resource. Call `RunAsContainer` (or `runAsContainer`) to switch to a local container:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -212,10 +212,10 @@ When `RunAsContainer` is active, Aspire pulls a SQL Server container image and r
 You might have an existing Azure SQL Database service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -336,11 +336,11 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API. For example, you can configure the `sku`, `version`, and more. The following example demonstrates how to customize the Azure SQL Database resource:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -409,10 +409,10 @@ You can modify the default behavior in the following ways:
 Call `ClearDefaultRoleAssignments` (or `clearDefaultRoleAssignments`) to disable the deployment script entirely:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -451,10 +451,10 @@ await builder.build().run();
 Call `WithAdminDeploymentScriptSubnet` (or `withAdminDeploymentScriptSubnet`) to provide your own subnet for the deployment script container:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -501,10 +501,10 @@ await builder.build().run();
 Call `WithAdminDeploymentScriptStorage` (or `withAdminDeploymentScriptStorage`) to provide your own storage account for the deployment script:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
@@ -31,10 +31,10 @@ If you're new to the Azure Blob Storage integration, start with the [Get started
 To start building an Aspire app that uses Azure Blob Storage, install the [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -87,10 +87,10 @@ This updates your `aspire.config.json` with the Azure Storage hosting integratio
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Storage account resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -138,10 +138,10 @@ await builder.build().run();
 After creating an Azure Storage resource, you can add a blob service resource to it using `AddBlobs` (or `addBlobs`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -190,10 +190,10 @@ The preceding code:
 You can add a specific named blob container resource directly using `AddBlobContainer` (or `addBlobContainer`). This is useful when your app needs access to a specific container by name:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -238,10 +238,10 @@ The `blobContainerName` option (or `options.blobContainerName` in TypeScript) se
 During local development, you can configure the Azure Storage resource to use [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) — the open-source Azure Storage emulator — instead of a real Azure subscription. Call `RunAsEmulator` (or `runAsEmulator`) on the storage resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -296,10 +296,10 @@ By default, the Azurite container exposes the following endpoints:
 To configure fixed host ports, use the port configuration methods on the Azurite container resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -345,10 +345,10 @@ await builder.build().run();
 To configure the Azurite container with a persistent lifetime, call `WithLifetime` (or `withLifetime`) with `ContainerLifetime.Persistent`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -390,10 +390,10 @@ await builder.build().run();
 To add a data volume to the Azurite container, call `WithDataVolume` (or `withDataVolume`) on the emulator resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -437,10 +437,10 @@ The data volume is used to persist Azurite data outside the lifecycle of its con
 To add a data bind mount to the Azurite container, call `WithDataBindMount` (or `withDataBindMount`) on the emulator resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -494,10 +494,10 @@ Data bind mounts rely on the host machine's filesystem to persist the Azurite da
 You might have an existing Azure Storage account that you want to connect to instead of provisioning a new one. Chain a call to `AsExisting` (or `asExisting`) on the storage resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -579,10 +579,10 @@ You're free to explore the storage account and its contents using the Azure Stor
 By default, Aspire assigns the `StorageBlobDataContributor` role to the resource when provisioning in Azure. You can override the default roles using `WithRoleAssignments` (or `withRoleAssignments`) on the consuming resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -692,10 +692,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` (or `configureInfrastructure`) API. For example, you can configure the `sku`, `accessTier`, and more:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-host.mdx
@@ -30,7 +30,12 @@ If you're new to the Azure Blob Storage integration, start with the [Get started
 
 To start building an Aspire app that uses Azure Blob Storage, install the [📦 Aspire.Hosting.Azure.Storage](https://www.nuget.org/packages/Aspire.Hosting.Azure.Storage) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -38,7 +43,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -59,7 +65,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Storage hosting integration package:
@@ -79,7 +86,12 @@ This updates your `aspire.config.json` with the Azure Storage hosting integratio
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Storage account resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -88,7 +100,8 @@ var storage = builder.AddAzureStorage("storage");
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -100,37 +113,51 @@ const storage = await builder.addAzureStorage("storage");
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="caution">
-When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls `AddAzureProvisioning`—which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls
+  `AddAzureProvisioning`—which adds support for generating Azure resources
+  dynamically during app startup. The app must configure the appropriate
+  subscription and location. For more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure Storage resource from the AppHost, Aspire makes connection properties available to the consuming project. For a complete list of these properties and per-language connection examples, see [Connect to Azure Blob Storage](../azure-storage-blobs-connect/).
+  When you reference an Azure Storage resource from the AppHost, Aspire makes
+  connection properties available to the consuming project. For a complete list
+  of these properties and per-language connection examples, see [Connect to
+  Azure Blob Storage](../azure-storage-blobs-connect/).
 </Aside>
 
 ## Add blob resource
 
 After creating an Azure Storage resource, you can add a blob service resource to it using `AddBlobs` (or `addBlobs`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var blobs = builder.AddAzureStorage("storage")
-    .AddBlobs("blobs");
+.AddBlobs("blobs");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(blobs)
-    .WaitFor(blobs);
+.WithReference(blobs)
+.WaitFor(blobs);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -147,7 +174,8 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -161,21 +189,27 @@ The preceding code:
 
 You can add a specific named blob container resource directly using `AddBlobContainer` (or `addBlobContainer`). This is useful when your app needs access to a specific container by name:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var container = builder.AddAzureStorage("storage")
-    .AddBlobContainer("uploads", blobContainerName: "upload-data");
+.AddBlobContainer("uploads", blobContainerName: "upload-data");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(container)
-    .WaitFor(container);
+.WithReference(container)
+.WaitFor(container);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -192,7 +226,8 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -202,22 +237,28 @@ The `blobContainerName` option (or `options.blobContainerName` in TypeScript) se
 
 During local development, you can configure the Azure Storage resource to use [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) — the open-source Azure Storage emulator — instead of a real Azure subscription. Call `RunAsEmulator` (or `runAsEmulator`) on the storage resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var blobs = builder.AddAzureStorage("storage")
-    .RunAsEmulator()
-    .AddBlobs("blobs");
+.RunAsEmulator()
+.AddBlobs("blobs");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(blobs)
-    .WaitFor(blobs);
+.WithReference(blobs)
+.WaitFor(blobs);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -235,7 +276,8 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -246,29 +288,35 @@ await builder.build().run();
 By default, the Azurite container exposes the following endpoints:
 
 | Endpoint | Container port | Host port |
-|----------|----------------|-----------|
+| -------- | -------------- | --------- |
 | `blob`   | 10000          | dynamic   |
 | `queue`  | 10001          | dynamic   |
 | `table`  | 10002          | dynamic   |
 
 To configure fixed host ports, use the port configuration methods on the Azurite container resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator(azurite =>
-    {
-        azurite.WithBlobPort(27000)
-               .WithQueuePort(27001)
-               .WithTablePort(27002);
-    });
+.RunAsEmulator(azurite =>
+{
+azurite.WithBlobPort(27000)
+.WithQueuePort(27001)
+.WithTablePort(27002);
+});
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -287,7 +335,8 @@ const storage = await builder.addAzureStorage("storage")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -295,20 +344,26 @@ await builder.build().run();
 
 To configure the Azurite container with a persistent lifetime, call `WithLifetime` (or `withLifetime`) with `ContainerLifetime.Persistent`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator(azurite =>
-    {
-        azurite.WithLifetime(ContainerLifetime.Persistent);
-    });
+.RunAsEmulator(azurite =>
+{
+azurite.WithLifetime(ContainerLifetime.Persistent);
+});
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -325,7 +380,8 @@ const storage = await builder.addAzureStorage("storage")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -333,20 +389,26 @@ await builder.build().run();
 
 To add a data volume to the Azurite container, call `WithDataVolume` (or `withDataVolume`) on the emulator resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator(azurite =>
-    {
-        azurite.WithDataVolume();
-    });
+.RunAsEmulator(azurite =>
+{
+azurite.WithDataVolume();
+});
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -363,7 +425,8 @@ const storage = await builder.addAzureStorage("storage")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -373,20 +436,26 @@ The data volume is used to persist Azurite data outside the lifecycle of its con
 
 To add a data bind mount to the Azurite container, call `WithDataBindMount` (or `withDataBindMount`) on the emulator resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator(azurite =>
-    {
-        azurite.WithDataBindMount("../azurite/data");
-    });
+.RunAsEmulator(azurite =>
+{
+azurite.WithDataBindMount("../azurite/data");
+});
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -403,12 +472,19 @@ const storage = await builder.addAzureStorage("storage")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist the Azurite data across container restarts. The data bind mount is mounted at the `../azurite/data` path on the host machine relative to the AppHost directory in the Azurite container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -417,7 +493,12 @@ Data bind mounts rely on the host machine's filesystem to persist the Azurite da
 
 You might have an existing Azure Storage account that you want to connect to instead of provisioning a new one. Chain a call to `AsExisting` (or `asExisting`) on the storage resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -426,15 +507,16 @@ var existingStorageName = builder.AddParameter("existingStorageName");
 var existingStorageResourceGroup = builder.AddParameter("existingStorageResourceGroup");
 
 var blobs = builder.AddAzureStorage("storage")
-    .AsExisting(existingStorageName, existingStorageResourceGroup)
-    .AddBlobs("blobs");
+.AsExisting(existingStorageName, existingStorageResourceGroup)
+.AddBlobs("blobs");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(blobs);
+.WithReference(blobs);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -454,7 +536,8 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -482,9 +565,10 @@ To connect to the storage resource from Azure Storage Explorer, follow these ste
 1. Expand the **Storage Accounts** node.
 1. You should see a storage account with your resource's name as a prefix:
 
-    <Image
-      src={storageExplorerImage}
-      alt="Azure Storage Explorer: Azurite storage resource discovered." />
+   <Image
+     src={storageExplorerImage}
+     alt="Azure Storage Explorer: Azurite storage resource discovered."
+   />
 
 </Steps>
 
@@ -494,7 +578,12 @@ You're free to explore the storage account and its contents using the Azure Stor
 
 By default, Aspire assigns the `StorageBlobDataContributor` role to the resource when provisioning in Azure. You can override the default roles using `WithRoleAssignments` (or `withRoleAssignments`) on the consuming resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -503,12 +592,13 @@ var storage = builder.AddAzureStorage("storage");
 var blobs = storage.AddBlobs("blobs");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(blobs)
-    .WithRoleAssignments(storage, AzureStorageRole.StorageBlobDataReader);
+.WithReference(blobs)
+.WithRoleAssignments(storage, AzureStorageRole.StorageBlobDataReader);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -525,18 +615,19 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The `AzureStorageRole` enum exposes all Azure Storage built-in roles. Common blob-related roles include:
 
-| Role | Description |
-|------|-------------|
-| `StorageBlobDataContributor` | Read, write, and delete blob containers and data (default) |
-| `StorageBlobDataOwner` | Full access to blob containers and data, including POSIX access control |
-| `StorageBlobDataReader` | Read and list blob containers and data |
-| `StorageBlobDelegator` | Get a user delegation key for signing SAS tokens |
+| Role                         | Description                                                             |
+| ---------------------------- | ----------------------------------------------------------------------- |
+| `StorageBlobDataContributor` | Read, write, and delete blob containers and data (default)              |
+| `StorageBlobDataOwner`       | Full access to blob containers and data, including POSIX access control |
+| `StorageBlobDataReader`      | Read and list blob containers and data                                  |
+| `StorageBlobDelegator`       | Get a user delegation key for signing SAS tokens                        |
 
 For more information on Azure Storage role-based access control, see [Azure built-in roles for Storage](https://learn.microsoft.com/azure/role-based-access-control/built-in-roles/storage).
 
@@ -600,17 +691,22 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` (or `configureInfrastructure`) API. For example, you can configure the `sku`, `accessTier`, and more:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .ConfigureInfrastructure(infra =>
-    {
-        var storageAccount = infra.GetProvisionableResources()
-            .OfType<StorageAccount>()
-            .Single();
+.ConfigureInfrastructure(infra =>
+{
+var storageAccount = infra.GetProvisionableResources()
+.OfType<StorageAccount>()
+.Single();
 
         storageAccount.Sku = new StorageSku { Name = StorageSkuName.PremiumLrs };
         storageAccount.AccessTier = StorageAccountAccessTier.Premium;
@@ -621,7 +717,8 @@ var blobs = storage.AddBlobs("blobs");
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -639,7 +736,8 @@ const blobs = await storage.addBlobs("blobs");
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-datalake.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-datalake.mdx
@@ -181,7 +181,14 @@ func main() {
 	}
 
 	storage := builder.AddAzureStorage("storage")
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	dataLake := storage.AddDataLake("datalake")
+	if err := dataLake.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("api", "../ExampleProject/ExampleProject.csproj").
 		WithReference(dataLake).
@@ -332,13 +339,24 @@ func main() {
 	}
 
 	storage := builder.AddAzureStorage("storage")
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	dataLake := storage.AddDataLake("datalake")
+	if err := dataLake.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	fileSystemName := "analytics-data"
 	fileSystem := storage.AddDataLakeFileSystem(
 		"analytics",
 		&aspire.AddDataLakeFileSystemOptions{
 			DataLakeFileSystemName: &fileSystemName,
 		})
+	if err := fileSystem.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("api", "../ExampleProject/ExampleProject.csproj").
 		WithReference(dataLake).

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-datalake.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-datalake.mdx
@@ -34,7 +34,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -55,7 +56,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Storage hosting integration package:
@@ -67,6 +69,42 @@ This updates your `aspire.config.json` with the Azure Storage hosting integratio
   }
 }
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
 
 </Fragment>
 </AppHostTabs>
@@ -84,12 +122,13 @@ var storage = builder.AddAzureStorage("storage");
 var dataLake = storage.AddDataLake("datalake");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(dataLake)
-    .WaitFor(dataLake);
+.WithReference(dataLake)
+.WaitFor(dataLake);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -106,7 +145,98 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+storage = builder.add_azure_storage("storage")
+data_lake = storage.add_data_lake("datalake")
+
+    builder.add_project("api", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(data_lake) \
+        .wait_for(data_lake)
+
+    builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage")
+	dataLake := storage.AddDataLake("datalake")
+
+	builder.AddProject("api", "../ExampleProject/ExampleProject.csproj").
+		WithReference(dataLake).
+		WaitFor(dataLake)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage");
+    var dataLake = storage.addDataLake("datalake");
+
+    builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
+        .withReference(dataLake)
+        .waitFor(dataLake);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let storage = builder.add_azure_storage("storage")?;
+    let data_lake = storage.add_data_lake("datalake")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -117,7 +247,9 @@ The preceding code:
 - Passes a reference to the Data Lake resource to the consuming project and waits for it to be ready.
 
 <Aside type="caution" title="Emulator not supported">
-Azure Data Lake Storage does **not** support the Azure Storage emulator. You must use an actual Azure Storage account with hierarchical namespace (HNS) enabled, or use connection strings for local development.
+  Azure Data Lake Storage does **not** support the Azure Storage emulator. You
+  must use an actual Azure Storage account with hierarchical namespace (HNS)
+  enabled, or use connection strings for local development.
 </Aside>
 
 ### Add Azure Data Lake file system resource
@@ -134,13 +266,14 @@ var dataLake = storage.AddDataLake("datalake");
 var fileSystem = storage.AddDataLakeFileSystem("analytics", "analytics-data");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(dataLake)
-    .WithReference(fileSystem)
-    .WaitFor(dataLake);
+.WithReference(dataLake)
+.WithReference(fileSystem)
+.WaitFor(dataLake);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -159,33 +292,148 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+storage = builder.add_azure_storage("storage")
+data_lake = storage.add_data_lake("datalake")
+file_system = storage.add_data_lake_file_system(
+"analytics",
+data_lake_file_system_name="analytics-data")
+
+    builder.add_project("api", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(data_lake) \
+        .with_reference(file_system) \
+        .wait_for(data_lake)
+
+    builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage")
+	dataLake := storage.AddDataLake("datalake")
+	fileSystemName := "analytics-data"
+	fileSystem := storage.AddDataLakeFileSystem(
+		"analytics",
+		&aspire.AddDataLakeFileSystemOptions{
+			DataLakeFileSystemName: &fileSystemName,
+		})
+
+	builder.AddProject("api", "../ExampleProject/ExampleProject.csproj").
+		WithReference(dataLake).
+		WithReference(fileSystem).
+		WaitFor(dataLake)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage");
+    var dataLake = storage.addDataLake("datalake");
+    var fileSystem = storage.addDataLakeFileSystem("analytics", "analytics-data");
+
+    builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
+        .withReference(dataLake)
+        .withReference(fileSystem)
+        .waitFor(dataLake);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let storage = builder.add_azure_storage("storage")?;
+    let data_lake = storage.add_data_lake("datalake")?;
+    let file_system = storage.add_data_lake_file_system(
+        "analytics", Some("analytics-data"))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
 The `AddDataLakeFileSystem` (or `addDataLakeFileSystem`) method takes:
+
 - `name`: The resource name used in Aspire.
 - `dataLakeFileSystemName` (optional): The actual file system name in Azure. Defaults to the resource name if not specified.
 
 <Aside type="note">
-Both `AddDataLake` and `AddDataLakeFileSystem` are called on the storage resource, not on each other. When you call either method, the storage account is automatically configured with hierarchical namespace (HNS) enabled, which is required for Data Lake Storage Gen2.
+  Both `AddDataLake` and `AddDataLakeFileSystem` are called on the storage
+  resource, not on each other. When you call either method, the storage account
+  is automatically configured with hierarchical namespace (HNS) enabled, which
+  is required for Data Lake Storage Gen2.
 </Aside>
 
 ### Customize provisioning infrastructure
 
 The Data Lake resource is part of the Azure Storage resource, which is a subclass of `AzureProvisioningResource`. You can customize the generated Bicep using the `ConfigureInfrastructure` (or `configureInfrastructure`) API on the storage resource. For example, you can configure the storage SKU, access tier, and other properties:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Python daily SDK generates configure_infrastructure, but AzureResourceInfrastructure does not generate get_provisionable_resources, so the documented StorageAccount callback cannot be written.',
+  go: 'The Go daily SDK generates ConfigureInfrastructure, but AzureResourceInfrastructure does not generate GetProvisionableResources, so the documented StorageAccount callback cannot be written.',
+  java: 'The Java daily SDK generates configureInfrastructure, but AzureResourceInfrastructure does not generate getProvisionableResources, so the documented StorageAccount callback cannot be written.',
+  rust: 'The Rust daily SDK generates configure_infrastructure with an untyped Vec<Value> callback, and AzureResourceInfrastructure does not generate get_provisionable_resources, so the documented StorageAccount callback cannot be written.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .ConfigureInfrastructure(infra =>
-    {
-        var storageAccount = infra.GetProvisionableResources()
-            .OfType<StorageAccount>()
-            .Single();
+.ConfigureInfrastructure(infra =>
+{
+var storageAccount = infra.GetProvisionableResources()
+.OfType<StorageAccount>()
+.Single();
 
         storageAccount.Sku = new StorageSku { Name = StorageSkuName.PremiumLrs };
         storageAccount.Tags.Add("workload", "analytics");
@@ -194,11 +442,12 @@ var storage = builder.AddAzureStorage("storage")
 var dataLake = storage.AddDataLake("datalake");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(dataLake);
+.WithReference(dataLake);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -222,7 +471,8 @@ await builder.addProject("api", "../ExampleProject/ExampleProject.csproj")
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-host.mdx
@@ -188,7 +188,15 @@ func main() {
 		log.Fatal(aspire.FormatError(err))
 	}
 
-	queues := builder.AddAzureStorage("storage").AddQueues("queues")
+	storage := builder.AddAzureStorage("storage")
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	queues := storage.AddQueues("queues")
+	if err := queues.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
 		WithReference(queues).
@@ -346,7 +354,14 @@ func main() {
 	}
 
 	storage := builder.AddAzureStorage("storage").RunAsEmulator()
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	queues := storage.AddQueues("queues")
+	if err := queues.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
 		WithReference(queues).
@@ -975,13 +990,27 @@ func main() {
 	}
 
 	existingStorageName := builder.AddParameter("existingStorageName")
-	existingStorageResourceGroup := builder.AddParameter("existingStorageResourceGroup")
+	if err := existingStorageName.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
-	queues := builder.AddAzureStorage("storage").
+	existingStorageResourceGroup := builder.AddParameter("existingStorageResourceGroup")
+	if err := existingStorageResourceGroup.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").
 		AsExisting(existingStorageName, &aspire.AsExistingOptions{
 			ResourceGroup: existingStorageResourceGroup,
-		}).
-		AddQueues("queues")
+		})
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	queues := storage.AddQueues("queues")
+	if err := queues.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
 		WithReference(queues)

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-host.mdx
@@ -22,7 +22,7 @@ import storageExplorerImage from '@assets/integrations/cloud/azure/storage/azure
   data-zoom-off
 />
 
-This article is the reference for the Aspire Azure Queue Storage Hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model an Azure Storage account and its queue resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Azure Queue Storage Hosting integration. It enumerates the AppHost APIs — with examples for C#, TypeScript, Python, Go, Java, and Rust where the generated SDK supports them — that you use to model an Azure Storage account and its queue resources in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the Azure Queue Storage integration, start with the [Get started with Azure Queue Storage integrations](/integrations/cloud/azure/azure-storage-queues/azure-storage-queues-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Azure Queue Storage](../azure-storage-queues-connect/).
 
@@ -38,7 +38,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -59,7 +60,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Storage hosting integration package:
@@ -71,6 +73,42 @@ This updates your `aspire.config.json` with the Azure Storage hosting integratio
   }
 }
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
 
 </Fragment>
 </AppHostTabs>
@@ -104,15 +142,107 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const queues = await builder.addAzureStorage("storage")
-    .addQueues("queues");
+const queues = await builder.addAzureStorage('storage').addQueues('queues');
 
-await builder.addNodeApp("apiservice", "./api", "index.js")
-    .withReference(queues)
-    .waitFor(queues);
+await builder
+  .addNodeApp('apiservice', './api', 'index.js')
+  .withReference(queues)
+  .waitFor(queues);
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage")
+    queues = storage.add_queues("queues")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(queues) \
+        .wait_for(queues)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	queues := builder.AddAzureStorage("storage").AddQueues("queues")
+
+	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
+		WithReference(queues).
+		WaitFor(queues)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var queues = builder.addAzureStorage("storage")
+        .addQueues("queues");
+
+    builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+        .withReference(queues)
+        .waitFor(queues);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let storage = builder.add_azure_storage("storage")?;
+    let queues = storage.add_queues("queues")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -121,18 +251,28 @@ await builder.build().run();
 The preceding code adds an Azure Storage resource named `storage`, attaches a queue storage resource named `queues` to it, and passes the queue's connection information to the consuming project.
 
 <Aside type="caution">
-When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls `AddAzureProvisioning`—which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls
+  `AddAzureProvisioning`—which adds support for generating Azure resources
+  dynamically during app startup. The app must configure the appropriate
+  subscription and location. For more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-When you reference the queue resource from the AppHost, Aspire makes several connection properties available to the consuming project, such as the service URI and connection string. For a complete list of these properties and per-language connection examples, see [Connect to Azure Queue Storage](../azure-storage-queues-connect/).
+  When you reference the queue resource from the AppHost, Aspire makes several
+  connection properties available to the consuming project, such as the service
+  URI and connection string. For a complete list of these properties and
+  per-language connection examples, see [Connect to Azure Queue
+  Storage](../azure-storage-queues-connect/).
 </Aside>
 
 ## Run as Azurite emulator
 
 For local development, Aspire can run the [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) emulator in a container to avoid requiring an Azure subscription. Call `RunAsEmulator` (C#) or `runAsEmulator` (TypeScript) on the storage resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented emulator operation is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -158,16 +298,88 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator();
-const queues = await storage.addQueues("queues");
+const storage = await builder.addAzureStorage('storage').runAsEmulator();
+const queues = await storage.addQueues('queues');
 
-await builder.addNodeApp("apiservice", "./api", "index.js")
-    .withReference(queues)
-    .waitFor(queues);
+await builder
+  .addNodeApp('apiservice', './api', 'index.js')
+  .withReference(queues)
+  .waitFor(queues);
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage").run_as_emulator()
+    queues = storage.add_queues("queues")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(queues) \
+        .wait_for(queues)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator()
+	queues := storage.AddQueues("queues")
+
+	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
+		WithReference(queues).
+		WaitFor(queues)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage").runAsEmulator();
+    var queues = storage.addQueues("queues");
+
+    builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+        .withReference(queues)
+        .waitFor(queues);
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -182,14 +394,16 @@ When running as an emulator, Aspire pulls the `mcr.microsoft.com/azure-storage/a
 By default, the Azurite container exposes the following endpoints:
 
 | Endpoint | Container port | Host port |
-|----------|----------------|-----------|
+| -------- | -------------- | --------- |
 | `blob`   | 10000          | dynamic   |
 | `queue`  | 10001          | dynamic   |
 | `table`  | 10002          | dynamic   |
 
-The host port is dynamic by default. To fix the ports, pass a configuration callback to `RunAsEmulator` (C#) or `runAsEmulator` (TypeScript):
+The host port is dynamic by default. To fix the ports, pass a configuration callback to the emulator operation:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented port configuration callback is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -215,17 +429,93 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withBlobPort(27000);
-            await azurite.withQueuePort(27001);
-            await azurite.withTablePort(27002);
-        },
-    });
+const storage = await builder.addAzureStorage('storage').runAsEmulator({
+  configureContainer: async (azurite) => {
+    await azurite.withBlobPort(27000);
+    await azurite.withQueuePort(27001);
+    await azurite.withTablePort(27002);
+  },
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+def configure_azurite(azurite):
+    azurite.with_blob_port(27000) \
+        .with_queue_port(27001) \
+        .with_table_port(27002)
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage") \
+        .run_as_emulator(configure_container=configure_azurite)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator(
+		&aspire.RunAsEmulatorOptions{
+			ConfigureContainer: func(azurite aspire.AzureStorageEmulatorResource) {
+				azurite.WithBlobPort(27000).
+					WithQueuePort(27001).
+					WithTablePort(27002)
+			},
+		})
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage")
+        .runAsEmulator(azurite -> azurite
+            .withBlobPort(27000)
+            .withQueuePort(27001)
+            .withTablePort(27002));
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -233,17 +523,19 @@ await builder.build().run();
 
 The resulting port mappings (`container:host`) are:
 
-| Endpoint | Port mapping |
-|----------|--------------|
+| Endpoint | Port mapping  |
+| -------- | ------------- |
 | `blob`   | `10000:27000` |
 | `queue`  | `10001:27001` |
 | `table`  | `10002:27002` |
 
 ## Configure Azurite container with persistent lifetime
 
-To keep the Azurite container alive across AppHost restarts, call `WithLifetime` with `ContainerLifetime.Persistent`:
+To keep the Azurite container alive across AppHost restarts, configure the emulator container with a persistent lifetime:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented lifetime callback is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -267,15 +559,85 @@ import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withLifetime(ContainerLifetime.Persistent);
-        },
-    });
+const storage = await builder.addAzureStorage('storage').runAsEmulator({
+  configureContainer: async (azurite) => {
+    await azurite.withLifetime(ContainerLifetime.Persistent);
+  },
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+def configure_azurite(azurite):
+    azurite.with_lifetime("Persistent")
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage") \
+        .run_as_emulator(configure_container=configure_azurite)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator(
+		&aspire.RunAsEmulatorOptions{
+			ConfigureContainer: func(azurite aspire.AzureStorageEmulatorResource) {
+				azurite.WithLifetime(aspire.ContainerLifetimePersistent)
+			},
+		})
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage")
+        .runAsEmulator(azurite ->
+            azurite.withLifetime(ContainerLifetime.PERSISTENT));
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -285,7 +647,9 @@ await builder.build().run();
 
 To persist Azurite data outside the container lifecycle, add a data volume:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented data-volume callback is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -309,15 +673,84 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withDataVolume();
-        },
-    });
+const storage = await builder.addAzureStorage('storage').runAsEmulator({
+  configureContainer: async (azurite) => {
+    await azurite.withDataVolume();
+  },
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+def configure_azurite(azurite):
+    azurite.with_data_volume()
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage") \
+        .run_as_emulator(configure_container=configure_azurite)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator(
+		&aspire.RunAsEmulatorOptions{
+			ConfigureContainer: func(azurite aspire.AzureStorageEmulatorResource) {
+				azurite.WithDataVolume()
+			},
+		})
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage")
+        .runAsEmulator(azurite -> azurite.withDataVolume());
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -327,9 +760,11 @@ The data volume is mounted at the `/data` path in the Azurite container. When a 
 
 ## Configure Azurite container with data bind mount
 
-To use a bind mount instead of a volume, call `WithDataBindMount`:
+To use a bind mount instead of a volume, configure the emulator container with a data bind mount:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented data-bind-mount callback is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -353,22 +788,101 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withDataBindMount({ path: "../azurite/data" });
-        },
-    });
+const storage = await builder.addAzureStorage('storage').runAsEmulator({
+  configureContainer: async (azurite) => {
+    await azurite.withDataBindMount({ path: '../azurite/data' });
+  },
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+def configure_azurite(azurite):
+    azurite.with_data_bind_mount(path="../azurite/data")
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage") \
+        .run_as_emulator(configure_container=configure_azurite)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	path := "../azurite/data"
+	storage := builder.AddAzureStorage("storage").RunAsEmulator(
+		&aspire.RunAsEmulatorOptions{
+			ConfigureContainer: func(azurite aspire.AzureStorageEmulatorResource) {
+				azurite.WithDataBindMount(&aspire.WithDataBindMountOptions{
+					Path: &path,
+				})
+			},
+		})
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage")
+        .runAsEmulator(azurite -> azurite.withDataBindMount(
+            new WithDataBindMountOptions().path("../azurite/data")));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Azurite data across container restarts. The data bind mount is mounted at the `../azurite/data` path on the host machine relative to the AppHost directory. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -405,24 +919,147 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const existingStorageName = await builder.addParameter("existingStorageName");
+const existingStorageName = await builder.addParameter('existingStorageName');
 
-const queues = await builder.addAzureStorage("storage")
-    .asExisting(existingStorageName)
-    .addQueues("queues");
+const queues = await builder
+  .addAzureStorage('storage')
+  .asExisting(existingStorageName)
+  .addQueues('queues');
 
-await builder.addNodeApp("apiservice", "./api", "index.js")
-    .withReference(queues);
+await builder
+  .addNodeApp('apiservice', './api', 'index.js')
+  .withReference(queues);
 
 // After adding all resources, run the app...
 await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    existing_storage_name = builder.add_parameter("existingStorageName")
+    existing_storage_resource_group = builder.add_parameter("existingStorageResourceGroup")
+
+    queues = builder.add_azure_storage("storage") \
+        .as_existing(
+            existing_storage_name,
+            resource_group=existing_storage_resource_group) \
+        .add_queues("queues")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(queues)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	existingStorageName := builder.AddParameter("existingStorageName")
+	existingStorageResourceGroup := builder.AddParameter("existingStorageResourceGroup")
+
+	queues := builder.AddAzureStorage("storage").
+		AsExisting(existingStorageName, &aspire.AsExistingOptions{
+			ResourceGroup: existingStorageResourceGroup,
+		}).
+		AddQueues("queues")
+
+	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
+		WithReference(queues)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var existingStorageName = builder.addParameter("existingStorageName");
+    var existingStorageResourceGroup = builder.addParameter("existingStorageResourceGroup");
+
+    var queues = builder.addAzureStorage("storage")
+        .asExisting(existingStorageName, existingStorageResourceGroup)
+        .addQueues("queues");
+
+    builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+        .withReference(queues);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let existing_storage_name = builder.add_parameter(
+        "existingStorageName", None, None, None)?;
+    let existing_storage_resource_group = builder.add_parameter(
+        "existingStorageResourceGroup", None, None, None)?;
+
+    let storage = builder.add_azure_storage("storage")?;
+    storage.as_existing(
+        existing_storage_name.handle().to_json(),
+        Some(existing_storage_resource_group.handle().to_json()))?;
+    let queues = storage.add_queues("queues")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="caution">
-When you call `RunAsExisting`, `PublishAsExisting`, or `AsExisting` to work with resources that are already present in your Azure subscription, you must add certain configuration values to your AppHost so that Aspire can locate them. The necessary configuration values include **SubscriptionId**, **AllowResourceGroupCreation**, **ResourceGroup**, and **Location**. If you don't set them, "Missing configuration" errors appear in the Aspire dashboard. For more information about how to set them, see [Use existing Azure resources](/integrations/cloud/azure/overview/#use-existing-azure-resources).
+  When you call `RunAsExisting`, `PublishAsExisting`, or `AsExisting` to work
+  with resources that are already present in your Azure subscription, you must
+  add certain configuration values to your AppHost so that Aspire can locate
+  them. The necessary configuration values include **SubscriptionId**,
+  **AllowResourceGroupCreation**, **ResourceGroup**, and **Location**. If you
+  don't set them, "Missing configuration" errors appear in the Aspire dashboard.
+  For more information about how to set them, see [Use existing Azure
+  resources](/integrations/cloud/azure/overview/#use-existing-azure-resources).
 </Aside>
 
 ## Connect to storage resources from Azure Storage Explorer
@@ -430,7 +1067,10 @@ When you call `RunAsExisting`, `PublishAsExisting`, or `AsExisting` to work with
 When the Aspire AppHost runs, the storage resources can be accessed by external tools such as the [Azure Storage Explorer](https://azure.microsoft.com/features/storage-explorer/). If your storage resource is running locally using Azurite, it will automatically be picked up by the Azure Storage Explorer.
 
 <Aside type="note">
-The Azure Storage Explorer discovers Azurite storage resources assuming the default ports are used. If you've [configured the Azurite container to use different ports](#configure-azurite-container-ports), you'll need to configure the Azure Storage Explorer to connect to the correct ports.
+  The Azure Storage Explorer discovers Azurite storage resources assuming the
+  default ports are used. If you've [configured the Azurite container to use
+  different ports](#configure-azurite-container-ports), you'll need to configure
+  the Azure Storage Explorer to connect to the correct ports.
 </Aside>
 
 To connect to the storage resource from Azure Storage Explorer, follow these steps:
@@ -445,9 +1085,10 @@ To connect to the storage resource from Azure Storage Explorer, follow these ste
 1. Expand the **Storage Accounts** node.
 1. You should see a storage account with your resource's name as a prefix:
 
-    <Image
-      src={storageExplorerImage}
-      alt="Azure Storage Explorer: Azurite storage resource discovered." />
+   <Image
+     src={storageExplorerImage}
+     alt="Azure Storage Explorer: Azurite storage resource discovered."
+   />
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
@@ -402,10 +402,10 @@ By default, when Aspire configures the Azurite container, it exposes the followi
 The host port is dynamic by default. When the container starts, the ports are mapped to random ports on the host machine. To fix the endpoint ports, configure them inside the `RunAsEmulator` (or `runAsEmulator`) callback:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -460,10 +460,10 @@ The preceding code configures the Azurite container ports as follows:
 To configure the Azurite container with a persistent lifetime so it survives app restarts, call `WithLifetime` (or `withLifetime`) with `ContainerLifetime.Persistent`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -505,10 +505,10 @@ await builder.build().run();
 To persist Azurite data across container restarts with a data volume, call `WithDataVolume` (or `withDataVolume`) on the emulator resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -552,10 +552,10 @@ The data volume is mounted at the `/data` path in the Azurite container and when
 To add a data bind mount to the Azurite container instead of a named volume, call `WithDataBindMount` (or `withDataBindMount`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -631,10 +631,10 @@ For more information on using the Azure Storage Explorer, see [Get started with 
 If you have an existing Azure Storage account, you can connect to it using the `AsExisting` (or `asExisting`) method instead of provisioning a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
@@ -182,7 +182,15 @@ func main() {
 		log.Fatal(aspire.FormatError(err))
 	}
 
-	tables := builder.AddAzureStorage("storage").AddTables("tables")
+	storage := builder.AddAzureStorage("storage")
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tables := storage.AddTables("tables")
+	if err := tables.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
 		WithReference(tables).
@@ -346,7 +354,14 @@ func main() {
 	}
 
 	storage := builder.AddAzureStorage("storage").RunAsEmulator()
+	if err := storage.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
 	tables := storage.AddTables("tables")
+	if err := tables.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 
 	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
 		WithReference(tables).

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-host.mdx
@@ -21,7 +21,7 @@ import storageExplorerImage from '@assets/integrations/cloud/azure/storage/azure
   data-zoom-off
 />
 
-This article is the reference for the Aspire Azure Table Storage hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model Azure Storage accounts and table resources in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Azure Table Storage hosting integration. It enumerates the AppHost APIs — with examples for C#, TypeScript, Python, Go, Java, and Rust where the generated SDK supports them — that you use to model Azure Storage accounts and table resources in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the Azure Table Storage integration, start with the [Get started with Azure Table Storage integrations](/integrations/cloud/azure/azure-storage-tables/azure-storage-tables-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Azure Table Storage](../azure-storage-tables-connect/).
 
@@ -37,7 +37,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +59,8 @@ aspire add azure-storage
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Storage hosting integration package:
@@ -70,6 +72,42 @@ This updates your `aspire.config.json` with the Azure Storage hosting integratio
   }
 }
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add azure-storage
+```
+
+This updates your `aspire.config.json` with the Azure Storage hosting integration package.
 
 </Fragment>
 </AppHostTabs>
@@ -84,15 +122,16 @@ Once you've installed the hosting integration in your AppHost project, you can a
 var builder = DistributedApplication.CreateBuilder(args);
 
 var tables = builder.AddAzureStorage("storage")
-    .AddTables("tables");
+.AddTables("tables");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(tables)
-    .WaitFor(tables);
+.WithReference(tables)
+.WaitFor(tables);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -109,7 +148,95 @@ await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj"
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+tables = builder.add_azure_storage("storage").add_tables("tables")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(tables) \
+        .wait_for(tables)
+
+    builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tables := builder.AddAzureStorage("storage").AddTables("tables")
+
+	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
+		WithReference(tables).
+		WaitFor(tables)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var tables = builder.addAzureStorage("storage")
+        .addTables("tables");
+
+    builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+        .withReference(tables)
+        .waitFor(tables);
+
+    builder.build().run();
+
+}
+
+````
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let tables = builder.add_azure_storage("storage")?.add_tables("tables")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -126,34 +253,45 @@ await builder.build().run();
 </Steps>
 
 <Aside type="caution">
-When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls `AddAzureProvisioning` (or `addAzureProvisioning`) — which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureStorage` (or `addAzureStorage`), it implicitly calls
+  `AddAzureProvisioning` (or `addAzureProvisioning`) — which adds support for
+  generating Azure resources dynamically during app startup. The app must
+  configure the appropriate subscription and location. For more information, see
+  [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-When you reference an Azure Table Storage resource from the AppHost, Aspire injects connection properties into the consuming app. For a complete list of these properties and per-language connection examples, see [Connect to Azure Table Storage](../azure-storage-tables-connect/).
+  When you reference an Azure Table Storage resource from the AppHost, Aspire
+  injects connection properties into the consuming app. For a complete list of
+  these properties and per-language connection examples, see [Connect to Azure
+  Table Storage](../azure-storage-tables-connect/).
 </Aside>
 
 ## Run as emulator (Azurite)
 
-For local development, configure the storage resource to use the [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) emulator instead of a real Azure Storage account. Call `RunAsEmulator` (or `runAsEmulator`) on the storage resource:
+For local development, configure the storage resource to use the [Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite) emulator instead of a real Azure Storage account:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust daily SDK generates run_as_emulator with an untyped Vec<Value> callback instead of a typed AzureStorageEmulatorResource callback, so the documented emulator operation is not available.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.AddAzureStorage("storage")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 var tables = storage.AddTables("tables");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(tables)
-    .WaitFor(tables);
+.WithReference(tables)
+.WaitFor(tables);
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -172,7 +310,78 @@ await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj"
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+````
+
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+storage = builder.add_azure_storage("storage").run_as_emulator()
+tables = storage.add_tables("tables")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj") \
+        .with_reference(tables) \
+        .wait_for(tables)
+
+    builder.run()
+
+````
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator()
+	tables := storage.AddTables("tables")
+
+	builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj").
+		WithReference(tables).
+		WaitFor(tables)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+````
+
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var storage = builder.addAzureStorage("storage").runAsEmulator();
+    var tables = storage.addTables("tables");
+
+    builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+        .withReference(tables)
+        .waitFor(tables);
+
+    builder.build().run();
+
+}
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -192,7 +401,12 @@ By default, when Aspire configures the Azurite container, it exposes the followi
 
 The host port is dynamic by default. When the container starts, the ports are mapped to random ports on the host machine. To fix the endpoint ports, configure them inside the `RunAsEmulator` (or `runAsEmulator`) callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -207,7 +421,8 @@ var storage = builder.AddAzureStorage("storage")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -216,18 +431,19 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite
-                .withBlobPort(27000)
-                .withQueuePort(27001)
-                .withTablePort(27002);
-        }
-    });
+.runAsEmulator({
+configureContainer: async (azurite) => {
+await azurite
+.withBlobPort(27000)
+.withQueuePort(27001)
+.withTablePort(27002);
+}
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -243,7 +459,12 @@ The preceding code configures the Azurite container ports as follows:
 
 To configure the Azurite container with a persistent lifetime so it survives app restarts, call `WithLifetime` (or `withLifetime`) with `ContainerLifetime.Persistent`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -256,7 +477,8 @@ var storage = builder.AddAzureStorage("storage")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -265,15 +487,16 @@ import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withLifetime(ContainerLifetime.Persistent);
-        }
-    });
+.runAsEmulator({
+configureContainer: async (azurite) => {
+await azurite.withLifetime(ContainerLifetime.Persistent);
+}
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -281,7 +504,12 @@ await builder.build().run();
 
 To persist Azurite data across container restarts with a data volume, call `WithDataVolume` (or `withDataVolume`) on the emulator resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -294,7 +522,8 @@ var storage = builder.AddAzureStorage("storage")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -303,15 +532,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withDataVolume();
-        }
-    });
+.runAsEmulator({
+configureContainer: async (azurite) => {
+await azurite.withDataVolume();
+}
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -321,7 +551,12 @@ The data volume is mounted at the `/data` path in the Azurite container and when
 
 To add a data bind mount to the Azurite container instead of a named volume, call `WithDataBindMount` (or `withDataBindMount`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -334,7 +569,8 @@ var storage = builder.AddAzureStorage("storage")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -343,15 +579,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 const storage = await builder.addAzureStorage("storage")
-    .runAsEmulator({
-        configureContainer: async (azurite) => {
-            await azurite.withDataBindMount({ path: '../azurite/data' });
-        }
-    });
+.runAsEmulator({
+configureContainer: async (azurite) => {
+await azurite.withDataBindMount({ path: '../azurite/data' });
+}
+});
 
 // After adding all resources, run the app...
 await builder.build().run();
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -393,7 +630,12 @@ For more information on using the Azure Storage Explorer, see [Get started with 
 
 If you have an existing Azure Storage account, you can connect to it using the `AsExisting` (or `asExisting`) method instead of provisioning a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -411,7 +653,8 @@ builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -423,15 +666,16 @@ const existingStorageName = await builder.addParameter("existingStorageName");
 const existingStorageResourceGroup = await builder.addParameter("existingStorageResourceGroup");
 
 const storageAccount = await builder.addAzureStorage("storage")
-    .asExisting(existingStorageName, { resourceGroup: existingStorageResourceGroup });
+.asExisting(existingStorageName, { resourceGroup: existingStorageResourceGroup });
 
 const tables = await storageAccount.addTables("tables");
 
 await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj")
-    .withReference(tables);
+.withReference(tables);
 
 // After adding all resources, run the app...
 await builder.build().run();
+
 ```
 </Fragment>
 </AppHostTabs>
@@ -454,3 +698,4 @@ For example, for a resource named `tables`, the environment variables are `TABLE
 <LearnMore>
   For per-language connection examples and client library setup, see [Connect to Azure Table Storage](../azure-storage-tables-connect/).
 </LearnMore>
+```

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
@@ -45,7 +45,12 @@ The Azure Virtual Network hosting integration models network resources as the fo
 
 To start building an Aspire app that uses Azure Virtual Network, install the [📦 Aspire.Hosting.Azure.Network](https://www.nuget.org/packages/Aspire.Hosting.Azure.Network) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -104,7 +109,12 @@ This updates your `aspire.config.json` with the Azure Network hosting integratio
 
 To add a virtual network, call `AddAzureVirtualNetwork` (or `addAzureVirtualNetwork`) on the `builder` instance:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -133,7 +143,12 @@ await builder.build().run();
 
 By default, the virtual network uses the address prefix `10.0.0.0/16`. You can specify a custom address prefix:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -154,7 +169,12 @@ const vnet = await builder.addAzureVirtualNetwork('vnet', '10.1.0.0/16');
 
 Call `AddSubnet` (or `addSubnet`) on the virtual network builder to add a subnet with a name and address prefix:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var vnet = builder.AddAzureVirtualNetwork("vnet");
@@ -179,7 +199,12 @@ You can add multiple subnets with different address ranges to a single virtual n
 
 A [NAT gateway](https://learn.microsoft.com/azure/nat-gateway/) provides deterministic outbound public IP addresses for subnet resources. Call `AddNatGateway` (or `addNatGateway`) to create a NAT gateway, then associate it with a subnet using `WithNatGateway` (or `withNatGateway`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var natGateway = builder.AddNatGateway("nat");
@@ -204,7 +229,12 @@ const subnet = vnet.addSubnet("aca-subnet", "10.0.0.0/23")
 
 By default, a public IP address is automatically created for the NAT gateway. To provide an explicit public IP address for full control, call `AddPublicIPAddress` (or `addPublicIPAddress`) and associate it with `WithPublicIPAddress` (or `withPublicIPAddress`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -234,7 +264,12 @@ For advanced settings like idle timeout or availability zones, use [`ConfigureIn
 
 The shorthand API uses fluent methods on subnet builders that automatically create an NSG, auto-increment priority, and auto-generate rule names:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var vnet = builder.AddAzureVirtualNetwork("vnet");
@@ -280,7 +315,12 @@ Priority auto-increments by 100 (100, 200, 300...) and rule names are auto-gener
 
 For full control over security rules, create a standalone NSG with `AddNetworkSecurityGroup` (or `addNetworkSecurityGroup`) on the `builder` and attach it to a subnet with `WithNetworkSecurityGroup` (or `withNetworkSecurityGroup`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -342,7 +382,12 @@ A single NSG can be shared across multiple subnets.
 
 Compute environment integrations that support regional virtual network integration expose a `WithDelegatedSubnet` (or `withDelegatedSubnet` in TypeScript) extension method that assigns a subnet to the environment, enabling subnet delegation so the environment can inject its infrastructure. For example, [Azure Container Apps](/integrations/cloud/azure/configure-container-apps/) and [Azure App Service](/integrations/cloud/azure/azure-app-service/azure-app-service-host/#regional-virtual-network-integration) both support `WithDelegatedSubnet`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var vnet = builder.AddAzureVirtualNetwork("vnet");
@@ -351,13 +396,14 @@ var appServiceSubnet = vnet.AddSubnet("app-service-subnet", "10.0.1.0/24");
 
 // Azure Container Apps environment
 builder.AddAzureContainerAppEnvironment("aca-env")
-    .WithDelegatedSubnet(acaSubnet);
+.WithDelegatedSubnet(acaSubnet);
 
 // Azure App Service environment (requires ASPIREAZURE003 suppression)
 #pragma warning disable ASPIREAZURE003
 builder.AddAzureAppServiceEnvironment("app-service-env")
-    .WithDelegatedSubnet(appServiceSubnet);
+.WithDelegatedSubnet(appServiceSubnet);
 #pragma warning restore ASPIREAZURE003
+
 ````
 </Fragment>
 <Fragment slot="typescript">
@@ -384,7 +430,12 @@ Each compute environment delegates the subnet to its own Azure service (for exam
 
 For scenarios that aren't covered by a compute environment's `WithDelegatedSubnet` helper, call `WithServiceDelegation` (or `withServiceDelegation` in TypeScript) directly on the subnet builder to delegate it to a supported Azure service. The delegation `name` defaults to `serviceName` so you don't have to repeat the value:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var vnet = builder.AddAzureVirtualNetwork("vnet");
@@ -393,8 +444,9 @@ var subnet = vnet.AddSubnet("aci-subnet", "10.0.0.0/23")
 
 // Or specify a custom delegation name.
 subnet.WithServiceDelegation(
-    AzureSubnetServiceDelegations.ContainerInstances,
-    name: "aci-delegation");
+AzureSubnetServiceDelegations.ContainerInstances,
+name: "aci-delegation");
+
 ````
 </Fragment>
 <Fragment slot="typescript">
@@ -417,12 +469,12 @@ await subnet.withServiceDelegation(
 
 `AzureSubnetServiceDelegations` provides discoverable, well-known service identifiers so you don't have to remember or duplicate the underlying Azure resource provider strings:
 
-| Constant                          | Value                                                   |
-| --------------------------------- | ------------------------------------------------------- |
-| `ContainerInstances`              | `Microsoft.ContainerInstance/containerGroups`           |
-| `ContainerAppEnvironments`        | `Microsoft.App/environments`                            |
-| `AppServiceEnvironments`          | `Microsoft.Web/serverFarms`                             |
-| `ApplicationGatewayForContainers` | `Microsoft.ServiceNetworking/trafficControllers`       |
+| Constant                          | Value                                            |
+| --------------------------------- | ------------------------------------------------ |
+| `ContainerInstances`              | `Microsoft.ContainerInstance/containerGroups`    |
+| `ContainerAppEnvironments`        | `Microsoft.App/environments`                     |
+| `AppServiceEnvironments`          | `Microsoft.Web/serverFarms`                      |
+| `ApplicationGatewayForContainers` | `Microsoft.ServiceNetworking/trafficControllers` |
 
 You can also pass another supported Azure resource provider path as `serviceName` if the service doesn't have a well-known constant. Aspire models and emits one service delegation for a subnet, so use one compute-environment delegation helper or service delegation per subnet. Repeated direct `WithServiceDelegation` calls replace the previous service-delegation annotation, so the latest direct call wins. `WithDelegatedSubnet` allows an existing delegation for the same required service, but throws an `InvalidOperationException` when the subnet's effective existing service delegation differs.
 
@@ -430,7 +482,12 @@ You can also pass another supported Azure resource provider path as `serviceName
 
 [Private endpoints](https://learn.microsoft.com/azure/private-link/) enable secure connectivity to Azure services over a private network. Call `AddPrivateEndpoint` (or `addPrivateEndpoint`) on a subnet builder and pass the Azure resource to connect to:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var vnet = builder.AddAzureVirtualNetwork("vnet");
@@ -492,7 +549,8 @@ storage.ConfigureInfrastructure(infra =>
   TypeScript AppHosts can use curated provisioning helper APIs when an
   integration exposes them. This example directly customizes Azure.Provisioning
   objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a [polyglot](/get-started/glossary/#polyglot)-friendly helper.
+  the integration wraps the scenario in a
+  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
 </Aside>
 
 #### Service-specific requirements
@@ -536,7 +594,12 @@ NSPs complement private endpoints with a higher-level grouping model. Instead of
 
 Call `AddNetworkSecurityPerimeter` (or `addNetworkSecurityPerimeter`) on the `builder` instance to create an NSP with a default profile:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -567,7 +630,12 @@ await builder.build().run();
 
 Access rules control traffic flowing into and out of the perimeter. Call `WithAccessRule` (or `withAccessRule`) and pass an `AzureNspAccessRule` to define a rule:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var nsp = builder.AddNetworkSecurityPerimeter("my-nsp")
@@ -622,7 +690,12 @@ Each property also has a corresponding `*References` variant (for example, `Addr
 
 Call `WithNetworkSecurityPerimeter` (or `withNetworkSecurityPerimeter`) on a PaaS resource builder to associate it with an NSP:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var nsp = builder.AddNetworkSecurityPerimeter("my-nsp");
@@ -666,7 +739,12 @@ The following Azure resources support NSP association:
 
 By default, associations use **Enforced** mode—resources within the perimeter can communicate with each other, and any public traffic that doesn't match an access rule is blocked. You can switch to **Learning** mode to log violations without blocking traffic, which is helpful when onboarding resources to identify which access rules are needed before switching to enforced mode:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 // Enforced mode (default) — blocks traffic that violates the rules
@@ -706,7 +784,12 @@ The following example demonstrates a complete network topology with a virtual ne
   stable, the warning can be removed.
 </Aside>
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 #pragma warning disable AZPROVISION001

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
@@ -535,6 +535,15 @@ The private DNS zone ensures that services within the virtual network automatica
 
 To keep public access enabled on a resource that has a private endpoint, use `ConfigureInfrastructure` to override the automatic lockdown:
 
+<AppHostTabs limitations={{
+  typescript: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not available to TypeScript AppHosts.',
+  python: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Python generated SDK.',
+  go: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Go generated SDK.',
+  java: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Java generated SDK.',
+  rust: 'This example directly customizes Azure.Provisioning objects through ConfigureInfrastructure, which is not compatible with the Rust generated SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 storage.ConfigureInfrastructure(infra =>
 {
@@ -545,13 +554,8 @@ storage.ConfigureInfrastructure(infra =>
 });
 ```
 
-<Aside type="note">
-  TypeScript AppHosts can use curated provisioning helper APIs when an
-  integration exposes them. This example directly customizes Azure.Provisioning
-  objects through `ConfigureInfrastructure`, which is currently C#-only unless
-  the integration wraps the scenario in a
-  [polyglot](/get-started/glossary/#polyglot)-friendly helper.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 #### Service-specific requirements
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-virtual-network.mdx
@@ -46,10 +46,10 @@ The Azure Virtual Network hosting integration models network resources as the fo
 To start building an Aspire app that uses Azure Virtual Network, install the [📦 Aspire.Hosting.Azure.Network](https://www.nuget.org/packages/Aspire.Hosting.Azure.Network) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -110,10 +110,10 @@ This updates your `aspire.config.json` with the Azure Network hosting integratio
 To add a virtual network, call `AddAzureVirtualNetwork` (or `addAzureVirtualNetwork`) on the `builder` instance:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -144,10 +144,10 @@ await builder.build().run();
 By default, the virtual network uses the address prefix `10.0.0.0/16`. You can specify a custom address prefix:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -170,10 +170,10 @@ const vnet = await builder.addAzureVirtualNetwork('vnet', '10.1.0.0/16');
 Call `AddSubnet` (or `addSubnet`) on the virtual network builder to add a subnet with a name and address prefix:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -200,10 +200,10 @@ You can add multiple subnets with different address ranges to a single virtual n
 A [NAT gateway](https://learn.microsoft.com/azure/nat-gateway/) provides deterministic outbound public IP addresses for subnet resources. Call `AddNatGateway` (or `addNatGateway`) to create a NAT gateway, then associate it with a subnet using `WithNatGateway` (or `withNatGateway`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -230,10 +230,10 @@ const subnet = vnet.addSubnet("aca-subnet", "10.0.0.0/23")
 By default, a public IP address is automatically created for the NAT gateway. To provide an explicit public IP address for full control, call `AddPublicIPAddress` (or `addPublicIPAddress`) and associate it with `WithPublicIPAddress` (or `withPublicIPAddress`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -265,10 +265,10 @@ For advanced settings like idle timeout or availability zones, use [`ConfigureIn
 The shorthand API uses fluent methods on subnet builders that automatically create an NSG, auto-increment priority, and auto-generate rule names:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -316,10 +316,10 @@ Priority auto-increments by 100 (100, 200, 300...) and rule names are auto-gener
 For full control over security rules, create a standalone NSG with `AddNetworkSecurityGroup` (or `addNetworkSecurityGroup`) on the `builder` and attach it to a subnet with `WithNetworkSecurityGroup` (or `withNetworkSecurityGroup`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -383,10 +383,10 @@ A single NSG can be shared across multiple subnets.
 Compute environment integrations that support regional virtual network integration expose a `WithDelegatedSubnet` (or `withDelegatedSubnet` in TypeScript) extension method that assigns a subnet to the environment, enabling subnet delegation so the environment can inject its infrastructure. For example, [Azure Container Apps](/integrations/cloud/azure/configure-container-apps/) and [Azure App Service](/integrations/cloud/azure/azure-app-service/azure-app-service-host/#regional-virtual-network-integration) both support `WithDelegatedSubnet`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -431,10 +431,10 @@ Each compute environment delegates the subnet to its own Azure service (for exam
 For scenarios that aren't covered by a compute environment's `WithDelegatedSubnet` helper, call `WithServiceDelegation` (or `withServiceDelegation` in TypeScript) directly on the subnet builder to delegate it to a supported Azure service. The delegation `name` defaults to `serviceName` so you don't have to repeat the value:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -483,10 +483,10 @@ You can also pass another supported Azure resource provider path as `serviceName
 [Private endpoints](https://learn.microsoft.com/azure/private-link/) enable secure connectivity to Azure services over a private network. Call `AddPrivateEndpoint` (or `addPrivateEndpoint`) on a subnet builder and pass the Azure resource to connect to:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -599,10 +599,10 @@ NSPs complement private endpoints with a higher-level grouping model. Instead of
 Call `AddNetworkSecurityPerimeter` (or `addNetworkSecurityPerimeter`) on the `builder` instance to create an NSP with a default profile:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -635,10 +635,10 @@ await builder.build().run();
 Access rules control traffic flowing into and out of the perimeter. Call `WithAccessRule` (or `withAccessRule`) and pass an `AzureNspAccessRule` to define a rule:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -695,10 +695,10 @@ Each property also has a corresponding `*References` variant (for example, `Addr
 Call `WithNetworkSecurityPerimeter` (or `withNetworkSecurityPerimeter`) on a PaaS resource builder to associate it with an NSP:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -744,10 +744,10 @@ The following Azure resources support NSP association:
 By default, associations use **Enforced** mode—resources within the perimeter can communicate with each other, and any public traffic that doesn't match an access rule is blocked. You can switch to **Learning** mode to log violations without blocking traffic, which is helpful when onboarding resources to identify which access rules are needed before switching to enforced mode:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -789,10 +789,10 @@ The following example demonstrates a complete network topology with a virtual ne
 </Aside>
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-web-pubsub/azure-web-pubsub-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-web-pubsub/azure-web-pubsub-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Azure Web PubSub integration, start with the [Get started w
 To start building an Aspire app that uses Azure Web PubSub, install the [📦 Aspire.Hosting.Azure.WebPubSub](https://www.nuget.org/packages/Aspire.Hosting.Azure.WebPubSub) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -84,10 +84,10 @@ This updates your `aspire.config.json` with the Azure Web PubSub hosting integra
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Web PubSub resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -147,10 +147,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 A hub is a logical grouping of connections and event handlers in Azure Web PubSub. To add a hub to a Web PubSub resource, chain a call to `AddHub` (or `addHub`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -185,10 +185,10 @@ The preceding code adds a hub resource named `messages` with a hub name of `mess
 Event handlers allow your backend services to receive events from Azure Web PubSub. To add an event handler to a hub, chain a call to `AddEventHandler` (or `addEventHandler`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -238,10 +238,10 @@ The preceding code registers an event handler URL pointing to the worker service
 By default, Azure Web PubSub resources are provisioned with the `WebPubSubServiceOwner` role assigned to the consuming service's identity. To customize role assignments, call `WithRoleAssignments` (or `withRoleAssignments`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -294,10 +294,10 @@ The available roles for Azure Web PubSub are:
 You might have an existing Azure Web PubSub service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource is externally managed:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -430,10 +430,10 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/azure-web-pubsub/azure-web-pubsub-host.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/azure-web-pubsub/azure-web-pubsub-host.mdx
@@ -27,7 +27,12 @@ If you're new to the Azure Web PubSub integration, start with the [Get started w
 
 To start building an Aspire app that uses Azure Web PubSub, install the [📦 Aspire.Hosting.Azure.WebPubSub](https://www.nuget.org/packages/Aspire.Hosting.Azure.WebPubSub) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add azure-web-pubsub
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add azure-web-pubsub
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Web PubSub hosting integration package:
@@ -76,7 +83,12 @@ This updates your `aspire.config.json` with the Azure Web PubSub hosting integra
 
 Once you've installed the hosting integration in your AppHost project, you can add an Azure Web PubSub resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -84,10 +96,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 var webPubSub = builder.AddAzureWebPubSub("web-pubsub");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(webPubSub);
+.WithReference(webPubSub);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -101,7 +114,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(webPubSub);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -122,14 +136,22 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure Web PubSub resource from the AppHost, Aspire makes the service endpoint available to the consuming project as an environment variable. For a complete list of these properties and per-language connection examples, see [Connect to Azure Web PubSub](../azure-web-pubsub-connect/).
+  When you reference an Azure Web PubSub resource from the AppHost, Aspire makes
+  the service endpoint available to the consuming project as an environment
+  variable. For a complete list of these properties and per-language connection
+  examples, see [Connect to Azure Web PubSub](../azure-web-pubsub-connect/).
 </Aside>
 
 ## Add Azure Web PubSub hub resource
 
 A hub is a logical grouping of connections and event handlers in Azure Web PubSub. To add a hub to a Web PubSub resource, chain a call to `AddHub` (or `addHub`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -138,7 +160,8 @@ var webPubSub = builder.AddAzureWebPubSub("web-pubsub");
 var messagesHub = webPubSub.AddHub(name: "messages", hubName: "messageHub");
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -150,7 +173,8 @@ const webPubSub = await builder.addAzureWebPubSub("web-pubsub");
 const messagesHub = await webPubSub.addHub("messages", { hubName: "messageHub" });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -160,23 +184,29 @@ The preceding code adds a hub resource named `messages` with a hub name of `mess
 
 Event handlers allow your backend services to receive events from Azure Web PubSub. To add an event handler to a hub, chain a call to `AddEventHandler` (or `addEventHandler`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var worker = builder.AddProject<Projects.WorkerService>("worker")
-    .WithExternalHttpEndpoints();
+.WithExternalHttpEndpoints();
 
 var webPubSub = builder.AddAzureWebPubSub("web-pubsub");
 var messagesHub = webPubSub.AddHub(name: "messages", hubName: "messageHub");
 
 messagesHub.AddEventHandler(
-    $"{worker.GetEndpoint("https")}/eventhandler/",
-    systemEvents: ["connected"]);
+$"{worker.GetEndpoint("https")}/eventhandler/",
+systemEvents: ["connected"]);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -196,7 +226,8 @@ await messagesHub.addEventHandler(workerEndpoint, {
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -206,7 +237,12 @@ The preceding code registers an event handler URL pointing to the worker service
 
 By default, Azure Web PubSub resources are provisioned with the `WebPubSubServiceOwner` role assigned to the consuming service's identity. To customize role assignments, call `WithRoleAssignments` (or `withRoleAssignments`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -214,14 +250,15 @@ var builder = DistributedApplication.CreateBuilder(args);
 var webPubSub = builder.AddAzureWebPubSub("web-pubsub");
 
 var api = builder.AddProject<Projects.ApiService>("api")
-    .WithReference(webPubSub);
+.WithReference(webPubSub);
 
 // Assign WebPubSubServiceReader role (read-only access)
 builder.AddAzureWebPubSub("web-pubsub")
-    .WithRoleAssignments(api, [AzureWebPubSubRole.WebPubSubServiceReader]);
+.WithRoleAssignments(api, [AzureWebPubSubRole.WebPubSubServiceReader]);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -239,23 +276,29 @@ await builder.addAzureEnvironment()
     .withRoleAssignments(webPubSub, [AzureWebPubSubRole.WebPubSubServiceReader]);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 The available roles for Azure Web PubSub are:
 
-| Role | Description |
-| ---- | ----------- |
-| `WebPubSubContributor` | Contributes to Azure Web PubSub resources |
-| `WebPubSubServiceOwner` | Full access to the Web PubSub service, including data and management operations |
-| `WebPubSubServiceReader` | Read-only access to the Web PubSub service |
+| Role                     | Description                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| `WebPubSubContributor`   | Contributes to Azure Web PubSub resources                                       |
+| `WebPubSubServiceOwner`  | Full access to the Web PubSub service, including data and management operations |
+| `WebPubSubServiceReader` | Read-only access to the Web PubSub service                                      |
 
 ## Connect to an existing Azure Web PubSub instance
 
 You might have an existing Azure Web PubSub service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource is externally managed:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -264,13 +307,14 @@ var existingPubSubName = builder.AddParameter("existingPubSubName");
 var existingPubSubResourceGroup = builder.AddParameter("existingPubSubResourceGroup");
 
 var webPubSub = builder.AddAzureWebPubSub("web-pubsub")
-    .AsExisting(existingPubSubName, existingPubSubResourceGroup);
+.AsExisting(existingPubSubName, existingPubSubResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(webPubSub);
+.WithReference(webPubSub);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -287,15 +331,17 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(webPubSub);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 For more information on treating Azure resources as existing, see [Use existing Azure resources](/integrations/cloud/azure/overview/#use-existing-azure-resources).
 
 <Aside type="note">
-  Alternatively, you can add a connection string to the AppHost. This approach is weakly typed and
-  doesn't work with role assignments or infrastructure customizations.
+  Alternatively, you can add a connection string to the AppHost. This approach
+  is weakly typed and doesn't work with role assignments or infrastructure
+  customizations.
 </Aside>
 
 ## Provisioning-generated Bicep
@@ -383,17 +429,22 @@ The generated Bicep is a starting point and is influenced by changes to the prov
 
 All Aspire Azure resources are subclasses of the `AzureProvisioningResource` type. This type enables the customization of the generated Bicep by providing a fluent API to configure the Azure resources using the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureWebPubSub("web-pubsub")
-    .ConfigureInfrastructure(infra =>
-    {
-        var webPubSubService = infra.GetProvisionableResources()
-                                    .OfType<WebPubSubService>()
-                                    .Single();
+.ConfigureInfrastructure(infra =>
+{
+var webPubSubService = infra.GetProvisionableResources()
+.OfType<WebPubSubService>()
+.Single();
 
         webPubSubService.Sku.Name = "Standard_S1";
         webPubSubService.Sku.Capacity = 5;
@@ -401,7 +452,8 @@ builder.AddAzureWebPubSub("web-pubsub")
     });
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -420,7 +472,8 @@ await webPubSub.configureInfrastructure(async (infra) => {
 });
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/configure-container-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/configure-container-apps.mdx
@@ -51,10 +51,10 @@ By using the `Azure.Provisioning` APIs (explained in [Customize Azure resources]
 The `AzureContainerAppEnvironmentResource` type models an ACA environment resource. When you call the `AddAzureContainerAppEnvironment` method, it creates an instance of this type (wrapped in the `IResourceBuilder<AzureContainerAppEnvironmentResource>`).
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -204,10 +204,10 @@ Using the `acaEnv` variable, you can chain a call to the `ConfigureInfrastructur
 If you've already provisioned an Azure Container Apps environment, chain `AsExisting` (or `asExisting`) on `AddAzureContainerAppEnvironment` to deploy your container apps into it instead of creating a new one:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -258,10 +258,10 @@ Some configurations are incompatible with an existing environment and are reject
 By default, even when the environment is existing, Aspire still emits a new user-assigned managed identity and an `AcrPull` role assignment on the container registry so that newly deployed container apps can pull their images. If your deployment principal can't create identities or role assignments, or if you have an existing identity that you want to reuse, supply a pre-existing identity with `WithAcrPullIdentity` (or `withAcrPullIdentity`):
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -351,10 +351,10 @@ The following `PublishAsAzureContainerApp` overloads let you customize the gener
 The callback receives an `AzureResourceInfrastructure` instance and the strongly-typed `ContainerApp` resource. This lets you set any property that Azure Container Apps supports — such as scaling rules, ingress settings, or environment variables — before the Bicep is generated.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -394,10 +394,10 @@ builder.Build().Run();
 By default, `AddAzureContainerAppEnvironment` uses a different Azure resource naming scheme than the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/). If you're upgrading an existing deployment that previously used `azd`, you might see duplicate Azure resources. To avoid this issue, call the `WithAzdResourceNaming` method to revert to the naming convention used by `azd`:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -478,10 +478,10 @@ builder.Build().Run();
 All Azure resources are subclasses of the `AzureProvisioningResource` type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resources — using the `ConfigureInfrastructure` API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/configure-container-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/configure-container-apps.mdx
@@ -50,7 +50,12 @@ By using the `Azure.Provisioning` APIs (explained in [Customize Azure resources]
 
 The `AzureContainerAppEnvironmentResource` type models an ACA environment resource. When you call the `AddAzureContainerAppEnvironment` method, it creates an instance of this type (wrapped in the `IResourceBuilder<AzureContainerAppEnvironmentResource>`).
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -60,7 +65,8 @@ var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env");
 // Omitted for brevity...
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -71,7 +77,8 @@ const builder = await createBuilder();
 const acaEnv = await builder.addAzureContainerAppEnvironment("aca-env");
 
 // Omitted for brevity...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -196,7 +203,12 @@ Using the `acaEnv` variable, you can chain a call to the `ConfigureInfrastructur
 
 If you've already provisioned an Azure Container Apps environment, chain `AsExisting` (or `asExisting`) on `AddAzureContainerAppEnvironment` to deploy your container apps into it instead of creating a new one:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -205,12 +217,13 @@ var existingEnvName = builder.AddParameter("existingEnvName");
 var existingEnvResourceGroup = builder.AddParameter("existingEnvResourceGroup");
 
 var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env")
-    .AsExisting(existingEnvName, existingEnvResourceGroup);
+.AsExisting(existingEnvName, existingEnvResourceGroup);
 
 builder.AddProject<Projects.ApiService>("api");
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -227,7 +240,8 @@ await acaEnv.asExisting(existingEnvName, { resourceGroup: existingEnvResourceGro
 await builder.addProject("api", "../ApiService/ApiService.csproj");
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -243,7 +257,12 @@ Some configurations are incompatible with an existing environment and are reject
 
 By default, even when the environment is existing, Aspire still emits a new user-assigned managed identity and an `AcrPull` role assignment on the container registry so that newly deployed container apps can pull their images. If your deployment principal can't create identities or role assignments, or if you have an existing identity that you want to reuse, supply a pre-existing identity with `WithAcrPullIdentity` (or `withAcrPullIdentity`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -254,20 +273,21 @@ var existingIdentityName = builder.AddParameter("existingIdentityName");
 var existingResourceGroup = builder.AddParameter("existingResourceGroup");
 
 var acr = builder.AddAzureContainerRegistry("acr")
-    .AsExisting(existingAcrName, existingResourceGroup);
+.AsExisting(existingAcrName, existingResourceGroup);
 
 var pullIdentity = builder.AddAzureUserAssignedIdentity("acr-pull")
-    .AsExisting(existingIdentityName, existingResourceGroup);
+.AsExisting(existingIdentityName, existingResourceGroup);
 
 builder.AddAzureContainerAppEnvironment("aca-env")
-    .AsExisting(existingEnvName, existingResourceGroup)
-    .WithAzureContainerRegistry(acr)
-    .WithAcrPullIdentity(pullIdentity);
+.AsExisting(existingEnvName, existingResourceGroup)
+.WithAzureContainerRegistry(acr)
+.WithAcrPullIdentity(pullIdentity);
 
 builder.AddProject<Projects.ApiService>("api");
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -294,7 +314,8 @@ await acaEnv.withAcrPullIdentity(pullIdentity);
 await builder.addProject("api", "../ApiService/ApiService.csproj");
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -306,16 +327,16 @@ The supplied identity must already have the `AcrPull` role on the registry. Aspi
 
 The environment, container registry, and ACR pull identity can each independently be new or existing. The combination determines whether Aspire emits new resources alongside the references to existing ones:
 
-| Environment | Container registry | Pull identity (`WithAcrPullIdentity`) | What gets emitted beyond references |
-|-------------|--------------------|---------------------------------------|---------------------------------------------|
-| New | New (default or user-added) | Not supplied | New environment, Log Analytics, Aspire Dashboard, identity, `AcrPull` role assignment |
-| New | New | Supplied | New environment, Log Analytics, Aspire Dashboard. No identity or role assignment in the env module — wire the role on the identity yourself |
-| New | Existing | Not supplied | New environment, Log Analytics, Aspire Dashboard, identity, `AcrPull` role assignment on existing registry |
-| New | Existing | Supplied | New environment, Log Analytics, Aspire Dashboard. No identity or role assignment in the env module |
-| Existing | New | Not supplied | New identity, new registry, `AcrPull` role assignment |
-| Existing | New | Supplied | New registry. No identity or role assignment in the env module |
-| Existing | Existing | Not supplied | New identity, `AcrPull` role assignment on existing registry |
-| Existing | Existing | Supplied | Nothing — only references to existing resources |
+| Environment | Container registry          | Pull identity (`WithAcrPullIdentity`) | What gets emitted beyond references                                                                                                         |
+| ----------- | --------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| New         | New (default or user-added) | Not supplied                          | New environment, Log Analytics, Aspire Dashboard, identity, `AcrPull` role assignment                                                       |
+| New         | New                         | Supplied                              | New environment, Log Analytics, Aspire Dashboard. No identity or role assignment in the env module — wire the role on the identity yourself |
+| New         | Existing                    | Not supplied                          | New environment, Log Analytics, Aspire Dashboard, identity, `AcrPull` role assignment on existing registry                                  |
+| New         | Existing                    | Supplied                              | New environment, Log Analytics, Aspire Dashboard. No identity or role assignment in the env module                                          |
+| Existing    | New                         | Not supplied                          | New identity, new registry, `AcrPull` role assignment                                                                                       |
+| Existing    | New                         | Supplied                              | New registry. No identity or role assignment in the env module                                                                              |
+| Existing    | Existing                    | Not supplied                          | New identity, `AcrPull` role assignment on existing registry                                                                                |
+| Existing    | Existing                    | Supplied                              | Nothing — only references to existing resources                                                                                             |
 
 The last row is the only configuration in which the env module emits no new identities, role assignments, or supporting resources. Use it when you already have all of the necessary resources provisioned.
 
@@ -329,7 +350,12 @@ The following `PublishAsAzureContainerApp` overloads let you customize the gener
 
 The callback receives an `AzureResourceInfrastructure` instance and the strongly-typed `ContainerApp` resource. This lets you set any property that Azure Container Apps supports — such as scaling rules, ingress settings, or environment variables — before the Bicep is generated.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -337,17 +363,18 @@ var builder = DistributedApplication.CreateBuilder(args);
 builder.AddAzureContainerAppEnvironment("aca-env");
 
 builder.AddProject<Projects.ApiService>("api")
-    .PublishAsAzureContainerApp((infrastructure, containerApp) =>
-    {
-        containerApp.Template.Value!.Scale = new ContainerAppScale
-        {
-            MinReplicas = 1,
-            MaxReplicas = 10
-        };
-    });
+.PublishAsAzureContainerApp((infrastructure, containerApp) =>
+{
+containerApp.Template.Value!.Scale = new ContainerAppScale
+{
+MinReplicas = 1,
+MaxReplicas = 10
+};
+});
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -366,7 +393,12 @@ builder.Build().Run();
 
 By default, `AddAzureContainerAppEnvironment` uses a different Azure resource naming scheme than the [Azure Developer CLI (`azd`)](https://learn.microsoft.com/azure/developer/azure-developer-cli/). If you're upgrading an existing deployment that previously used `azd`, you might see duplicate Azure resources. To avoid this issue, call the `WithAzdResourceNaming` method to revert to the naming convention used by `azd`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -377,7 +409,8 @@ var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env")
 // Omitted for brevity...
 
 builder.Build().Run();
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -389,7 +422,8 @@ const acaEnv = await builder.addAzureContainerAppEnvironment("aca-env");
 await acaEnv.withAzdResourceNaming();
 
 // Omitted for brevity...
-```
+
+````
 </Fragment>
 </AppHostTabs>
 
@@ -403,6 +437,10 @@ Publish and deploy detect this collision up front and fail with guidance to call
 
 <AppHostTabs limitations={{
   typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -417,14 +455,20 @@ var env2 = builder.AddAzureContainerAppEnvironment("cae2")
 // Omitted for brevity...
 
 builder.Build().Run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 `WithUniqueResourceNaming` preserves digits in the resource name when computing the managed environment `name`, so `cae1` and `cae2` produce distinct names and can coexist in the same resource group.
 
 <Aside type="caution">
-  This method is marked with `[Experimental("ASPIREACANAMING002")]` and changes the managed environment `name` for the environment it's applied to. Applying it to an *already-deployed* single environment changes its name, which causes Azure to recreate the resource. Apply it only when deploying more than one environment to a single resource group, or to new deployments. For more information, see [ASPIREACANAMING002](/diagnostics/aspireacanaming002/).
+  This method is marked with `[Experimental("ASPIREACANAMING002")]` and changes
+  the managed environment `name` for the environment it's applied to. Applying
+  it to an *already-deployed* single environment changes its name, which causes
+  Azure to recreate the resource. Apply it only when deploying more than one
+  environment to a single resource group, or to new deployments. For more
+  information, see [ASPIREACANAMING002](/diagnostics/aspireacanaming002/).
 </Aside>
 
 `WithUniqueResourceNaming` acts as a fallback after any name resolver you configure explicitly through `AzureProvisioningOptions.ProvisioningBuildOptions`, and it has no effect when `WithAzdResourceNaming` is used, since `azd` naming sets the environment name explicitly.
@@ -433,7 +477,12 @@ builder.Build().Run();
 
 All Azure resources are subclasses of the `AzureProvisioningResource` type. This enables customization of the generated Bicep by providing a fluent API to configure the Azure resources — using the `ConfigureInfrastructure` API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -442,13 +491,15 @@ var acaEnv = builder.AddAzureContainerAppEnvironment("aca-env");
 
 acaEnv.ConfigureInfrastructure(infra =>
 {
-    var resources = infra.GetProvisionableResources();
-    var containerEnvironment = resources.OfType<ContainerAppManagedEnvironment>().FirstOrDefault();
+var resources = infra.GetProvisionableResources();
+var containerEnvironment = resources.OfType<ContainerAppManagedEnvironment>().FirstOrDefault();
 
     containerEnvironment.Tags.Add("ExampleKey", "Example value");
+
 });
 
 builder.Build().Run();
+
 ```
 </Fragment>
 <Fragment slot="typescript">
@@ -478,3 +529,4 @@ The preceding C# code:
 - [Customize Azure resources](/integrations/cloud/azure/customize-resources/)
 - [Azure Container Apps documentation](https://learn.microsoft.com/azure/container-apps/)
 - [Container Apps pricing](https://learn.microsoft.com/azure/container-apps/billing)
+```

--- a/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
@@ -24,24 +24,30 @@ import containerAppsIcon from '@assets/icons/azure-container-apps-environments.s
 
 The following resource types can be published as Azure Container App Jobs:
 
-| Resource type | Description |
-|---|---|
-| `ProjectResource` | A .NET project added via `AddProject<T>`. |
-| `ContainerResource` | A container image added via `AddContainer`. |
+| Resource type        | Description                                      |
+| -------------------- | ------------------------------------------------ |
+| `ProjectResource`    | A .NET project added via `AddProject<T>`.        |
+| `ContainerResource`  | A container image added via `AddContainer`.      |
 | `ExecutableResource` | An executable process added via `AddExecutable`. |
 
 ## Publish a project as a Container App Job
 
 Use `PublishAsAzureContainerAppJob` to deploy a project, container, or executable as an Azure Container App Job. Use `PublishAsScheduledAzureContainerAppJob` as a convenience wrapper that sets the cron schedule in one call.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Projects.DataProcessor>("data-processor")
-    .PublishAsScheduledAzureContainerAppJob("0 0 * * *"); // Every day at midnight
-```
+.PublishAsScheduledAzureContainerAppJob("0 0 \* \* \*"); // Every day at midnight
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -51,7 +57,8 @@ const builder = await createBuilder();
 
 const dataProcessor = await builder.addProject("data-processor", "../DataProcessor/DataProcessor.csproj");
 await dataProcessor.publishAsScheduledAzureContainerAppJob("0 0 * * *"); // Every day at midnight
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -61,17 +68,23 @@ Azure Container App Jobs support three trigger types: **manual**, **schedule**, 
 
 ### Manual trigger
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Projects.ManualTask>("manual-task")
-    .PublishAsAzureContainerAppJob((_, job) =>
-    {
-        job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
-    });
-```
+.PublishAsAzureContainerAppJob((\_, job) =>
+{
+job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
+});
+
+````
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -82,7 +95,12 @@ builder.AddProject<Projects.ManualTask>("manual-task")
 
 ### Schedule trigger
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -95,7 +113,8 @@ builder.AddProject<Projects.ScheduledTask>("scheduled-task")
         job.Configuration.ScheduleTriggerConfig.Parallelism = 1;
         job.Configuration.ScheduleTriggerConfig.ReplicaCompletionCount = 1;
     });
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -106,21 +125,27 @@ builder.AddProject<Projects.ScheduledTask>("scheduled-task")
 
 ### Event trigger
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddProject<Projects.EventDrivenTask>("event-task")
-    .PublishAsAzureContainerAppJob((_, job) =>
-    {
-        job.Configuration.TriggerType = ContainerAppJobTriggerType.Event;
-        job.Configuration.EventTriggerConfig.Scale.MinExecutions = 1;
-        job.Configuration.EventTriggerConfig.Scale.MaxExecutions = 10;
-        job.Configuration.EventTriggerConfig.Parallelism = 1;
-        job.Configuration.EventTriggerConfig.ReplicaCompletionCount = 1;
-    });
-```
+.PublishAsAzureContainerAppJob((\_, job) =>
+{
+job.Configuration.TriggerType = ContainerAppJobTriggerType.Event;
+job.Configuration.EventTriggerConfig.Scale.MinExecutions = 1;
+job.Configuration.EventTriggerConfig.Scale.MaxExecutions = 10;
+job.Configuration.EventTriggerConfig.Parallelism = 1;
+job.Configuration.EventTriggerConfig.ReplicaCompletionCount = 1;
+});
+
+````
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -135,7 +160,12 @@ builder.AddProject<Projects.EventDrivenTask>("event-task")
 
 Configure CPU and memory for your job:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -147,7 +177,8 @@ builder.AddProject<Projects.ResourceIntensiveTask>("intensive-task")
         job.Template.Containers[0].Value!.Resources.Cpu = 1.0;
         job.Template.Containers[0].Value!.Resources.Memory = "2Gi";
     });
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -160,7 +191,12 @@ builder.AddProject<Projects.ResourceIntensiveTask>("intensive-task")
 
 Pass environment variables — including provisioning parameters — into the job container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -168,16 +204,17 @@ var builder = DistributedApplication.CreateBuilder(args);
 var connectionString = builder.AddParameter("connectionString");
 
 builder.AddProject<Projects.DatabaseTask>("db-task")
-    .PublishAsAzureContainerAppJob((infra, job) =>
-    {
-        job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
-        job.Template.Containers[0].Value!.Env.Add(new ContainerAppEnvironmentVariable
-        {
-            Name = "ConnectionString",
-            Value = connectionString.AsProvisioningParameter(infra)
-        });
-    });
-```
+.PublishAsAzureContainerAppJob((infra, job) =>
+{
+job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
+job.Template.Containers[0].Value!.Env.Add(new ContainerAppEnvironmentVariable
+{
+Name = "ConnectionString",
+Value = connectionString.AsProvisioningParameter(infra)
+});
+});
+
+````
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -188,7 +225,12 @@ builder.AddProject<Projects.DatabaseTask>("db-task")
 
 ### Configure timeout and retry policy
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -200,7 +242,8 @@ builder.AddProject<Projects.RetryableTask>("retryable-task")
         job.Configuration.ReplicaTimeout = 1800; // 30 minutes
         job.Configuration.ReplicaRetryLimit = 3;
     });
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -211,18 +254,24 @@ builder.AddProject<Projects.RetryableTask>("retryable-task")
 
 ## Publish a container resource as a job
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddContainer("batch-processor", "myregistry.azurecr.io/batch-processor:latest")
-    .PublishAsAzureContainerAppJob((_, job) =>
-    {
-        job.Configuration.TriggerType = ContainerAppJobTriggerType.Schedule;
-        job.Configuration.ScheduleTriggerConfig.CronExpression = "0 2 * * 0"; // Weekly on Sunday at 2 AM
-    });
-```
+.PublishAsAzureContainerAppJob((\_, job) =>
+{
+job.Configuration.TriggerType = ContainerAppJobTriggerType.Schedule;
+job.Configuration.ScheduleTriggerConfig.CronExpression = "0 2 \* \* 0"; // Weekly on Sunday at 2 AM
+});
+
+````
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -233,7 +282,12 @@ builder.AddContainer("batch-processor", "myregistry.azurecr.io/batch-processor:l
 
 ## Publish an executable resource as a job
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -243,7 +297,8 @@ builder.AddExecutable("data-script", "python", ".", "process_data.py")
     {
         job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
     });
-```
+````
+
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">

--- a/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/container-app-jobs.mdx
@@ -35,10 +35,10 @@ The following resource types can be published as Azure Container App Jobs:
 Use `PublishAsAzureContainerAppJob` to deploy a project, container, or executable as an Azure Container App Job. Use `PublishAsScheduledAzureContainerAppJob` as a convenience wrapper that sets the cron schedule in one call.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -69,10 +69,10 @@ Azure Container App Jobs support three trigger types: **manual**, **schedule**, 
 ### Manual trigger
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -96,10 +96,10 @@ job.Configuration.TriggerType = ContainerAppJobTriggerType.Manual;
 ### Schedule trigger
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -126,10 +126,10 @@ builder.AddProject<Projects.ScheduledTask>("scheduled-task")
 ### Event trigger
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -161,10 +161,10 @@ job.Configuration.EventTriggerConfig.ReplicaCompletionCount = 1;
 Configure CPU and memory for your job:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -192,10 +192,10 @@ builder.AddProject<Projects.ResourceIntensiveTask>("intensive-task")
 Pass environment variables — including provisioning parameters — into the job container:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -226,10 +226,10 @@ Value = connectionString.AsProvisioningParameter(infra)
 ### Configure timeout and retry policy
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -255,10 +255,10 @@ builder.AddProject<Projects.RetryableTask>("retryable-task")
 ## Publish a container resource as a job
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -283,10 +283,10 @@ job.Configuration.ScheduleTriggerConfig.CronExpression = "0 2 \* \* 0"; // Weekl
 ## Publish an executable resource as a job
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -22,7 +22,9 @@ import azureIcon from '@assets/icons/azure-icon.png';
 When working with Azure integrations in Aspire, you often need to customize the provisioned infrastructure beyond the default settings. The same customization patterns apply across Azure hosting integrations such as Storage, Service Bus, Key Vault, user-assigned identities, Azure Container Apps, and Azure App Service. This page documents all customization APIs supported across both C# and TypeScript AppHost projects.
 
 <LearnMore>
-For target-specific generated resource customization, see [Deploy to Azure Container Apps](/deployment/azure/container-apps/) and [Deploy to Azure App Service](/deployment/azure/app-service/).
+  For target-specific generated resource customization, see [Deploy to Azure
+  Container Apps](/deployment/azure/container-apps/) and [Deploy to Azure App
+  Service](/deployment/azure/app-service/).
 </LearnMore>
 
 ## Shared Azure customization patterns
@@ -31,7 +33,12 @@ For target-specific generated resource customization, see [Deploy to Azure Conta
 
 Use `AsExisting`, `RunAsExisting`, and `PublishAsExisting` when you want Aspire to reference an Azure resource that already exists instead of provisioning a new one.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -40,10 +47,11 @@ var existingBusName = builder.AddParameter("existingServiceBusName");
 var existingBusResourceGroup = builder.AddParameter("existingServiceBusResourceGroup");
 
 var serviceBus = builder.AddAzureServiceBus("messaging")
-    .PublishAsExisting(existingBusName, existingBusResourceGroup);
+.PublishAsExisting(existingBusName, existingBusResourceGroup);
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -58,7 +66,8 @@ const serviceBus = await builder.addAzureServiceBus("messaging");
 await serviceBus.publishAsExisting(existingBusName, existingBusResourceGroup);
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -73,16 +82,22 @@ Use `RunAsExisting` when only local run mode should use the existing resource, `
 
 Aspire automatically assigns Azure RBAC roles based on how resources reference one another. When you need to opt out of those defaults before applying different permissions, use `ClearDefaultRoleAssignments`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddAzureServiceBus("messaging")
-    .ClearDefaultRoleAssignments();
+.ClearDefaultRoleAssignments();
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -94,19 +109,26 @@ const serviceBus = await builder.addAzureServiceBus("messaging");
 await serviceBus.clearDefaultRoleAssignments();
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
 <LearnMore>
-For built-in and custom RBAC guidance, see [Manage Azure role assignments](/integrations/cloud/azure/role-assignments/).
+  For built-in and custom RBAC guidance, see [Manage Azure role
+  assignments](/integrations/cloud/azure/role-assignments/).
 </LearnMore>
 
 ### Read generated output values
 
 Azure resources expose output references for values that Azure assigns during provisioning. Use those references when another resource, deployment step, or app setting needs the resolved Azure value.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -114,10 +136,11 @@ var builder = DistributedApplication.CreateBuilder(args);
 var identity = builder.AddAzureUserAssignedIdentity("identity");
 
 builder.AddProject<Projects.Api>("api")
-    .WithEnvironment("IDENTITY_CLIENT_ID", identity.Resource.ClientId);
+.WithEnvironment("IDENTITY_CLIENT_ID", identity.Resource.ClientId);
 
 builder.Build().Run();
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts" twoslash
@@ -132,7 +155,8 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withEnvironment("IDENTITY_CLIENT_ID", clientId);
 
 await builder.build().run();
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -143,14 +167,22 @@ Use `GetBicepIdentifier()` inside `ConfigureInfrastructure` or infrastructure re
 The `ConfigureInfrastructure` API lets you customize the Azure resources that Aspire generates during provisioning. In C#, it provides a strongly-typed surface over the [Azure.Provisioning](https://www.nuget.org/packages/Azure.Provisioning) library, letting you modify any property of the generated Azure resource types before Bicep is emitted.
 
 <Aside type="tip" title="Azure.Provisioning resources">
-For detailed API documentation and examples, see the [Azure.Provisioning API reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning) and the [Azure.Provisioning README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/provisioning/Azure.Provisioning/README.md).
+  For detailed API documentation and examples, see the [Azure.Provisioning API
+  reference](https://learn.microsoft.com/dotnet/api/overview/azure/provisioning)
+  and the [Azure.Provisioning
+  README](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/provisioning/Azure.Provisioning/README.md).
 </Aside>
 
 ### Basic infrastructure customization
 
 All Azure hosting resources in Aspire inherit from `AzureProvisioningResource`, which exposes `ConfigureInfrastructure`. The callback receives an `AzureResourceInfrastructure` instance that gives you access to all provisioned constructs for that resource.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 In C#, use `GetProvisionableResources()` with the strongly-typed Azure SDK types (for example `StorageAccount`, `ServiceBusNamespace`) to navigate and mutate each construct:
@@ -192,13 +224,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addAzureStorage("storage");
+const storage = await builder.addAzureStorage('storage');
 
 await storage.configureInfrastructure(async (infra) => {
-    // Strongly-typed Azure SDK types are not available in TypeScript.
-    // Use getProvisionableResources() to access constructs dynamically.
-    const resources = await infra.getProvisionableResources();
-    // Work with resources generically as needed.
+  // Strongly-typed Azure SDK types are not available in TypeScript.
+  // Use getProvisionableResources() to access constructs dynamically.
+  const resources = await infra.getProvisionableResources();
+  // Work with resources generically as needed.
 });
 
 await builder.build().run();
@@ -209,7 +241,12 @@ await builder.build().run();
 
 ### Configure SKUs and tiers
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs (Storage)"
@@ -269,7 +306,12 @@ redis.ConfigureInfrastructure(infra =>
 
 ### Configure networking
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -307,7 +349,12 @@ storage.ConfigureInfrastructure(infra =>
 
 ### Configure security and compliance
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -349,7 +396,12 @@ storage.ConfigureInfrastructure(infra =>
 
 When an integration creates multiple resources (for example, a Service Bus namespace and its queues), you can customize each one inside a single `ConfigureInfrastructure` call:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -380,9 +432,9 @@ servicebus.ConfigureInfrastructure(infra =>
 
 <Aside type="note">
   Strongly-typed construct types (such as `ServiceBusNamespace`,
-  `ServiceBusQueue`) are not available in TypeScript. Use `getProvisionableResources()`
-  to iterate constructs dynamically, or use the C# AppHost for multi-resource
-  customization.
+  `ServiceBusQueue`) are not available in TypeScript. Use
+  `getProvisionableResources()` to iterate constructs dynamically, or use the C#
+  AppHost for multi-resource customization.
 </Aside>
 
 </Fragment>
@@ -392,7 +444,12 @@ servicebus.ConfigureInfrastructure(infra =>
 
 For common scenarios, prefer Aspire's higher-level resource builders. For example, to add a private endpoint to a storage account, use `AddPrivateEndpoint` from the `Aspire.Hosting.Azure.Network` package, which automatically wires up the Private DNS Zone, VNet link, and DNS Zone Group:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -417,11 +474,11 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const vnet = await builder.addAzureVirtualNetwork("vnet");
-const peSubnet = vnet.addSubnet("pe-subnet", "10.0.1.0/24");
+const vnet = await builder.addAzureVirtualNetwork('vnet');
+const peSubnet = vnet.addSubnet('pe-subnet', '10.0.1.0/24');
 
-const storage = await builder.addAzureStorage("storage");
-const blobs = storage.addBlobs("blobs");
+const storage = await builder.addAzureStorage('storage');
+const blobs = storage.addBlobs('blobs');
 
 peSubnet.addPrivateEndpoint(blobs);
 
@@ -437,7 +494,12 @@ When no Aspire-native resource builder exists for what you need, fall back to `C
 
 Another way to customize Azure provisioning is to create an [`InfrastructureResolver`](https://learn.microsoft.com/dotnet/api/azure.provisioning.primitives.infrastructureresolver). This is a C#-only API that lets you apply organization-wide naming conventions or other centralized provisioning behavior across many Azure resources.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Define a resolver by inheriting from `InfrastructureResolver` and overriding the relevant virtual members:
@@ -526,7 +588,12 @@ output storageAccountName string = storageAccount.name
 
 Reference the file from the AppHost using `AddBicepTemplate` (C#) or `addBicepTemplate` (TypeScript). Use `WithParameter` / `withParameter` to supply input parameters, and `GetOutput` / `getOutput` to consume a named output by passing the resulting reference to another resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -549,13 +616,18 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const storage = await builder.addBicepTemplate("storage", "./custom-storage.bicep");
-await storage.withParameter("storageAccountName", { value: "mystorageaccount" });
+const storage = await builder.addBicepTemplate(
+  'storage',
+  './custom-storage.bicep'
+);
+await storage.withParameter('storageAccountName', {
+  value: 'mystorageaccount',
+});
 
-const storageAccountName = await storage.getOutput("storageAccountName");
+const storageAccountName = await storage.getOutput('storageAccountName');
 
-const webapp = await builder.addProject("webapp", "../WebApp/WebApp.csproj");
-await webapp.withEnvironment("STORAGE_ACCOUNT_NAME", storageAccountName);
+const webapp = await builder.addProject('webapp', '../WebApp/WebApp.csproj');
+await webapp.withEnvironment('STORAGE_ACCOUNT_NAME', storageAccountName);
 
 await builder.build().run();
 ```
@@ -564,7 +636,10 @@ await builder.build().run();
 </AppHostTabs>
 
 <Aside type="tip">
-For inline Bicep snippets, use `AddBicepTemplateString` (C#) or `addBicepTemplateString` (TypeScript) instead of `AddBicepTemplate`. Both APIs return the same `AzureBicepResource` and support the same `WithParameter` and `GetOutput` patterns.
+  For inline Bicep snippets, use `AddBicepTemplateString` (C#) or
+  `addBicepTemplateString` (TypeScript) instead of `AddBicepTemplate`. Both APIs
+  return the same `AzureBicepResource` and support the same `WithParameter` and
+  `GetOutput` patterns.
 </Aside>
 
 ### Pass parameters and read outputs
@@ -599,7 +674,12 @@ resource sqlServer 'Microsoft.Sql/servers@2021-11-01' = {
 output sqlServerName string = sqlServer.name
 ```
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -624,15 +704,17 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const adminPassword = await builder.addParameter("adminPassword", { secret: true });
+const adminPassword = await builder.addParameter('adminPassword', {
+  secret: true,
+});
 
-const sql = await builder.addBicepTemplate("sql", "./custom-sql.bicep");
-await sql.withParameter("administratorLoginPassword", { value: adminPassword });
+const sql = await builder.addBicepTemplate('sql', './custom-sql.bicep');
+await sql.withParameter('administratorLoginPassword', { value: adminPassword });
 
-const sqlServerName = await sql.getOutput("sqlServerName");
+const sqlServerName = await sql.getOutput('sqlServerName');
 
-const api = await builder.addProject("api", "../Api/Api.csproj");
-await api.withEnvironment("SQL_SERVER_NAME", sqlServerName);
+const api = await builder.addProject('api', '../Api/Api.csproj');
+await api.withEnvironment('SQL_SERVER_NAME', sqlServerName);
 
 await builder.build().run();
 ```
@@ -641,14 +723,22 @@ await builder.build().run();
 </AppHostTabs>
 
 <LearnMore>
-For more end-to-end examples — including chaining outputs between Bicep resources and using the `existing` Bicep keyword to reference resources that Aspire didn't provision — see the [Aspire `playground/bicep` sample](https://github.com/dotnet/aspire/tree/main/playground/bicep).
+  For more end-to-end examples — including chaining outputs between Bicep
+  resources and using the `existing` Bicep keyword to reference resources that
+  Aspire didn't provision — see the [Aspire `playground/bicep`
+  sample](https://github.com/dotnet/aspire/tree/main/playground/bicep).
 </LearnMore>
 
 ### Set the deployment scope
 
 By default, Aspire deploys Bicep resources at the resource group scope. Some Bicep templates require a different [deployment scope](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deploy-to-subscription), such as the subscription or the tenant.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 Set the `Scope` property on the Bicep resource using `AzureBicepResourceScope.CreateForSubscription` or `AzureBicepResourceScope.CreateForTenant`:
@@ -689,13 +779,16 @@ builder.Build().Run();
 `AzureBicepResourceScope.CreateForSubscription` and `AzureBicepResourceScope.CreateForTenant` are available in Aspire 13.5 and later, and require a `using Aspire.Hosting.Azure;` directive. `targetScope` in the Bicep template must match the scope you assign in C#. `CreateForSubscription` requires a subscription identifier; `CreateForTenant` targets the current tenant and takes no arguments.
 
 Keep the `param location string` declaration in each template. `location` is a well-known Aspire parameter that the provisioner fills in automatically from the environment's location and passes to every Bicep deployment — including subscription- and tenant-scoped ones — so the template must declare it to accept the value.
+
 </Aside>
 
 </Fragment>
 <Fragment slot="typescript">
 
 <Aside type="note">
-  `AzureBicepResourceScope` and `Resource.Scope` are not currently exposed in the TypeScript AppHost APIs, so subscription/tenant deployment scopes for Bicep resources are currently C# only.
+  `AzureBicepResourceScope` and `Resource.Scope` are not currently exposed in
+  the TypeScript AppHost APIs, so subscription/tenant deployment scopes for
+  Bicep resources are currently C# only.
 </Aside>
 
 </Fragment>
@@ -710,11 +803,13 @@ To see the Bicep that Aspire emits after applying your `ConfigureInfrastructure`
 3. Review the generated `.bicep` files to verify your customizations.
 
 <Aside type="note">
-Neither `aspire run` nor `aspire deploy` writes Bicep into your AppHost directory. Use `aspire publish` to materialize the generated Bicep on disk.
+  Neither `aspire run` nor `aspire deploy` writes Bicep into your AppHost
+  directory. Use `aspire publish` to materialize the generated Bicep on disk.
 </Aside>
 
 <Aside type="tip">
-Use the Azure Portal's **Export template** feature to view Bicep for manually configured resources, then adapt it for Aspire.
+  Use the Azure Portal's **Export template** feature to view Bicep for manually
+  configured resources, then adapt it for Aspire.
 </Aside>
 
 ## See also

--- a/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/customize-resources.mdx
@@ -34,10 +34,10 @@ When working with Azure integrations in Aspire, you often need to customize the 
 Use `AsExisting`, `RunAsExisting`, and `PublishAsExisting` when you want Aspire to reference an Azure resource that already exists instead of provisioning a new one.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -83,10 +83,10 @@ Use `RunAsExisting` when only local run mode should use the existing resource, `
 Aspire automatically assigns Azure RBAC roles based on how resources reference one another. When you need to opt out of those defaults before applying different permissions, use `ClearDefaultRoleAssignments`.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -124,10 +124,10 @@ await builder.build().run();
 Azure resources expose output references for values that Azure assigns during provisioning. Use those references when another resource, deployment step, or app setting needs the resolved Azure value.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -178,10 +178,10 @@ The `ConfigureInfrastructure` API lets you customize the Azure resources that As
 All Azure hosting resources in Aspire inherit from `AzureProvisioningResource`, which exposes `ConfigureInfrastructure`. The callback receives an `AzureResourceInfrastructure` instance that gives you access to all provisioned constructs for that resource.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -242,10 +242,10 @@ await builder.build().run();
 ### Configure SKUs and tiers
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -307,10 +307,10 @@ redis.ConfigureInfrastructure(infra =>
 ### Configure networking
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -350,10 +350,10 @@ storage.ConfigureInfrastructure(infra =>
 ### Configure security and compliance
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -397,10 +397,10 @@ storage.ConfigureInfrastructure(infra =>
 When an integration creates multiple resources (for example, a Service Bus namespace and its queues), you can customize each one inside a single `ConfigureInfrastructure` call:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -445,10 +445,10 @@ servicebus.ConfigureInfrastructure(infra =>
 For common scenarios, prefer Aspire's higher-level resource builders. For example, to add a private endpoint to a storage account, use `AddPrivateEndpoint` from the `Aspire.Hosting.Azure.Network` package, which automatically wires up the Private DNS Zone, VNet link, and DNS Zone Group:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -495,10 +495,10 @@ When no Aspire-native resource builder exists for what you need, fall back to `C
 Another way to customize Azure provisioning is to create an [`InfrastructureResolver`](https://learn.microsoft.com/dotnet/api/azure.provisioning.primitives.infrastructureresolver). This is a C#-only API that lets you apply organization-wide naming conventions or other centralized provisioning behavior across many Azure resources.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -589,10 +589,10 @@ output storageAccountName string = storageAccount.name
 Reference the file from the AppHost using `AddBicepTemplate` (C#) or `addBicepTemplate` (TypeScript). Use `WithParameter` / `withParameter` to supply input parameters, and `GetOutput` / `getOutput` to consume a named output by passing the resulting reference to another resource:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -675,10 +675,10 @@ output sqlServerName string = sqlServer.name
 ```
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -734,10 +734,10 @@ await builder.build().run();
 By default, Aspire deploys Bicep resources at the resource group scope. Some Bicep templates require a different [deployment scope](https://learn.microsoft.com/azure/azure-resource-manager/bicep/deploy-to-subscription), such as the subscription or the tenant.
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
@@ -101,16 +101,16 @@ $env:Azure__Location = "eastus"
 
 The following configuration options are available:
 
-| Setting | Description | Default |
-| --- | --- | --- |
-| `Azure:SubscriptionId` | Your Azure subscription ID | (required) |
-| `Azure:Location` | Azure region for resources | (required) |
-| `Azure:TenantId` | Azure tenant to use when selecting subscriptions and credentials | Current credential tenant |
-| `Azure:ResourceGroup` | Specific resource group to create or reuse | Auto-generated |
-| `Azure:ResourceGroupPrefix` | Prefix used when Aspire generates a resource group name | `rg-aspire` |
-| `Azure:CredentialSource` | Authentication method for local provisioning | `Default` |
-| `Azure:AllowResourceGroupCreation` | Allow creating resource groups | `true` |
-| `Azure:CredentialProcessTimeoutSeconds` | Timeout in seconds for credential subprocess operations (must be between 5 and 600) | Azure SDK default |
+| Setting                                 | Description                                                                         | Default                   |
+| --------------------------------------- | ----------------------------------------------------------------------------------- | ------------------------- |
+| `Azure:SubscriptionId`                  | Your Azure subscription ID                                                          | (required)                |
+| `Azure:Location`                        | Azure region for resources                                                          | (required)                |
+| `Azure:TenantId`                        | Azure tenant to use when selecting subscriptions and credentials                    | Current credential tenant |
+| `Azure:ResourceGroup`                   | Specific resource group to create or reuse                                          | Auto-generated            |
+| `Azure:ResourceGroupPrefix`             | Prefix used when Aspire generates a resource group name                             | `rg-aspire`               |
+| `Azure:CredentialSource`                | Authentication method for local provisioning                                        | `Default`                 |
+| `Azure:AllowResourceGroupCreation`      | Allow creating resource groups                                                      | `true`                    |
+| `Azure:CredentialProcessTimeoutSeconds` | Timeout in seconds for credential subprocess operations (must be between 5 and 600) | Azure SDK default         |
 
 ## Resource group management
 
@@ -149,7 +149,12 @@ To prevent Aspire from creating resource groups:
 
 Add Azure resources to your AppHost using the relevant `Add*` APIs, then reference them from your consuming projects:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -158,10 +163,11 @@ var storage = builder.AddAzureStorage("storage");
 var blobs = storage.AddBlobs("blobs");
 
 builder.AddProject<Projects.WebApp>("webapp")
-       .WithReference(blobs);
+.WithReference(blobs);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -176,7 +182,8 @@ await builder.addNodeApp("webapp", "./webapp", "index.js")
     .withReference(blobs);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -215,15 +222,15 @@ When `Azure:CredentialSource` isn't set, local provisioning uses a development-f
 
 If you want to force a specific local credential, set `Azure:CredentialSource` to one of the supported values:
 
-| Value | Uses |
-| --- | --- |
-| `Default` | Development credential chain for local provisioning |
-| `AzureCli` | Azure CLI sign-in (`az login`) |
-| `AzureDeveloperCli` | Azure Developer CLI sign-in (`azd auth login`) |
-| `VisualStudio` | Visual Studio Azure account |
-| `VisualStudioCode` | Visual Studio Code Azure account |
-| `AzurePowerShell` | Azure PowerShell sign-in |
-| `InteractiveBrowser` | Browser-based sign-in prompt |
+| Value                | Uses                                                |
+| -------------------- | --------------------------------------------------- |
+| `Default`            | Development credential chain for local provisioning |
+| `AzureCli`           | Azure CLI sign-in (`az login`)                      |
+| `AzureDeveloperCli`  | Azure Developer CLI sign-in (`azd auth login`)      |
+| `VisualStudio`       | Visual Studio Azure account                         |
+| `VisualStudioCode`   | Visual Studio Code Azure account                    |
+| `AzurePowerShell`    | Azure PowerShell sign-in                            |
+| `InteractiveBrowser` | Browser-based sign-in prompt                        |
 
 ### Credential process timeout
 
@@ -290,7 +297,10 @@ Some Azure resource types are location-immutable — moving them to a new region
 If the acknowledgement is missing, Aspire fails the command before deleting the resource, persisting any location override, resetting provisioning state, or reprovisioning.
 
 <Aside type="note">
-Aspire doesn't require this acknowledgement when the resource's current location already matches the requested location, when the resource has no cached Azure resource ID (nothing to delete), or when the cached resource is already absent from Azure.
+  Aspire doesn't require this acknowledgement when the resource's current
+  location already matches the requested location, when the resource has no
+  cached Azure resource ID (nothing to delete), or when the cached resource is
+  already absent from Azure.
 </Aside>
 
 ## Limitations

--- a/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/local-provisioning.mdx
@@ -150,10 +150,10 @@ To prevent Aspire from creating resource groups:
 Add Azure resources to your AppHost using the relevant `Add*` APIs, then reference them from your consuming projects:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/cloud/azure/overview.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/overview.mdx
@@ -5,7 +5,7 @@ description: Learn how to model, configure, and deploy Azure resources in Aspire
 
 import AppHostTabs from '@components/AppHostTabs.astro';
 
-import { Kbd } from 'starlight-kbd/components'
+import { Kbd } from 'starlight-kbd/components';
 import { Aside, Steps } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import azureIcon from '@assets/icons/azure-icon.png';
@@ -54,20 +54,24 @@ Aspire aims to minimize costs by defaulting to _Basic_ or _Standard_ [Stock Keep
 
 Some Azure services can be emulated to run locally. Currently, Aspire supports the following Azure emulators:
 
-| Hosting integration | Description |
-|--|--|
+| Hosting integration                                                                                               | Description                                                                                                                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [Azure App Configuration](/integrations/cloud/azure/azure-app-configuration/azure-app-configuration-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureAppConfigurationResource>` to configure the Azure App Configuration resource to be [emulated with the Azure App Configuration Emulator](https://learn.microsoft.com/azure/azure-app-configuration/emulator-overview). |
-| [Azure Cosmos DB](/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureCosmosDBResource>` to configure the Cosmos DB resource to be [emulated with the NoSQL API](https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator). |
-| [Microsoft Foundry](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/) | Call `RunAsFoundryLocal` on the `IResourceBuilder<FoundryResource>` to configure the resource to be [emulated with Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started). |
-| [Azure Event Hubs](/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureEventHubsResource>` to configure the Event Hubs resource to be [emulated](https://learn.microsoft.com/azure/event-hubs/overview-emulator). |
-| [Azure Service Bus](/integrations/cloud/azure/azure-service-bus/azure-service-bus-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureServiceBusResource>` to configure the Service Bus resource to be [emulated with Service Bus emulator](https://learn.microsoft.com/azure/service-bus-messaging/overview-emulator). |
-| [Azure SignalR Service](/integrations/cloud/azure/azure-signalr/azure-signalr-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureSignalRResource>` to configure the SignalR resource to be [emulated with Azure SignalR emulator](https://learn.microsoft.com/azure/azure-signalr/signalr-howto-emulator). |
-| [Azure Storage](/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-get-started/) | Call `RunAsEmulator` on the `IResourceBuilder<AzureStorageResource>` to configure the Storage resource to be [emulated with Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite). |
+| [Azure Cosmos DB](/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-get-started/)                         | Call `RunAsEmulator` on the `IResourceBuilder<AzureCosmosDBResource>` to configure the Cosmos DB resource to be [emulated with the NoSQL API](https://learn.microsoft.com/azure/cosmos-db/how-to-develop-emulator).                                                      |
+| [Microsoft Foundry](/integrations/cloud/azure/azure-ai-foundry/azure-ai-foundry-get-started/)                     | Call `RunAsFoundryLocal` on the `IResourceBuilder<FoundryResource>` to configure the resource to be [emulated with Foundry Local](https://learn.microsoft.com/azure/ai-foundry/foundry-local/get-started).                                                               |
+| [Azure Event Hubs](/integrations/cloud/azure/azure-event-hubs/azure-event-hubs-get-started/)                      | Call `RunAsEmulator` on the `IResourceBuilder<AzureEventHubsResource>` to configure the Event Hubs resource to be [emulated](https://learn.microsoft.com/azure/event-hubs/overview-emulator).                                                                            |
+| [Azure Service Bus](/integrations/cloud/azure/azure-service-bus/azure-service-bus-get-started/)                   | Call `RunAsEmulator` on the `IResourceBuilder<AzureServiceBusResource>` to configure the Service Bus resource to be [emulated with Service Bus emulator](https://learn.microsoft.com/azure/service-bus-messaging/overview-emulator).                                     |
+| [Azure SignalR Service](/integrations/cloud/azure/azure-signalr/azure-signalr-get-started/)                       | Call `RunAsEmulator` on the `IResourceBuilder<AzureSignalRResource>` to configure the SignalR resource to be [emulated with Azure SignalR emulator](https://learn.microsoft.com/azure/azure-signalr/signalr-howto-emulator).                                             |
+| [Azure Storage](/integrations/cloud/azure/azure-storage-blobs/azure-storage-blobs-get-started/)                   | Call `RunAsEmulator` on the `IResourceBuilder<AzureStorageResource>` to configure the Storage resource to be [emulated with Azurite](https://learn.microsoft.com/azure/storage/common/storage-use-azurite).                                                              |
 
 To have your Azure resources use the local emulators, chain a call the `RunAsEmulator` method on the Azure resource builder. This method configures the Azure resource to use the local emulator instead of the actual Azure service.
 
 <Aside type="caution">
-Calling any of the available `RunAsEmulator` APIs on an Azure resource builder doesn't affect the [publishing manifest](/architecture/resource-publishing/). When you publish your app, [the generated Bicep file](/integrations/cloud/azure/customize-resources/) reflects the actual Azure service, not the local emulator.
+  Calling any of the available `RunAsEmulator` APIs on an Azure resource builder
+  doesn't affect the [publishing manifest](/architecture/resource-publishing/).
+  When you publish your app, [the generated Bicep
+  file](/integrations/cloud/azure/customize-resources/) reflects the actual
+  Azure service, not the local emulator.
 </Aside>
 
 ### Local containers
@@ -76,14 +80,18 @@ Some Azure resources can be substituted locally using open-source or on-premises
 
 Currently, Aspire supports the following Azure services as containers:
 
-| Hosting integration | Details |
-|--|--|
-| [Azure Cache for Redis](/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-get-started/) | Call `RunAsContainer` on the `IResourceBuilder<AzureRedisCacheResource>` to configure it to run locally in a container, based on the `docker.io/library/redis` image. |
+| Hosting integration                                                                                          | Details                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| [Azure Cache for Redis](/integrations/cloud/azure/azure-cache-redis/azure-cache-redis-get-started/)          | Call `RunAsContainer` on the `IResourceBuilder<AzureRedisCacheResource>` to configure it to run locally in a container, based on the `docker.io/library/redis` image.                |
 | [Azure PostgreSQL Flexible Server](/integrations/cloud/azure/azure-postgresql/azure-postgresql-get-started/) | Call `RunAsContainer` on the `IResourceBuilder<AzurePostgresFlexibleServerResource>` to configure it to run locally in a container, based on the `docker.io/library/postgres` image. |
-| [Azure SQL Server](/integrations/cloud/azure/azure-sql-database/azure-sql-database-get-started/) | Call `RunAsContainer` on the `IResourceBuilder<AzureSqlServerResource>` to configure it to run locally in a container, based on the `mcr.microsoft.com/mssql/server` image. |
+| [Azure SQL Server](/integrations/cloud/azure/azure-sql-database/azure-sql-database-get-started/)             | Call `RunAsContainer` on the `IResourceBuilder<AzureSqlServerResource>` to configure it to run locally in a container, based on the `mcr.microsoft.com/mssql/server` image.          |
 
 <Aside type="note">
-Like emulators, calling `RunAsContainer` on an Azure resource builder doesn't affect the [publishing manifest](/architecture/resource-publishing/). When you publish your app, the [generated Bicep file](/integrations/cloud/azure/customize-resources/) reflects the actual Azure service, not the local container.
+  Like emulators, calling `RunAsContainer` on an Azure resource builder doesn't
+  affect the [publishing manifest](/architecture/resource-publishing/). When you
+  publish your app, the [generated Bicep
+  file](/integrations/cloud/azure/customize-resources/) reflects the actual
+  Azure service, not the local container.
 </Aside>
 
 ### Understand Azure integration APIs
@@ -94,19 +102,19 @@ In the preceding containers section, you saw how to run Azure services locally i
 
 The answer is that there's no difference when running locally. However, when they're published you get different resources:
 
-| API | Run mode | Publish mode |
-|--|--|--|
-| `AddAzureRedis("redis").RunAsContainer()` | Local Redis container | Azure Cache for Redis |
-| `AddRedis("redis")` | Local Redis container | Azure Container App with Redis image |
+| API                                       | Run mode              | Publish mode                         |
+| ----------------------------------------- | --------------------- | ------------------------------------ |
+| `AddAzureRedis("redis").RunAsContainer()` | Local Redis container | Azure Cache for Redis                |
+| `AddRedis("redis")`                       | Local Redis container | Azure Container App with Redis image |
 
 The same is true for SQL and PostgreSQL services:
 
-| API | Run mode | Publish mode |
-|--|--|--|
-| `AddAzurePostgresFlexibleServer("postgres").RunAsContainer()` | Local PostgreSQL container | Azure PostgreSQL Flexible Server |
-| `AddPostgres("postgres")` | Local PostgreSQL container | Azure Container App with PostgreSQL image |
-| `AddAzureSqlServer("sql").RunAsContainer()` | Local SQL Server container | Azure SQL Server |
-| `AddSqlServer("sql")` | Local SQL Server container | Azure Container App with SQL Server image |
+| API                                                           | Run mode                   | Publish mode                              |
+| ------------------------------------------------------------- | -------------------------- | ----------------------------------------- |
+| `AddAzurePostgresFlexibleServer("postgres").RunAsContainer()` | Local PostgreSQL container | Azure PostgreSQL Flexible Server          |
+| `AddPostgres("postgres")`                                     | Local PostgreSQL container | Azure Container App with PostgreSQL image |
+| `AddAzureSqlServer("sql").RunAsContainer()`                   | Local SQL Server container | Azure SQL Server                          |
+| `AddSqlServer("sql")`                                         | Local SQL Server container | Azure Container App with SQL Server image |
 
 For more information on the difference between run and publish modes, see [Aspire AppHost: Execution context](/get-started/app-host/).
 
@@ -118,14 +126,14 @@ When the AppHost executes, the [_execution context_](/get-started/app-host/) is 
 
 The following table summarizes the naming conventions used to express Azure resources:
 
-| Operation | API | Description |
-|--|--|--|
-| Publish | `PublishAsConnectionString` _(obsolete)_ | Changes the resource to be published as a connection string reference in the manifest. Use `AddConnectionString` with the [execution context](/get-started/app-host/) instead. |
-| Publish | `PublishAsExisting` | Uses an existing Azure resource when the application is deployed instead of creating a new one. |
-| Run | `RunAsContainer` | Configures an equivalent container to run locally. For more information, see [Local containers](#local-containers). |
-| Run | `RunAsEmulator` | Configures the Azure resource to be emulated. For more information, see [Local emulators](#local-emulators). |
-| Run | `RunAsExisting` | Uses an existing resource when the application is running instead of creating a new one. |
-| Publish and Run | `AsExisting` | Uses an existing resource regardless of the operation. |
+| Operation       | API                                      | Description                                                                                                                                                                    |
+| --------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Publish         | `PublishAsConnectionString` _(obsolete)_ | Changes the resource to be published as a connection string reference in the manifest. Use `AddConnectionString` with the [execution context](/get-started/app-host/) instead. |
+| Publish         | `PublishAsExisting`                      | Uses an existing Azure resource when the application is deployed instead of creating a new one.                                                                                |
+| Run             | `RunAsContainer`                         | Configures an equivalent container to run locally. For more information, see [Local containers](#local-containers).                                                            |
+| Run             | `RunAsEmulator`                          | Configures the Azure resource to be emulated. For more information, see [Local emulators](#local-emulators).                                                                   |
+| Run             | `RunAsExisting`                          | Uses an existing resource when the application is running instead of creating a new one.                                                                                       |
+| Publish and Run | `AsExisting`                             | Uses an existing resource regardless of the operation.                                                                                                                         |
 
 :::caution[PublishAsConnectionString is obsolete]
 `PublishAsConnectionString` is obsolete as of Aspire 9.5. It only changes the manifest representation and has no effect on other publishers. To add the Azure resource in run mode and represent it as a connection string in publish mode, use [`AddConnectionString`](/fundamentals/external-parameters/#connection-string-values) with the execution context:
@@ -139,7 +147,8 @@ IResourceBuilder<IResourceWithConnectionString> resource = builder.ExecutionCont
 :::
 
 <Aside type="note">
-Not all APIs are available on all Azure resources. For example, some Azure resources can be containerized or emulated, while others can't.
+  Not all APIs are available on all Azure resources. For example, some Azure
+  resources can be containerized or emulated, while others can't.
 </Aside>
 
 For more information on execution modes, see [Execution context](/get-started/app-host/).
@@ -154,9 +163,15 @@ You can query whether a resource is marked as an existing resource, by calling t
 
 Aspire provides support for referencing existing Azure resources. You mark an existing resource through the `PublishAsExisting`, `RunAsExisting`, and `AsExisting` APIs. These APIs allow developers to reference already-deployed Azure resources, configure them, and generate appropriate deployment manifests using Bicep templates.
 
-
 <Aside type="caution">
-When you call `RunAsExisting`, `PublishAsExisting`, or `AsExisting` methods to work with resources that are already present in your Azure subscription, you must add certain configuration values to your AppHost to ensure that Aspire can locate them. The necessary configuration values include **SubscriptionId**, **AllowResourceGroupCreation**, **ResourceGroup**, and **Location**. If you don't set them, "Missing configuration" errors appear in the Aspire dashboard. For more information about how to set them, see [Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `RunAsExisting`, `PublishAsExisting`, or `AsExisting` methods to
+  work with resources that are already present in your Azure subscription, you
+  must add certain configuration values to your AppHost to ensure that Aspire
+  can locate them. The necessary configuration values include
+  **SubscriptionId**, **AllowResourceGroupCreation**, **ResourceGroup**, and
+  **Location**. If you don't set them, "Missing configuration" errors appear in
+  the Aspire dashboard. For more information about how to set them, see
+  [Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 Existing resources referenced with these APIs can be enhanced with [role assignments](/integrations/cloud/azure/role-assignments/) and other customizations that are available with Aspire's [infrastructure as code capabilities](/integrations/cloud/azure/customize-resources/). These APIs are limited to Azure resources that can be deployed with Bicep templates.
@@ -165,7 +180,12 @@ Existing resources referenced with these APIs can be enhanced with [role assignm
 
 The `RunAsExisting` method is used when a distributed application is executing in "run" mode. In this mode, it assumes that the referenced Azure resource already exists and integrates with it during execution without provisioning the resource. To mark an Azure resource as existing, call the `RunAsExisting` method on the resource builder. Consider the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder();
@@ -174,10 +194,11 @@ var existingServiceBusName = builder.AddParameter("existingServiceBusName");
 var existingServiceBusResourceGroup = builder.AddParameter("existingServiceBusResourceGroup");
 
 var serviceBus = builder.AddAzureServiceBus("messaging")
-                        .RunAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
+.RunAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 serviceBus.AddServiceBusQueue("queue");
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -192,7 +213,8 @@ const serviceBus = await builder.addAzureServiceBus("messaging");
 await serviceBus.runAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 await serviceBus.addServiceBusQueue("queue");
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -212,7 +234,12 @@ The `PublishAsExisting` method is used in "publish" mode when the intent is to d
 
 To mark an Azure resource as existing in for the "publish" mode, call the `PublishAsExisting` method on the resource builder. Consider the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder();
@@ -221,10 +248,11 @@ var existingServiceBusName = builder.AddParameter("existingServiceBusName");
 var existingServiceBusResourceGroup = builder.AddParameter("existingServiceBusResourceGroup");
 
 var serviceBus = builder.AddAzureServiceBus("messaging")
-                        .PublishAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
+.PublishAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 serviceBus.AddServiceBusQueue("queue");
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -239,7 +267,8 @@ const serviceBus = await builder.addAzureServiceBus("messaging");
 await serviceBus.publishAsExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 await serviceBus.addServiceBusQueue("queue");
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -290,7 +319,13 @@ output serviceBusEndpoint string = messaging.properties.serviceBusEndpoint
 For more information on the generated Bicep templates, see [Customize Azure resources](/integrations/cloud/azure/customize-resources/) and [consider other publishing APIs](#publish-as-azure-container-app).
 
 <Aside type="caution">
-When interacting with existing resources that require authentication, ensure the authentication strategy that you're configuring in the Aspire application model aligns with the authentication strategy allowed by the existing resource. For example, it's not possible to use managed identity against an existing Azure PostgreSQL resource that isn't configured to allow managed identity. Similarly, if an existing Azure Redis resource disabled access keys, it's not possible to use access key authentication.
+  When interacting with existing resources that require authentication, ensure
+  the authentication strategy that you're configuring in the Aspire application
+  model aligns with the authentication strategy allowed by the existing
+  resource. For example, it's not possible to use managed identity against an
+  existing Azure PostgreSQL resource that isn't configured to allow managed
+  identity. Similarly, if an existing Azure Redis resource disabled access keys,
+  it's not possible to use access key authentication.
 </Aside>
 
 ### Configure existing Azure resources in all modes
@@ -299,7 +334,12 @@ The `AsExisting` method is used when the distributed application is running in "
 
 To mark an Azure resource as existing, call the `AsExisting` method on the resource builder. Consider the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder();
@@ -308,10 +348,11 @@ var existingServiceBusName = builder.AddParameter("existingServiceBusName");
 var existingServiceBusResourceGroup = builder.AddParameter("existingServiceBusResourceGroup");
 
 var serviceBus = builder.AddAzureServiceBus("messaging")
-    .AsExisting(existingServiceBusName, existingServiceBusResourceGroup);
+.AsExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 serviceBus.AddServiceBusQueue("queue");
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -326,7 +367,8 @@ const serviceBus = await builder.addAzureServiceBus("messaging");
 await serviceBus.asExisting(existingServiceBusName, existingServiceBusResourceGroup);
 
 await serviceBus.addServiceBusQueue("queue");
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -343,25 +385,34 @@ The preceding code:
 Aspire provides the ability to [connect to existing resources](/get-started/resources/), including Azure resources. Expressing connection strings is useful when you have existing Azure resources that you want to use in your Aspire app. The `AddConnectionString` API is used with the AppHost's [execution context](/get-started/app-host/) to conditionally add a connection string to the app model.
 
 <Aside type="note">
-Connection strings are used to represent a wide range of connection information, including database connections, message brokers, endpoint URIs, and other services. In Aspire nomenclature, the term "connection string" is used to represent any kind of connection information.
+  Connection strings are used to represent a wide range of connection
+  information, including database connections, message brokers, endpoint URIs,
+  and other services. In Aspire nomenclature, the term "connection string" is
+  used to represent any kind of connection information.
 </Aside>
 
 Consider the following example, where in _publish_ mode you add an Azure Storage resource while in _run_ mode you add a connection string to an existing Azure Storage:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var storage = builder.ExecutionContext.IsPublishMode
-    ? builder.AddAzureStorage("storage")
-    : builder.AddConnectionString("storage");
+? builder.AddAzureStorage("storage")
+: builder.AddConnectionString("storage");
 
 builder.AddProject<Projects.Api>("api")
-    .WithReference(storage);
+.WithReference(storage);
 
 // After adding all resources, run the app...
-```
+
+````
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -377,7 +428,8 @@ await builder.addNodeApp("api", "./api", "index.js")
     .withReference(storage);
 
 // After adding all resources, run the app...
-```
+````
+
 </Fragment>
 </AppHostTabs>
 
@@ -411,6 +463,15 @@ Use the following APIs when you want to customize the generated Container App re
 
 You don't need `PublishAsAzureContainerApp` for a standard ACA deployment. Use it only when you want to customize the generated Container App resource. As an example, consider the following code:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -429,8 +490,15 @@ var api = builder.AddProject<Projects.AspireApi>("api")
     });
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
-The `PublishAsAzureContainerApp` customization callback uses strongly-typed Azure SDK types (`AzureResourceInfrastructure`, `ContainerApp`, `ContainerAppEnvironmentVariable`) that are only available in a C# AppHost. TypeScript AppHosts support standard ACA deployment but do not expose these strongly-typed Azure provisioning APIs directly.
+  The `PublishAsAzureContainerApp` customization callback uses strongly-typed
+  Azure SDK types (`AzureResourceInfrastructure`, `ContainerApp`,
+  `ContainerAppEnvironmentVariable`) that are only available in a C# AppHost.
+  TypeScript AppHosts support standard ACA deployment but do not expose these
+  strongly-typed Azure provisioning APIs directly.
 </Aside>
 
 The preceding code:
@@ -446,7 +514,9 @@ The preceding code:
 To configure the Azure Container App environment, see [Configure Azure Container Apps environments](/integrations/cloud/azure/configure-container-apps/). For information about publishing resources as Azure Container App Jobs, see [Azure Container App Jobs](/integrations/cloud/azure/container-app-jobs/). For more information, see [Azure.Provisioning.AppContainers.ContainerApp](https://learn.microsoft.com/dotnet/api/azure.provisioning.appcontainers.containerapp) and the `AsProvisioningParameter` API documentation.
 
 <Aside type="tip">
-If you're working with Azure Container Apps, you might also be interested in the [Aspire Azure Container Registry integration](/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started/).
+  If you're working with Azure Container Apps, you might also be interested in
+  the [Aspire Azure Container Registry
+  integration](/integrations/cloud/azure/azure-container-registry/azure-container-registry-get-started/).
 </Aside>
 
 ## See also

--- a/src/frontend/src/content/docs/integrations/cloud/azure/overview.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/overview.mdx
@@ -181,10 +181,10 @@ Existing resources referenced with these APIs can be enhanced with [role assignm
 The `RunAsExisting` method is used when a distributed application is executing in "run" mode. In this mode, it assumes that the referenced Azure resource already exists and integrates with it during execution without provisioning the resource. To mark an Azure resource as existing, call the `RunAsExisting` method on the resource builder. Consider the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -235,10 +235,10 @@ The `PublishAsExisting` method is used in "publish" mode when the intent is to d
 To mark an Azure resource as existing in for the "publish" mode, call the `PublishAsExisting` method on the resource builder. Consider the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -335,10 +335,10 @@ The `AsExisting` method is used when the distributed application is running in "
 To mark an Azure resource as existing, call the `AsExisting` method on the resource builder. Consider the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -394,10 +394,10 @@ Aspire provides the ability to [connect to existing resources](/get-started/reso
 Consider the following example, where in _publish_ mode you add an Azure Storage resource while in _run_ mode you add a connection string to an existing Azure Storage:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -464,11 +464,11 @@ Use the following APIs when you want to customize the generated Container App re
 You don't need `PublishAsAzureContainerApp` for a standard ACA deployment. Use it only when you want to customize the generated Container App resource. As an example, consider the following code:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/role-assignments.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/role-assignments.mdx
@@ -26,7 +26,12 @@ When you add an Azure resource to the [AppHost](/get-started/app-host/), it's as
 
 Consider a scenario where an API project resource references an [Azure Search](/integrations/cloud/azure/azure-ai-search/azure-ai-search-get-started/) resource. The API project is given the default role assignments, as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -65,7 +70,12 @@ These role assignments allow the API project to read and write data to the Azure
 
 To override the default role assignment, use the [WithRoleAssignments APIs](https://learn.microsoft.com/dotnet/api/?preserve-view=true&view=dotnet-aspire-13.0&term=WithRoleAssignments) and assign built-in roles as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -115,6 +125,15 @@ Aspire represents each set of role assignments as an `AzureRoleAssignmentResourc
 
 The following example shows how to add a pipeline step that runs during `WellKnownPipelineSteps.BeforeStart` and enumerates all `AzureRoleAssignmentResource` instances that target a specific Azure resource:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREAZURE001 // AzureEnvironmentResource is Experimental
 
@@ -144,6 +163,9 @@ builder.Pipeline.AddStep(
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 :::note
 TypeScript AppHost support for inspecting role assignments through pipeline

--- a/src/frontend/src/content/docs/integrations/cloud/azure/role-assignments.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/role-assignments.mdx
@@ -27,10 +27,10 @@ When you add an Azure resource to the [AppHost](/get-started/app-host/), it's as
 Consider a scenario where an API project resource references an [Azure Search](/integrations/cloud/azure/azure-ai-search/azure-ai-search-get-started/) resource. The API project is given the default role assignments, as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -71,10 +71,10 @@ These role assignments allow the API project to read and write data to the Azure
 To override the default role assignment, use the [WithRoleAssignments APIs](https://learn.microsoft.com/dotnet/api/?preserve-view=true&view=dotnet-aspire-13.0&term=WithRoleAssignments) and assign built-in roles as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
@@ -126,11 +126,11 @@ Aspire represents each set of role assignments as an `AzureRoleAssignmentResourc
 The following example shows how to add a pipeline step that runs during `WellKnownPipelineSteps.BeforeStart` and enumerates all `AzureRoleAssignmentResource` instances that target a specific Azure resource:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  typescript: 'TypeScript AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/cloud/azure/user-assigned-identity.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/user-assigned-identity.mdx
@@ -26,7 +26,12 @@ A user-assigned managed identity is a standalone Azure resource that you assign 
 
 To create a new user-assigned managed identity, use the `AddAzureUserAssignedIdentity` (or `addAzureUserAssignedIdentity`) API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -46,7 +51,7 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const sharedMi = await builder.addAzureUserAssignedIdentity("custom-umi");
+const sharedMi = await builder.addAzureUserAssignedIdentity('custom-umi');
 
 // After adding all resources, run the app...
 await builder.build().run();
@@ -62,14 +67,20 @@ The preceding code creates a new managed identity named `"custom-umi"` that you 
   implicitly calls `AddAzureProvisioning`, which adds support for generating
   Azure resources dynamically during app startup. The app must configure the
   appropriate subscription and location. For more information, see [Local
-  provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 ## Reference an existing managed identity
 
 If you already have a managed identity, reference it using the `PublishAsExisting` (or `publishAsExisting`) method. This is useful when you want to use an identity created outside of your Aspire project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -93,10 +104,10 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const miName = await builder.addParameter("miName");
-const miResourceGroup = await builder.addParameter("miResourceGroup");
+const miName = await builder.addParameter('miName');
+const miResourceGroup = await builder.addParameter('miResourceGroup');
 
-const sharedMi = await builder.addAzureUserAssignedIdentity("custom-umi");
+const sharedMi = await builder.addAzureUserAssignedIdentity('custom-umi');
 await sharedMi.publishAsExisting(miName, miResourceGroup);
 
 // After adding all resources, run the app...
@@ -112,7 +123,12 @@ In the preceding example, parameters supply the name and resource group of the e
 
 Grant Azure roles to your managed identity using the `WithRoleAssignments` (or `withRoleAssignments`) API, giving the identity access to other Azure resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -135,10 +151,12 @@ import { createBuilder, AzureKeyVaultRole } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const sharedMi = await builder.addAzureUserAssignedIdentity("custom-umi");
+const sharedMi = await builder.addAzureUserAssignedIdentity('custom-umi');
 
-const secrets = await builder.addAzureKeyVault("secrets");
-await sharedMi.withRoleAssignments(secrets, [AzureKeyVaultRole.KeyVaultSecretsUser]);
+const secrets = await builder.addAzureKeyVault('secrets');
+await sharedMi.withRoleAssignments(secrets, [
+  AzureKeyVaultRole.KeyVaultSecretsUser,
+]);
 
 // After adding all resources, run the app...
 await builder.build().run();

--- a/src/frontend/src/content/docs/integrations/cloud/azure/user-assigned-identity.mdx
+++ b/src/frontend/src/content/docs/integrations/cloud/azure/user-assigned-identity.mdx
@@ -27,10 +27,10 @@ A user-assigned managed identity is a standalone Azure resource that you assign 
 To create a new user-assigned managed identity, use the `AddAzureUserAssignedIdentity` (or `addAzureUserAssignedIdentity`) API:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -76,10 +76,10 @@ The preceding code creates a new managed identity named `"custom-umi"` that you 
 If you already have a managed identity, reference it using the `PublishAsExisting` (or `publishAsExisting`) method. This is useful when you want to use an identity created outside of your Aspire project:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -124,10 +124,10 @@ In the preceding example, parameters supply the name and resource group of the e
 Grant Azure roles to your managed identity using the `WithRoleAssignments` (or `withRoleAssignments`) API, giving the identity access to other Azure resources:
 
 <AppHostTabs limitations={{
-  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
-  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in Aspire daily 13.6.0-preview.1.26458.6.',
+  python: 'Python AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  go: 'Go AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  java: 'Java AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
+  rust: 'Rust AppHosts do not have a complete generated-SDK example verified for this scenario in the Aspire daily build used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/compute/docker.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/docker.mdx
@@ -67,13 +67,46 @@ This updates your `aspire.config.json` with the Docker hosting integration packa
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add docker
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add docker
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add docker
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add docker
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Add Docker Compose environment resource
 
 The following example demonstrates how to add a Docker Compose environment to your app model:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for Docker Compose service callback customization in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for Docker Compose service callback customization in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for Docker Compose service callback customization in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for Docker Compose service callback customization in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -147,10 +180,13 @@ When a Docker Compose environment is present, all resources are automatically pu
 <Aside type="tip">
   With the `compose` variable assigned, you can pass it to the compute environment API to
   disambiguate compute resources for solutions that define more than one. Otherwise, the `compose`
-  variable isn't required. This API is named `WithComputeEnvironment` in C# AppHosts and
-  `withComputeEnvironment` in TypeScript AppHosts.
+  variable isn't required. The generated API is named `withComputeEnvironment` in TypeScript and
+  Java, `with_compute_env` in Python, and `WithComputeEnvironment` in Go. The Rust export currently
+  requires an unvalidated compute-environment interface conversion.
 
-  <AppHostTabs>
+  <AppHostTabs limitations={{
+  rust: 'The generated Rust SDK exposes both resources, but its compute-environment API requires an interface conversion that is not validated for this example.',
+}}>
   <Fragment slot="csharp">
   ```csharp title="AppHost.cs"
   var compose = builder.AddDockerComposeEnvironment("compose");
@@ -167,14 +203,88 @@ When a Docker Compose environment is present, all resources are automatically pu
   await api.withComputeEnvironment(compose);
   ```
   </Fragment>
-  </AppHostTabs>
+  <Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    compose = builder.add_docker_compose_env("compose")
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_compute_env(compose)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	compose := builder.AddDockerComposeEnvironment("compose")
+	api := builder.AddProject("api", "../Api/Api.csproj").WithComputeEnvironment(compose)
+
+	if err := compose.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var compose = builder.addDockerComposeEnvironment("compose");
+    var api = builder.addProject("api", "../Api/Api.csproj")
+        .withComputeEnvironment(compose);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 </Aside>
 
 ### Add Docker Compose environment resource with properties
 
 You can configure various properties of the Docker Compose environment using the `WithProperties` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the Docker Compose environment-properties callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the Docker Compose environment-properties callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the Docker Compose environment-properties callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the Docker Compose environment-properties callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddDockerComposeEnvironment("compose")
@@ -206,7 +316,12 @@ The `DashboardEnabled` property determines whether to include an Aspire dashboar
 
 You can customize the generated Docker Compose file using the `ConfigureComposeFile` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the mutable Docker Compose file and service collection callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the mutable Docker Compose file and service collection callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the mutable Docker Compose file and service collection callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the mutable Docker Compose file and service collection callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddDockerComposeEnvironment("compose")
@@ -244,7 +359,12 @@ The `ConfigureComposeFile` callback runs after Aspire generates the Docker Compo
 
 The Docker hosting integration includes an Aspire dashboard for telemetry visualization. You can configure or disable it using the `WithDashboard` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the Docker Compose dashboard configuration callbacks in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the Docker Compose dashboard configuration callbacks in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the Docker Compose dashboard configuration callbacks in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the Docker Compose dashboard configuration callbacks in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 // Enable dashboard with custom configuration
@@ -314,6 +434,108 @@ const apiEndpoint = await api.getEndpoint("http");
 const apiHost = await compose.getHostAddressExpression(apiEndpoint);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    compose = builder.add_docker_compose_env("compose")
+    api = builder.add_container("api", "nginx:alpine")
+    api.with_http_endpoint(name="http", target_port=80)
+    api_endpoint = api.get_endpoint("http")
+    api_host = compose.get_host_address_expression(api_endpoint)
+    builder.run()
+````
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	stringPtr := func(value string) *string { return &value }
+
+	targetPort := 80.0
+	compose := builder.AddDockerComposeEnvironment("compose")
+	api := builder.AddContainer("api", "nginx:alpine").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Name: stringPtr("http"), TargetPort: &targetPort})
+	apiEndpoint := api.GetEndpoint("http")
+	_ = compose.GetHostAddressExpression(apiEndpoint)
+
+	if err := compose.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var compose = builder.addDockerComposeEnvironment("compose");
+    var api = builder.addContainer("api", "nginx:alpine")
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("http").targetPort(80));
+    var apiHost = compose.getHostAddressExpression(api.getEndpoint("http"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let compose = builder.add_docker_compose_environment("compose")?;
+    let api = builder.add_container("api", json!("nginx:alpine"))?;
+    api.with_http_endpoint(None, Some(80.0), Some("http"), None, None)?;
+    let api_endpoint = api.get_endpoint("http")?;
+    let _api_host = compose.get_host_address_expression(&api_endpoint)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Publishing and deployment
@@ -328,7 +550,12 @@ The Docker hosting integration captures environment variables from your app mode
 
 For advanced scenarios, use `ConfigureEnvFile` to customize the generated `.env` file:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the Docker Compose environment-file dictionary callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the Docker Compose environment-file dictionary callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the Docker Compose environment-file dictionary callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the Docker Compose environment-file dictionary callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -371,7 +598,12 @@ This is useful when you need to add custom environment variables to the generate
 
 To customize the generated Docker Compose service for a specific resource, use the `PublishAsDockerComposeService` method. This is optional — all resources are automatically included in the Docker Compose output. Use this method only when you need to modify the generated service definition:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the mutable Docker Compose service callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the mutable Docker Compose service callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the mutable Docker Compose service callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the mutable Docker Compose service callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -428,7 +660,12 @@ Use `AddDockerfileBuilder` to create a container resource from a Dockerfile gene
   [`ASPIREDOCKERFILEBUILDER001`](/diagnostics/aspiredockerfilebuilder001/) when you choose to use them.
 </Aside>
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the programmatic Dockerfile builder callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the programmatic Dockerfile builder callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the programmatic Dockerfile builder callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the programmatic Dockerfile builder callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.ApplicationModel.Docker;
@@ -523,6 +760,90 @@ await container.withImagePullPolicy(ImagePullPolicy.Always);
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    container = builder.add_container("mycontainer", "myimage:latest")
+    container.with_image_pull_policy("Always")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	container := builder.AddContainer("mycontainer", "myimage:latest").WithImagePullPolicy(aspire.ImagePullPolicyAlways)
+
+	if err := container.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var container = builder.addContainer("mycontainer", "myimage:latest")
+        .withImagePullPolicy(ImagePullPolicy.ALWAYS);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let container = builder.add_container("mycontainer", json!("myimage:latest"))?;
+    let _container = container.with_image_pull_policy(ImagePullPolicy::Always)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Use `Never` with locally-built images
@@ -549,6 +870,90 @@ await app.withImagePullPolicy(ImagePullPolicy.Never);
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_container("myapp", "my-local-image:dev")
+    app.with_image_pull_policy("Never")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	appResource := builder.AddContainer("myapp", "my-local-image:dev").WithImagePullPolicy(aspire.ImagePullPolicyNever)
+
+	if err := appResource.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var app = builder.addContainer("myapp", "my-local-image:dev")
+        .withImagePullPolicy(ImagePullPolicy.NEVER);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let app = builder.add_container("myapp", json!("my-local-image:dev"))?;
+    let _app = app.with_image_pull_policy(ImagePullPolicy::Never)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -579,7 +984,12 @@ When deploying containers, you can customize how container images are named and 
 
 Use `WithRemoteImageName` and `WithRemoteImageTag` to customize the image reference:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for Docker Compose publication plus remote-image metadata in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for Docker Compose publication plus remote-image metadata in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for Docker Compose publication plus remote-image metadata in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for Docker Compose publication plus remote-image metadata in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -614,7 +1024,12 @@ await api.withRemoteImageTag("v1.0.0");
 
 For more complex scenarios, use `WithImagePushOptions` to register a callback that can dynamically configure push options:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the image-push options callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the image-push options callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the image-push options callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the image-push options callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -660,7 +1075,12 @@ await api
 
 For asynchronous operations (such as retrieving configuration from external sources), use the async overload:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the asynchronous image-push options callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the asynchronous image-push options callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the asynchronous image-push options callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the asynchronous image-push options callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -721,7 +1141,12 @@ You can configure your Aspire application to push container images to registries
 
 Use the `AddContainerRegistry` method to define a container registry and the `WithContainerRegistry` method to associate resources with that registry:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with a container registry in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with a container registry in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with a container registry in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with a container registry in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -770,7 +1195,12 @@ For GitHub Container Registry, the registry endpoint is `ghcr.io` and the reposi
 
 For more flexible configuration, especially in CI/CD pipelines, you can use parameters with environment variables:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with parameterized registry configuration in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with parameterized registry configuration in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with parameterized registry configuration in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for Docker Compose publication callbacks used with parameterized registry configuration in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/integrations/compute/docker.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/docker.mdx
@@ -234,12 +234,11 @@ func main() {
 	}
 
 	compose := builder.AddDockerComposeEnvironment("compose")
-	api := builder.AddProject("api", "../Api/Api.csproj").WithComputeEnvironment(compose)
-
 	if err := compose.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	api := builder.AddProject("api", "../Api/Api.csproj").WithComputeEnvironment(compose)
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -470,17 +469,17 @@ func main() {
 
 	targetPort := 80.0
 	compose := builder.AddDockerComposeEnvironment("compose")
-	api := builder.AddContainer("api", "nginx:alpine").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Name: stringPtr("http"), TargetPort: &targetPort})
-	apiEndpoint := api.GetEndpoint("http")
-	_ = compose.GetHostAddressExpression(apiEndpoint)
-
 	if err := compose.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	api := builder.AddContainer("api", "nginx:alpine").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Name: stringPtr("http"), TargetPort: &targetPort})
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
+
+	apiEndpoint := api.GetEndpoint("http")
+	_ = compose.GetHostAddressExpression(apiEndpoint)
 
 	app, err := builder.Build()
 	if err != nil {

--- a/src/frontend/src/content/docs/integrations/compute/k3s.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/k3s.mdx
@@ -51,7 +51,12 @@ If this command fails with a permission error, you may need to enable privileged
 
 To start building an Aspire app that uses k3s, install the [📦 CommunityToolkit.Aspire.Hosting.K3s](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.K3s) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -119,7 +124,12 @@ The examples below show how to use the k3s integration APIs. They assume you alr
 Then adapt the snippets below to your project structure and configuration.
 :::
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -158,7 +168,12 @@ await builder.build().run();
 
 All cluster options are available as fluent builder methods:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -219,7 +234,12 @@ The available options are:
 
 ## Persist cluster state across runs
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -250,7 +270,12 @@ With persistent containers, `agentCount` must stay constant across runs. Decreas
 
 `AddHelmRelease` runs `helm upgrade --install --wait` inside an `alpine/helm` container — no host-side `helm` binary is required:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -305,7 +330,12 @@ Use `WithHelmValuesFile` for structured overrides (values with commas, braces, o
 | Directory (no `kustomization.yaml`) | `kubectl apply -f <dir>` (all YAML files, lexicographic order) |
 | Directory containing `kustomization.yaml` | `kubectl apply -k <dir>` (Kustomize) |
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -340,7 +370,12 @@ await monitoring.waitForCompletion(appConfig);
 
 `AddServiceEndpoint` starts an in-process WebSocket port-forward bound to `0.0.0.0:{allocatedPort}` — no `NodePort` or `LoadBalancer` configuration is required. The endpoint transitions to `Running` only after the target service has a ready pod.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -391,7 +426,12 @@ Scheme is inferred from the port: `443` and `8443` resolve to `https`, all other
 
 Both `K3sClusterResource` and `K3sServiceEndpointResource` implement `IResourceWithConnectionString`, so the standard `WithReference` overload handles credential injection automatically:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -431,7 +471,12 @@ await api.withReference(podinfoWeb);
 
 k3s pods run on the internal pod network (`10.42.0.0/16`). Flannel masquerades outbound pod traffic through the k3s container's DCP network IP, so pods can reach DCP services using `host.docker.internal` and the host-mapped port:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.K3s operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
@@ -171,12 +171,11 @@ func main() {
 
 	envName := "PORT"
 	k8s := builder.AddKubernetesEnvironment("k8s")
-	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: &envName}).WithExternalHttpEndpoints()
-
 	if err := k8s.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: &envName}).WithExternalHttpEndpoints()
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -292,12 +291,11 @@ func main() {
 	}
 
 	k8s := builder.AddKubernetesEnvironment("k8s")
-	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithComputeEnvironment(k8s)
-
 	if err := k8s.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithComputeEnvironment(k8s)
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -441,12 +439,11 @@ func main() {
 	}
 
 	registry := builder.AddContainerRegistry("registry", "myregistry.example.com:5000")
-	k8s := builder.AddKubernetesEnvironment("k8s").WithContainerRegistry(registry)
-
 	if err := registry.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	k8s := builder.AddKubernetesEnvironment("k8s").WithContainerRegistry(registry)
 	if err := k8s.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
+++ b/src/frontend/src/content/docs/integrations/compute/kubernetes.mdx
@@ -73,6 +73,34 @@ This updates your `aspire.config.json` with the Kubernetes hosting integration p
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add kubernetes
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add kubernetes
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add kubernetes
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add kubernetes
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add Kubernetes environment
@@ -111,15 +139,112 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    k8s = builder.add_kubernetes_env("k8s")
+    api = builder.add_node_app("api", "./api", "src/index.ts")
+    api.with_http_endpoint(env="PORT").with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	envName := "PORT"
+	k8s := builder.AddKubernetesEnvironment("k8s")
+	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: &envName}).WithExternalHttpEndpoints()
+
+	if err := k8s.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var k8s = builder.addKubernetesEnvironment("k8s");
+    var api = builder.addNodeApp("api", "./api", "src/index.ts")
+        .withHttpEndpoint(new WithHttpEndpointOptions().env("PORT"))
+        .withExternalHttpEndpoints();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _k8s = builder.add_kubernetes_environment("k8s")?;
+    let api = builder.add_node_app("api", "./api", "src/index.ts")?;
+    api.with_http_endpoint(None, None, None, Some("PORT"), None)?;
+    api.with_external_http_endpoints()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="tip">
   With the `k8s` variable assigned, you can pass it to the compute environment API to
   disambiguate compute resources for solutions that define more than one. Otherwise, the `k8s`
-  variable isn't required. This API is named `WithComputeEnvironment` in C# AppHosts and
-  `withComputeEnvironment` in TypeScript AppHosts.
+  variable isn't required. The generated API is named `withComputeEnvironment` in TypeScript and
+  Java, `with_compute_env` in Python, and `WithComputeEnvironment` in Go. The Rust export currently
+  requires an unvalidated compute-environment interface conversion.
 
-  <AppHostTabs>
+  <AppHostTabs limitations={{
+  rust: 'The generated Rust SDK exposes both resources, but its compute-environment API requires an interface conversion that is not validated for this example.',
+}}>
   <Fragment slot="csharp">
   ```csharp title="AppHost.cs"
   var k8s = builder.AddKubernetesEnvironment("k8s");
@@ -136,14 +261,88 @@ await builder.build().run();
   await api.withComputeEnvironment(k8s);
   ```
   </Fragment>
-  </AppHostTabs>
+  <Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    k8s = builder.add_kubernetes_env("k8s")
+    api = builder.add_node_app("api", "./api", "src/index.ts")
+    api.with_compute_env(k8s)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	k8s := builder.AddKubernetesEnvironment("k8s")
+	api := builder.AddNodeApp("api", "./api", "src/index.ts").WithComputeEnvironment(k8s)
+
+	if err := k8s.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var k8s = builder.addKubernetesEnvironment("k8s");
+    var api = builder.addNodeApp("api", "./api", "src/index.ts")
+        .withComputeEnvironment(k8s);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 </Aside>
 
 ## Configure Helm chart options
 
 You can configure the generated Helm chart using the `WithHelm` method, which provides a fluent `HelmChartOptions` builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the Helm configuration callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the Helm configuration callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the Helm configuration callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the Helm configuration callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -191,7 +390,9 @@ The `WithHelm` method is the single configuration entry point for Helm chart set
 
 A vanilla Kubernetes cluster doesn't know which container registry to use for your application images. Use `AddContainerRegistry` and `WithContainerRegistry` to specify a registry that is accessible from both your local machine and from the cluster:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The generated Rust SDK exposes container registries, but withContainerRegistry requires an IResource conversion that is not validated for this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -209,6 +410,77 @@ await k8s.withContainerRegistry(registry);
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    registry = builder.add_container_registry("registry", "myregistry.example.com:5000")
+    k8s = builder.add_kubernetes_env("k8s")
+    k8s.with_container_registry(registry)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	registry := builder.AddContainerRegistry("registry", "myregistry.example.com:5000")
+	k8s := builder.AddKubernetesEnvironment("k8s").WithContainerRegistry(registry)
+
+	if err := registry.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := k8s.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var registry = builder.addContainerRegistry(
+        "registry",
+        AspireUnion.of("myregistry.example.com:5000"));
+    var k8s = builder.addKubernetesEnvironment("k8s")
+        .withContainerRegistry(registry);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="note">
@@ -219,7 +491,10 @@ await k8s.withContainerRegistry(registry);
 
 To create durable storage in a Kubernetes cluster, model it as a first-class `KubernetesPersistentVolumeResource` with `AddPersistentVolume`. Then configure its storage class, capacity, and access modes, and bind it to workloads. At publish time, the volume renders as a `v1.PersistentVolumeClaim`, and any workload bound to it is promoted to a `StatefulSet`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'The PostgreSQL package used by this persistent-volume example was not generated in the available Go SDK batch.',
+  rust: 'The PostgreSQL package used by this persistent-volume example was not generated in the available Rust SDK batch.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -252,6 +527,43 @@ await pg.withKubernetesPersistentVolume(pgData);
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    k8s = builder.add_kubernetes_env("k8s")
+    pg_data = k8s.add_persistent_volume("pg-data")
+    pg_data.with_storage_class("managed-csi").with_capacity("20Gi")
+    pg = builder.add_postgres("pg")
+    pg.with_data_volume(name="pg-data")
+    pg.with_kubernetes_persistent_volume(pg_data)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var k8s = builder.addKubernetesEnvironment("k8s");
+    var pgData = k8s.addPersistentVolume("pg-data")
+        .withStorageClass("managed-csi")
+        .withCapacity("20Gi");
+    var pg = builder.addPostgres("pg")
+        .withDataVolume(new WithDataVolumeOptions().name("pg-data"))
+        .withKubernetesPersistentVolume(pgData);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <LearnMore>
@@ -262,7 +574,12 @@ await pg.withKubernetesPersistentVolume(pgData);
 
 Use `PublishAsKubernetesService` to modify the generated Kubernetes resources for individual services:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the mutable Kubernetes workload callback in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the mutable Kubernetes workload callback in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the mutable Kubernetes workload callback in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the mutable Kubernetes workload callback in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -302,7 +619,12 @@ The API surface differs by language:
 - **C#**: add subclasses of `BaseKubernetesResource` directly to the `AdditionalResources` collection. Several built-in types (such as `ConfigMap`) are available in the `Aspire.Hosting.Kubernetes.Resources` namespace, and you can subclass `BaseKubernetesResource` to model any custom resource definition (CRD).
 - **TypeScript**: call `addManifest` on the resource. It takes the manifest's `apiVersion`, `kind`, and `metadata.name`, and returns a handle for setting labels, annotations, a namespace, and arbitrary field values using dot-notation paths.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for custom Kubernetes resource authoring and mutable additional-resource collections in the daily SDK.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for custom Kubernetes resource authoring and mutable additional-resource collections in the daily SDK.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for custom Kubernetes resource authoring and mutable additional-resource collections in the daily SDK.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for custom Kubernetes resource authoring and mutable additional-resource collections in the daily SDK.',
+}}>
 <Fragment slot="csharp">
 
 Define a class for the custom resource by deriving from `BaseKubernetesResource`, then add an instance to `AdditionalResources`. The example below models a cert-manager `Certificate` CRD:

--- a/src/frontend/src/content/docs/integrations/custom-integrations/client-integrations.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/client-integrations.mdx
@@ -4,6 +4,7 @@ description: Learn how to create a custom Aspire client integration for an exist
 ---
 
 import { Aside, Badge, Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import { Kbd } from 'starlight-kbd/components';
 import ThemeImage from '@components/ThemeImage.astro';
 import maildevWithNewsletterDashboard from '@assets/integrations/custom-integrations/maildev-with-newsletterservice-dashboard.png';
@@ -564,6 +565,15 @@ The most notable changes in the preceding code are:
 
 Back in the `AppHost.cs` file, update it to configure the scalar API reference endpoint:
 
+<AppHostTabs limitations={{
+  typescript: 'This custom MailDev AppHost scenario combines an unvalidated generated integration with a mutable URL callback, so an exact TypeScript call is not documented.',
+  python: 'This custom MailDev AppHost scenario combines an unvalidated generated integration with a mutable URL callback, so an exact Python call is not documented.',
+  go: 'This custom MailDev AppHost scenario combines an unvalidated generated integration with a mutable URL callback, so an exact Go call is not documented.',
+  java: 'This custom MailDev AppHost scenario combines an unvalidated generated integration with a mutable URL callback, so an exact Java call is not documented.',
+  rust: 'This custom MailDev AppHost scenario combines an unvalidated generated integration with a mutable URL callback, so an exact Rust call is not documented.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -579,6 +589,9 @@ builder.AddProject<Projects.MailDevResource_NewsletterService>("newsletterservic
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Run the sample
 

--- a/src/frontend/src/content/docs/integrations/custom-integrations/hosting-integrations.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/hosting-integrations.mdx
@@ -26,6 +26,12 @@ Aspire improves the development experience by providing reusable building blocks
 
 Consider the code below:
 
+<AppHostTabs limitations={{
+  go: 'The available Go SDK module does not include the Redis and PostgreSQL packages used by this introductory AppHost model.',
+  rust: 'The available Rust SDK module does not include the Redis and PostgreSQL packages used by this introductory AppHost model.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -38,6 +44,65 @@ builder.AddProject<Projects.InventoryService>("inventoryservice")
     .WithReference(redis)
     .WithReference(db);
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const redis = await builder.addRedis('cache');
+const postgres = await builder.addPostgres('pgserver');
+const db = await postgres.addDatabase('inventorydb');
+
+const inventory = await builder.addProject(
+  'inventoryservice',
+  '../InventoryService/InventoryService.csproj'
+);
+await inventory.withReference(redis);
+await inventory.withReference(db);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_redis("cache")
+    postgres = builder.add_postgres("pgserver")
+    db = postgres.add_database("inventorydb")
+    inventory = builder.add_project(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+    )
+    inventory.with_reference(redis).with_reference(db)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var redis = builder.addRedis("cache");
+    var db = builder.addPostgres("pgserver").addDatabase("inventorydb");
+    var inventory = builder.addProject(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj")
+        .withReference(redis)
+        .withReference(db);
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 In the preceding code there are four resources represented:
 
@@ -184,6 +249,15 @@ This is because Aspire treats project references in the AppHost as if they're se
 
 The `MailDev.Hosting` class library contains the resource type and extension methods for adding the resource to the AppHost. You should first think about the experience that you want to give developers when using your custom resource. In the case of this custom resource, you would want developers to be able to write code like the following:
 
+<AppHostTabs limitations={{
+  typescript: 'This conceptual API-design example shows the C# hosting extension before its ATS exports and generated TypeScript API are implemented.',
+  python: 'This conceptual API-design example shows the C# hosting extension before its ATS exports and generated Python API are implemented.',
+  go: 'This conceptual API-design example shows the C# hosting extension before its ATS exports and generated Go API are implemented.',
+  java: 'This conceptual API-design example shows the C# hosting extension before its ATS exports and generated Java API are implemented.',
+  rust: 'This conceptual API-design example shows the C# hosting extension before its ATS exports and generated Rust API are implemented.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -192,6 +266,9 @@ var maildev = builder.AddMailDev("maildev");
 builder.AddProject<Projects.NewsletterService>("newsletterservice")
     .WithReference(maildev);
 ```
+
+</Fragment>
+</AppHostTabs>
 
 To achieve this, you need a custom resource named `MailDevResource` which implements `IResourceWithConnectionString` so that consumers can use it with the `WithReference` extension to inject the connection details for the MailDev server as a connection string.
 
@@ -311,7 +388,12 @@ This example uses MailDev version 2.2.1. Be sure to check the [MailDev Docker Hu
 
 Now that the basic structure for the custom resource is complete, test it in an AppHost. The `[AspireExport]` attributes make the same C# implementation available to both AppHost languages.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'This custom MailDev hosting integration sample has not been generated and validated for the Python AppHost SDK.',
+  go: 'This custom MailDev hosting integration sample has not been generated and validated for the Go AppHost SDK.',
+  java: 'This custom MailDev hosting integration sample has not been generated and validated for the Java AppHost SDK.',
+  rust: 'This custom MailDev hosting integration sample has not been generated and validated for the Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 Open the `AppHost.cs` file in the `MailDevResource.AppHost` project and update it with the following code:
@@ -414,6 +496,14 @@ In order to test the end-to-end scenario, you need a .NET project which we can i
 
 After the project has been added and references have been updated, open the `AppHost.cs` of the `MailDevResource.AppHost.csproj` project, and update the source file to look like the following:
 
+<AppHostTabs limitations={{
+  python: 'The custom MailDev hosting integration in this tutorial has not been generated and validated for the Python AppHost SDK.',
+  go: 'The custom MailDev hosting integration in this tutorial has not been generated and validated for the Go AppHost SDK.',
+  java: 'The custom MailDev hosting integration in this tutorial has not been generated and validated for the Java AppHost SDK.',
+  rust: 'The custom MailDev hosting integration in this tutorial has not been generated and validated for the Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -424,6 +514,29 @@ builder.AddProject<Projects.MailDevResource_NewsletterService>("newsletterservic
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+After referencing the local integration from `aspire.config.json`, run `aspire restore` to generate its TypeScript API:
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const maildev = await builder.addMailDev('maildev');
+const newsletter = await builder.addProject(
+  'newsletterservice',
+  '../MailDevResource.NewsletterService/MailDevResource.NewsletterService.csproj'
+);
+await newsletter.withReference(maildev);
+
+await builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
 
 After updating the `AppHost.cs` file, launch the AppHost again. Then verify that the Newsletter Service started and that the environment variable `ConnectionStrings__maildev` was added to the process. From the **Resources** page, find the `newsletterservice` row, and select the **...** button on the **Actions** column, then select **View details**. In the **Environment Variables** section, you should see the following:
 

--- a/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
+++ b/src/frontend/src/content/docs/integrations/custom-integrations/secure-communication.mdx
@@ -186,7 +186,12 @@ The preceding code updates the `AddMailDev` extension method to include the `use
 
 Now that the resource includes username and password parameters, update the AppHost to provide them. Mark the password parameter as secret so tooling and deployment environments can handle it appropriately.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'This custom MailDev hosting integration and its parameter overload have not been generated and validated for the Python AppHost SDK.',
+  go: 'This custom MailDev hosting integration and its parameter overload have not been generated and validated for the Go AppHost SDK.',
+  java: 'This custom MailDev hosting integration and its parameter overload have not been generated and validated for the Java AppHost SDK.',
+  rust: 'This custom MailDev hosting integration and its parameter overload have not been generated and validated for the Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/databases/clickhouse/clickhouse-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/clickhouse/clickhouse-host.mdx
@@ -45,11 +45,11 @@ aspire add clickhouse
 Or, choose a manual installation approach:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -68,11 +68,11 @@ Or, choose a manual installation approach:
 Once you've installed the hosting integration in your AppHost project, you can add a ClickHouse server resource and then add a database resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -125,11 +125,11 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 Add a data volume to the ClickHouse resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -164,11 +164,11 @@ The data volume is used to persist the ClickHouse data outside the lifecycle of 
 Add a data bind mount to the ClickHouse resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -203,11 +203,11 @@ Data bind mounts rely on the host machine's filesystem to persist the ClickHouse
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -245,11 +245,11 @@ For more information, see [External parameters](/get-started/resources/).
 You can also specify a custom host port:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/clickhouse/clickhouse-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/clickhouse/clickhouse-host.mdx
@@ -1,8 +1,10 @@
 ---
 title: Set up ClickHouse in the AppHost
-seoTitle: "Set up ClickHouse in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up ClickHouse in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire ClickHouse Hosting integration to orchestrate and configure a ClickHouse database in an Aspire solution.
 ---
+
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 import { Image } from 'astro:assets';
 import { Aside, Steps } from '@astrojs/starlight/components';
@@ -23,7 +25,8 @@ This article is the reference for the Aspire ClickHouse Hosting integration. It 
 If you're new to the ClickHouse integration, start with the [Get started with ClickHouse integrations](/integrations/databases/clickhouse/clickhouse-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to ClickHouse](../clickhouse-connect/).
 
 <Aside type="note">
-    TypeScript AppHost support for the ClickHouse integration is not yet available. All examples on this page are for C# AppHosts.
+  TypeScript AppHost support for the ClickHouse integration is not yet
+  available. All examples on this page are for C# AppHosts.
 </Aside>
 
 ## Installation
@@ -35,15 +38,27 @@ aspire add clickhouse
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 #:package Aspire.Hosting.ClickHouse@*
 ```
 
+</Fragment>
+</AppHostTabs>
 ```xml title="AppHost.csproj"
 <PackageReference Include="Aspire.Hosting.ClickHouse" Version="*" />
 ```
@@ -52,6 +67,15 @@ Or, choose a manual installation approach:
 
 Once you've installed the hosting integration in your AppHost project, you can add a ClickHouse server resource and then add a database resource as shown in the following example:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -59,12 +83,15 @@ var clickhouse = builder.AddClickHouse("clickhouse");
 var clickhousedb = clickhouse.AddDatabase("clickhousedb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(clickhousedb)
-    .WaitFor(clickhousedb);
+.WithReference(clickhousedb)
+.WaitFor(clickhousedb);
 
 // After adding all resources, run the app...
+
 ```
 
+</Fragment>
+</AppHostTabs>
 <Steps>
 
 1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `clickhouse/clickhouse-server` image, it creates a new ClickHouse server instance on your local machine. A reference to the `clickhousedb` database resource is then used to add a dependency to the consuming project.
@@ -97,6 +124,15 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 Add a data volume to the ClickHouse resource as shown in the following example:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -112,35 +148,50 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</Fragment>
+</AppHostTabs>
 The data volume is used to persist the ClickHouse data outside the lifecycle of its container. The data volume is mounted at the `/var/lib/clickhouse` path in the ClickHouse container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-clickhouse-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
     Some database integrations, including the ClickHouse integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
 
     You can resolve the problem by deploying to a Kubernetes cluster, such as Azure Kubernetes Services (AKS). For more information, see [Deploy your first Aspire app](/get-started/deploy-first-app/).
+
 </Aside>
 
 ## Add ClickHouse resource with data bind mount
 
 Add a data bind mount to the ClickHouse resource as shown in the following example:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var clickhouse = builder.AddClickHouse("clickhouse")
-    .WithDataBindMount(
-        source: "/ClickHouse/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/ClickHouse/Data",
+isReadOnly: false);
 
 var clickhousedb = clickhouse.AddDatabase("clickhousedb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(clickhousedb)
-    .WaitFor(clickhousedb);
+.WithReference(clickhousedb)
+.WaitFor(clickhousedb);
 
 // After adding all resources, run the app...
+
 ```
 
+</Fragment>
+</AppHostTabs>
 <Aside type="note">
     Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
 </Aside>
@@ -150,6 +201,15 @@ Data bind mounts rely on the host machine's filesystem to persist the ClickHouse
 ## Add ClickHouse resource with parameters
 
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -167,6 +227,8 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</Fragment>
+</AppHostTabs>
 The username and password parameters are usually specified as user secrets:
 
 ```json title="secrets.json"
@@ -182,10 +244,21 @@ For more information, see [External parameters](/get-started/resources/).
 
 You can also specify a custom host port:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var clickhouse = builder.AddClickHouse("clickhouse", port: 18123);
 ```
 
+</Fragment>
+</AppHostTabs>
 ## Connection properties
 
 For the full reference of ClickHouse connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to ClickHouse](../clickhouse-connect/).

--- a/src/frontend/src/content/docs/integrations/databases/efcore/azure-cosmos-db/azure-cosmos-db-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/azure-cosmos-db/azure-cosmos-db-host.mdx
@@ -28,14 +28,27 @@ This article is the AppHost reference for the Azure Cosmos DB hosting integratio
 If you're new to the EF Core Azure Cosmos DB integration, start with the [Get started with the EF Core Azure Cosmos DB integrations](/integrations/databases/efcore/azure-cosmos-db/azure-cosmos-db-get-started/) guide. For how C# consuming apps register a `DbContext` from the resources this page exposes, see [Connect to Azure Cosmos DB with EF Core](../azure-cosmos-db-connect/).
 
 <Aside type="note">
-  The AppHost hosting integration is **shared** between the direct `CosmosClient` integration and this EF Core integration — both use the same `Aspire.Hosting.Azure.CosmosDB` package and the same `AddAzureCosmosDB` API. The difference is in the client-side package: EF Core apps install `Aspire.Microsoft.EntityFrameworkCore.Cosmos` and call `AddCosmosDbContext`, while direct SDK apps install `Aspire.Microsoft.Azure.Cosmos` and call `AddAzureCosmosClient`. For the full AppHost reference including TypeScript examples, see [Azure Cosmos DB Hosting integration](/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host/).
+  The AppHost hosting integration is **shared** between the direct
+  `CosmosClient` integration and this EF Core integration — both use the same
+  `Aspire.Hosting.Azure.CosmosDB` package and the same `AddAzureCosmosDB` API.
+  The difference is in the client-side package: EF Core apps install
+  `Aspire.Microsoft.EntityFrameworkCore.Cosmos` and call `AddCosmosDbContext`,
+  while direct SDK apps install `Aspire.Microsoft.Azure.Cosmos` and call
+  `AddAzureCosmosClient`. For the full AppHost reference including TypeScript
+  examples, see [Azure Cosmos DB Hosting
+  integration](/integrations/cloud/azure/azure-cosmos-db/azure-cosmos-db-host/).
 </Aside>
 
 ## Installation
 
 To start building an Aspire app that uses Azure Cosmos DB, install the [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB) NuGet package in your AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -43,7 +56,8 @@ aspire add cosmosdb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -64,7 +78,8 @@ aspire add cosmosdb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure Cosmos DB hosting integration package:
@@ -84,17 +99,26 @@ This updates your `aspire.config.json` with the Azure Cosmos DB hosting integrat
 
 In your AppHost project, call `AddAzureCosmosDB` to add and return an Azure Cosmos DB resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db");
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -104,19 +128,30 @@ const cosmos = await builder.addAzureCosmosDb("cosmos-db");
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="caution">
-  When you call `AddAzureCosmosDB`, it implicitly calls `AddAzureProvisioning` — which adds support for generating Azure resources dynamically during app startup. The app must configure the appropriate subscription and location. For more information, see [Local provisioning: Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
+  When you call `AddAzureCosmosDB`, it implicitly calls `AddAzureProvisioning` —
+  which adds support for generating Azure resources dynamically during app
+  startup. The app must configure the appropriate subscription and location. For
+  more information, see [Local provisioning:
+  Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 ## Add Azure Cosmos DB database and container resources
 
 Aspire models parent-child relationships between Azure Cosmos DB resources. For example, a Cosmos DB account can have multiple databases, and each database can have multiple containers.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -125,13 +160,16 @@ var db = cosmos.AddCosmosDatabase("db");
 var container = db.AddContainer("entries", "/id");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WaitFor(container)
-    .WithReference(container);
+.WaitFor(container)
+.WithReference(container);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -147,6 +185,7 @@ await builder.addProject("apiservice", { projectPath: "../ExampleProject/Example
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -165,18 +204,27 @@ For more information, see [Databases, containers, and items in Azure Cosmos DB](
 
 To run locally without an Azure subscription, chain a call to `RunAsEmulator` on the Cosmos DB resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos-db")
-    .RunAsEmulator();
+.RunAsEmulator();
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -187,6 +235,7 @@ await cosmos.runAsEmulator();
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -198,6 +247,15 @@ For the full emulator configuration reference — gateway port, data volumes, pa
 
 You might have an existing Azure Cosmos DB account that you want to connect to. Chain a call to `AsExisting` to annotate that your resource is an existing resource:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -205,14 +263,17 @@ var existingCosmosName = builder.AddParameter("existingCosmosName");
 var existingCosmosResourceGroup = builder.AddParameter("existingCosmosResourceGroup");
 
 var cosmosdb = builder.AddAzureCosmosDB("cosmos-db")
-    .AsExisting(existingCosmosName, existingCosmosResourceGroup);
+.AsExisting(existingCosmosName, existingCosmosResourceGroup);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(cosmosdb);
+.WithReference(cosmosdb);
 
 // After adding all resources, run the app...
+
 ```
 
+</Fragment>
+</AppHostTabs>
 For more information on treating Azure Cosmos DB resources as existing resources, see [Use existing Azure resources](/integrations/cloud/azure/overview/#use-existing-azure-resources).
 
 ## Provisioning-generated Bicep
@@ -224,3 +285,4 @@ When you publish your app, Aspire generates Bicep for the Cosmos DB account alon
 The Azure Cosmos DB hosting integration automatically adds a health check for the Cosmos DB resource. The health check verifies that the Cosmos DB is running and that a connection can be established to it.
 
 The hosting integration relies on the [📦 AspNetCore.HealthChecks.CosmosDb](https://www.nuget.org/packages/AspNetCore.HealthChecks.CosmosDb) NuGet package.
+```

--- a/src/frontend/src/content/docs/integrations/databases/efcore/azure-cosmos-db/azure-cosmos-db-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/azure-cosmos-db/azure-cosmos-db-host.mdx
@@ -44,10 +44,10 @@ If you're new to the EF Core Azure Cosmos DB integration, start with the [Get st
 To start building an Aspire app that uses Azure Cosmos DB, install the [📦 Aspire.Hosting.Azure.CosmosDB](https://www.nuget.org/packages/Aspire.Hosting.Azure.CosmosDB) NuGet package in your AppHost project:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -100,10 +100,10 @@ This updates your `aspire.config.json` with the Azure Cosmos DB hosting integrat
 In your AppHost project, call `AddAzureCosmosDB` to add and return an Azure Cosmos DB resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -145,10 +145,10 @@ const cosmos = await builder.addAzureCosmosDb("cosmos-db");
 Aspire models parent-child relationships between Azure Cosmos DB resources. For example, a Cosmos DB account can have multiple databases, and each database can have multiple containers.
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -205,10 +205,10 @@ For more information, see [Databases, containers, and items in Azure Cosmos DB](
 To run locally without an Azure subscription, chain a call to `RunAsEmulator` on the Cosmos DB resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -248,11 +248,11 @@ For the full emulator configuration reference — gateway port, data volumes, pa
 You might have an existing Azure Cosmos DB account that you want to connect to. Chain a call to `AsExisting` to annotate that your resource is an existing resource:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/azure-sql/azure-sql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/azure-sql/azure-sql-host.mdx
@@ -29,10 +29,10 @@ If you're new to the Azure SQL EF Core integration, start with the [Get started 
 The Aspire Azure SQL Database hosting integration models the SQL server as the `AzureSqlServerResource` type and SQL databases as the `AzureSqlDatabaseResource` type. To access these types and APIs, install the [📦 Aspire.Hosting.Azure.Sql](https://www.nuget.org/packages/Aspire.Hosting.Azure.Sql) NuGet package in your AppHost project:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -85,10 +85,10 @@ This updates your `aspire.config.json` with the Azure SQL Database hosting integ
 In your AppHost project, call `AddAzureSqlServer` to add and return an Azure SQL server resource builder. Chain a call to `AddDatabase` to add an Azure SQL database resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -158,10 +158,10 @@ await builder.build().run();
 You might have an existing Azure SQL Database service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -215,10 +215,10 @@ For more information on treating Azure SQL resources as existing resources, see 
 During local development and testing, you can run an Azure SQL server as a local SQL Server container instead of provisioning an actual Azure resource. Call `RunAsContainer` (or `runAsContainer`) to switch to a local container:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/azure-sql/azure-sql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/azure-sql/azure-sql-host.mdx
@@ -28,7 +28,12 @@ If you're new to the Azure SQL EF Core integration, start with the [Get started 
 
 The Aspire Azure SQL Database hosting integration models the SQL server as the `AzureSqlServerResource` type and SQL databases as the `AzureSqlDatabaseResource` type. To access these types and APIs, install the [📦 Aspire.Hosting.Azure.Sql](https://www.nuget.org/packages/Aspire.Hosting.Azure.Sql) NuGet package in your AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -36,7 +41,8 @@ aspire add azure-sql
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -57,7 +63,8 @@ aspire add azure-sql
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Azure SQL Database hosting integration package:
@@ -77,8 +84,14 @@ This updates your `aspire.config.json` with the Azure SQL Database hosting integ
 
 In your AppHost project, call `AddAzureSqlServer` to add and return an Azure SQL server resource builder. Chain a call to `AddDatabase` to add an Azure SQL database resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -86,13 +99,16 @@ var sql = builder.AddAzureSqlServer("sql");
 var db = sql.AddDatabase("database");
 
 var myService = builder.AddProject<Projects.MyService>()
-    .WithReference(db);
+.WithReference(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -107,6 +123,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -121,23 +138,33 @@ await builder.build().run();
 </Steps>
 
 <Aside type="caution">
-  When you call `AddAzureSqlServer`, it implicitly calls
-  `AddAzureProvisioning` — which adds support for generating Azure resources
-  dynamically during app startup. The app must configure the appropriate
-  subscription and location. For more information, see [Local provisioning:
+  When you call `AddAzureSqlServer`, it implicitly calls `AddAzureProvisioning`
+  — which adds support for generating Azure resources dynamically during app
+  startup. The app must configure the appropriate subscription and location. For
+  more information, see [Local provisioning:
   Configuration](/integrations/cloud/azure/local-provisioning/#configuration).
 </Aside>
 
 <Aside type="note">
-    When you reference an Azure SQL Database resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection strings, URIs, and port numbers. For a complete list of these properties, see [Connect to Azure SQL with EF Core](../azure-sql-connect/#connection-properties).
+  When you reference an Azure SQL Database resource from the AppHost, Aspire
+  makes several properties available to the consuming project, such as
+  connection strings, URIs, and port numbers. For a complete list of these
+  properties, see [Connect to Azure SQL with EF
+  Core](../azure-sql-connect/#connection-properties).
 </Aside>
 
 ## Connect to an existing Azure SQL server
 
 You might have an existing Azure SQL Database service that you want to connect to. Chain a call to `AsExisting` (or `asExisting`) to annotate that your resource already exists in Azure:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -145,17 +172,20 @@ var existingName = builder.AddParameter("existingSqlServerName");
 var existingResourceGroup = builder.AddParameter("existingSqlServerResourceGroup");
 
 var sql = builder.AddAzureSqlServer("sql")
-    .AsExisting(existingName, existingResourceGroup)
-    .AddDatabase("database");
+.AsExisting(existingName, existingResourceGroup)
+.AddDatabase("database");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(sql);
+.WithReference(sql);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -174,6 +204,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -183,24 +214,33 @@ For more information on treating Azure SQL resources as existing resources, see 
 
 During local development and testing, you can run an Azure SQL server as a local SQL Server container instead of provisioning an actual Azure resource. Call `RunAsContainer` (or `runAsContainer`) to switch to a local container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddAzureSqlServer("sql")
-    .RunAsContainer();
+.RunAsContainer();
 
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(db);
+.WithReference(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -217,13 +257,19 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
 When `RunAsContainer` is active, Aspire pulls a SQL Server container image and runs it locally. The consuming project receives the same connection environment variables it would receive when deployed to Azure, so your code works without modification between local and cloud environments.
 
 <Aside type="tip">
-  `RunAsContainer` accepts an optional delegate (C#) or options object (TypeScript) that lets you customize the underlying `SqlServerServerResource` configuration. For example, you can add a data volume or data bind mount. For more information, see the [Aspire SQL Server hosting integration](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume) section.
+  `RunAsContainer` accepts an optional delegate (C#) or options object
+  (TypeScript) that lets you customize the underlying `SqlServerServerResource`
+  configuration. For example, you can add a data volume or data bind mount. For
+  more information, see the [Aspire SQL Server hosting
+  integration](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume)
+  section.
 </Aside>
 
 ## Admin deployment script

--- a/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
@@ -404,24 +404,26 @@ The migration service is created, but it needs to be added to the Aspire AppHost
 
    </Fragment>
    </AppHostTabs>
+
    This code enlists the *`SupportTicketApi.MigrationService`* project as a service in the Aspire AppHost. It also ensures that the API resource doesn't run until the migrations are complete.
 
-:::note
-In the preceding code, the call to `AddDatabase` adds a representation of a SQL Server database to the Aspire application model with a connection string. It _doesn't_ create a database in the SQL Server container. To ensure that the database is created, the sample project calls the EF Core `IDatabaseCreator.EnsureCreated` method from the support ticket API's `Program.cs` file.
-:::
+   :::note
+   In the preceding code, the call to `AddDatabase` adds a representation of a SQL Server database to the Aspire application model with a connection string. It _doesn't_ create a database in the SQL Server container. To ensure that the database is created, the sample project calls the EF Core `IDatabaseCreator.EnsureCreated` method from the support ticket API's `Program.cs` file.
+   :::
 
-:::tip
-The code creates the SQL Server container each time it runs and applies migrations to it. Data doesn't persist across debugging sessions and any new database rows you create during testing will not survive an app restart. If you would prefer to persist this data, add a data volume to your container. For more information, see [Add SQL Server resource with data volume](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume).
-:::
+   :::tip
+   The code creates the SQL Server container each time it runs and applies migrations to it. Data doesn't persist across debugging sessions and any new database rows you create during testing will not survive an app restart. If you would prefer to persist this data, add a data volume to your container. For more information, see [Add SQL Server resource with data volume](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume).
+   :::
 
 1. If the code cannot resolve the migration service project, add a reference to the migration service project in the AppHost project:
 
-```bash title=".NET CLI"
-dotnet add SupportTicketApi.AppHost reference SupportTicketApi.MigrationService
-```
-:::caution
-If you are using Visual Studio, and you selected the **`Enlist in Aspire orchestration`** option when creating the Worker Service project, similar code is added automatically with the service name `supportticketapi-migrationservice`. Replace that code with the preceding code.
-:::
+   ```bash title=".NET CLI"
+   dotnet add SupportTicketApi.AppHost reference SupportTicketApi.MigrationService
+   ```
+
+   :::caution
+   If you are using Visual Studio, and you selected the **`Enlist in Aspire orchestration`** option when creating the Worker Service project, similar code is added automatically with the service name `supportticketapi-migrationservice`. Replace that code with the preceding code.
+   :::
 
 </Steps>
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
@@ -83,7 +83,7 @@ Start by creating some migrations to apply.
         - Runs EF Core migration command-line tool in the *SupportTicketApi.Api* directory. `dotnet ef` is run in this location because the API service is where the DB context is used.
         - Creates a migration named *InitialCreate*.
         - Creates the migration in the in the *Migrations* folder in the *SupportTicketApi.Data* project.
-    </Steps>
+</Steps>
 
   </TabItem>
   <TabItem label="Package Manager Console">
@@ -374,33 +374,33 @@ The migration service is created, but it needs to be added to the Aspire AppHost
 1. In the _`SupportTicketApi.AppHost`_ project, open the _`AppHost.cs`_ file.
 1. Add the following highlighted code:
 
-      <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
-}}>
-<Fragment slot="csharp">
+   <AppHostTabs limitations={{
+     typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+     python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+     go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+     java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+     rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+   }}>
+   <Fragment slot="csharp">
 
-```csharp title="AppHost.cs" {6-8,12-13}
-var builder = DistributedApplication.CreateBuilder(args);
+   ```csharp title="AppHost.cs" {6-8,12-13}
+   var builder = DistributedApplication.CreateBuilder(args);
 
-   var sql = builder.AddSqlServer("sql")
-   .AddDatabase("sqldata");
+      var sql = builder.AddSqlServer("sql")
+      .AddDatabase("sqldata");
 
-   var migrations = builder.AddProject<Projects.SupportTicketApi_MigrationService>("migrations")
-   .WithReference(sql)
-   .WaitFor(sql);
+      var migrations = builder.AddProject<Projects.SupportTicketApi_MigrationService>("migrations")
+      .WithReference(sql)
+      .WaitFor(sql);
 
-   builder.AddProject<Projects.SupportTicketApi_Api>("api")
-   .WithReference(sql)
-   .WithReference(migrations)
-   .WaitForCompletion(migrations);
+      builder.AddProject<Projects.SupportTicketApi_Api>("api")
+      .WithReference(sql)
+      .WithReference(migrations)
+      .WaitForCompletion(migrations);
 
-   builder.Build().Run();
+      builder.Build().Run();
 
-```
+   ```
 
    </Fragment>
    </AppHostTabs>
@@ -414,7 +414,6 @@ In the preceding code, the call to `AddDatabase` adds a representation of a SQL 
 The code creates the SQL Server container each time it runs and applies migrations to it. Data doesn't persist across debugging sessions and any new database rows you create during testing will not survive an app restart. If you would prefer to persist this data, add a data volume to your container. For more information, see [Add SQL Server resource with data volume](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume).
 :::
 
-```
 1. If the code cannot resolve the migration service project, add a reference to the migration service project in the AppHost project:
 
 ```bash title=".NET CLI"
@@ -478,7 +477,7 @@ Create a dedicated migration service for each database. This approach provides b
         </Fragment>
         </AppHostTabs>
 
-    </Steps>
+</Steps>
 
 ### Option 2: Single migration service with multiple contexts
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
@@ -375,11 +375,11 @@ The migration service is created, but it needs to be added to the Aspire AppHost
 1. Add the following highlighted code:
 
       <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -447,11 +447,11 @@ Create a dedicated migration service for each database. This approach provides b
 1.  Add both migration services to your AppHost:
 
         <AppHostTabs limitations={{
-          typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-          python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-          go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-          java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-          rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+          typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+          python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+          go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+          java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+          rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
         }}>
         <Fragment slot="csharp">
         ```csharp title="AppHost.cs"
@@ -587,11 +587,11 @@ dotnet add package Aspire.Hosting.EntityFrameworkCore
 Call `AddEFMigrations` on any project resource that hosts an EF Core `DbContext`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -612,11 +612,11 @@ The first argument is a resource name for the migration resource. The optional s
 If your migrations live in a separate project (for example, `Projects.Data`), reference that project from your AppHost and point to it using `.WithMigrationsProject<Projects.Data>()`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -632,11 +632,11 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
 To apply migrations automatically when running locally with [`aspire run`](/reference/cli/commands/aspire-run/), chain `RunDatabaseUpdateOnStart()`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -669,11 +669,11 @@ When `RunDatabaseUpdateOnStart()` is called, a health check is registered for th
 To generate migration artifacts during [`aspire publish`](/reference/cli/commands/aspire-publish/), use `PublishAsMigrationScript` or `PublishAsMigrationBundle`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -693,11 +693,11 @@ Both methods add pipeline steps that run during [`aspire publish`](/reference/cl
 Pass `publishContainer: true` to `PublishAsMigrationBundle` to wrap the generated bundle in a container image. The migration resource becomes a compute resource that each compute environment (Docker Compose, Azure Container Apps, Kubernetes, and so on) deploys like any other container:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -736,11 +736,11 @@ A migration bundle is idempotent (running it twice is safe), but different compu
 Publish the migration resource as an [Azure Container App Job](https://learn.microsoft.com/azure/container-apps/jobs) so it runs once and stops:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -760,11 +760,11 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
 Tell Compose not to restart the container after it exits:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/migrations.mdx
@@ -3,6 +3,8 @@ title: Apply EF Core migrations in Aspire
 description: Learn about how to apply Entity Framework Core migrations in Aspire, including running migrations at startup and publishing migration bundles as container images for deployment.
 ---
 
+import AppHostTabs from '@components/AppHostTabs.astro';
+
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
 import { Kbd } from 'starlight-kbd/components';
 import ThemeImage from '@components/ThemeImage.astro';
@@ -32,7 +34,7 @@ This tutorial uses a sample app that demonstrates how to apply EF Core migration
 git clone https://github.com/MicrosoftDocs/aspire-docs-samples/
 ```
 
-The sample app is in the *SupportTicketApi* folder. Open the solution in Visual Studio or VS Code and take a moment to review the sample app and make sure it runs before proceeding. The sample app is a rudimentary support ticket API, and it contains the following projects:
+The sample app is in the _SupportTicketApi_ folder. Open the solution in Visual Studio or VS Code and take a moment to review the sample app and make sure it runs before proceeding. The sample app is a rudimentary support ticket API, and it contains the following projects:
 
 - **SupportTicketApi.Api**: The ASP.NET Core project that hosts the API.
 - **SupportTicketApi.AppHost**: Contains the Aspire AppHost and configuration.
@@ -82,6 +84,7 @@ Start by creating some migrations to apply.
         - Creates a migration named *InitialCreate*.
         - Creates the migration in the in the *Migrations* folder in the *SupportTicketApi.Data* project.
     </Steps>
+
   </TabItem>
   <TabItem label="Package Manager Console">
 
@@ -103,43 +106,42 @@ Start by creating some migrations to apply.
 
     </Steps>
     </TabItem>
+
 </Tabs>
 
 <Steps>
 
 1. Modify the model so that it includes a new property. Open `SupportTicketApi.Data/Models/SupportTicket.cs` and add a new property to the `SupportTicket` class:
 
-    ```csharp title="SupportTicket.cs" {12}
-    using System.ComponentModel.DataAnnotations;
+   ```csharp title="SupportTicket.cs" {12}
+   using System.ComponentModel.DataAnnotations;
 
-    namespace SupportTicketApi.Data.Models;
+   namespace SupportTicketApi.Data.Models;
 
-    public sealed class SupportTicket
-    {
-        public int Id { get; set; }
-        [Required]
-        public string Title { get; set; } = string.Empty;
-        [Required]
-        public string Description { get; set; } = string.Empty;
-        public bool Completed { get; set; }
-    }
+   public sealed class SupportTicket
+   {
+       public int Id { get; set; }
+       [Required]
+       public string Title { get; set; } = string.Empty;
+       [Required]
+       public string Description { get; set; } = string.Empty;
+       public bool Completed { get; set; }
+   }
 
-    ```
+   ```
 
 1. Create another new migration to capture the changes to the model:
 
-    <Tabs syncKey='nuget-installer'>
-    <TabItem label=".NET CLI">    
-        ```bash title=".NET CLI"
-        dotnet ef migrations add AddCompleted --project ../SupportTicketApi.Data/SupportTicketApi.Data.csproj
-        ```
-    </TabItem>
-    <TabItem label="Package Manager Console">
-        ```powershell title="Package Manager Console"
-        Add-Migration AddCompleted
-        ```
-    </TabItem>
-    </Tabs>
+   <Tabs syncKey="nuget-installer">
+     <TabItem label=".NET CLI">
+       ```bash title=".NET CLI" dotnet ef migrations add AddCompleted --project
+       ../SupportTicketApi.Data/SupportTicketApi.Data.csproj ```
+     </TabItem>
+     <TabItem label="Package Manager Console">
+       ```powershell title="Package Manager Console" Add-Migration AddCompleted
+       ```
+     </TabItem>
+   </Tabs>
 
 </Steps>
 
@@ -160,13 +162,13 @@ If you get an error like "No database provider has been configured for this DbCo
 1. In your API project (where the DbContext is registered), open or create an `appsettings.json` file.
 1. Add a connection string with the same name used in your Aspire AppHost:
 
-    ```json title="appsettings.json"
-    {
-      "ConnectionStrings": {
-        "ticketdb": "Server=(localdb)\\mssqllocaldb;Database=TicketDb;Trusted_Connection=true"
-      }
-    }
-    ```
+   ```json title="appsettings.json"
+   {
+     "ConnectionStrings": {
+       "ticketdb": "Server=(localdb)\\mssqllocaldb;Database=TicketDb;Trusted_Connection=true"
+     }
+   }
+   ```
 
 1. Run your migration commands as normal.
 1. Remove the connection string from `appsettings.json` when you're done, as Aspire will provide it at runtime.
@@ -186,13 +188,13 @@ When your Aspire solution has multiple services with different databases, create
 1. Navigate to each service project directory that has a DbContext.
 1. Run migration commands with the appropriate project reference:
 
-    ```bash title=".NET CLI"
-    # For the first service/database
-    dotnet ef migrations add InitialCreate --project ../FirstService.Data/FirstService.Data.csproj
+   ```bash title=".NET CLI"
+   # For the first service/database
+   dotnet ef migrations add InitialCreate --project ../FirstService.Data/FirstService.Data.csproj
 
-    # For the second service/database  
-    dotnet ef migrations add InitialCreate --project ../SecondService.Data/SecondService.Data.csproj
-    ```
+   # For the second service/database
+   dotnet ef migrations add InitialCreate --project ../SecondService.Data/SecondService.Data.csproj
+   ```
 
 1. Create separate migration services for each database, or handle multiple DbContexts in a single migration service.
 
@@ -210,7 +212,7 @@ Ensure you're running migration commands from the correct project:
 To execute migrations, call the EF Core `Microsoft.EntityFrameworkCore.Migrations.IMigrator.Migrate` method or the `IMigrator.MigrateAsync` method. In this tutorial, you'll create a separate worker service to apply migrations. This approach separates migration concerns into a dedicated project, which is easier to maintain and allows migrations to run before other services start.
 
 :::note
-**Where to create migrations**: Migrations should be created in the project that contains your Entity Framework DbContext and model classes (in this example, *SupportTicketApi.Data*). The migration service project references this data project to apply the migrations at startup.
+**Where to create migrations**: Migrations should be created in the project that contains your Entity Framework DbContext and model classes (in this example, _SupportTicketApi.Data_). The migration service project references this data project to apply the migrations at startup.
 :::
 
 To create a service that applies the migrations:
@@ -219,147 +221,147 @@ To create a service that applies the migrations:
 
 1. Add a new Worker Service project to the solution. If using Visual Studio, right-click the solution in Solution Explorer and select `Add > New Project`. Select `Worker Service`, name the project `SupportTicketApi.MigrationService` and target **.NET 10.0**. If using the command line, use the following commands from the solution directory:
 
-    ```bash title=".NET CLI"
-    dotnet new worker -n SupportTicketApi.MigrationService -f "net10.0"
-    dotnet sln add SupportTicketApi.MigrationService
-    ```
+   ```bash title=".NET CLI"
+   dotnet new worker -n SupportTicketApi.MigrationService -f "net10.0"
+   dotnet sln add SupportTicketApi.MigrationService
+   ```
 
-1. Add the SupportTicketApi.Data` and `SupportTicketApi.ServiceDefaults` project references to the `SupportTicketApi.MigrationService` project using Visual Studio or the command line:
+1. Add the SupportTicketApi.Data`and`SupportTicketApi.ServiceDefaults`project references to the`SupportTicketApi.MigrationService` project using Visual Studio or the command line:
 
-    ```bash title=".NET CLI"
-    dotnet add SupportTicketApi.MigrationService reference SupportTicketApi.Data
-    dotnet add SupportTicketApi.MigrationService reference SupportTicketApi.ServiceDefaults
-    ```
+   ```bash title=".NET CLI"
+   dotnet add SupportTicketApi.MigrationService reference SupportTicketApi.Data
+   dotnet add SupportTicketApi.MigrationService reference SupportTicketApi.ServiceDefaults
+   ```
 
-1. Add the [📦 Aspire.Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Aspire.Microsoft.EntityFrameworkCore.SqlServer) NuGet package reference to the *`SupportTicketApi.MigrationService`* project using Visual Studio or the command line:
+1. Add the [📦 Aspire.Microsoft.EntityFrameworkCore.SqlServer](https://www.nuget.org/packages/Aspire.Microsoft.EntityFrameworkCore.SqlServer) NuGet package reference to the _`SupportTicketApi.MigrationService`_ project using Visual Studio or the command line:
 
-    ```bash title=".NET CLI"
-    cd SupportTicketApi.MigrationService
-    dotnet add package Aspire.Microsoft.EntityFrameworkCore.SqlServer -v "%ASPIRE_VERSION%"
-    ```
+   ```bash title=".NET CLI"
+   cd SupportTicketApi.MigrationService
+   dotnet add package Aspire.Microsoft.EntityFrameworkCore.SqlServer -v "%ASPIRE_VERSION%"
+   ```
 
-    :::tip
-    In some cases, you might also need to add the [📦 Microsoft.EntityFrameworkCore.Tools](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools) package to prevent EF Core from failing silently without applying migrations. This is particularly relevant when using databases other than SQL Server, such as PostgreSQL. For more information, see [dotnet/efcore#27215](https://github.com/dotnet/efcore/issues/27215#issuecomment-2045767772).
-    :::
+   :::tip
+   In some cases, you might also need to add the [📦 Microsoft.EntityFrameworkCore.Tools](https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.Tools) package to prevent EF Core from failing silently without applying migrations. This is particularly relevant when using databases other than SQL Server, such as PostgreSQL. For more information, see [dotnet/efcore#27215](https://github.com/dotnet/efcore/issues/27215#issuecomment-2045767772).
+   :::
 
-1. Add the highlighted lines to the *`Program.cs`* file in the *`SupportTicketApi.MigrationService`* project:
+1. Add the highlighted lines to the _`Program.cs`_ file in the _`SupportTicketApi.MigrationService`_ project:
 
-    ```csharp title="Program.cs" {6,9-10,12}
-    using SupportTicketApi.Data.Contexts;
-    using SupportTicketApi.MigrationService;
+   ```csharp title="Program.cs" {6,9-10,12}
+   using SupportTicketApi.Data.Contexts;
+   using SupportTicketApi.MigrationService;
 
-    var builder = Host.CreateApplicationBuilder(args);
+   var builder = Host.CreateApplicationBuilder(args);
 
-    builder.AddServiceDefaults();
-    builder.Services.AddHostedService<Worker>();
+   builder.AddServiceDefaults();
+   builder.Services.AddHostedService<Worker>();
 
-    builder.Services.AddOpenTelemetry()
-        .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
+   builder.Services.AddOpenTelemetry()
+       .WithTracing(tracing => tracing.AddSource(Worker.ActivitySourceName));
 
-    builder.AddSqlServerDbContext<TicketContext>("sqldata");
+   builder.AddSqlServerDbContext<TicketContext>("sqldata");
 
-    var host = builder.Build();
-    host.Run();
-    ```
+   var host = builder.Build();
+   host.Run();
+   ```
 
-    In the preceding code:
+   In the preceding code:
 
-    - The `AddServiceDefaults` extension method [adds service defaults functionality](/get-started/csharp-service-defaults/#add-service-defaults-functionality).
-    - The `AddOpenTelemetry` extension method [configures OpenTelemetry functionality](/fundamentals/telemetry/#aspire-opentelemetry-integration).
-    - The `AddSqlServerDbContext` extension method adds the `TicketContext` service to the service collection. This service is used to run migrations and seed the database.
+   - The `AddServiceDefaults` extension method [adds service defaults functionality](/get-started/csharp-service-defaults/#add-service-defaults-functionality).
+   - The `AddOpenTelemetry` extension method [configures OpenTelemetry functionality](/fundamentals/telemetry/#aspire-opentelemetry-integration).
+   - The `AddSqlServerDbContext` extension method adds the `TicketContext` service to the service collection. This service is used to run migrations and seed the database.
 
-1. Replace the contents of the `Worker.cs` file in the *`SupportTicketApi.MigrationService`* project with the following code:
+1. Replace the contents of the `Worker.cs` file in the _`SupportTicketApi.MigrationService`_ project with the following code:
 
-    ```csharp title="Worker.cs"
-    using System.Diagnostics;
+   ```csharp title="Worker.cs"
+   using System.Diagnostics;
 
-    using Microsoft.EntityFrameworkCore;
-    using Microsoft.EntityFrameworkCore.Infrastructure;
-    using Microsoft.EntityFrameworkCore.Storage;
+   using Microsoft.EntityFrameworkCore;
+   using Microsoft.EntityFrameworkCore.Infrastructure;
+   using Microsoft.EntityFrameworkCore.Storage;
 
-    using OpenTelemetry.Trace;
+   using OpenTelemetry.Trace;
 
-    using SupportTicketApi.Data.Contexts;
-    using SupportTicketApi.Data.Models;
+   using SupportTicketApi.Data.Contexts;
+   using SupportTicketApi.Data.Models;
 
-    namespace SupportTicketApi.MigrationService;
+   namespace SupportTicketApi.MigrationService;
 
-    public class Worker(
-        IServiceProvider serviceProvider,
-        IHostApplicationLifetime hostApplicationLifetime) : BackgroundService
-    {
-        public const string ActivitySourceName = "Migrations";
-        private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
+   public class Worker(
+       IServiceProvider serviceProvider,
+       IHostApplicationLifetime hostApplicationLifetime) : BackgroundService
+   {
+       public const string ActivitySourceName = "Migrations";
+       private static readonly ActivitySource s_activitySource = new(ActivitySourceName);
 
-        protected override async Task ExecuteAsync(
-            CancellationToken cancellationToken)
-        {
-            using var activity = s_activitySource.StartActivity(
-                "Migrating database", ActivityKind.Client);
+       protected override async Task ExecuteAsync(
+           CancellationToken cancellationToken)
+       {
+           using var activity = s_activitySource.StartActivity(
+               "Migrating database", ActivityKind.Client);
 
-            try
-            {
-                using var scope = serviceProvider.CreateScope();
-                var dbContext = scope.ServiceProvider.GetRequiredService<TicketContext>();
+           try
+           {
+               using var scope = serviceProvider.CreateScope();
+               var dbContext = scope.ServiceProvider.GetRequiredService<TicketContext>();
 
-                await RunMigrationAsync(dbContext, cancellationToken);
-                await SeedDataAsync(dbContext, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                activity?.AddException(ex);
-                throw;
-            }
+               await RunMigrationAsync(dbContext, cancellationToken);
+               await SeedDataAsync(dbContext, cancellationToken);
+           }
+           catch (Exception ex)
+           {
+               activity?.AddException(ex);
+               throw;
+           }
 
-            hostApplicationLifetime.StopApplication();
-        }
+           hostApplicationLifetime.StopApplication();
+       }
 
-        private static async Task RunMigrationAsync(
-            TicketContext dbContext, CancellationToken cancellationToken)
-        {
-            var strategy = dbContext.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                // Run migration in a transaction to avoid partial migration if it fails.
-                await dbContext.Database.MigrateAsync(cancellationToken);
-            });
-        }
+       private static async Task RunMigrationAsync(
+           TicketContext dbContext, CancellationToken cancellationToken)
+       {
+           var strategy = dbContext.Database.CreateExecutionStrategy();
+           await strategy.ExecuteAsync(async () =>
+           {
+               // Run migration in a transaction to avoid partial migration if it fails.
+               await dbContext.Database.MigrateAsync(cancellationToken);
+           });
+       }
 
-        private static async Task SeedDataAsync(
-            TicketContext dbContext, CancellationToken cancellationToken)
-        {
-            SupportTicket firstTicket = new()
-            {
-                Title = "Test Ticket",
-                Description = "Default ticket, please ignore!",
-                Completed = true
-            };
+       private static async Task SeedDataAsync(
+           TicketContext dbContext, CancellationToken cancellationToken)
+       {
+           SupportTicket firstTicket = new()
+           {
+               Title = "Test Ticket",
+               Description = "Default ticket, please ignore!",
+               Completed = true
+           };
 
-            var strategy = dbContext.Database.CreateExecutionStrategy();
-            await strategy.ExecuteAsync(async () =>
-            {
-                // Seed the database
-                await using var transaction = await dbContext.Database
-                    .BeginTransactionAsync(cancellationToken);
+           var strategy = dbContext.Database.CreateExecutionStrategy();
+           await strategy.ExecuteAsync(async () =>
+           {
+               // Seed the database
+               await using var transaction = await dbContext.Database
+                   .BeginTransactionAsync(cancellationToken);
 
-                await dbContext.Tickets.AddAsync(firstTicket, cancellationToken);
-                await dbContext.SaveChangesAsync(cancellationToken);
-                await transaction.CommitAsync(cancellationToken);
-            });
-        }
-    }
-    ```
+               await dbContext.Tickets.AddAsync(firstTicket, cancellationToken);
+               await dbContext.SaveChangesAsync(cancellationToken);
+               await transaction.CommitAsync(cancellationToken);
+           });
+       }
+   }
+   ```
 
-    In the preceding code:
+   In the preceding code:
 
-    - The `ExecuteAsync` method is called when the worker starts. It in turn performs the following steps:
-      <Steps>
-      1. Gets a reference to the `TicketContext` service from the service provider.
-      1. Calls `RunMigrationAsync` to apply any pending migrations.
-      1. Calls `SeedDataAsync` to seed the database with initial data.
-      1. Stops the worker with `StopApplication`.
-      </Steps>
-    - The `RunMigrationAsync` and `SeedDataAsync` methods both encapsulate their respective database operations using execution strategies to handle transient errors that may occur when interacting with the database. To learn more about execution strategies, see [Connection Resiliency](https://learn.microsoft.com/ef/core/miscellaneous/connection-resiliency).
+   - The `ExecuteAsync` method is called when the worker starts. It in turn performs the following steps:
+     <Steps>
+       1. Gets a reference to the `TicketContext` service from the service
+       provider. 1. Calls `RunMigrationAsync` to apply any pending migrations.
+       1. Calls `SeedDataAsync` to seed the database with initial data. 1. Stops
+       the worker with `StopApplication`.
+     </Steps>
+   - The `RunMigrationAsync` and `SeedDataAsync` methods both encapsulate their respective database operations using execution strategies to handle transient errors that may occur when interacting with the database. To learn more about execution strategies, see [Connection Resiliency](https://learn.microsoft.com/ef/core/miscellaneous/connection-resiliency).
 
 </Steps>
 
@@ -369,46 +371,58 @@ The migration service is created, but it needs to be added to the Aspire AppHost
 
 <Steps>
 
-1. In the *`SupportTicketApi.AppHost`* project, open the *`AppHost.cs`* file.
+1. In the _`SupportTicketApi.AppHost`_ project, open the _`AppHost.cs`_ file.
 1. Add the following highlighted code:
 
-    ```csharp title="AppHost.cs" {6-8,12-13}
-    var builder = DistributedApplication.CreateBuilder(args);
+      <AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
-    var sql = builder.AddSqlServer("sql")
-        .AddDatabase("sqldata");
+```csharp title="AppHost.cs" {6-8,12-13}
+var builder = DistributedApplication.CreateBuilder(args);
 
-    var migrations = builder.AddProject<Projects.SupportTicketApi_MigrationService>("migrations")
-        .WithReference(sql)
-        .WaitFor(sql);
+   var sql = builder.AddSqlServer("sql")
+   .AddDatabase("sqldata");
 
-    builder.AddProject<Projects.SupportTicketApi_Api>("api")
-        .WithReference(sql)
-        .WithReference(migrations)
-        .WaitForCompletion(migrations);
+   var migrations = builder.AddProject<Projects.SupportTicketApi_MigrationService>("migrations")
+   .WithReference(sql)
+   .WaitFor(sql);
 
-    builder.Build().Run();
-    ```
+   builder.AddProject<Projects.SupportTicketApi_Api>("api")
+   .WithReference(sql)
+   .WithReference(migrations)
+   .WaitForCompletion(migrations);
 
-    This code enlists the *`SupportTicketApi.MigrationService`* project as a service in the Aspire AppHost. It also ensures that the API resource doesn't run until the migrations are complete.
+   builder.Build().Run();
 
-    :::note
-    In the preceding code, the call to `AddDatabase` adds a representation of a SQL Server database to the Aspire application model with a connection string. It *doesn't* create a database in the SQL Server container. To ensure that the database is created, the sample project calls the EF Core `IDatabaseCreator.EnsureCreated` method from the support ticket API's `Program.cs` file.
-    :::
+```
 
-    :::tip
-    The code creates the SQL Server container each time it runs and applies migrations to it. Data doesn't persist across debugging sessions and any new database rows you create during testing will not survive an app restart. If you would prefer to persist this data, add a data volume to your container. For more information, see [Add SQL Server resource with data volume](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume).
-    :::
+   </Fragment>
+   </AppHostTabs>
+   This code enlists the *`SupportTicketApi.MigrationService`* project as a service in the Aspire AppHost. It also ensures that the API resource doesn't run until the migrations are complete.
 
+:::note
+In the preceding code, the call to `AddDatabase` adds a representation of a SQL Server database to the Aspire application model with a connection string. It _doesn't_ create a database in the SQL Server container. To ensure that the database is created, the sample project calls the EF Core `IDatabaseCreator.EnsureCreated` method from the support ticket API's `Program.cs` file.
+:::
+
+:::tip
+The code creates the SQL Server container each time it runs and applies migrations to it. Data doesn't persist across debugging sessions and any new database rows you create during testing will not survive an app restart. If you would prefer to persist this data, add a data volume to your container. For more information, see [Add SQL Server resource with data volume](/integrations/databases/sql-server/sql-server-host/#add-sql-server-resource-with-data-volume).
+:::
+
+```
 1. If the code cannot resolve the migration service project, add a reference to the migration service project in the AppHost project:
 
-    ```bash title=".NET CLI"
-    dotnet add SupportTicketApi.AppHost reference SupportTicketApi.MigrationService
-    ```
-
-    :::caution
-    If you are using Visual Studio, and you selected the **`Enlist in Aspire orchestration`** option when creating the Worker Service project, similar code is added automatically with the service name `supportticketapi-migrationservice`. Replace that code with the preceding code.
-    :::
+```bash title=".NET CLI"
+dotnet add SupportTicketApi.AppHost reference SupportTicketApi.MigrationService
+```
+:::caution
+If you are using Visual Studio, and you selected the **`Enlist in Aspire orchestration`** option when creating the Worker Service project, similar code is added automatically with the service name `supportticketapi-migrationservice`. Replace that code with the preceding code.
+:::
 
 </Steps>
 
@@ -422,37 +436,49 @@ Create a dedicated migration service for each database. This approach provides b
 
 <Steps>
 
-1. Create separate migration service projects for each database:
+1.  Create separate migration service projects for each database:
 
     ```bash title=".NET CLI"
     dotnet new worker -n FirstService.MigrationService -f "net8.0"
     dotnet new worker -n SecondService.MigrationService -f "net8.0"
     ```
 
-1. Configure each migration service to handle its specific database context.
-1. Add both migration services to your AppHost:
+1.  Configure each migration service to handle its specific database context.
+1.  Add both migration services to your AppHost:
 
-    ```csharp title="AppHost.cs"
-    var firstDb = sqlServer.AddDatabase("firstdb");
-    var secondDb = postgres.AddDatabase("seconddb");
+        <AppHostTabs limitations={{
+          typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+          python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+          go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+          java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+          rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+        }}>
+        <Fragment slot="csharp">
+        ```csharp title="AppHost.cs"
+        var firstDb = sqlServer.AddDatabase("firstdb");
+        var secondDb = postgres.AddDatabase("seconddb");
 
-    var firstMigrations = builder.AddProject<Projects.FirstService_MigrationService>()
-        .WithReference(firstDb);
+        var firstMigrations = builder.AddProject<Projects.FirstService_MigrationService>()
+            .WithReference(firstDb);
 
-    var secondMigrations = builder.AddProject<Projects.SecondService_MigrationService>()
-        .WithReference(secondDb);
+        var secondMigrations = builder.AddProject<Projects.SecondService_MigrationService>()
+            .WithReference(secondDb);
 
-    // Ensure services wait for their respective migrations
-    builder.AddProject<Projects.FirstService_Api>()
-        .WithReference(firstDb)
-        .WaitFor(firstMigrations);
+        // Ensure services wait for their respective migrations
+        builder.AddProject<Projects.FirstService_Api>()
+            .WithReference(firstDb)
+            .WaitFor(firstMigrations);
 
-    builder.AddProject<Projects.SecondService_Api>()
-        .WithReference(secondDb)
-        .WaitFor(secondMigrations);
-    ```
+        builder.AddProject<Projects.SecondService_Api>()
+            .WithReference(secondDb)
+            .WaitFor(secondMigrations);
+        ```
 
-</Steps>
+
+        </Fragment>
+        </AppHostTabs>
+
+    </Steps>
 
 ### Option 2: Single migration service with multiple contexts
 
@@ -464,20 +490,20 @@ Alternatively, you can create one migration service that handles multiple databa
 1. Register all DbContexts in the migration service's `Program.cs`.
 1. Modify the `Worker.cs` to apply migrations for each context:
 
-    ```csharp title="Worker.cs"
-    public async Task<bool> RunMigrationAsync(IServiceProvider serviceProvider)
-    {
-        await using var scope = serviceProvider.CreateAsyncScope();
-        
-        var firstContext = scope.ServiceProvider.GetRequiredService<FirstDbContext>();
-        var secondContext = scope.ServiceProvider.GetRequiredService<SecondDbContext>();
-        
-        await firstContext.Database.MigrateAsync();
-        await secondContext.Database.MigrateAsync();
-        
-        return true;
-    }
-    ```
+   ```csharp title="Worker.cs"
+   public async Task<bool> RunMigrationAsync(IServiceProvider serviceProvider)
+   {
+       await using var scope = serviceProvider.CreateAsyncScope();
+
+       var firstContext = scope.ServiceProvider.GetRequiredService<FirstDbContext>();
+       var secondContext = scope.ServiceProvider.GetRequiredService<SecondDbContext>();
+
+       await firstContext.Database.MigrateAsync();
+       await secondContext.Database.MigrateAsync();
+
+       return true;
+   }
+   ```
 
 </Steps>
 
@@ -487,33 +513,33 @@ Since the migration service seeds the database, you should remove the existing d
 
 <Steps>
 
-1. In the *`SupportTicketApi.Api`* project, open the *`Program.cs`* file.
+1. In the _`SupportTicketApi.Api`_ project, open the _`Program.cs`_ file.
 1. Delete the highlighted lines.
 
-    ```csharp title="Program.cs" {6-21}
-    if (app.Environment.IsDevelopment())
-    {
-        app.UseSwagger();
-        app.UseSwaggerUI();
+   ```csharp title="Program.cs" {6-21}
+   if (app.Environment.IsDevelopment())
+   {
+       app.UseSwagger();
+       app.UseSwaggerUI();
 
-        using (var scope = app.Services.CreateScope())
-        {
-            var context = scope.ServiceProvider.GetRequiredService<TicketContext>();
-            context.Database.EnsureCreated();
+       using (var scope = app.Services.CreateScope())
+       {
+           var context = scope.ServiceProvider.GetRequiredService<TicketContext>();
+           context.Database.EnsureCreated();
 
-            if(!context.Tickets.Any())
-            {
-                context.Tickets.Add(new SupportTicket
-                {
-                    Title = "Initial Ticket",
-                    Description = "Test ticket, please ignore."
-                });
+           if(!context.Tickets.Any())
+           {
+               context.Tickets.Add(new SupportTicket
+               {
+                   Title = "Initial Ticket",
+                   Description = "Test ticket, please ignore."
+               });
 
-                context.SaveChanges();
-            }
-        }
-    }
-    ```
+               context.SaveChanges();
+           }
+       }
+   }
+   ```
 
 </Steps>
 
@@ -526,10 +552,11 @@ Now that the migration service is configured, run the app to test the migrations
 1. Run the app and observe the `SupportTicketApi` dashboard.
 1. After a short wait, the `migrations` service state will display **Finished**.
 
-    <ThemeImage
-      dark={dashboardPostMigrationDark}
-      light={dashboardPostMigrationLight}
-      alt="A screenshot of the Aspire dashboard with the migration service in a Finished state." />
+   <ThemeImage
+     dark={dashboardPostMigrationDark}
+     light={dashboardPostMigrationLight}
+     alt="A screenshot of the Aspire dashboard with the migration service in a Finished state."
+   />
 
 1. Select the `Console logs` icon on the migration service to investigate the logs showing the SQL commands that were executed.
 
@@ -559,27 +586,59 @@ dotnet add package Aspire.Hosting.EntityFrameworkCore
 
 Call `AddEFMigrations` on any project resource that hosts an EF Core `DbContext`:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var db = builder.AddPostgres("pg").AddDatabase("appdb");
 
 var api = builder.AddProject<Projects.Api>("api")
-    .WithReference(db);
+.WithReference(db);
 
 var apiMigrations = api.AddEFMigrations("api-migrations");
+
 ```
 
+</Fragment>
+</AppHostTabs>
 The first argument is a resource name for the migration resource. The optional second argument is the fully qualified name of the `DbContext` type; it's only required when the target assembly contains more than one `DbContext`.
 
 If your migrations live in a separate project (for example, `Projects.Data`), reference that project from your AppHost and point to it using `.WithMigrationsProject<Projects.Data>()`:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var apiMigrations = api.AddEFMigrations("api-migrations")
     .WithMigrationsProject<Projects.Data>();
 ```
 
+</Fragment>
+</AppHostTabs>
 ### Run migrations on startup
 
 To apply migrations automatically when running locally with [`aspire run`](/reference/cli/commands/aspire-run/), chain `RunDatabaseUpdateOnStart()`:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var apiMigrations = api.AddEFMigrations("api-migrations")
@@ -587,8 +646,11 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
 
 // The api project waits for migrations to complete before starting
 api.WaitForCompletion(apiMigrations);
+
 ```
 
+</Fragment>
+</AppHostTabs>
 :::note
 `RunDatabaseUpdateOnStart` only affects local run mode. The migration resource is not deployed with the app, so this call has no effect during [`aspire publish`](/reference/cli/commands/aspire-publish/) or deployment.
 :::
@@ -606,6 +668,15 @@ When `RunDatabaseUpdateOnStart()` is called, a health check is registered for th
 
 To generate migration artifacts during [`aspire publish`](/reference/cli/commands/aspire-publish/), use `PublishAsMigrationScript` or `PublishAsMigrationBundle`:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 // Generate both a SQL script and a self-contained bundle during publish
 var apiMigrations = api.AddEFMigrations("api-migrations")
@@ -613,22 +684,36 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
     .PublishAsMigrationBundle();
 ```
 
+</Fragment>
+</AppHostTabs>
 Both methods add pipeline steps that run during [`aspire publish`](/reference/cli/commands/aspire-publish/) and write their artifacts into the publish output directory under `efmigrations/`.
 
 ### Publish the migration bundle as a container image
 
 Pass `publishContainer: true` to `PublishAsMigrationBundle` to wrap the generated bundle in a container image. The migration resource becomes a compute resource that each compute environment (Docker Compose, Azure Container Apps, Kubernetes, and so on) deploys like any other container:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var db  = builder.AddPostgres("pg").AddDatabase("appdb");
 var api = builder.AddProject<Projects.Api>("api").WithReference(db);
 
 var apiMigrations = api.AddEFMigrations("api-migrations")
-    .WithReference(db)
-    .WaitFor(db)
-    .PublishAsMigrationBundle(publishContainer: true);
+.WithReference(db)
+.WaitFor(db)
+.PublishAsMigrationBundle(publishContainer: true);
+
 ```
 
+</Fragment>
+</AppHostTabs>
 :::note
 When using `publishContainer: true`, declaring both `.WithReference(db)` and `.WaitFor(db)` is the recommended approach. `.WithReference(db)` provides the authoritative connection-string source for the migration container, and `.WaitFor(db)` ensures the database is healthy before the container starts.
 
@@ -650,6 +735,15 @@ A migration bundle is idempotent (running it twice is safe), but different compu
 
 Publish the migration resource as an [Azure Container App Job](https://learn.microsoft.com/azure/container-apps/jobs) so it runs once and stops:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var apiMigrations = api.AddEFMigrations("api-migrations")
     .WithReference(db)
@@ -658,10 +752,21 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
     .PublishAsAzureContainerAppJob(); // requires Aspire.Hosting.Azure.AppContainers
 ```
 
+</Fragment>
+</AppHostTabs>
 </TabItem>
 <TabItem label="Docker Compose">
 
 Tell Compose not to restart the container after it exits:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var apiMigrations = api.AddEFMigrations("api-migrations")
@@ -671,6 +776,8 @@ var apiMigrations = api.AddEFMigrations("api-migrations")
     .PublishAsDockerComposeService((_, service) => service.Restart = "no"); // requires Aspire.Hosting.Docker
 ```
 
+</Fragment>
+</AppHostTabs>
 </TabItem>
 <TabItem label="Kubernetes">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
@@ -46,11 +46,11 @@ aspire add oracle
 Or, choose a manual installation approach:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -69,11 +69,11 @@ Or, choose a manual installation approach:
 In the AppHost project, call `AddOracle` to add and return an Oracle server resource builder. Chain a call to `AddDatabase` on the returned resource builder to add an Oracle database to the server resource:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -118,11 +118,11 @@ When you reference an Oracle resource from the AppHost, Aspire makes several pro
 The Oracle resource includes default credentials with a random password. Oracle supports configuration-based default passwords using the `ORACLE_PWD` environment variable. When you want to provide a password explicitly, pass it as a parameter:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -160,11 +160,11 @@ For more information, see [External parameters](/get-started/resources/).
 To add a data volume to the Oracle resource, call the `WithDataVolume` method:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -198,11 +198,11 @@ The password is stored in the data volume. When using a data volume and if the p
 To add a data bind mount to the Oracle resource, call the `WithDataBindMount` method:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/oracle/oracle-host.mdx
@@ -1,8 +1,10 @@
 ---
 title: Set up Oracle in the AppHost
-seoTitle: "Set up Oracle in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Oracle in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Oracle Hosting integration to orchestrate and configure an Oracle database in an Aspire solution.
 ---
+
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 import { Image } from 'astro:assets';
 import { Aside, Steps } from '@astrojs/starlight/components';
@@ -24,7 +26,8 @@ This article is the reference for the Aspire Oracle Hosting integration. It enum
 If you're new to the Oracle EF Core integration, start with the [Get started with Oracle EF Core integrations](/integrations/databases/efcore/oracle/oracle-get-started/) guide. For how consuming C# apps connect to the database this page exposes, see [Connect to Oracle with EF Core](../oracle-connect/).
 
 <Aside type="note">
-TypeScript AppHost support for the Oracle EF Core hosting integration is not yet available.
+  TypeScript AppHost support for the Oracle EF Core hosting integration is not
+  yet available.
 </Aside>
 
 ## Installation
@@ -42,10 +45,21 @@ aspire add oracle
 
 Or, choose a manual installation approach:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #:package Aspire.Hosting.Oracle@*
 ```
 
+</Fragment>
+</AppHostTabs>
 ```xml title="AppHost.csproj"
 <PackageReference Include="Aspire.Hosting.Oracle" Version="*" />
 ```
@@ -54,21 +68,33 @@ Or, choose a manual installation approach:
 
 In the AppHost project, call `AddOracle` to add and return an Oracle server resource builder. Chain a call to `AddDatabase` on the returned resource builder to add an Oracle database to the server resource:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var oracle = builder.AddOracle("oracle")
-                    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var oracledb = oracle.AddDatabase("oracledb");
 
 builder.AddProject<Projects.ExampleProject>()
-       .WithReference(oracledb)
-       .WaitFor(oracledb);
+.WithReference(oracledb)
+.WaitFor(oracledb);
 
 // After adding all resources, run the app...
+
 ```
 
+</Fragment>
+</AppHostTabs>
 <Steps>
 
 1. When Aspire adds a container image to the AppHost, as shown in the preceding example with the `container-registry.oracle.com/database/free` image, it creates a new Oracle server instance on your local machine.
@@ -91,6 +117,15 @@ When you reference an Oracle resource from the AppHost, Aspire makes several pro
 
 The Oracle resource includes default credentials with a random password. Oracle supports configuration-based default passwords using the `ORACLE_PWD` environment variable. When you want to provide a password explicitly, pass it as a parameter:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -106,6 +141,8 @@ var myService = builder.AddProject<Projects.ExampleProject>()
                        .WaitFor(oracledb);
 ```
 
+</Fragment>
+</AppHostTabs>
 The preceding code gets a parameter to pass to the `AddOracle` API, and internally assigns the parameter to the `ORACLE_PWD` environment variable of the Oracle container. The `password` parameter is usually specified as a user secret:
 
 ```json title="secrets.json"
@@ -122,22 +159,34 @@ For more information, see [External parameters](/get-started/resources/).
 
 To add a data volume to the Oracle resource, call the `WithDataVolume` method:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var oracle = builder.AddOracle("oracle")
-                    .WithDataVolume()
-                    .WithLifetime(ContainerLifetime.Persistent);
+.WithDataVolume()
+.WithLifetime(ContainerLifetime.Persistent);
 
 var oracledb = oracle.AddDatabase("oracledb");
 
 builder.AddProject<Projects.ExampleProject>()
-       .WithReference(oracledb)
-       .WaitFor(oracledb);
+.WithReference(oracledb)
+.WaitFor(oracledb);
 
 // After adding all resources, run the app...
+
 ```
 
+</Fragment>
+</AppHostTabs>
 The data volume is used to persist the Oracle data outside the lifecycle of its container. The data volume is mounted at the `/opt/oracle/oradata` path in the Oracle container and, when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-oracle-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 :::danger
@@ -147,6 +196,15 @@ The password is stored in the data volume. When using a data volume and if the p
 ## Add Oracle resource with data bind mount
 
 To add a data bind mount to the Oracle resource, call the `WithDataBindMount` method:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -163,10 +221,13 @@ builder.AddProject<Projects.ExampleProject>()
 // After adding all resources, run the app...
 ```
 
+</Fragment>
+</AppHostTabs>
 <Aside>
 Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
 
 Data bind mounts rely on the host machine's filesystem to persist Oracle data across container restarts. The bind mount path is `C:\Oracle\Data` on Windows (or `/Oracle/Data` on Unix). For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
+
 </Aside>
 
 ## Hosting integration health checks

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -225,7 +225,7 @@ var postgres = builder.AddPostgres("postgres")
 // Configure the container to store data in a volume so that it persists across instances.
 .WithDataVolume()
 .WithPgWeb()
-// Keep the container running between app host sessions.
+// Keep the container running between AppHost sessions.
 .WithLifetime(ContainerLifetime.Persistent);
 
 // Add the default database to the application model so that it can be referenced by other resources.

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -144,11 +144,11 @@ Adjust the `Include` parameter to match the path to your SQL script in the proje
 Next, in the _AppHost.cs_ file, create the database and run the creation script:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -204,11 +204,11 @@ ON CONFLICT DO NOTHING;
 In the _AppHost.cs_ file, create the database and mount the folder that contains the SQL script as a bind mount:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -243,11 +243,11 @@ With Aspire, you can use the `WithCreationScript` method to ensure a MySQL scrip
 In the following AppHost code, the script is created as a string and passed to the `WithCreationScript` method:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/efcore/seed-database.mdx
@@ -3,6 +3,8 @@ title: Seed data in a database using Aspire
 description: Learn how to seed database data in Aspire projects using SQL scripts or Entity Framework Core during app startup.
 ---
 
+import AppHostTabs from '@components/AppHostTabs.astro';
+
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 import { Image } from 'astro:assets';
 import dotnetIcon from '@assets/icons/dotnet.svg';
@@ -105,7 +107,7 @@ END;
 GO
 ```
 
-You must ensure that this script is copied to the AppHost's output directory, so that Aspire can execute it. Add the following XML to your *.csproj* file:
+You must ensure that this script is copied to the AppHost's output directory, so that Aspire can execute it. Add the following XML to your _.csproj_ file:
 
 ```xml title="DatabaseContainers.AppHost.csproj" {11-15}
 <Project Sdk="Aspire.AppHost.Sdk/%ASPIRE_VERSION%">
@@ -141,6 +143,15 @@ Adjust the `Include` parameter to match the path to your SQL script in the proje
 
 Next, in the _AppHost.cs_ file, create the database and run the creation script:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var sqlserver = builder.AddSqlServer("sqlserver")
     // Configure the container to store data in a volume so that it persists across instances.
@@ -151,9 +162,12 @@ var sqlserver = builder.AddSqlServer("sqlserver")
 // Add the database to the application model so that it can be referenced by other resources.
 var initScriptPath = Path.Join(Path.GetDirectoryName(typeof(Program).Assembly.Location), "init.sql");
 var addressBookDb = sqlserver.AddDatabase("AddressBook")
-    .WithCreationScript(File.ReadAllText(initScriptPath));
+.WithCreationScript(File.ReadAllText(initScriptPath));
+
 ```
 
+</Fragment>
+</AppHostTabs>
 The preceding code:
 
 - Create a SQL Server container by calling `builder.AddSqlServer()`.
@@ -187,8 +201,16 @@ VALUES
     ('Do the groceries', false)
 ON CONFLICT DO NOTHING;
 ```
-
 In the _AppHost.cs_ file, create the database and mount the folder that contains the SQL script as a bind mount:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 // PostgreSQL container is configured with an auto-generated password by default
@@ -196,26 +218,38 @@ In the _AppHost.cs_ file, create the database and mount the folder that contains
 var todosDbName = "Todos";
 
 var postgres = builder.AddPostgres("postgres")
-    // Set the name of the default database to auto-create on container startup.
-    .WithEnvironment("POSTGRES_DB", todosDbName)
-    // Mount the SQL scripts directory into the container so that the init scripts run.
-    .WithBindMount("../DatabaseContainers.ApiService/data/postgres", "/docker-entrypoint-initdb.d")
-    // Configure the container to store data in a volume so that it persists across instances.
-    .WithDataVolume()
-    .WithPgWeb()
-    // Keep the container running between app host sessions.
-    .WithLifetime(ContainerLifetime.Persistent);
+// Set the name of the default database to auto-create on container startup.
+.WithEnvironment("POSTGRES_DB", todosDbName)
+// Mount the SQL scripts directory into the container so that the init scripts run.
+.WithBindMount("../DatabaseContainers.ApiService/data/postgres", "/docker-entrypoint-initdb.d")
+// Configure the container to store data in a volume so that it persists across instances.
+.WithDataVolume()
+.WithPgWeb()
+// Keep the container running between app host sessions.
+.WithLifetime(ContainerLifetime.Persistent);
 
 // Add the default database to the application model so that it can be referenced by other resources.
 var todosDb = postgres.AddDatabase(todosDbName);
+
 ```
 
+</Fragment>
+</AppHostTabs>
 </TabItem>
 <TabItem label="Pomelo MySQL">
 
 With Aspire, you can use the `WithCreationScript` method to ensure a MySQL script is run when the database is created. Add SQL code to this script that creates and populates the database, the necessary tables, and other database objects.
 
 In the following AppHost code, the script is created as a string and passed to the `WithCreationScript` method:
+
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -253,10 +287,12 @@ WHERE NOT EXISTS (SELECT NULL FROM catalog)
 
 var mysqldb = mysql.AddDatabase(catalogDbName)
                    .WithCreationScript(creationScript);
-                   
+
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
 The preceding code:
 
 - Create a MySQL container by calling `builder.AddMySql()`.
@@ -286,7 +322,7 @@ Add the following code to the `Program.cs` file of your **API Service** project:
 <TabItem label="SQL Server">
 
 ```csharp title="Program.cs"
-builder.AddSqlServerDbContext<TicketContext>("TicketsDB", 
+builder.AddSqlServerDbContext<TicketContext>("TicketsDB",
     configureDbContextOptions: options =>
 {
     if (builder.Environment.IsDevelopment())
@@ -306,7 +342,7 @@ builder.AddSqlServerDbContext<TicketContext>("TicketsDB",
             }
 
         });
-    
+
         options.UseAsyncSeeding(async (context, _, cancellationToken) =>
         {
             var testTicket = await context.Set<SupportTicket>()
@@ -363,7 +399,7 @@ builder.AddNpgsqlDbContext<TicketContext>("TicketsDB",
             }
 
         });
-    
+
         options.UseAsyncSeeding(async (context, _, cancellationToken) =>
         {
             var testTicket = await context.Set<SupportTicket>()
@@ -400,7 +436,7 @@ if (app.Environment.IsDevelopment())
 <TabItem label="Pomelo MySQL">
 
 ```csharp title="Program.cs"
-builder.AddMySqlDbContext<TicketContext>("TicketsDB", 
+builder.AddMySqlDbContext<TicketContext>("TicketsDB",
     configureDbContextOptions: options =>
 {
     if (builder.Environment.IsDevelopment())
@@ -420,7 +456,7 @@ builder.AddMySqlDbContext<TicketContext>("TicketsDB",
             }
 
         });
-    
+
         options.UseAsyncSeeding(async (context, _, cancellationToken) =>
         {
             var testTicket = await context.Set<SupportTicket>()
@@ -502,7 +538,7 @@ if (app.Environment.IsDevelopment())
             context.Tickets.AddRange(
                 new Ticket
                 {
-                    Title = "Example Ticket", 
+                    Title = "Example Ticket",
                     Description = "This is a sample ticket for testing"
                 }
             );
@@ -537,7 +573,7 @@ if (app.Environment.IsDevelopment())
             context.Tickets.AddRange(
                 new Ticket
                 {
-                    Title = "Example Ticket", 
+                    Title = "Example Ticket",
                     Description = "This is a sample ticket for testing"
                 }
             );
@@ -572,7 +608,7 @@ if (app.Environment.IsDevelopment())
             context.Tickets.AddRange(
                 new Ticket
                 {
-                    Title = "Example Ticket", 
+                    Title = "Example Ticket",
                     Description = "This is a sample ticket for testing"
                 }
             );

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
@@ -19,7 +19,7 @@ import elasticIcon from '@assets/icons/elastic-icon.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire Elasticsearch Hosting integration. It enumerates the AppHost APIs — with C# examples — that you use to model an Elasticsearch resource in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Elasticsearch Hosting integration. It enumerates the available AppHost APIs and identifies the current language-specific limitations for modeling an Elasticsearch resource in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the Elasticsearch integration, start with the [Get started with Elasticsearch integrations](/integrations/databases/elasticsearch/elasticsearch-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Elasticsearch](../elasticsearch-connect/).
 
@@ -27,7 +27,12 @@ If you're new to the Elasticsearch integration, start with the [Get started with
 
 To start building an Aspire app that uses Elasticsearch, install the [📦 Aspire.Hosting.Elasticsearch](https://www.nuget.org/packages/Aspire.Hosting.Elasticsearch) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Python integration SDK could not be generated and validated.',
+  go: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Go integration SDK could not be generated and validated.',
+  java: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Java integration SDK could not be generated and validated.',
+  rust: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Rust integration SDK could not be generated and validated.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -35,7 +40,8 @@ aspire add elasticsearch
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -56,7 +62,8 @@ aspire add elasticsearch
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Elasticsearch hosting integration package:
@@ -70,7 +77,10 @@ This updates your `aspire.config.json` with the Elasticsearch hosting integratio
 ```
 
 <Aside type="caution">
-  The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. After installing the package, use `builder.addConnectionString(...)` to reference an existing Elasticsearch instance, or `builder.addContainer(...)` with the `docker.io/library/elasticsearch` image to spin up a new one.
+  The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)`
+  API. After installing the package, use `builder.addConnectionString(...)` to
+  reference an existing Elasticsearch instance, or `builder.addContainer(...)`
+  with the `docker.io/library/elasticsearch` image to spin up a new one.
 </Aside>
 
 </Fragment>
@@ -80,18 +90,26 @@ This updates your `aspire.config.json` with the Elasticsearch hosting integratio
 
 Once you've installed the hosting integration in your AppHost project, you can add an Elasticsearch resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so addElasticsearch could not be generated and validated for Python.',
+  go: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so AddElasticsearch could not be generated and validated for Go.',
+  java: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so addElasticsearch could not be generated and validated for Java.',
+  rust: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so add_elasticsearch could not be generated and validated for Rust.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var elasticsearch = builder.AddElasticsearch("elasticsearch");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(elasticsearch);
+.WithReference(elasticsearch);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. To add an Elasticsearch instance to a TypeScript AppHost, use `builder.addContainer(...)` with the `docker.io/library/elasticsearch` image, or use [`builder.addConnectionString(...)`](/get-started/app-host/) to reference an existing instance.
@@ -109,15 +127,24 @@ The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. 
 </Steps>
 
 <Aside type="note">
-    When you reference an Elasticsearch resource from the AppHost, Aspire makes several properties available to the consuming project, such as the connection URI. For a complete list of these properties and per-language connection examples, see [Connect to Elasticsearch](../elasticsearch-connect/).
+  When you reference an Elasticsearch resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the connection
+  URI. For a complete list of these properties and per-language connection
+  examples, see [Connect to Elasticsearch](../elasticsearch-connect/).
 </Aside>
 
 ## Add Elasticsearch resource with data volume
 
 Add a data volume to the Elasticsearch resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-volume APIs could not be generated and validated for Python.',
+  go: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-volume APIs could not be generated and validated for Go.',
+  java: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-volume APIs could not be generated and validated for Java.',
+  rust: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-volume APIs could not be generated and validated for Rust.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -129,6 +156,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. Data volume configuration is not available for Elasticsearch in TypeScript AppHosts.
@@ -141,21 +169,29 @@ The data volume is used to persist Elasticsearch data outside the lifecycle of i
 
 Add a data bind mount to the Elasticsearch resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-bind-mount APIs could not be generated and validated for Python.',
+  go: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-bind-mount APIs could not be generated and validated for Go.',
+  java: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-bind-mount APIs could not be generated and validated for Java.',
+  rust: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so Elasticsearch data-bind-mount APIs could not be generated and validated for Rust.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var elasticsearch = builder.AddElasticsearch("elasticsearch")
-    .WithDataBindMount(
-        source: @"C:\Elasticsearch\Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: @"C:\Elasticsearch\Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(elasticsearch);
+.WithReference(elasticsearch);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. Data bind mount configuration is not available for Elasticsearch in TypeScript AppHosts.
@@ -163,7 +199,13 @@ The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. 
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Elasticsearch data across container restarts. The data bind mount is mounted at the `C:\Elasticsearch\Data` on Windows (or `/Elasticsearch/Data` on Unix) path on the host machine in the Elasticsearch container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -172,8 +214,14 @@ Data bind mounts rely on the host machine's filesystem to persist Elasticsearch 
 
 When you want to explicitly provide the password used by the container image, you can pass it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so the password-enabled addElasticsearch API could not be generated and validated for Python.',
+  go: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so the password-enabled AddElasticsearch API could not be generated and validated for Go.',
+  java: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so the password-enabled addElasticsearch API could not be generated and validated for Java.',
+  rust: 'The pinned daily Aspire.Hosting.Elasticsearch package is unavailable, so the password-enabled add_elasticsearch API could not be generated and validated for Rust.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -186,6 +234,7 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 The TypeScript AppHost doesn't currently expose an `addElasticsearch(...)` API. Password parameters are not available for Elasticsearch in TypeScript AppHosts.
@@ -200,31 +249,145 @@ To reference an externally managed Elasticsearch instance instead of running one
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var elasticsearch = builder.AddConnectionString("elasticsearch");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(elasticsearch);
+.WithReference(elasticsearch);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const elasticsearch = await builder.addConnectionString("elasticsearch");
+const elasticsearch = await builder.addConnectionString('elasticsearch');
 
-await builder.addNodeApp("my-app", "./app", "index.js")
-    .withReference(elasticsearch);
+await builder
+  .addNodeApp('my-app', './app', 'index.js')
+  .withReference(elasticsearch);
 
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    elasticsearch = builder.add_connection_string("elasticsearch")
+
+    builder.add_project("apiservice", "../ExampleProject/ExampleProject.csproj").with_reference(
+        elasticsearch
+    )
+
+    builder.run()
+
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	elasticsearch := builder.AddConnectionString("elasticsearch")
+	if err := elasticsearch.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("apiservice", "../ExampleProject/ExampleProject.csproj")
+	api.WithReference(elasticsearch)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+var builder = DistributedApplication.CreateBuilder();
+
+    var elasticsearch = builder.addConnectionString("elasticsearch");
+    var api = builder.addProject(
+        "apiservice",
+        "../ExampleProject/ExampleProject.csproj");
+    api.withReference(elasticsearch);
+
+    builder.build().run();
+
+}
+
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let elasticsearch = builder.add_connection_string("elasticsearch", None)?;
+    let api = builder.add_project(
+        "apiservice",
+        "../ExampleProject/ExampleProject.csproj",
+        None,
+    )?;
+    api.with_reference(
+        elasticsearch.handle().to_json(),
+        None,
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/elasticsearch/elasticsearch-host.mdx
@@ -28,10 +28,10 @@ If you're new to the Elasticsearch integration, start with the [Get started with
 To start building an Aspire app that uses Elasticsearch, install the [📦 Aspire.Hosting.Elasticsearch](https://www.nuget.org/packages/Aspire.Hosting.Elasticsearch) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Python integration SDK could not be generated and validated.',
-  go: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Go integration SDK could not be generated and validated.',
-  java: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Java integration SDK could not be generated and validated.',
-  rust: 'Aspire.Hosting.Elasticsearch version 13.6.0-preview.1.26458.6 is not available from the daily feed, so a Rust integration SDK could not be generated and validated.',
+  python: 'Aspire.Hosting.Elasticsearch was not available from the daily feed used for validation, so a Python integration SDK could not be generated and validated.',
+  go: 'Aspire.Hosting.Elasticsearch was not available from the daily feed used for validation, so a Go integration SDK could not be generated and validated.',
+  java: 'Aspire.Hosting.Elasticsearch was not available from the daily feed used for validation, so a Java integration SDK could not be generated and validated.',
+  rust: 'Aspire.Hosting.Elasticsearch was not available from the daily feed used for validation, so a Rust integration SDK could not be generated and validated.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -34,10 +34,10 @@ If you're new to the KurrentDB integration, start with the [Get started with Kur
 To start building an Aspire app that uses KurrentDB, install the [📦 CommunityToolkit.Aspire.Hosting.KurrentDB](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.KurrentDB) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -83,10 +83,10 @@ This updates your `aspire.config.json` with the KurrentDB hosting integration pa
 Once you've installed the hosting integration in your AppHost project, you can add a KurrentDB resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -144,10 +144,10 @@ await builder.build().run();
 Add a data volume to the KurrentDB resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -193,10 +193,10 @@ The data volume is used to persist KurrentDB data outside the lifecycle of its c
 Add a data bind mount to the KurrentDB resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/kurrentdb/kurrentdb-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up KurrentDB in the AppHost
-seoTitle: "Set up KurrentDB in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up KurrentDB in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire KurrentDB Hosting integration to orchestrate and configure a KurrentDB resource in an Aspire solution.
 ---
 
@@ -33,7 +33,12 @@ If you're new to the KurrentDB integration, start with the [Get started with Kur
 
 To start building an Aspire app that uses KurrentDB, install the [📦 CommunityToolkit.Aspire.Hosting.KurrentDB](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.KurrentDB) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.KurrentDB" />
@@ -56,7 +61,8 @@ aspire add CommunityToolkit.Aspire.Hosting.KurrentDB
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the KurrentDB hosting integration package:
@@ -76,7 +82,12 @@ This updates your `aspire.config.json` with the KurrentDB hosting integration pa
 
 Once you've installed the hosting integration in your AppHost project, you can add a KurrentDB resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -98,9 +109,12 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const kurrentdb = await builder.addKurrentDB("kurrentdb");
+const kurrentdb = await builder.addKurrentDB('kurrentdb');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(kurrentdb);
 
 await builder.build().run();
@@ -118,14 +132,23 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    When you reference a KurrentDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, and port numbers. For a complete list of these properties and per-language connection examples, see [Connect to KurrentDB](../kurrentdb-connect/).
+  When you reference a KurrentDB resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, and port numbers. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  KurrentDB](../kurrentdb-connect/).
 </Aside>
 
 ## Add KurrentDB resource with data volume
 
 Add a data volume to the KurrentDB resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -148,10 +171,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const kurrentdb = await builder.addKurrentDB("kurrentdb");
+const kurrentdb = await builder.addKurrentDB('kurrentdb');
 await kurrentdb.withDataVolume();
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(kurrentdb);
 
 await builder.build().run();
@@ -166,7 +192,12 @@ The data volume is used to persist KurrentDB data outside the lifecycle of its c
 
 Add a data bind mount to the KurrentDB resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -189,10 +220,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const kurrentdb = await builder.addKurrentDB("kurrentdb");
-await kurrentdb.withDataBindMount("C:\\KurrentDB\\Data");
+const kurrentdb = await builder.addKurrentDB('kurrentdb');
+await kurrentdb.withDataBindMount('C:\\KurrentDB\\Data');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(kurrentdb);
 
 await builder.build().run();
@@ -202,7 +236,13 @@ await builder.build().run();
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist KurrentDB data across container restarts. The data bind mount is mounted at the `C:\KurrentDB\Data` on Windows (or `/KurrentDB/Data` on Unix) path on the host machine in the KurrentDB container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -32,10 +32,10 @@ If you're new to the Meilisearch integration, start with the [Get started with M
 To start building an Aspire app that uses Meilisearch, install the [📦 CommunityToolkit.Aspire.Hosting.Meilisearch](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Meilisearch) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -88,10 +88,10 @@ This updates your `aspire.config.json` with the Meilisearch hosting integration 
 Once you've installed the hosting integration in your AppHost project, you can add a Meilisearch resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -151,10 +151,10 @@ await builder.build().run();
 To add a data volume to the Meilisearch resource, call the `WithDataVolume` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -200,10 +200,10 @@ The data volume is used to persist Meilisearch data outside the lifecycle of its
 To add a data bind mount to the Meilisearch resource, call the `WithDataBindMount` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -259,10 +259,10 @@ Data bind mounts rely on the host machine's filesystem to persist Meilisearch da
 When you want to explicitly provide the master key used by the container image, you can provide it as a parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/meilisearch/meilisearch-host.mdx
@@ -31,7 +31,12 @@ If you're new to the Meilisearch integration, start with the [Get started with M
 
 To start building an Aspire app that uses Meilisearch, install the [📦 CommunityToolkit.Aspire.Hosting.Meilisearch](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Meilisearch) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -39,7 +44,8 @@ aspire add CommunityToolkit.Aspire.Hosting.Meilisearch
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -60,7 +66,8 @@ aspire add CommunityToolkit.Aspire.Hosting.Meilisearch
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Meilisearch hosting integration package:
@@ -80,7 +87,12 @@ This updates your `aspire.config.json` with the Meilisearch hosting integration 
 
 Once you've installed the hosting integration in your AppHost project, you can add a Meilisearch resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -102,9 +114,12 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const meilisearch = await builder.addMeilisearch("meilisearch");
+const meilisearch = await builder.addMeilisearch('meilisearch');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(meilisearch);
 
 await builder.build().run();
@@ -124,14 +139,23 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    When you reference a Meilisearch resource from the AppHost, Aspire makes several properties available to the consuming project, such as the URL, hostname, port, and master key. For a complete list of these properties and per-language connection examples, see [Connect to Meilisearch](../meilisearch-connect/).
+  When you reference a Meilisearch resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as the URL,
+  hostname, port, and master key. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  Meilisearch](../meilisearch-connect/).
 </Aside>
 
 ## Add Meilisearch resource with data volume
 
 To add a data volume to the Meilisearch resource, call the `WithDataVolume` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -154,10 +178,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const meilisearch = await builder.addMeilisearch("meilisearch");
+const meilisearch = await builder.addMeilisearch('meilisearch');
 await meilisearch.withDataVolume();
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(meilisearch);
 
 await builder.build().run();
@@ -172,7 +199,12 @@ The data volume is used to persist Meilisearch data outside the lifecycle of its
 
 To add a data bind mount to the Meilisearch resource, call the `WithDataBindMount` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -195,10 +227,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const meilisearch = await builder.addMeilisearch("meilisearch");
-await meilisearch.withDataBindMount("C:\\Meilisearch\\Data");
+const meilisearch = await builder.addMeilisearch('meilisearch');
+await meilisearch.withDataBindMount('C:\\Meilisearch\\Data');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(meilisearch);
 
 await builder.build().run();
@@ -208,7 +243,13 @@ await builder.build().run();
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Meilisearch data across container restarts. The data bind mount is mounted at `C:\Meilisearch\Data` on Windows (or the equivalent path on Unix) on the host machine. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -217,7 +258,12 @@ Data bind mounts rely on the host machine's filesystem to persist Meilisearch da
 
 When you want to explicitly provide the master key used by the container image, you can provide it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -241,11 +287,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const masterKey = await builder.addParameter("masterKey", { secret: true });
+const masterKey = await builder.addParameter('masterKey', { secret: true });
 
-const meilisearch = await builder.addMeilisearch("meilisearch", { masterKey });
+const meilisearch = await builder.addMeilisearch('meilisearch', { masterKey });
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(meilisearch);
 
 await builder.build().run();

--- a/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Milvus in the AppHost
-seoTitle: "Set up Milvus in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Milvus in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Milvus Hosting integration to orchestrate and configure Milvus vector databases in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the Milvus integration, start with the [Get started with Milvus
 
 To start building an Aspire app that uses Milvus, install the [📦 Aspire.Hosting.Milvus](https://www.nuget.org/packages/Aspire.Hosting.Milvus) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add milvus
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add milvus
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Milvus hosting integration package:
@@ -78,24 +85,33 @@ This updates your `aspire.config.json` with the Milvus hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add a Milvus server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var milvus = builder.AddMilvus("milvus")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(milvusdb)
-    .WaitFor(milvusdb);
+.WithReference(milvusdb)
+.WaitFor(milvusdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -112,6 +128,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -126,15 +143,24 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-The Milvus container can be slow to start, so it's best to use a persistent lifetime to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
+  The Milvus container can be slow to start, so it's best to use a persistent
+  lifetime to avoid unnecessary restarts. For more information, see [Container
+  resource
+  lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
 </Aside>
 
 <Aside type="note">
-    When you reference a Milvus resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and the authentication token. For a complete list of these properties and per-language connection examples, see [Connect to Milvus](../milvus-connect/).
+  When you reference a Milvus resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and the authentication token. For a complete list of
+  these properties and per-language connection examples, see [Connect to
+  Milvus](../milvus-connect/).
 </Aside>
 
 <Aside type="tip">
-If you'd rather connect to an existing Milvus server, call `AddConnectionString` instead. For more information, see [Reference existing resources](/get-started/resources/).
+  If you'd rather connect to an existing Milvus server, call
+  `AddConnectionString` instead. For more information, see [Reference existing
+  resources](/get-started/resources/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Milvus" only="Milvus" />
@@ -143,26 +169,35 @@ If you'd rather connect to an existing Milvus server, call `AddConnectionString`
 
 To change the default API key used by the Milvus container, pass an `apiKey` parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var apiKey = builder.AddParameter("apiKey", secret: true);
 
 var milvus = builder.AddMilvus("milvus", apiKey)
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(milvusdb)
-    .WaitFor(milvusdb);
+.WithReference(milvusdb)
+.WaitFor(milvusdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -181,6 +216,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -200,25 +236,34 @@ For more information, see [External parameters](/get-started/resources/).
 
 Add a data volume to the Milvus resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var milvus = builder.AddMilvus("milvus")
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithDataVolume()
+.WithLifetime(ContainerLifetime.Persistent);
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(milvusdb)
-    .WaitFor(milvusdb);
+.WithReference(milvusdb)
+.WaitFor(milvusdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -236,6 +281,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -245,25 +291,34 @@ The data volume is used to persist the Milvus data outside the lifecycle of its 
 
 Add a data bind mount to the Milvus resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var milvus = builder.AddMilvus("milvus")
-    .WithDataBindMount(source: "/Milvus/Data")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithDataBindMount(source: "/Milvus/Data")
+.WithLifetime(ContainerLifetime.Persistent);
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(milvusdb)
-    .WaitFor(milvusdb);
+.WithReference(milvusdb)
+.WaitFor(milvusdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -281,11 +336,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist the Milvus data across container restarts. The data bind mount is mounted at the `C:\Milvus\Data` on Windows (or `/Milvus/Data` on Unix) path on the host machine in the Milvus container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -294,25 +356,34 @@ Data bind mounts rely on the host machine's filesystem to persist the Milvus dat
 
 [Attu](https://zilliz.com/attu) is a graphical user interface (GUI) and management tool for Milvus. To add an Attu container alongside your Milvus server, call `WithAttu` (or `withAttu`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var milvus = builder.AddMilvus("milvus")
-    .WithAttu()
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithAttu()
+.WithLifetime(ContainerLifetime.Persistent);
 
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(milvusdb)
-    .WaitFor(milvusdb);
+.WithReference(milvusdb)
+.WaitFor(milvusdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -330,6 +401,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -339,19 +411,28 @@ When you run the Aspire solution, an Attu container is listed in the dashboard r
 
 To configure the Attu container name or container further, pass a callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var milvus = builder.AddMilvus("milvus")
-    .WithAttu(attu => attu.WithHostPort(8080))
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithAttu(attu => attu.WithHostPort(8080))
+.WithLifetime(ContainerLifetime.Persistent);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -367,6 +448,7 @@ await milvus.withLifetime("Persistent");
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -374,8 +456,14 @@ await milvus.withLifetime("Persistent");
 
 By default, Aspire injects the Milvus connection information using variable names derived from the resource name (for example, `MILVUSDB_HOST`, `MILVUSDB_PORT`, `MILVUSDB_TOKEN`, `MILVUSDB_URI`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -383,18 +471,21 @@ var milvus = builder.AddMilvus("milvus");
 var milvusdb = milvus.AddDatabase("milvusdb");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(milvusdb)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["MILVUS_HOST"] = milvus.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["MILVUS_PORT"] = milvus.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["MILVUS_TOKEN"] = milvus.Resource.ApiKeyParameter;
-    });
+.WithReference(milvusdb)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["MILVUS_HOST"] = milvus.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["MILVUS_PORT"] = milvus.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["MILVUS_TOKEN"] = milvus.Resource.ApiKeyParameter;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -414,6 +505,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/milvus/milvus-host.mdx
@@ -30,10 +30,10 @@ If you're new to the Milvus integration, start with the [Get started with Milvus
 To start building an Aspire app that uses Milvus, install the [📦 Aspire.Hosting.Milvus](https://www.nuget.org/packages/Aspire.Hosting.Milvus) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the Milvus hosting integration packa
 Once you've installed the hosting integration in your AppHost project, you can add a Milvus server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -170,10 +170,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 To change the default API key used by the Milvus container, pass an `apiKey` parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -237,10 +237,10 @@ For more information, see [External parameters](/get-started/resources/).
 Add a data volume to the Milvus resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -292,10 +292,10 @@ The data volume is used to persist the Milvus data outside the lifecycle of its 
 Add a data bind mount to the Milvus resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -357,10 +357,10 @@ Data bind mounts rely on the host machine's filesystem to persist the Milvus dat
 [Attu](https://zilliz.com/attu) is a graphical user interface (GUI) and management tool for Milvus. To add an Attu container alongside your Milvus server, call `WithAttu` (or `withAttu`):
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -412,10 +412,10 @@ When you run the Aspire solution, an Attu container is listed in the dashboard r
 To configure the Attu container name or container further, pass a callback:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -457,10 +457,10 @@ await milvus.withLifetime("Persistent");
 By default, Aspire injects the Milvus connection information using variable names derived from the resource name (for example, `MILVUSDB_HOST`, `MILVUSDB_PORT`, `MILVUSDB_TOKEN`, `MILVUSDB_URI`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
@@ -51,7 +51,12 @@ For TypeScript AppHosts, add the Community Toolkit MongoDB extensions package to
 
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `MongoDBServerResource` builder with `WithDbGate` / `withDbGate`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -92,7 +97,12 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the MongoDB server:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-extensions.mdx
@@ -52,10 +52,10 @@ For TypeScript AppHosts, add the Community Toolkit MongoDB extensions package to
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `MongoDBServerResource` builder with `WithDbGate` / `withDbGate`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -98,10 +98,10 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the MongoDB server:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up MongoDB in the AppHost
-seoTitle: "Set up MongoDB in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up MongoDB in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire MongoDB Hosting integration to orchestrate and configure a MongoDB database in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the MongoDB integration, start with the [Get started with Mongo
 
 To start building an Aspire app that uses MongoDB, install the [📦 Aspire.Hosting.MongoDB](https://www.nuget.org/packages/Aspire.Hosting.MongoDB) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add mongodb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add mongodb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the MongoDB hosting integration package:
@@ -78,24 +85,33 @@ This updates your `aspire.config.json` with the MongoDB hosting integration pack
 
 Once you've installed the hosting integration in your AppHost project, you can add a MongoDB server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mongodb = mongo.AddDatabase("mongodb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -112,6 +128,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -123,15 +140,24 @@ The MongoDB server resource includes default credentials:
 - `MONGO_INITDB_ROOT_PASSWORD`: A randomly generated password stored in the AppHost's secret store under `Parameters:mongo-password`
 
 <Aside type="note">
-The MongoDB container can be slow to start, so it's best to use a persistent lifetime to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
+  The MongoDB container can be slow to start, so it's best to use a persistent
+  lifetime to avoid unnecessary restarts. For more information, see [Container
+  resource
+  lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
 </Aside>
 
 <Aside type="tip">
-If you'd rather connect to an existing MongoDB server, call `AddConnectionString` instead. For more information, see [Reference existing resources](/get-started/resources/).
+  If you'd rather connect to an existing MongoDB server, call
+  `AddConnectionString` instead. For more information, see [Reference existing
+  resources](/get-started/resources/).
 </Aside>
 
 <Aside type="note">
-    When you reference a MongoDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, and port numbers. For a complete list of these properties and per-language connection examples, see [Connect to MongoDB](../mongodb-connect/).
+  When you reference a MongoDB resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, and port numbers. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  MongoDB](../mongodb-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.MongoDB" only="MongoDB" />
@@ -140,8 +166,14 @@ If you'd rather connect to an existing MongoDB server, call `AddConnectionString
 
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -152,13 +184,16 @@ var mongo = builder.AddMongoDB("mongo", userName: username, password: password);
 var mongodb = mongo.AddDatabase("mongodb");
 
 var myService = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -176,6 +211,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -192,16 +228,25 @@ The username and password parameters are typically provided as user secrets:
 
 You can also specify a port:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var mongo = builder.AddMongoDB("mongo", port: 27017);
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 const mongo = await builder.addMongoDB("mongo", { port: 27017 });
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -211,25 +256,34 @@ For more information, see [External parameters](/get-started/resources/).
 
 To add a data volume to the MongoDB server resource, call the `WithDataVolume` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithDataVolume()
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithDataVolume()
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mongodb = mongo.AddDatabase("mongodb");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -247,44 +301,56 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 The data volume is used to persist the MongoDB server data outside the lifecycle of its container. The data volume is mounted at the `/data/db` path in the MongoDB server container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-mongodb-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
-The password is stored in the data volume. When using a data volume and if the password changes, it will not work until you delete the volume.
+  The password is stored in the data volume. When using a data volume and if the
+  password changes, it will not work until you delete the volume.
 </Aside>
 
 <Aside type="danger">
 Some database integrations, including the MongoDB integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
 
 You can resolve the problem by deploying to a Kubernetes cluster, such as Azure Kubernetes Services (AKS). For more information, see [Deploy your first Aspire app](/get-started/deploy-first-app/).
+
 </Aside>
 
 ## Add MongoDB server resource with data bind mount
 
 To add a data bind mount to the MongoDB server resource, call the `WithDataBindMount` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithDataBindMount(source: @"C:\MongoDB\Data")
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithDataBindMount(source: @"C:\MongoDB\Data")
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mongodb = mongo.AddDatabase("mongodb");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -302,6 +368,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -309,31 +376,41 @@ await builder.addNodeApp("api", "./api", "index.js")
 Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
 
 Data bind mounts rely on the host machine's filesystem to persist the MongoDB server data across container restarts. The data bind mount is mounted at the `C:\MongoDB\Data` on Windows (or `/MongoDB/Data` on Unix) path on the host machine in the MongoDB server container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
+
 </Aside>
 
 ## Add MongoDB server resource with init files
 
 Use initialization files to seed the MongoDB server with data or run scripts at startup. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithInitBindMount(source: @"C:\MongoDB\Init")
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithInitBindMount(source: @"C:\MongoDB\Init")
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mongodb = mongo.AddDatabase("mongodb");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -351,10 +428,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
-
 :::note
 The TypeScript AppHost exposes `withInitFiles(source)` instead of `withInitBindMount(source)`. The `withInitFiles` method copies the specified files into the container's init folder, whereas the C# `WithInitBindMount` performs a host bind mount. The functional outcome — running initialization scripts at container startup — is the same.
 :::
+
 </Fragment>
 </AppHostTabs>
 
@@ -364,25 +441,34 @@ MongoDB executes any JavaScript or shell scripts found in the init folder when t
 
 [MongoDB Express](https://github.com/mongo-express/mongo-express) is a web-based MongoDB admin user interface. To add a MongoDB Express resource that corresponds to the `docker.io/library/mongo-express` container image, call the `WithMongoExpress` method on the MongoDB server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithMongoExpress()
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithMongoExpress()
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mongodb = mongo.AddDatabase("mongodb");
 
 var myService = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mongodb)
-    .WaitFor(mongodb);
+.WithReference(mongodb)
+.WaitFor(mongodb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -400,6 +486,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -419,19 +506,28 @@ The MongoDB Express resource is configured to connect to the MongoDB server reso
 
 To configure the host port for the Mongo Express container, pass a configuration callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mongo = builder.AddMongoDB("mongo")
-                   .WithMongoExpress(c => c.WithHostPort(8081))
-                   .WithLifetime(ContainerLifetime.Persistent);
+.WithMongoExpress(c => c.WithHostPort(8081))
+.WithLifetime(ContainerLifetime.Persistent);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -447,6 +543,7 @@ await mongo.withLifetime("Persistent");
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -454,8 +551,14 @@ await mongo.withLifetime("Persistent");
 
 By default, Aspire injects the MongoDB connection information using variable names derived from the resource name (for example, `MONGODB_URI`, `MONGODB_HOST`, `MONGODB_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -463,20 +566,23 @@ var mongo = builder.AddMongoDB("mongo");
 var mongodb = mongo.AddDatabase("mongodb");
 
 var app = builder.AddNodeApp("api", "./api", scriptPath: "index.js")
-    .WithReference(mongodb)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["MONGO_HOST"] = mongo.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["MONGO_PORT"] = mongo.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["MONGO_USERNAME"] = mongo.Resource.UserNameReference;
-        context.EnvironmentVariables["MONGO_PASSWORD"] = mongo.Resource.PasswordParameter;
-        context.EnvironmentVariables["MONGO_DATABASE"] = mongodb.Resource.DatabaseName;
-    });
+.WithReference(mongodb)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["MONGO_HOST"] = mongo.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["MONGO_PORT"] = mongo.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["MONGO_USERNAME"] = mongo.Resource.UserNameReference;
+context.EnvironmentVariables["MONGO_PASSWORD"] = mongo.Resource.PasswordParameter;
+context.EnvironmentVariables["MONGO_DATABASE"] = mongodb.Resource.DatabaseName;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -498,6 +604,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mongodb/mongodb-host.mdx
@@ -30,10 +30,10 @@ If you're new to the MongoDB integration, start with the [Get started with Mongo
 To start building an Aspire app that uses MongoDB, install the [📦 Aspire.Hosting.MongoDB](https://www.nuget.org/packages/Aspire.Hosting.MongoDB) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the MongoDB hosting integration pack
 Once you've installed the hosting integration in your AppHost project, you can add a MongoDB server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -167,10 +167,10 @@ The MongoDB server resource includes default credentials:
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -229,10 +229,10 @@ The username and password parameters are typically provided as user secrets:
 You can also specify a port:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -257,10 +257,10 @@ For more information, see [External parameters](/get-started/resources/).
 To add a data volume to the MongoDB server resource, call the `WithDataVolume` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -324,10 +324,10 @@ You can resolve the problem by deploying to a Kubernetes cluster, such as Azure 
 To add a data bind mount to the MongoDB server resource, call the `WithDataBindMount` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -384,10 +384,10 @@ Data bind mounts rely on the host machine's filesystem to persist the MongoDB se
 Use initialization files to seed the MongoDB server with data or run scripts at startup. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -442,10 +442,10 @@ MongoDB executes any JavaScript or shell scripts found in the init folder when t
 [MongoDB Express](https://github.com/mongo-express/mongo-express) is a web-based MongoDB admin user interface. To add a MongoDB Express resource that corresponds to the `docker.io/library/mongo-express` container image, call the `WithMongoExpress` method on the MongoDB server resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -507,10 +507,10 @@ The MongoDB Express resource is configured to connect to the MongoDB server reso
 To configure the host port for the Mongo Express container, pass a configuration callback:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -552,10 +552,10 @@ await mongo.withLifetime("Persistent");
 By default, Aspire injects the MongoDB connection information using variable names derived from the resource name (for example, `MONGODB_URI`, `MONGODB_HOST`, `MONGODB_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
@@ -52,7 +52,12 @@ For TypeScript AppHosts, add the Community Toolkit MySQL extensions package to `
 
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `MySqlServerResource` builder with `WithDbGate` / `withDbGate`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -93,7 +98,12 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 
 To add the [Adminer](https://adminer.org/) management UI, decorate the official `MySqlServerResource` builder with `WithAdminer` / `withAdminer`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -134,7 +144,12 @@ This adds a new Adminer resource to the AppHost which is available from the Aspi
 
 You can use both management UIs together on the same MySQL resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -175,7 +190,12 @@ await builder.build().run();
 
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the MySQL server:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-extensions.mdx
@@ -53,10 +53,10 @@ For TypeScript AppHosts, add the Community Toolkit MySQL extensions package to `
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `MySqlServerResource` builder with `WithDbGate` / `withDbGate`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -99,10 +99,10 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 To add the [Adminer](https://adminer.org/) management UI, decorate the official `MySqlServerResource` builder with `WithAdminer` / `withAdminer`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -145,10 +145,10 @@ This adds a new Adminer resource to the AppHost which is available from the Aspi
 You can use both management UIs together on the same MySQL resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -191,10 +191,10 @@ await builder.build().run();
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the MySQL server:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up MySQL in the AppHost
-seoTitle: "Set up MySQL in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up MySQL in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire MySQL Hosting integration to orchestrate and configure a MySQL database in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the MySQL integration, start with the [Get started with MySQL i
 
 To start building an Aspire app that uses MySQL, install the [📦 Aspire.Hosting.MySql](https://www.nuget.org/packages/Aspire.Hosting.MySql) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add mysql
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add mysql
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the MySQL hosting integration package:
@@ -78,24 +85,33 @@ This updates your `aspire.config.json` with the MySQL hosting integration packag
 
 Once you've installed the hosting integration in your AppHost project, you can add a MySQL server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { ContainerLifetime, createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -112,6 +128,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -126,11 +143,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    The MySQL container can be slow to start, so it's best to use a _persistent_ lifetime to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
+  The MySQL container can be slow to start, so it's best to use a _persistent_
+  lifetime to avoid unnecessary restarts. For more information, see [Container
+  resource
+  lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
 </Aside>
 
 <Aside type="note">
-    When you reference a MySQL resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and the password. For a complete list of these properties and per-language connection examples, see [Connect to MySQL](../mysql-connect/).
+  When you reference a MySQL resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and the password. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  MySQL](../mysql-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.MySql" only="MySQL" />
@@ -139,29 +163,37 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 You can use the `WithCreationScript` method to execute SQL scripts when the database is created. This is useful for initializing database schema or seeding data:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mysqldb = mysql.AddDatabase("mysqldb")
-    .WithCreationScript("""
-        CREATE TABLE IF NOT EXISTS users (
-            id INT AUTO_INCREMENT PRIMARY KEY,
-            name VARCHAR(255) NOT NULL,
-            email VARCHAR(255) NOT NULL
-        );
-        """);
+.WithCreationScript("""
+CREATE TABLE IF NOT EXISTS users (
+id INT AUTO_INCREMENT PRIMARY KEY,
+name VARCHAR(255) NOT NULL,
+email VARCHAR(255) NOT NULL
+);
+""");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 
@@ -194,31 +226,42 @@ await myService
 </AppHostTabs>
 
 <Aside type="note">
-The script is executed only when the database is first created. If you need to run scripts on every startup, consider using init files or application-level migrations instead.
+  The script is executed only when the database is first created. If you need to
+  run scripts on every startup, consider using init files or application-level
+  migrations instead.
 </Aside>
 
 ## Add MySQL resource with phpMyAdmin
 
 [**phpMyAdmin**](https://www.phpmyadmin.net/) is a popular web-based administration tool for MySQL. Call the `WithPhpMyAdmin` (or `withPhpMyAdmin`) method to add a phpMyAdmin container resource that connects to the MySQL container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithPhpMyAdmin();
+.WithPhpMyAdmin();
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -235,6 +278,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -246,24 +290,33 @@ When you run the solution, the Aspire dashboard displays the phpMyAdmin resource
 
 To set a custom container name for the phpMyAdmin resource in TypeScript:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithPhpMyAdmin(phpMyAdmin => phpMyAdmin.WithHostPort(8080));
+.WithPhpMyAdmin(phpMyAdmin => phpMyAdmin.WithHostPort(8080));
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -285,6 +338,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -292,24 +346,33 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the MySQL server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -326,45 +389,57 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 The data volume is used to persist the MySQL server data outside the lifecycle of its container. The data volume is mounted at the `/var/lib/mysql` path in the MySQL container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-a-mysql-resource-with-a-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
-The password is stored in the data volume. When using a data volume and if the password changes, it will not work until you delete the volume.
+  The password is stored in the data volume. When using a data volume and if the
+  password changes, it will not work until you delete the volume.
 </Aside>
 
 <Aside type="danger">
 Some database integrations, including the MySQL integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
 
 You can resolve the problem by deploying to a Kubernetes cluster, such as Azure Kubernetes Services (AKS). For more information, see [Deploy your first Aspire app](/get-started/deploy-first-app/).
+
 </Aside>
 
 ## Add a MySQL resource with a data bind mount
 
 Add a data bind mount to the MySQL server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithDataBindMount(
-        source: "/MySQL/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/MySQL/Data",
+isReadOnly: false);
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -381,11 +456,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist the MySQL server data across container restarts. The data bind mount is mounted at the `C:\MySQL\Data` on Windows (or `/MySQL/Data` on Unix) path on the host machine in the MySQL server container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -394,24 +476,33 @@ Data bind mounts rely on the host machine's filesystem to persist the MySQL serv
 
 Use initialization files to seed or configure the MySQL server at startup. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var mysql = builder.AddMySql("mysql")
-    .WithInitBindMount(@"C:\MySQL\Init");
+.WithInitBindMount(@"C:\MySQL\Init");
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -428,8 +519,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
-
 The TypeScript AppHost doesn't currently expose a `withInitBindMount(...)` API for MySQL. Use `withInitFiles(...)` to copy initialization files into the container instead.
+
 </Fragment>
 </AppHostTabs>
 
@@ -439,26 +530,35 @@ The init files are executed when the MySQL server container starts. Place execut
 
 When you want to provide a root MySQL password and optional port explicitly, you can pass them as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var password = builder.AddParameter("password", secret: true);
 
 var mysql = builder.AddMySql("mysql", password)
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(mysqldb)
-    .WaitFor(mysqldb);
+.WithReference(mysqldb)
+.WaitFor(mysqldb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -475,6 +575,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -484,8 +585,14 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 By default, Aspire injects the MySQL connection information using variable names derived from the resource name (for example, `MYSQLDB_URI`, `MYSQLDB_HOST`, `MYSQLDB_PORT`, `MYSQLDB_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -493,19 +600,22 @@ var mysql = builder.AddMySql("mysql");
 var mysqldb = mysql.AddDatabase("mysqldb");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(mysqldb)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["MYSQL_HOST"] = mysql.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["MYSQL_PORT"] = mysql.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["MYSQL_PASSWORD"] = mysql.Resource.PasswordParameter;
-        context.EnvironmentVariables["MYSQL_DATABASE"] = mysqldb.Resource.DatabaseName;
-    });
+.WithReference(mysqldb)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["MYSQL_HOST"] = mysql.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["MYSQL_PORT"] = mysql.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["MYSQL_PASSWORD"] = mysql.Resource.PasswordParameter;
+context.EnvironmentVariables["MYSQL_DATABASE"] = mysqldb.Resource.DatabaseName;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -526,6 +636,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/mysql/mysql-host.mdx
@@ -30,10 +30,10 @@ If you're new to the MySQL integration, start with the [Get started with MySQL i
 To start building an Aspire app that uses MySQL, install the [📦 Aspire.Hosting.MySql](https://www.nuget.org/packages/Aspire.Hosting.MySql) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the MySQL hosting integration packag
 Once you've installed the hosting integration in your AppHost project, you can add a MySQL server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -164,10 +164,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 You can use the `WithCreationScript` method to execute SQL scripts when the database is created. This is useful for initializing database schema or seeding data:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -236,10 +236,10 @@ await myService
 [**phpMyAdmin**](https://www.phpmyadmin.net/) is a popular web-based administration tool for MySQL. Call the `WithPhpMyAdmin` (or `withPhpMyAdmin`) method to add a phpMyAdmin container resource that connects to the MySQL container:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -291,10 +291,10 @@ When you run the solution, the Aspire dashboard displays the phpMyAdmin resource
 To set a custom container name for the phpMyAdmin resource in TypeScript:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -347,10 +347,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the MySQL server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -412,10 +412,10 @@ You can resolve the problem by deploying to a Kubernetes cluster, such as Azure 
 Add a data bind mount to the MySQL server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -477,10 +477,10 @@ Data bind mounts rely on the host machine's filesystem to persist the MySQL serv
 Use initialization files to seed or configure the MySQL server at startup. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -531,10 +531,10 @@ The init files are executed when the MySQL server container starts. Place execut
 When you want to provide a root MySQL password and optional port explicitly, you can pass them as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -586,10 +586,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 By default, Aspire injects the MySQL connection information using variable names derived from the resource name (for example, `MYSQLDB_URI`, `MYSQLDB_HOST`, `MYSQLDB_PORT`, `MYSQLDB_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -30,10 +30,10 @@ If you're new to the PostgreSQL integration, start with the [Get started with Po
 To start building an Aspire app that uses PostgreSQL, install the [📦 Aspire.Hosting.PostgreSQL](https://www.nuget.org/packages/Aspire.Hosting.PostgreSQL) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the PostgreSQL hosting integration p
 Once you've installed the hosting integration in your AppHost project, you can add a PostgreSQL server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -159,10 +159,10 @@ CREATE DATABASE "<QUOTED_DATABASE_NAME>"
 To alter the default script, configure the database resource with a custom creation script:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -230,10 +230,10 @@ The preceding example creates a database named `app_db`. The script is run when 
 Add the [**dpage/pgadmin4**](https://www.pgadmin.org/) container to the PostgreSQL resource to get a web-based admin dashboard, as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -283,10 +283,10 @@ The preceding code adds a container based on the `docker.io/dpage/pgadmin4` imag
 To configure the host port for the pgAdmin container, configure the pgAdmin resource inside the callback as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -338,10 +338,10 @@ The preceding code adds and configures the host port for the pgAdmin container. 
 Add the [**sosedoff/pgweb**](https://sosedoff.github.io/pgweb/) container to the PostgreSQL resource to get a web-based admin dashboard, as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -391,10 +391,10 @@ The preceding code adds a container based on the `docker.io/sosedoff/pgweb` imag
 To configure the host port for the pgWeb container, configure the pgWeb resource inside the callback as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -446,10 +446,10 @@ The preceding code adds and configures the host port for the pgWeb container. Th
 Add a data volume to the PostgreSQL server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -512,10 +512,10 @@ The data volume is used to persist the PostgreSQL server data outside the lifecy
 Add a data bind mount to the PostgreSQL server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -575,10 +575,10 @@ Data bind mounts rely on the host machine's filesystem to persist the PostgreSQL
 Use initialization files to seed the PostgreSQL server. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -627,10 +627,10 @@ The init bind mount relies on the host machine's filesystem to initialize the Po
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters. Consider the following alternative examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -678,10 +678,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 By default, Aspire injects the PostgreSQL connection information using variable names derived from the resource name (for example, `POSTGRESDB_URI`, `POSTGRESDB_HOST`, `POSTGRESDB_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -753,10 +753,10 @@ You have two ways to recover.
 Pin the image back to a PostgreSQL 17 tag with `WithImageTag(...)` **before** calling `WithDataVolume(...)`. Aspire then selects the legacy `/var/lib/postgresql/data` path and your existing volume keeps working with no migration:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgres-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up PostgreSQL in the AppHost
-seoTitle: "Set up PostgreSQL in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up PostgreSQL in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire PostgreSQL Hosting integration to orchestrate and configure a PostgreSQL database in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the PostgreSQL integration, start with the [Get started with Po
 
 To start building an Aspire app that uses PostgreSQL, install the [📦 Aspire.Hosting.PostgreSQL](https://www.nuget.org/packages/Aspire.Hosting.PostgreSQL) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add postgres
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add postgres
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the PostgreSQL hosting integration package:
@@ -78,8 +85,14 @@ This updates your `aspire.config.json` with the PostgreSQL hosting integration p
 
 Once you've installed the hosting integration in your AppHost project, you can add a PostgreSQL server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -87,12 +100,15 @@ var postgres = builder.AddPostgres("postgres");
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -106,6 +122,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -122,7 +139,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a PostgreSQL resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, and port numbers. For a complete list of these properties and per-language connection examples, see [Connect to PostgreSQL](../postgres-connect/).
+  When you reference a PostgreSQL resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as connection
+  URIs, hostnames, and port numbers. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  PostgreSQL](../postgres-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.PostgreSQL" only="PostgreSQL" />
@@ -137,8 +158,14 @@ CREATE DATABASE "<QUOTED_DATABASE_NAME>"
 
 To alter the default script, configure the database resource with a custom creation script:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -146,22 +173,25 @@ var postgres = builder.AddPostgres("postgres");
 
 var databaseName = "app_db";
 var creationScript = $$"""
-    -- Create the database
-    CREATE DATABASE {{databaseName}};
+-- Create the database
+CREATE DATABASE {{databaseName}};
 
     """;
 
 var db = postgres.AddDatabase(databaseName)
-    .WithCreationScript(creationScript);
+.WithCreationScript(creationScript);
 
 builder.AddProject<Projects.ExampleProject>()
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -184,36 +214,47 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 The preceding example creates a database named `app_db`. The script is run when the database resource is created. The script is passed as a string to the database resource's creation-script API and then run in the context of the PostgreSQL resource.
 
 <Aside type="note">
-    The connect to a database command (`\c`) isn't supported when using the creation script.
+  The connect to a database command (`\c`) isn't supported when using the
+  creation script.
 </Aside>
 
 ## Add PostgreSQL pgAdmin resource
 
 Add the [**dpage/pgadmin4**](https://www.pgadmin.org/) container to the PostgreSQL resource to get a web-based admin dashboard, as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithPgAdmin();
+.WithPgAdmin();
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -229,6 +270,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -240,23 +282,32 @@ The preceding code adds a container based on the `docker.io/dpage/pgadmin4` imag
 
 To configure the host port for the pgAdmin container, configure the pgAdmin resource inside the callback as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithPgAdmin(pgAdmin => pgAdmin.WithHostPort(5050));
+.WithPgAdmin(pgAdmin => pgAdmin.WithHostPort(5050));
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -276,6 +327,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -285,23 +337,32 @@ The preceding code adds and configures the host port for the pgAdmin container. 
 
 Add the [**sosedoff/pgweb**](https://sosedoff.github.io/pgweb/) container to the PostgreSQL resource to get a web-based admin dashboard, as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithPgWeb();
+.WithPgWeb();
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -317,6 +378,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -328,23 +390,32 @@ The preceding code adds a container based on the `docker.io/sosedoff/pgweb` imag
 
 To configure the host port for the pgWeb container, configure the pgWeb resource inside the callback as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithPgWeb(pgWeb => pgWeb.WithHostPort(5050));
+.WithPgWeb(pgWeb => pgWeb.WithHostPort(5050));
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -364,6 +435,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -373,23 +445,32 @@ The preceding code adds and configures the host port for the pgWeb container. Th
 
 Add a data volume to the PostgreSQL server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -405,44 +486,59 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 The data volume is used to persist the PostgreSQL server data outside the lifecycle of its container. The container data directory depends on the PostgreSQL image version: PostgreSQL 17 and earlier use `/var/lib/postgresql/data`, while PostgreSQL 18 and later use `/var/lib/postgresql`. `WithDataVolume(...)` selects the correct path automatically based on the configured image tag. When a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-postgresql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
-  Aspire 13.4 bumped the default PostgreSQL image to 18, which uses a different on-disk data layout than PostgreSQL 17. A data volume or data bind mount created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after upgrading. See [PostgreSQL 18 data directory change](#postgresql-18-data-directory-change) for recovery options.
+  Aspire 13.4 bumped the default PostgreSQL image to 18, which uses a different
+  on-disk data layout than PostgreSQL 17. A data volume or data bind mount
+  created on PostgreSQL 17 (Aspire 13.3 or earlier) is incompatible after
+  upgrading. See [PostgreSQL 18 data directory
+  change](#postgresql-18-data-directory-change) for recovery options.
 </Aside>
 
 <Aside type="caution">
     Some database integrations, including the Aspire PostgreSQL integration, can't successfully use data volumes after deployment to Azure Container Apps (ACA). This is because ACA uses Server Message Block (SMB) to connect containers to data volumes, and some systems can't use this connection. In the Aspire Dashboard, a database affected by this issue has a status of **Activating** or **Activation Failed** but is never listed as **Running**.
 
     You can resolve the problem by using the managed service **Azure Database for PostgreSQL** to host the deployed database instead of a container in ACA, which is the recommended approach regardless of this issue. For that managed-service flow, see [Azure Database for PostgreSQL Hosting integration](/integrations/cloud/azure/azure-postgresql/azure-postgresql-host/).
+
 </Aside>
 
 ## Add PostgreSQL server resource with data bind mount
 
 Add a data bind mount to the PostgreSQL server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithDataBindMount(
-        source: "/PostgreSQL/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/PostgreSQL/Data",
+isReadOnly: false);
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -458,11 +554,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist the PostgreSQL server data across container restarts. The data bind mount is mounted at the `C:\PostgreSQL\Data` on Windows (or `/PostgreSQL/Data` on Unix) path on the host machine in the PostgreSQL server container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -471,23 +574,32 @@ Data bind mounts rely on the host machine's filesystem to persist the PostgreSQL
 
 Use initialization files to seed the PostgreSQL server. The C# AppHost exposes `WithInitBindMount(...)`, while the TypeScript AppHost exposes `withInitFiles(...)`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("postgres")
-    .WithInitBindMount(@"C:\PostgreSQL\Init");
+.WithInitBindMount(@"C:\PostgreSQL\Init");
 
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -503,8 +615,8 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
-
 The TypeScript AppHost doesn't currently expose a `withInitBindMount(...)` API for PostgreSQL. Use `withInitFiles(...)` when you want to copy initialization files into the container instead.
+
 </Fragment>
 </AppHostTabs>
 
@@ -514,8 +626,14 @@ The init bind mount relies on the host machine's filesystem to initialize the Po
 
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters. Consider the following alternative examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -526,12 +644,15 @@ var postgres = builder.AddPostgres("postgres", username, password);
 var postgresdb = postgres.AddDatabase("postgresdb");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(postgresdb);
+.WithReference(postgresdb);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -548,6 +669,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -555,8 +677,14 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 By default, Aspire injects the PostgreSQL connection information using variable names derived from the resource name (for example, `POSTGRESDB_URI`, `POSTGRESDB_HOST`, `POSTGRESDB_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -564,20 +692,23 @@ var postgres = builder.AddPostgres("postgres");
 var database = postgres.AddDatabase("myDatabase");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(database)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["POSTGRES_HOST"] = postgres.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["POSTGRES_PORT"] = postgres.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["POSTGRES_USER"] = postgres.Resource.UserNameParameter;
-        context.EnvironmentVariables["POSTGRES_PASSWORD"] = postgres.Resource.PasswordParameter;
-        context.EnvironmentVariables["POSTGRES_DATABASE"] = database.Resource.DatabaseName;
-    });
+.WithReference(database)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["POSTGRES_HOST"] = postgres.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["POSTGRES_PORT"] = postgres.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["POSTGRES_USER"] = postgres.Resource.UserNameParameter;
+context.EnvironmentVariables["POSTGRES_PASSWORD"] = postgres.Resource.PasswordParameter;
+context.EnvironmentVariables["POSTGRES_DATABASE"] = database.Resource.DatabaseName;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -599,6 +730,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -620,19 +752,28 @@ You have two ways to recover.
 
 Pin the image back to a PostgreSQL 17 tag with `WithImageTag(...)` **before** calling `WithDataVolume(...)`. Aspire then selects the legacy `/var/lib/postgresql/data` path and your existing volume keeps working with no migration:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var postgres = builder.AddPostgres("pgsql")
-    .WithImageTag("17.6")
-    .WithDataVolume();
+.WithImageTag("17.6")
+.WithDataVolume();
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -644,11 +785,14 @@ await postgres.withDataVolume();
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="caution">
-  Call `WithImageTag(...)` **before** `WithDataVolume(...)`. The data directory is chosen from the configured tag at the time `WithDataVolume(...)` runs, so the tag must be set first.
+  Call `WithImageTag(...)` **before** `WithDataVolume(...)`. The data directory
+  is chosen from the configured tag at the time `WithDataVolume(...)` runs, so
+  the tag must be set first.
 </Aside>
 
 ### Option 2: Upgrade the data volume to PostgreSQL 18

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
@@ -53,7 +53,12 @@ For TypeScript AppHosts, add the Community Toolkit PostgreSQL extensions package
 
 To add the DbGate management UI, decorate the official `PostgresServerResource` builder with `WithDbGate` / `withDbGate`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -97,7 +102,12 @@ This adds a new DbGate resource to the app host which is available from the Aspi
 
 To add the Adminer management UI, decorate the official `PostgresServerResource` builder with `WithAdminer` / `withAdminer`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -141,7 +151,12 @@ This adds a new Adminer resource to the app host which is available from the Asp
 
 You can use both management UIs together on the same PostgreSQL resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -185,7 +200,12 @@ await exampleProject.withReference(postgres);
 
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the PostgreSQL server:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -229,7 +249,12 @@ In C#, add a Flyway resource and pass it to `WithFlywayMigration`. In TypeScript
 
 Place versioned SQL files such as `V1__init.sql` in `./migrations`; Flyway discovers them by its versioned migration naming convention.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/postgres/postgresql-extensions.mdx
@@ -54,10 +54,10 @@ For TypeScript AppHosts, add the Community Toolkit PostgreSQL extensions package
 To add the DbGate management UI, decorate the official `PostgresServerResource` builder with `WithDbGate` / `withDbGate`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -103,10 +103,10 @@ This adds a new DbGate resource to the app host which is available from the Aspi
 To add the Adminer management UI, decorate the official `PostgresServerResource` builder with `WithAdminer` / `withAdminer`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -152,10 +152,10 @@ This adds a new Adminer resource to the app host which is available from the Asp
 You can use both management UIs together on the same PostgreSQL resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -201,10 +201,10 @@ await exampleProject.withReference(postgres);
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the PostgreSQL server:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -250,10 +250,10 @@ In C#, add a Flyway resource and pass it to `WithFlywayMigration`. In TypeScript
 Place versioned SQL files such as `V1__init.sql` in `./migrations`; Flyway discovers them by its versioned migration naming convention.
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Qdrant in the AppHost
-seoTitle: "Set up Qdrant in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Qdrant in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Qdrant Hosting integration to orchestrate and configure a Qdrant vector database in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the Qdrant integration, start with the [Get started with Qdrant
 
 To start building an Aspire app that uses Qdrant, install the [📦 Aspire.Hosting.Qdrant](https://www.nuget.org/packages/Aspire.Hosting.Qdrant) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add qdrant
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add qdrant
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Qdrant hosting integration package:
@@ -78,22 +85,31 @@ This updates your `aspire.config.json` with the Qdrant hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add a Qdrant resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var qdrant = builder.AddQdrant("qdrant")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(qdrant)
-    .WaitFor(qdrant);
+.WithReference(qdrant)
+.WaitFor(qdrant);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -108,6 +124,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -122,11 +139,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    The Qdrant container can be slow to start, so using a persistent lifetime is recommended to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
+  The Qdrant container can be slow to start, so using a persistent lifetime is
+  recommended to avoid unnecessary restarts. For more information, see
+  [Container resource
+  lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
 </Aside>
 
 <Aside type="note">
-    When you reference a Qdrant resource from the AppHost, Aspire makes several properties available to the consuming project, including REST and gRPC endpoints, hostnames, port numbers, and the API key. For a complete list of these properties and per-language connection examples, see [Connect to Qdrant](../qdrant-connect/).
+  When you reference a Qdrant resource from the AppHost, Aspire makes several
+  properties available to the consuming project, including REST and gRPC
+  endpoints, hostnames, port numbers, and the API key. For a complete list of
+  these properties and per-language connection examples, see [Connect to
+  Qdrant](../qdrant-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Qdrant" />
@@ -135,24 +159,33 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 The Qdrant resource includes a randomly generated API key by default. To provide an explicit API key, pass it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var apiKey = builder.AddParameter("apiKey", secret: true);
 
 var qdrant = builder.AddQdrant("qdrant", apiKey)
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(qdrant)
-    .WaitFor(qdrant);
+.WithReference(qdrant)
+.WaitFor(qdrant);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -169,6 +202,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -188,23 +222,32 @@ For more information, see [External parameters](/get-started/resources/).
 
 Add a data volume to the Qdrant resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var qdrant = builder.AddQdrant("qdrant")
-    .WithDataVolume()
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithDataVolume()
+.WithLifetime(ContainerLifetime.Persistent);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(qdrant)
-    .WaitFor(qdrant);
+.WithReference(qdrant)
+.WaitFor(qdrant);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -220,6 +263,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -229,23 +273,32 @@ The data volume is used to persist Qdrant data outside the lifecycle of its cont
 
 Add a data bind mount to the Qdrant resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var qdrant = builder.AddQdrant("qdrant")
-    .WithDataBindMount(source: @"C:\Qdrant\Data")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithDataBindMount(source: @"C:\Qdrant\Data")
+.WithLifetime(ContainerLifetime.Persistent);
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(qdrant)
-    .WaitFor(qdrant);
+.WithReference(qdrant)
+.WaitFor(qdrant);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -261,11 +314,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Qdrant data across container restarts. The data bind mount is mounted at the `C:\Qdrant\Data` on Windows (or `/Qdrant/Data` on Unix) path on the host machine in the Qdrant container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).

--- a/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/qdrant/qdrant-host.mdx
@@ -30,10 +30,10 @@ If you're new to the Qdrant integration, start with the [Get started with Qdrant
 To start building an Aspire app that uses Qdrant, install the [📦 Aspire.Hosting.Qdrant](https://www.nuget.org/packages/Aspire.Hosting.Qdrant) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the Qdrant hosting integration packa
 Once you've installed the hosting integration in your AppHost project, you can add a Qdrant resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -160,10 +160,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 The Qdrant resource includes a randomly generated API key by default. To provide an explicit API key, pass it as a parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -223,10 +223,10 @@ For more information, see [External parameters](/get-started/resources/).
 Add a data volume to the Qdrant resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -274,10 +274,10 @@ The data volume is used to persist Qdrant data outside the lifecycle of its cont
 Add a data bind mount to the Qdrant resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -32,10 +32,10 @@ If you're new to the RavenDB integration, start with the [Get started with Raven
 The Aspire RavenDB hosting integration models the RavenDB server as the `RavenDBServerResource` type and the database as the `RavenDBDatabaseResource` type. To start building an Aspire app that uses RavenDB, install the [📦 CommunityToolkit.Aspire.Hosting.RavenDB](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.RavenDB) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -88,10 +88,10 @@ This updates your `aspire.config.json` with the RavenDB hosting integration pack
 Once you've installed the hosting integration in your AppHost project, you can add a RavenDB server resource and then add a database resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -164,10 +164,10 @@ await builder.build().run();
 By default, `AddDatabase` registers the database in the Aspire model but does not create it in RavenDB automatically. Pass `ensureCreated: true` to have Aspire create the database on startup if it does not already exist:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -215,10 +215,10 @@ await builder.build().run();
 Add a data volume to the RavenDB server resource to persist data outside the lifecycle of its container:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -270,10 +270,10 @@ The data volume is mounted at the `/var/lib/ravendb/data` path in the RavenDB co
 Add a data bind mount to the RavenDB server resource as an alternative to a named volume:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -335,10 +335,10 @@ Data bind mounts rely on the host machine's filesystem to persist the RavenDB da
 Add a named volume for the RavenDB logs directory:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -392,11 +392,11 @@ The log volume is mounted at the `/var/log/ravendb/logs` path in the RavenDB con
 To create a secured RavenDB instance using a pre-configured `settings.json` file or a self-signed certificate, use `RavenDBServerSettings.Secured` or `RavenDBServerSettings.SecuredWithLetsEncrypt`:
 
 <AppHostTabs limitations={{
-  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/ravendb/ravendb-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up RavenDB in the AppHost
-seoTitle: "Set up RavenDB in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up RavenDB in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire RavenDB Hosting integration to orchestrate and configure a RavenDB database in an Aspire solution.
 ---
 
@@ -31,7 +31,12 @@ If you're new to the RavenDB integration, start with the [Get started with Raven
 
 The Aspire RavenDB hosting integration models the RavenDB server as the `RavenDBServerResource` type and the database as the `RavenDBDatabaseResource` type. To start building an Aspire app that uses RavenDB, install the [📦 CommunityToolkit.Aspire.Hosting.RavenDB](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.RavenDB) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -39,7 +44,8 @@ aspire add CommunityToolkit.Aspire.Hosting.RavenDB
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -60,7 +66,8 @@ aspire add CommunityToolkit.Aspire.Hosting.RavenDB
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the RavenDB hosting integration package:
@@ -80,7 +87,12 @@ This updates your `aspire.config.json` with the RavenDB hosting integration pack
 
 Once you've installed the hosting integration in your AppHost project, you can add a RavenDB server resource and then add a database resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -104,10 +116,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-const ravendb = await ravenServer.addDatabase("ravendb");
+const ravenServer = await builder.addRavenDB('ravenServer');
+const ravendb = await ravenServer.addDatabase('ravendb');
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
@@ -128,22 +143,32 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-  Depending on your usage, RavenDB may require a license. For development, request a free
-  [Developer license](https://ravendb.net/license/request/dev). For production, see the
-  [available licenses](https://ravendb.net/buy) — including a free Community license that's
-  eligible for commercial use. Pass your license via the `RAVEN_License` environment variable,
-  or with `RavenDBServerSettings` from a C# AppHost.
+  Depending on your usage, RavenDB may require a license. For development,
+  request a free [Developer license](https://ravendb.net/license/request/dev).
+  For production, see the [available licenses](https://ravendb.net/buy) —
+  including a free Community license that's eligible for commercial use. Pass
+  your license via the `RAVEN_License` environment variable, or with
+  `RavenDBServerSettings` from a C# AppHost.
 </Aside>
 
 <Aside type="note">
-    When you reference a RavenDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as the server URI, hostname, port, and database name. For a complete list of these properties and per-language connection examples, see [Connect to RavenDB](../ravendb-connect/).
+  When you reference a RavenDB resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as the server URI,
+  hostname, port, and database name. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  RavenDB](../ravendb-connect/).
 </Aside>
 
 ## Add RavenDB database resource with auto-create
 
 By default, `AddDatabase` registers the database in the Aspire model but does not create it in RavenDB automatically. Pass `ensureCreated: true` to have Aspire create the database on startup if it does not already exist:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -167,10 +192,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-const ravendb = await ravenServer.addDatabase("ravendb", { ensureCreated: true });
+const ravenServer = await builder.addRavenDB('ravenServer');
+const ravendb = await ravenServer.addDatabase('ravendb', {
+  ensureCreated: true,
+});
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
@@ -184,7 +214,12 @@ await builder.build().run();
 
 Add a data volume to the RavenDB server resource to persist data outside the lifecycle of its container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -210,12 +245,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
+const ravenServer = await builder.addRavenDB('ravenServer');
 await ravenServer.withDataVolume();
 
-const ravendb = await ravenServer.addDatabase("ravendb");
+const ravendb = await ravenServer.addDatabase('ravendb');
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
@@ -231,7 +269,12 @@ The data volume is mounted at the `/var/lib/ravendb/data` path in the RavenDB co
 
 Add a data bind mount to the RavenDB server resource as an alternative to a named volume:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -257,12 +300,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
-await ravenServer.withDataBindMount("C:\\RavenDb\\Data");
+const ravenServer = await builder.addRavenDB('ravenServer');
+await ravenServer.withDataBindMount('C:\\RavenDb\\Data');
 
-const ravendb = await ravenServer.addDatabase("ravendb");
+const ravendb = await ravenServer.addDatabase('ravendb');
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
@@ -275,14 +321,25 @@ await builder.build().run();
 Data bind mounts rely on the host machine's filesystem to persist the RavenDB data across container restarts. The bind mount maps the host path `C:\RavenDb\Data` (on Windows, or the equivalent Unix path) to the `/var/lib/ravendb/data` directory inside the RavenDB container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 ## Add RavenDB server resource with log volume
 
 Add a named volume for the RavenDB logs directory:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -309,13 +366,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const ravenServer = await builder.addRavenDB("ravenServer");
+const ravenServer = await builder.addRavenDB('ravenServer');
 await ravenServer.withDataVolume();
 await ravenServer.withLogVolume();
 
-const ravendb = await ravenServer.addDatabase("ravendb");
+const ravendb = await ravenServer.addDatabase('ravendb');
 
-const apiService = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const apiService = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await apiService.withReference(ravendb);
 await apiService.waitFor(ravendb);
 
@@ -331,25 +391,37 @@ The log volume is mounted at the `/var/log/ravendb/logs` path in the RavenDB con
 
 To create a secured RavenDB instance using a pre-configured `settings.json` file or a self-signed certificate, use `RavenDBServerSettings.Secured` or `RavenDBServerSettings.SecuredWithLetsEncrypt`:
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var serverSettings = RavenDBServerSettings.SecuredWithLetsEncrypt(
-    domainUrl: "https://mycontainer.development.run",
-    certificatePath: "/etc/ravendb/security/cluster.server.certificate.mycontainer.pfx");
+domainUrl: "https://mycontainer.development.run",
+certificatePath: "/etc/ravendb/security/cluster.server.certificate.mycontainer.pfx");
 
 var ravenServer = builder.AddRavenDB("ravenSecuredServer", serverSettings)
-    .WithBindMount("C:/RavenDB/Server/Security", "/etc/ravendb/security", isReadOnly: false);
+.WithBindMount("C:/RavenDB/Server/Security", "/etc/ravendb/security", isReadOnly: false);
 
 var ravendb = ravenServer.AddDatabase("ravendbSecured");
 
 builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(ravendb)
-    .WaitFor(ravendb);
+.WithReference(ravendb)
+.WaitFor(ravendb);
 
 builder.Build().Run();
+
 ```
 
+</Fragment>
+</AppHostTabs>
 <Aside type="caution">
   Ensure the certificate path is accessible to the container by bind-mounting the host certificate directory to `/etc/ravendb/security`.
 </Aside>
@@ -365,3 +437,4 @@ For the full reference of RavenDB connection properties — and how consuming ap
 ## Hosting integration health checks
 
 The RavenDB hosting integration automatically adds a health check for both the server resource and each database resource, verifying that the instance is running and reachable. The hosting integration relies on the [📦 AspNetCore.HealthChecks.RavenDB](https://www.nuget.org/packages/AspNetCore.HealthChecks.RavenDB) NuGet package.
+```

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
@@ -53,10 +53,10 @@ For TypeScript AppHosts, add the Community Toolkit SQL Server extensions package
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `SqlServerServerResource` builder with `WithDbGate` / `withDbGate`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -99,10 +99,10 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 To add the [Adminer](https://adminer.org/) management UI, decorate the official `SqlServerServerResource` builder with `WithAdminer` / `withAdminer`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -145,10 +145,10 @@ This adds a new Adminer resource to the AppHost which is available from the Aspi
 You can use both management UIs together on the same SQL Server resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -191,10 +191,10 @@ await builder.build().run();
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the SQL Server resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-extensions.mdx
@@ -52,7 +52,12 @@ For TypeScript AppHosts, add the Community Toolkit SQL Server extensions package
 
 To add the [DbGate](https://dbgate.org/) management UI, decorate the official `SqlServerServerResource` builder with `WithDbGate` / `withDbGate`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -93,7 +98,12 @@ This adds a new DbGate resource to the AppHost which is available from the Aspir
 
 To add the [Adminer](https://adminer.org/) management UI, decorate the official `SqlServerServerResource` builder with `WithAdminer` / `withAdminer`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -134,7 +144,12 @@ This adds a new Adminer resource to the AppHost which is available from the Aspi
 
 You can use both management UIs together on the same SQL Server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -175,7 +190,12 @@ await builder.build().run();
 
 [dbx](https://github.com/t8y2/dbx) is a lightweight, web-based database client and an alternative management UI to DbGate and Adminer. Use `WithDbx` / `withDbx` to add a dbx child resource configured for the SQL Server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up SQL Server in the AppHost
-seoTitle: "Set up SQL Server in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up SQL Server in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire SQL Server Hosting integration to orchestrate and configure a SQL Server database in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the SQL Server integration, start with the [Get started with SQ
 
 To start building an Aspire app that uses SQL Server, install the [📦 Aspire.Hosting.SqlServer](https://www.nuget.org/packages/Aspire.Hosting.SqlServer) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add sql-server
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add sql-server
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the SQL Server hosting integration package:
@@ -78,25 +85,34 @@ This updates your `aspire.config.json` with the SQL Server hosting integration p
 
 Once you've installed the hosting integration in your AppHost project, you can add a SQL Server resource and then add a database resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -114,6 +130,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -130,11 +147,18 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    The SQL Server container is slow to start, so it's best to use a _persistent_ lifetime to avoid unnecessary restarts. For more information, see [Container resource lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
+  The SQL Server container is slow to start, so it's best to use a _persistent_
+  lifetime to avoid unnecessary restarts. For more information, see [Container
+  resource
+  lifetime](/architecture/resource-model/#built-in-resources-and-lifecycle).
 </Aside>
 
 <Aside type="note">
-    When you reference a SQL Server resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, and port numbers. For a complete list of these properties and per-language connection examples, see [Connect to SQL Server](../sql-server-connect/).
+  When you reference a SQL Server resource from the AppHost, Aspire makes
+  several properties available to the consuming project, such as connection
+  URIs, hostnames, and port numbers. For a complete list of these properties and
+  per-language connection examples, see [Connect to SQL
+  Server](../sql-server-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.SqlServer" />
@@ -150,19 +174,25 @@ IF (NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = @DatabaseName))
 
 To supply a custom creation script, call `WithCreationScript` (or `withCreationScript`) on the database resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql")
-    .WithLifetime(ContainerLifetime.Persistent);
+.WithLifetime(ContainerLifetime.Persistent);
 
 var databaseName = "app-db";
 var creationScript = $$"""
-    IF DB_ID('{{databaseName}}') IS NULL
-        CREATE DATABASE [{{databaseName}}];
-    GO
+IF DB_ID('{{databaseName}}') IS NULL
+CREATE DATABASE [{{databaseName}}];
+GO
 
     USE [{{databaseName}}];
     GO
@@ -179,17 +209,20 @@ var creationScript = $$"""
     """;
 
 var db = sql.AddDatabase(databaseName)
-    .WithCreationScript(creationScript);
+.WithCreationScript(creationScript);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -225,6 +258,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -234,25 +268,34 @@ The preceding example creates a database named `app-db` with a single `todos` ta
 
 Add a data volume to the SQL Server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql")
-    .WithDataVolume();
+.WithDataVolume();
 
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -270,38 +313,49 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
 The data volume is used to persist the SQL Server data outside the lifecycle of its container. The data volume is mounted at the `/var/opt/mssql` path in the SQL Server container and when a `name` parameter isn't provided, the name is generated at random. For more information on data volumes and details on why they're preferred over [bind mounts](#add-sql-server-resource-with-data-bind-mount), see [Docker docs: Volumes](https://docs.docker.com/engine/storage/volumes).
 
 <Aside type="caution">
-The password is stored in the data volume. When using a data volume and if the password changes, it will not work until you delete the volume.
+  The password is stored in the data volume. When using a data volume and if the
+  password changes, it will not work until you delete the volume.
 </Aside>
 
 ## Add SQL Server resource with data bind mount
 
 Add a data bind mount to the SQL Server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql")
-    .WithDataBindMount(source: @"C:\SqlServer\Data");
+.WithDataBindMount(source: @"C:\SqlServer\Data");
 
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -319,11 +373,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist the SQL Server data across container restarts. The data bind mount is mounted at the `C:\SqlServer\Data` on Windows (or `/SqlServer/Data` on Unix) path on the host machine in the SQL Server container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -332,8 +393,14 @@ Data bind mounts rely on the host machine's filesystem to persist the SQL Server
 
 When you want to explicitly provide the password used by the container image, you can provide it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -343,14 +410,17 @@ var sql = builder.AddSqlServer("sql", password);
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -368,6 +438,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -377,25 +448,34 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 To pin the SQL Server container to a specific release, call `WithImageTag` (or `withImageTag`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddSqlServer("sql")
-    .WithImageTag("2025-RTM-ubuntu-24.04-preview");
+.WithImageTag("2025-RTM-ubuntu-24.04-preview");
 
 var db = sql.AddDatabase("database");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(db)
-    .WaitFor(db);
+.WithReference(db)
+.WaitFor(db);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -413,6 +493,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -422,8 +503,14 @@ For a list of available tags, see [SQL Server container image tags](https://mcr.
 
 By default, Aspire injects the SQL Server connection information using variable names derived from the resource name (for example, `DATABASE_URI`, `DATABASE_HOST`, `DATABASE_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -431,19 +518,22 @@ var sql = builder.AddSqlServer("sql");
 var database = sql.AddDatabase("database");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(database)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["SQL_HOST"] = sql.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["SQL_PORT"] = sql.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["SQL_PASSWORD"] = sql.Resource.PasswordParameter;
-        context.EnvironmentVariables["SQL_DATABASE"] = database.Resource.DatabaseName;
-    });
+.WithReference(database)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["SQL_HOST"] = sql.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["SQL_PORT"] = sql.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["SQL_PASSWORD"] = sql.Resource.PasswordParameter;
+context.EnvironmentVariables["SQL_DATABASE"] = database.Resource.DatabaseName;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -461,6 +551,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -468,21 +559,30 @@ await builder.build().run();
 
 To reference an externally managed SQL Server instance instead of running one as a container, use `AddConnectionString`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var sql = builder.AddConnectionString("sql");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("exampleproject")
-    .WithReference(sql);
+.WithReference(sql);
 
 // After adding all resources, run the app...
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -496,6 +596,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -556,6 +657,7 @@ When the AppHost runs, the server's database resources can be accessed from exte
             For more information, see [MSSQL for Visual Studio Code](https://learn.microsoft.com/sql/tools/visual-studio-code-extensions/mssql/mssql-extension-visual-studio-code).
         </LearnMore>
     </TabItem>
+
 </Tabs>
 
 ## Connection properties

--- a/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sql-server/sql-server-host.mdx
@@ -30,10 +30,10 @@ If you're new to the SQL Server integration, start with the [Get started with SQ
 To start building an Aspire app that uses SQL Server, install the [📦 Aspire.Hosting.SqlServer](https://www.nuget.org/packages/Aspire.Hosting.SqlServer) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the SQL Server hosting integration p
 Once you've installed the hosting integration in your AppHost project, you can add a SQL Server resource and then add a database resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -175,10 +175,10 @@ IF (NOT EXISTS (SELECT 1 FROM sys.databases WHERE name = @DatabaseName))
 To supply a custom creation script, call `WithCreationScript` (or `withCreationScript`) on the database resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -269,10 +269,10 @@ The preceding example creates a database named `app-db` with a single `todos` ta
 Add a data volume to the SQL Server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -329,10 +329,10 @@ The data volume is used to persist the SQL Server data outside the lifecycle of 
 Add a data bind mount to the SQL Server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -394,10 +394,10 @@ Data bind mounts rely on the host machine's filesystem to persist the SQL Server
 When you want to explicitly provide the password used by the container image, you can provide it as a parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -449,10 +449,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 To pin the SQL Server container to a specific release, call `WithImageTag` (or `withImageTag`):
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -504,10 +504,10 @@ For a list of available tags, see [SQL Server container image tags](https://mcr.
 By default, Aspire injects the SQL Server connection information using variable names derived from the resource name (for example, `DATABASE_URI`, `DATABASE_HOST`, `DATABASE_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -560,10 +560,10 @@ await builder.build().run();
 To reference an externally managed SQL Server instance instead of running one as a container, use `AddConnectionString`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up SQLite in the AppHost
-seoTitle: "Set up SQLite in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up SQLite in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire SQLite Hosting integration to orchestrate and configure a SQLite database resource in an Aspire solution.
 ---
 
@@ -28,14 +28,21 @@ This article is the reference for the Aspire SQLite Hosting integration. It enum
 If you're new to the SQLite integration, start with the [Get started with SQLite integrations](/integrations/databases/sqlite/sqlite-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to SQLite](../sqlite-connect/).
 
 <Aside type="note">
-  The SQLite hosting integration is part of the [Aspire Community Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in the core Aspire SDK.
+  The SQLite hosting integration is part of the [Aspire Community
+  Toolkit](https://github.com/CommunityToolkit/Aspire) and is not included in
+  the core Aspire SDK.
 </Aside>
 
 ## Installation
 
 To start building an Aspire app that uses SQLite, install the [📦 CommunityToolkit.Aspire.Hosting.Sqlite](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Sqlite) NuGet package in your AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -43,7 +50,8 @@ aspire add sqlite
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -64,7 +72,8 @@ aspire add sqlite
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the SQLite hosting integration package:
@@ -84,7 +93,12 @@ This updates your `aspire.config.json` with the SQLite hosting integration packa
 
 Once you've installed the hosting integration in your AppHost project, you can add a SQLite resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -106,9 +120,12 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const sqlite = await builder.addSqlite("sqlite");
+const sqlite = await builder.addSqlite('sqlite');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(sqlite);
 
 await builder.build().run();
@@ -126,14 +143,22 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    When you reference a SQLite resource from the AppHost, Aspire makes the database file path available to the consuming project as a `SQLITE_DATASOURCE` environment variable. For a complete list of these properties and per-language connection examples, see [Connect to SQLite](../sqlite-connect/).
+  When you reference a SQLite resource from the AppHost, Aspire makes the
+  database file path available to the consuming project as a `SQLITE_DATASOURCE`
+  environment variable. For a complete list of these properties and per-language
+  connection examples, see [Connect to SQLite](../sqlite-connect/).
 </Aside>
 
 ## Add SQLite resource with custom database file path
 
 By default, Aspire creates the SQLite database file in the user's temporary directory. To specify a custom location, provide the directory path and file name as arguments to `AddSqlite`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -155,12 +180,15 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const sqlite = await builder.addSqlite("sqlite", {
-    databasePath: "C:\\Database\\Location",
-    databaseFileName: "my-database.db",
+const sqlite = await builder.addSqlite('sqlite', {
+  databasePath: 'C:\\Database\\Location',
+  databaseFileName: 'my-database.db',
 });
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(sqlite);
 
 await builder.build().run();
@@ -175,7 +203,12 @@ The preceding code creates the SQLite database file at `C:\Database\Location\my-
 
 To add a browser-based management UI alongside your SQLite database, use the `WithSqliteWeb` extension method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -198,10 +231,13 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const sqlite = await builder.addSqlite("sqlite");
+const sqlite = await builder.addSqlite('sqlite');
 await sqlite.withSqliteWeb();
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(sqlite);
 
 await builder.build().run();

--- a/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/sqlite/sqlite-host.mdx
@@ -38,10 +38,10 @@ If you're new to the SQLite integration, start with the [Get started with SQLite
 To start building an Aspire app that uses SQLite, install the [📦 CommunityToolkit.Aspire.Hosting.Sqlite](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.Sqlite) NuGet package in your AppHost project:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -94,10 +94,10 @@ This updates your `aspire.config.json` with the SQLite hosting integration packa
 Once you've installed the hosting integration in your AppHost project, you can add a SQLite resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -154,10 +154,10 @@ await builder.build().run();
 By default, Aspire creates the SQLite database file in the user's temporary directory. To specify a custom location, provide the directory path and file name as arguments to `AddSqlite`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -204,10 +204,10 @@ The preceding code creates the SQLite database file at `C:\Database\Location\my-
 To add a browser-based management UI alongside your SQLite database, use the `WithSqliteWeb` extension method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up SurrealDB in the AppHost
-seoTitle: "Set up SurrealDB in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up SurrealDB in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire SurrealDB Hosting integration to orchestrate and configure a SurrealDB resource in an Aspire solution.
 ---
 
@@ -32,7 +32,12 @@ If you're new to the SurrealDB integration, start with the [Get started with Sur
 
 To start building an Aspire app that uses SurrealDB, install the [📦 CommunityToolkit.Aspire.Hosting.SurrealDb](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.SurrealDb) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.SurrealDb" />
@@ -55,7 +60,8 @@ aspire add CommunityToolkit.Aspire.Hosting.SurrealDb
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the SurrealDB hosting integration package:
@@ -75,7 +81,12 @@ This updates your `aspire.config.json` with the SurrealDB hosting integration pa
 
 Once you've installed the hosting integration in your AppHost project, you can add a SurrealDB server, namespace, and database resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -100,11 +111,14 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const surreal = await builder.addSurrealServer("surreal");
-const ns = await surreal.addNamespace("ns");
-const db = await ns.addDatabase("db");
+const surreal = await builder.addSurrealServer('surreal');
+const ns = await surreal.addNamespace('ns');
+const db = await ns.addDatabase('db');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
@@ -127,14 +141,23 @@ await builder.build().run();
 </Steps>
 
 <Aside type="note">
-    When you reference a SurrealDB resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection strings, hostnames, and port numbers. For a complete list of these properties and per-language connection examples, see [Connect to SurrealDB](../surrealdb-connect/).
+  When you reference a SurrealDB resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection strings,
+  hostnames, and port numbers. For a complete list of these properties and
+  per-language connection examples, see [Connect to
+  SurrealDB](../surrealdb-connect/).
 </Aside>
 
 ## Add Surrealist
 
 To add [Surrealist](https://hub.docker.com/r/surrealdb/surrealist) to the SurrealDB server resource, call the `WithSurrealist` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -162,13 +185,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-let surreal = await builder.addSurrealServer("surreal");
+let surreal = await builder.addSurrealServer('surreal');
 surreal = await surreal.withSurrealist();
 
-const ns = await surreal.addNamespace("ns");
-const db = await ns.addDatabase("db");
+const ns = await surreal.addNamespace('ns');
+const db = await ns.addDatabase('db');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
@@ -184,7 +210,12 @@ Surrealist is a web-based user interface for interacting with your SurrealDB dat
 
 To add a data bind mount to the SurrealDB resource, call the `WithDataBindMount` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -210,13 +241,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-let surreal = await builder.addSurrealServer("surreal");
-surreal = await surreal.withDataBindMount("./data/surreal/data");
+let surreal = await builder.addSurrealServer('surreal');
+surreal = await surreal.withDataBindMount('./data/surreal/data');
 
-const ns = await surreal.addNamespace("ns");
-const db = await ns.addDatabase("db");
+const ns = await surreal.addNamespace('ns');
+const db = await ns.addDatabase('db');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
@@ -232,7 +266,12 @@ Data bind mounts rely on the host machine's filesystem to persist SurrealDB data
 
 When you want to explicitly provide the password used by the container image, you can provide it as a parameter:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -259,13 +298,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const password = await builder.addParameter("password", { secret: true });
+const password = await builder.addParameter('password', { secret: true });
 
-const surreal = await builder.addSurrealServer("surreal", { password });
-const ns = await surreal.addNamespace("ns");
-const db = await ns.addDatabase("db");
+const surreal = await builder.addSurrealServer('surreal', { password });
+const ns = await surreal.addNamespace('ns');
+const db = await ns.addDatabase('db');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 
@@ -281,7 +323,12 @@ For more information on providing parameters, see [External parameters](/get-sta
 
 To configure the log level for the SurrealDB container, call the `WithLogLevel` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -309,13 +356,16 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-let surreal = await builder.addSurrealServer("surreal");
-surreal = await surreal.withLogLevel("Debug");
+let surreal = await builder.addSurrealServer('surreal');
+surreal = await surreal.withLogLevel('Debug');
 
-const ns = await surreal.addNamespace("ns");
-const db = await ns.addDatabase("db");
+const ns = await surreal.addNamespace('ns');
+const db = await ns.addDatabase('db');
 
-const exampleProject = await builder.addProject("apiservice", "../ExampleProject/ExampleProject.csproj");
+const exampleProject = await builder.addProject(
+  'apiservice',
+  '../ExampleProject/ExampleProject.csproj'
+);
 await exampleProject.withReference(db);
 await exampleProject.waitFor(db);
 

--- a/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
+++ b/src/frontend/src/content/docs/integrations/databases/surrealdb/surrealdb-host.mdx
@@ -33,10 +33,10 @@ If you're new to the SurrealDB integration, start with the [Get started with Sur
 To start building an Aspire app that uses SurrealDB, install the [📦 CommunityToolkit.Aspire.Hosting.SurrealDb](https://nuget.org/packages/CommunityToolkit.Aspire.Hosting.SurrealDb) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -82,10 +82,10 @@ This updates your `aspire.config.json` with the SurrealDB hosting integration pa
 Once you've installed the hosting integration in your AppHost project, you can add a SurrealDB server, namespace, and database resource as shown in the following example:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -153,10 +153,10 @@ await builder.build().run();
 To add [Surrealist](https://hub.docker.com/r/surrealdb/surrealist) to the SurrealDB server resource, call the `WithSurrealist` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -211,10 +211,10 @@ Surrealist is a web-based user interface for interacting with your SurrealDB dat
 To add a data bind mount to the SurrealDB resource, call the `WithDataBindMount` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -267,10 +267,10 @@ Data bind mounts rely on the host machine's filesystem to persist SurrealDB data
 When you want to explicitly provide the password used by the container image, you can provide it as a parameter:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -324,10 +324,10 @@ For more information on providing parameters, see [External parameters](/get-sta
 To configure the log level for the SurrealDB container, call the `WithLogLevel` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/devtools/browser-logs.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/browser-logs.mdx
@@ -78,6 +78,34 @@ This updates your `aspire.config.json` with the browser logs hosting integration
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add browsers
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add browsers
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add browsers
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add browsers
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add browser logs to a resource
@@ -110,6 +138,89 @@ builder.addViteApp("web", "../web")
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_vite_app("web", "../web")
+    web.with_browser_logs()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.AddViteApp("web", "../web").WithBrowserLogs()
+
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addViteApp("web", "../web")
+        .withBrowserLogs();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let web = builder.add_vite_app("web", "../web", None)?;
+    let _web = web.with_browser_logs(None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -146,6 +257,100 @@ builder.addViteApp("web", "../web")
         userDataMode: BrowserUserDataMode.Isolated,
     });
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_vite_app("web", "../web")
+    web.with_browser_logs(
+        browser="msedge",
+        user_data_mode="Isolated",
+    )
+    builder.run()
+````
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	browser := "msedge"
+	mode := aspire.BrowserUserDataModeIsolated
+	web := builder.AddViteApp("web", "../web").WithBrowserLogs(&aspire.WithBrowserLogsOptions{Browser: &browser, UserDataMode: &mode})
+
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addViteApp("web", "../web")
+        .withBrowserLogs(new WithBrowserLogsOptions()
+            .browser("msedge")
+            .userDataMode(BrowserUserDataMode.ISOLATED));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let web = builder.add_vite_app("web", "../web", None)?;
+    let _web = web.with_browser_logs(
+        Some("msedge"),
+        None,
+        Some(BrowserUserDataMode::Isolated),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/devtools/dab/dab-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/dab/dab-host.mdx
@@ -26,7 +26,12 @@ This article is the AppHost API reference for the [📦 CommunityToolkit.Aspire.
 
 ## Installation
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -64,7 +69,12 @@ This adds the package to `aspire.config.json`. After `aspire restore`, `.aspire/
 
 The integration uses `dab-config.json` by default. The file must exist when the AppHost builds the application model.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -151,7 +161,12 @@ The REST route for this entity is `/api/Product`; GraphQL requests use `/graphql
 
 Pass every configuration path to `AddDataAPIBuilder` or `addDataAPIBuilder`. Each file is mounted read-only under `/App` in the container.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -186,7 +201,12 @@ await builder.build().run();
 
 The DAB resource is a standard container resource, so you can replace the registry, image, or tag:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -223,7 +243,12 @@ await builder.build().run();
 
 The resource exports its primary endpoint, host, port, and URI expression for use in custom AppHost expressions:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Azure.DataApiBuilder operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/dev-tunnels.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/dev-tunnels.mdx
@@ -164,12 +164,11 @@ func main() {
 	}
 
 	web := builder.AddNodeApp("web", "../web", "index.js")
-	tunnel := builder.AddDevTunnel("my-tunnel").WithReference(web)
-
 	if err := web.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	tunnel := builder.AddDevTunnel("my-tunnel").WithReference(web)
 	if err := tunnel.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -267,12 +266,11 @@ func main() {
 	}
 
 	web := builder.AddNodeApp("web", "../web", "index.js")
-	tunnel := builder.AddDevTunnel("public-api").WithReference(web).WithAnonymousAccess()
-
 	if err := web.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	tunnel := builder.AddDevTunnel("public-api").WithReference(web).WithAnonymousAccess()
 	if err := tunnel.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -384,12 +382,11 @@ func main() {
 	allowAnonymous := false
 	description := "QA environment tunnel"
 	web := builder.AddNodeApp("web", "../web", "index.js")
-	tunnel := builder.AddDevTunnel("qa", &aspire.AddDevTunnelOptions{TunnelId: &tunnelID, AllowAnonymous: &allowAnonymous, Description: &description, Labels: []string{"qa", "testing"}}).WithReference(web)
-
 	if err := web.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	tunnel := builder.AddDevTunnel("qa", &aspire.AddDevTunnelOptions{TunnelId: &tunnelID, AllowAnonymous: &allowAnonymous, Description: &description, Labels: []string{"qa", "testing"}}).WithReference(web)
 	if err := tunnel.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/devtools/dev-tunnels.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/dev-tunnels.mdx
@@ -74,13 +74,43 @@ This updates your `aspire.config.json` with the Dev Tunnels hosting integration 
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add devtunnels
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add devtunnels
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add devtunnels
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add devtunnels
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Add a dev tunnel resource
 
 In the AppHost project, add a dev tunnel and configure it to expose specific resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Dev Tunnel resources, but its withReference operation currently requires an untyped Value and is not validated for resource references.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -103,6 +133,74 @@ const tunnel = await builder.addDevTunnel("my-tunnel")
     .withReference(web);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_node_app("web", "../web", "index.js")
+    tunnel = builder.add_dev_tunnel("my-tunnel")
+    tunnel.with_reference(web)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.AddNodeApp("web", "../web", "index.js")
+	tunnel := builder.AddDevTunnel("my-tunnel").WithReference(web)
+
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := tunnel.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addNodeApp("web", "../web", "index.js");
+    var tunnel = builder.addDevTunnel("my-tunnel").withReference(web);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 When you run the AppHost, the dev tunnel is created to expose the web application endpoints publicly. The tunnel URLs are shown in the Aspire dashboard. By default, the tunnel requires authentication and is available only to the user who created it.
@@ -111,7 +209,9 @@ When you run the AppHost, the dev tunnel is created to expose the web applicatio
 
 To allow anonymous (public) access to the entire tunnel, chain a call to the `WithAnonymousAccess` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Dev Tunnel resources, but its withReference operation currently requires an untyped Value and is not validated for resource references.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -136,13 +236,85 @@ const tunnel = await builder.addDevTunnel("public-api")
     .withAnonymousAccess();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_node_app("web", "../web", "index.js")
+    tunnel = builder.add_dev_tunnel("public-api")
+    tunnel.with_reference(web).with_anonymous_access()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.AddNodeApp("web", "../web", "index.js")
+	tunnel := builder.AddDevTunnel("public-api").WithReference(web).WithAnonymousAccess()
+
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := tunnel.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addNodeApp("web", "../web", "index.js");
+    var tunnel = builder.addDevTunnel("public-api")
+        .withReference(web)
+        .withAnonymousAccess();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Configure dev tunnel options
 
 To configure other options for the dev tunnel, provide the `DevTunnelOptions` to the `AddDevTunnel` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Dev Tunnel options, but its withReference operation currently requires an untyped Value and is not validated for resource references.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -172,13 +344,100 @@ const tunnel = await builder.addDevTunnel("qa", "my-tunnel-id", false, "QA envir
     .withReference(web);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_node_app("web", "../web", "index.js")
+    tunnel = builder.add_dev_tunnel(
+        "qa",
+        tunnel_id="my-tunnel-id",
+        allow_anonymous=False,
+        description="QA environment tunnel",
+        labels=["qa", "testing"],
+    )
+    tunnel.with_reference(web)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tunnelID := "my-tunnel-id"
+	allowAnonymous := false
+	description := "QA environment tunnel"
+	web := builder.AddNodeApp("web", "../web", "index.js")
+	tunnel := builder.AddDevTunnel("qa", &aspire.AddDevTunnelOptions{TunnelId: &tunnelID, AllowAnonymous: &allowAnonymous, Description: &description, Labels: []string{"qa", "testing"}}).WithReference(web)
+
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := tunnel.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addNodeApp("web", "../web", "index.js");
+    var options = new AddDevTunnelOptions()
+        .tunnelId("my-tunnel-id")
+        .allowAnonymous(false)
+        .description("QA environment tunnel")
+        .labels(new String[] { "qa", "testing" });
+    var tunnel = builder.addDevTunnel("qa", options).withReference(web);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Configure for mixed access
 
 To allow anonymous access to specific endpoints, use the appropriate `WithReference` overload:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the Dev Tunnel endpoint-specific reference overload with per-endpoint anonymous access.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the Dev Tunnel endpoint-specific reference overload with per-endpoint anonymous access.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the Dev Tunnel endpoint-specific reference overload with per-endpoint anonymous access.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the Dev Tunnel endpoint-specific reference overload with per-endpoint anonymous access.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-connect.mdx
@@ -255,7 +255,12 @@ dotnet add package OpenFeature.Providers.Ofrep
 
 In your AppHost, retrieve the OFREP endpoint from the flagd resource and pass it to your consuming project as an environment variable:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/flagd/flagd-host.mdx
@@ -55,7 +55,12 @@ Or, choose a manual installation approach:
 
 Once you've installed the hosting integration in your AppHost project, you can add a flagd resource. The flagd container requires a sync source. Use `WithBindFileSync` to mount a directory of flag-definition files into the container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -113,7 +118,12 @@ await builder.build().run();
 
 To specify the flag-definition filename explicitly, pass both the `fileSource` directory and the `filename` to `WithBindFileSync`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -191,6 +201,14 @@ For more information on flag configuration, see the [flagd flag definitions docu
 
 To enable debug logging for the flagd container, call `WithLogLevel`:
 
+<AppHostTabs limitations={{
+  python: 'CommunityToolkit.Aspire.Hosting.Flagd does not expose the logging operation in the generated Python AppHost SDK.',
+  go: 'CommunityToolkit.Aspire.Hosting.Flagd does not expose the logging operation in the generated Go AppHost SDK.',
+  java: 'CommunityToolkit.Aspire.Hosting.Flagd does not expose the logging operation in the generated Java AppHost SDK.',
+  rust: 'CommunityToolkit.Aspire.Hosting.Flagd does not expose the logging operation in the generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -205,17 +223,48 @@ builder.AddProject<Projects.ExampleProject>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+`WithLogLevel` is excluded from ATS exports. Set the equivalent `FLAGD_DEBUG` environment variable instead:
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const flagd = await builder.addFlagd('flagd');
+await flagd.withBindFileSync('./flags/');
+await flagd.withEnvironment('FLAGD_DEBUG', 'true');
+
+const api = await builder.addProject(
+  'api',
+  '../ExampleProject/ExampleProject.csproj'
+);
+await api.withReference(flagd);
+
+await builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
+
 Debug logging provides verbose output for troubleshooting flag evaluation issues. Currently, only the `Debug` log level is supported.
 
 :::note
-The flagd hosting source explicitly marks `WithLogLevel` with `[AspireExportIgnore]`, so the generated TypeScript API doesn't include `withLogLevel`. In a TypeScript AppHost, set the `FLAGD_DEBUG` environment variable directly instead.
+The flagd hosting source explicitly marks `WithLogLevel` with `[AspireExportIgnore]`, so generated SDKs don't include a direct logging method.
 :::
 
 ## Customize ports
 
 To use fixed host ports instead of randomly assigned ones, pass the `port` and `ofrepPort` parameters to `AddFlagd`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Flagd operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/goff/goff-host.mdx
@@ -53,7 +53,12 @@ Or, choose a manual installation approach:
 
 Once you've installed the hosting integration in your AppHost project, you can add a GO Feature Flag relay proxy resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -110,7 +115,12 @@ When you reference a GO Feature Flag resource from the AppHost, Aspire makes sev
 
 To point the relay proxy to a specific configuration file inside the container, pass the `pathToConfigFile` parameter to `AddGoFeatureFlag`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -157,7 +167,12 @@ The `pathToConfigFile` parameter sets the `--config` argument passed to the rela
 
 To persist relay proxy data (such as cached flag evaluations) across container restarts, add a named data volume:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -231,7 +246,12 @@ This instructs the relay proxy to load flags from the `flags.yaml` file inside t
 
 To configure the log level for the GO Feature Flag container resource, call `WithLogLevel`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -281,7 +301,12 @@ The `WithLogLevel` method sets the `LOGLEVEL` environment variable on the contai
 
 To use a specific host port for the relay proxy HTTP endpoint, pass the `port` parameter to `AddGoFeatureFlag`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.GoFeatureFlag operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/k6/k6-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/k6/k6-get-started.mdx
@@ -59,7 +59,12 @@ Add `CommunityToolkit.Aspire.Hosting.k6` to your AppHost. See [Set up k6 in the 
 
 Mount the directory that contains your tests, then select the script to run:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/k6/k6-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/k6/k6-host.mdx
@@ -29,7 +29,12 @@ This reference describes the Community Toolkit k6 hosting integration APIs for t
 
 Add [📦 CommunityToolkit.Aspire.Hosting.k6](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.k6) to the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -71,7 +76,12 @@ The command adds the package to `aspire.config.json`:
 
 Use `AddK6` / `addK6` to add a Grafana k6 container resource. The resource uses the `docker.io/grafana/k6` image, exposes its HTTP API as the `http` endpoint, and is visible in the dashboard.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -115,7 +125,12 @@ The examples read `PrimaryEndpoint` / `primaryEndpoint()` when an AppHost API ne
 
 The optional `enableBrowserExtensions` parameter selects the k6 image variant with browser support. The optional `port` parameter selects the host port for the HTTP API.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -147,7 +162,12 @@ The default image does not include browser support. Enable it only for tests tha
 
 Mount the script directory with the standard container `WithBindMount` / `withBindMount` API before selecting a path in the container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -174,7 +194,12 @@ await k6.withScript('/scripts/main.js', 25, '45s');
 
 `WithK6OtlpEnvironment` / `withK6OtlpEnvironment` copies every existing `OTEL_*` environment variable for the resource to a corresponding `K6_OTEL_*` variable. This enables the k6 OpenTelemetry output to use the OTLP configuration that Aspire has already set for the resource.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.k6 operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/mailpit/mailpit-host.mdx
@@ -55,7 +55,12 @@ Or, choose a manual installation approach:
 
 Once you've installed the hosting integration in your AppHost project, you can add a Mailpit resource as shown in the following example:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -121,7 +126,12 @@ You can open the Mailpit web UI from the Aspire dashboard by clicking the HTTP e
 
 Add a data volume to the Mailpit resource to persist captured emails across container restarts:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -166,7 +176,12 @@ The data volume is mounted at `/data` and the integration configures Mailpit to 
 
 Use a bind mount when you need direct access to Mailpit's database files from the host:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -201,7 +216,12 @@ The bind mount uses the same `/data` container path and `/data/mailpit.db` datab
 
 Pass `httpPort` and `smtpPort` to bind Mailpit's endpoints to fixed host ports:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.MailPit operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-get-started.mdx
@@ -57,7 +57,12 @@ aspire add CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects
 
 Then add the SQL Server database and a SQL project resource. Update the DACPAC path to match your database project's output.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-host.mdx
@@ -35,7 +35,12 @@ Add [📦 CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects](https://www.nuget
 
 Or add it manually:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -64,7 +69,12 @@ Run `aspire restore` after changing a TypeScript AppHost package configuration t
 
 In a C# AppHost, use `AddSqlProject<TProject>` when the AppHost references an MSBuild SQL project. The generic project metadata overload resolves the project's `SqlTargetPath` or `TargetPath` output. Use the non-generic overload with `WithDacpac` when you already have a DACPAC.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -142,7 +152,12 @@ The package resource uses `tools/<package-id>.dacpac` by default; `WithDacpac` s
 
 Use a DACFx publish profile with `WithDacDeployOptions`, or configure `DacDeployOptions` directly in a C# AppHost. A publish-profile path is loaded as supplied, so use a path that is valid for the AppHost process.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -181,7 +196,12 @@ await databaseProject.withReference(database);
 
 `WithSkipWhenDeployed` records a DACPAC checksum in the target database. On later deployments, the integration skips the DACPAC if the checksum is unchanged. It sets `DropExtendedPropertiesNotInSource` to `false` while this option is active.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -219,7 +239,12 @@ Use this with a persistent database when avoiding an unchanged schema deployment
 
 `WithReference` establishes a parent relationship to the target, waits for that target to be ready, and then deploys the DACPAC. A SQL Server database target supplies the database name automatically. You can instead target any connection-string resource; its connection string must contain `Database` or `Initial Catalog` so DACFx can infer the target database.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-host.mdx
+++ b/src/frontend/src/content/docs/integrations/devtools/sql-projects/sql-projects-host.mdx
@@ -140,13 +140,25 @@ In C#, `AddSqlPackage<TPackage>` models a DACPAC contained in a NuGet package. M
 </PackageReference>
 ```
 
+<AppHostTabs limitations={{
+  typescript: 'The generic AddSqlPackage overload requires C# IPackageMetadata and is not exported to the generated TypeScript AppHost SDK.',
+  python: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects package resource APIs are not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects package resource APIs are not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects package resource APIs are not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.SqlDatabaseProjects package resource APIs are not exposed by the generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var packageSchema = builder.AddSqlPackage<Packages.ErikEJ_Dacpac_Chinook>("chinook")
     .WithDacpac("tools/ErikEJ.Dacpac.Chinook.dacpac")
     .WithReference(database);
 ```
 
-The package resource uses `tools/<package-id>.dacpac` by default; `WithDacpac` selects a different path relative to the package. It also supports `WithDacDeployOptions`, `WithConfigureDacDeployOptions`, `WithSkipWhenDeployed`, and both `WithReference` target overloads. `AddSqlPackage<TPackage>` and these package APIs aren't exported to TypeScript because they require `IPackageMetadata`.
+</Fragment>
+</AppHostTabs>
+
+The package resource uses `tools/<package-id>.dacpac` by default; `WithDacpac` selects a different path relative to the package. It also supports `WithDacDeployOptions`, `WithConfigureDacDeployOptions`, `WithSkipWhenDeployed`, and both `WithReference` target overloads. `AddSqlPackage<TPackage>` and these package APIs aren't exported to the generated TypeScript, Python, Go, Java, or Rust AppHost SDKs because they require C# package metadata.
 
 ## Configure deployment
 

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-connect.mdx
@@ -128,17 +128,16 @@ func main() {
 
 	endpointName := "http"
 	weatherAPI := builder.AddProject("weatherapi", "../WeatherApi/WeatherApi.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Name: &endpointName})
-	blazorApp := builder.AddBlazorWasmProject("app", "../Client/Client.csproj").WithReference(weatherAPI.GetEndpoint("http"))
-	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
-
 	if err := weatherAPI.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	blazorApp := builder.AddBlazorWasmProject("app", "../Client/Client.csproj").WithReference(weatherAPI.GetEndpoint("http"))
 	if err := blazorApp.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
 	if err := gateway.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-connect.mdx
@@ -47,7 +47,9 @@ Common properties used in Blazor-hosted app models are:
 
 Use the AppHost to connect APIs to a Blazor WebAssembly project resource, then associate the client app with a Blazor Gateway.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Blazor resources, but its withReference operation currently requires an untyped Value and is not validated for endpoint references.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -88,6 +90,88 @@ await builder
   .withBlazorClientApp(blazorApp);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    weather_api = builder.add_project("weatherapi", "../WeatherApi/WeatherApi.csproj")
+    weather_api.with_http_endpoint(name="http")
+    blazor_app = builder.add_blazor_wasm_project("app", "../Client/Client.csproj")
+    blazor_app.with_reference(weather_api.get_endpoint("http"))
+    gateway = builder.add_blazor_gateway("gateway")
+    gateway.with_external_http_endpoints().with_blazor_client_app(blazor_app)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	endpointName := "http"
+	weatherAPI := builder.AddProject("weatherapi", "../WeatherApi/WeatherApi.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Name: &endpointName})
+	blazorApp := builder.AddBlazorWasmProject("app", "../Client/Client.csproj").WithReference(weatherAPI.GetEndpoint("http"))
+	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
+
+	if err := weatherAPI.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := blazorApp.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := gateway.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var weatherApi = builder.addProject("weatherapi", "../WeatherApi/WeatherApi.csproj")
+        .withHttpEndpoint(new WithHttpEndpointOptions().name("http"));
+    var blazorApp = builder.addBlazorWasmProject("app", "../Client/Client.csproj")
+        .withReference(weatherApi.getEndpoint("http"));
+    var gateway = builder.addBlazorGateway("gateway")
+        .withExternalHttpEndpoints()
+        .withBlazorClientApp(blazorApp);
+
+    builder.build().run();
+}
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-hosting.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-hosting.mdx
@@ -73,13 +73,43 @@ This updates your `aspire.config.json` with the Blazor hosting package:
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Blazor
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Blazor
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Blazor
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Blazor
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add Blazor WebAssembly project
 
 Use `AddBlazorWasmProject` / `addBlazorWasmProject` to add a Blazor WebAssembly project to the AppHost model.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Blazor resources, but its withReference operation currently requires an untyped Value and is not validated for endpoint references.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -108,6 +138,75 @@ const blazorApp = await builder
   .withReference(await api.getEndpoint('http'));
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../MyApi/MyApi.csproj")
+    blazor_app = builder.add_blazor_wasm_project("app", "../MyBlazorApp/MyBlazorApp.csproj")
+    blazor_app.with_reference(api.get_endpoint("http"))
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../MyApi/MyApi.csproj")
+	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(api.GetEndpoint("http"))
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := blazorApp.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("api", "../MyApi/MyApi.csproj");
+    var blazorApp = builder.addBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj")
+        .withReference(api.getEndpoint("http"));
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -145,6 +244,89 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    gateway = builder.add_blazor_gateway("gateway")
+    gateway.with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints()
+
+	if err := gateway.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var gateway = builder.addBlazorGateway("gateway")
+        .withExternalHttpEndpoints();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let gateway = builder.add_blazor_gateway("gateway")?;
+    let _gateway = gateway.with_external_http_endpoints()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 :::note
@@ -155,7 +337,9 @@ await builder.build().run();
 
 Use `WithBlazorClientApp` / `withBlazorClientApp` to bind the WebAssembly project resource to the Blazor Gateway:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK generates Blazor resources, but its withReference operation currently requires an untyped Value and is not validated for endpoint references.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -197,6 +381,85 @@ await builder
   .withBlazorClientApp(blazorApp);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    weather_api = builder.add_project("weatherapi", "../WeatherApi/WeatherApi.csproj")
+    blazor_app = builder.add_blazor_wasm_project("app", "../MyBlazorApp/MyBlazorApp.csproj")
+    blazor_app.with_reference(weather_api.get_endpoint("http"))
+    gateway = builder.add_blazor_gateway("gateway")
+    gateway.with_external_http_endpoints().with_blazor_client_app(blazor_app)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	weatherAPI := builder.AddProject("weatherapi", "../WeatherApi/WeatherApi.csproj")
+	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(weatherAPI.GetEndpoint("http"))
+	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
+
+	if err := weatherAPI.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := blazorApp.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := gateway.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var weatherApi = builder.addProject("weatherapi", "../WeatherApi/WeatherApi.csproj");
+    var blazorApp = builder.addBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj")
+        .withReference(weatherApi.getEndpoint("http"));
+    var gateway = builder.addBlazorGateway("gateway")
+        .withExternalHttpEndpoints()
+        .withBlazorClientApp(blazorApp);
+
+    builder.build().run();
+}
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/dotnet/blazor-hosting.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/blazor-hosting.mdx
@@ -172,12 +172,11 @@ func main() {
 	}
 
 	api := builder.AddProject("api", "../MyApi/MyApi.csproj")
-	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(api.GetEndpoint("http"))
-
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(api.GetEndpoint("http"))
 	if err := blazorApp.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -417,17 +416,16 @@ func main() {
 	}
 
 	weatherAPI := builder.AddProject("weatherapi", "../WeatherApi/WeatherApi.csproj")
-	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(weatherAPI.GetEndpoint("http"))
-	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
-
 	if err := weatherAPI.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	blazorApp := builder.AddBlazorWasmProject("app", "../MyBlazorApp/MyBlazorApp.csproj").WithReference(weatherAPI.GetEndpoint("http"))
 	if err := blazorApp.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	gateway := builder.AddBlazorGateway("gateway").WithExternalHttpEndpoints().WithBlazorClientApp(blazorApp)
 	if err := gateway.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
@@ -72,6 +72,86 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    worker = builder.add_c_sharp_app("worker", "../worker/Program.cs")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	worker := builder.AddCSharpApp("worker", "../worker/Program.cs")
+
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var worker = builder.addCSharpApp("worker", "../worker/Program.cs");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _worker = builder.add_c_sharp_app("worker", "../worker/Program.cs", None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 You can also point to a `.csproj` file or a directory that contains one:
@@ -111,6 +191,94 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_c_sharp_app("api", "../api/Api.csproj")
+    frontend = builder.add_c_sharp_app("frontend", "../frontend/")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddCSharpApp("api", "../api/Api.csproj")
+	frontend := builder.AddCSharpApp("frontend", "../frontend/")
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addCSharpApp("api", "../api/Api.csproj");
+    var frontend = builder.addCSharpApp("frontend", "../frontend/");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _api = builder.add_c_sharp_app("api", "../api/Api.csproj", None)?;
+    let _frontend = builder.add_c_sharp_app("frontend", "../frontend/", None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="tip">
@@ -125,7 +293,10 @@ When pointing to a `.csproj` file or directory, `AddCSharpApp` behaves similarly
 
 File-based apps integrate fully with Aspire's resource model. You can reference other resources and configure service discovery just like any other project resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'The PostgreSQL package used by this C# app dependency example was not generated in the available Go SDK batch.',
+  rust: 'The Redis and PostgreSQL packages used by this C# app dependency example are not present in the available Rust SDK module.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -165,6 +336,41 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+    pg = builder.add_postgres("pg")
+    db = pg.add_database("mydb")
+    worker = builder.add_c_sharp_app("worker", "../worker/Program.cs")
+    worker.with_reference(cache).with_reference(db).with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var cache = builder.addRedis("cache");
+    var db = builder.addPostgres("pg").addDatabase("mydb");
+    var worker = builder.addCSharpApp("worker", "../worker/Program.cs")
+        .withReference(cache)
+        .withReference(db)
+        .withExternalHttpEndpoints();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The file-based app receives connection strings and service discovery information through environment variables, exactly like projects added with `AddProject<T>` (or `addProject`).
@@ -173,7 +379,12 @@ The file-based app receives connection strings and service discovery information
 
 The C# `AddCSharpApp` method accepts an optional `Action<ProjectResourceOptions>` callback to configure launch settings:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for constructing and mutating ProjectResourceOptions for addCSharpApp.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for constructing and mutating ProjectResourceOptions for addCSharpApp.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for constructing and mutating ProjectResourceOptions for addCSharpApp.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for constructing and mutating ProjectResourceOptions for addCSharpApp.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -213,6 +424,15 @@ The available options are the same as those used with `AddProject<T>`:
 
 You can also write the AppHost itself as a file-based C# app using the `#:sdk` directive:
 
+<AppHostTabs limitations={{
+  typescript: 'The `#:sdk` and `#:package` directives are C# compiler features. TypeScript AppHosts use apphost.mts and aspire.config.json instead.',
+  python: 'The `#:sdk` and `#:package` directives are C# compiler features. Python AppHosts use apphost.py and aspire.config.json instead.',
+  go: 'The `#:sdk` and `#:package` directives are C# compiler features. Go AppHosts use apphost.go and aspire.config.json instead.',
+  java: 'The `#:sdk` and `#:package` directives are C# compiler features. Java AppHosts use AppHost.java and aspire.config.json instead.',
+  rust: 'The `#:sdk` and `#:package` directives are C# compiler features. Rust AppHosts use apphost.rs and aspire.config.json instead.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="apphost.cs"
 #:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
 #:package Aspire.Hosting.Redis@%ASPIRE_VERSION%
@@ -229,10 +449,13 @@ builder.AddCSharpApp("worker", "../worker/Program.cs")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 Use `#:package` directives to add NuGet package references directly in the source file instead of a `.csproj`.
 
 :::note
-A TypeScript AppHost (`apphost.mts`) is already a file-based script with no project file required. The `#:sdk` and `#:package` directives are specific to the C# file-based AppHost feature and have no TypeScript equivalent.
+Guest-language AppHosts already use source entry files without an AppHost project file. The `#:sdk` and `#:package` directives are specific to the C# file-based AppHost feature and have no TypeScript, Python, Go, Java, or Rust equivalent.
 :::
 
 <LearnMore>
@@ -276,7 +499,7 @@ dotnet_diagnostic.ASPIRECSHARPAPPS001.severity = none
 ```
 
 :::note
-`ASPIRECSHARPAPPS001` is a C# compiler diagnostic. TypeScript AppHosts call `addCSharpApp` without any diagnostic suppression needed.
+`ASPIRECSHARPAPPS001` is a C# compiler diagnostic. Generated guest-language SDKs call their `addCSharpApp` equivalent without diagnostic suppression.
 :::
 
 <LearnMore>

--- a/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/csharp-file-based-apps.mdx
@@ -221,12 +221,11 @@ func main() {
 	}
 
 	api := builder.AddCSharpApp("api", "../api/Api.csproj")
-	frontend := builder.AddCSharpApp("frontend", "../frontend/")
-
 	if err := api.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	frontend := builder.AddCSharpApp("frontend", "../frontend/")
 	if err := frontend.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
@@ -477,11 +476,23 @@ To use `AddCSharpApp` in a C# AppHost, suppress the `ASPIRECSHARPAPPS001` diagno
 
 **In code** with a pragma directive:
 
+<AppHostTabs limitations={{
+  typescript: 'ASPIRECSHARPAPPS001 is a C# compiler diagnostic; TypeScript AppHosts do not use pragma warning directives.',
+  python: 'ASPIRECSHARPAPPS001 is a C# compiler diagnostic; Python AppHosts do not use pragma warning directives.',
+  go: 'ASPIRECSHARPAPPS001 is a C# compiler diagnostic; Go AppHosts do not use pragma warning directives.',
+  java: 'ASPIRECSHARPAPPS001 is a C# compiler diagnostic; Java AppHosts do not use pragma warning directives.',
+  rust: 'ASPIRECSHARPAPPS001 is a C# compiler diagnostic; Rust AppHosts do not use pragma warning directives.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIRECSHARPAPPS001
 builder.AddCSharpApp("worker", "../worker/Program.cs");
 #pragma warning restore ASPIRECSHARPAPPS001
 ```
+
+</Fragment>
+</AppHostTabs>
 
 **In your project file** with `NoWarn`:
 

--- a/src/frontend/src/content/docs/integrations/dotnet/dotnet-tool-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/dotnet-tool-resources.mdx
@@ -1056,11 +1056,23 @@ The `ASPIREDOTNETTOOL` diagnostic applies to C# AppHosts only. Generated TypeScr
 
 ### Suppress in code
 
+<AppHostTabs limitations={{
+  typescript: 'ASPIREDOTNETTOOL is a C# compiler diagnostic; TypeScript AppHosts do not use pragma warning directives.',
+  python: 'ASPIREDOTNETTOOL is a C# compiler diagnostic; Python AppHosts do not use pragma warning directives.',
+  go: 'ASPIREDOTNETTOOL is a C# compiler diagnostic; Go AppHosts do not use pragma warning directives.',
+  java: 'ASPIREDOTNETTOOL is a C# compiler diagnostic; Java AppHosts do not use pragma warning directives.',
+  rust: 'ASPIREDOTNETTOOL is a C# compiler diagnostic; Rust AppHosts do not use pragma warning directives.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREDOTNETTOOL
 var tool = builder.AddDotnetTool("my-tool", "dotnet-tool-package");
 #pragma warning restore ASPIREDOTNETTOOL
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ### Suppress in project file
 

--- a/src/frontend/src/content/docs/integrations/dotnet/dotnet-tool-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/dotnet-tool-resources.mdx
@@ -77,6 +77,86 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    efTool = builder.add_dotnet_tool("ef", "dotnet-ef")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	efTool := builder.AddDotnetTool("ef", "dotnet-ef")
+
+	if err := efTool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var efTool = builder.addDotnetTool("ef", "dotnet-ef");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 When the AppHost runs, Aspire executes `dotnet tool exec dotnet-ef` to run the tool.
@@ -114,6 +194,89 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")
+    ef_tool.with_args(["migrations", "list"])
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	efTool := builder.AddDotnetTool("ef", "dotnet-ef").WithArgs([]string{"migrations", "list"})
+
+	if err := efTool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var efTool = builder.addDotnetTool("ef", "dotnet-ef")
+        .withArgs(new String[] { "migrations", "list" });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")?;
+    let _ef_tool = ef_tool.with_args(vec!["migrations".to_string(), "list".to_string()])?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 :::note
@@ -145,6 +308,88 @@ await efTool.withToolVersion("9.0.1");
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")
+    ef_tool.with_tool_version("9.0.1")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	efTool := builder.AddDotnetTool("ef", "dotnet-ef").WithToolVersion("9.0.1")
+
+	if err := efTool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var efTool = builder.addDotnetTool("ef", "dotnet-ef").withToolVersion("9.0.1");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")?;
+    let _ef_tool = ef_tool.with_tool_version("9.0.1")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 You can also use wildcard versions to get the latest patch:
@@ -163,6 +408,88 @@ var efTool = builder.AddDotnetTool("ef", "dotnet-ef")
 ```typescript title="apphost.mts"
 const efTool = await builder.addDotnetTool("ef", "dotnet-ef");
 await efTool.withToolVersion("10.0.*");
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")
+    ef_tool.with_tool_version("10.0.*")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	efTool := builder.AddDotnetTool("ef", "dotnet-ef").WithToolVersion("10.0.*")
+
+	if err := efTool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var efTool = builder.addDotnetTool("ef", "dotnet-ef").withToolVersion("10.0.*");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")?;
+    let _ef_tool = ef_tool.with_tool_version("10.0.*")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -186,6 +513,88 @@ var efTool = builder.AddDotnetTool("ef", "dotnet-ef")
 ```typescript title="apphost.mts"
 const efTool = await builder.addDotnetTool("ef", "dotnet-ef");
 await efTool.withToolPrerelease();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")
+    ef_tool.with_tool_prerelease()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	efTool := builder.AddDotnetTool("ef", "dotnet-ef").WithToolPrerelease()
+
+	if err := efTool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var efTool = builder.addDotnetTool("ef", "dotnet-ef").withToolPrerelease();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let ef_tool = builder.add_dotnet_tool("ef", "dotnet-ef")?;
+    let _ef_tool = ef_tool.with_tool_prerelease()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -216,6 +625,89 @@ await tool.withToolSource("https://my-private-feed.example.com/nuget/v3/index.js
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")
+    tool.with_tool_source("https://my-private-feed.example.com/nuget/v3/index.json")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tool := builder.AddDotnetTool("my-tool", "my-custom-tool").WithToolSource("https://my-private-feed.example.com/nuget/v3/index.json")
+
+	if err := tool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var tool = builder.addDotnetTool("my-tool", "my-custom-tool")
+        .withToolSource("https://my-private-feed.example.com/nuget/v3/index.json");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")?;
+    let _tool = tool.with_tool_source("https://my-private-feed.example.com/nuget/v3/index.json")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Use only specified sources
@@ -238,6 +730,91 @@ var tool = builder.AddDotnetTool("my-tool", "my-custom-tool")
 const tool = await builder.addDotnetTool("my-tool", "my-custom-tool");
 await tool.withToolSource("./local-packages");
 await tool.withToolIgnoreExistingFeeds();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")
+    tool.with_tool_source("./local-packages").with_tool_ignore_existing_feeds()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tool := builder.AddDotnetTool("my-tool", "my-custom-tool").WithToolSource("./local-packages").WithToolIgnoreExistingFeeds()
+
+	if err := tool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var tool = builder.addDotnetTool("my-tool", "my-custom-tool")
+        .withToolSource("./local-packages")
+        .withToolIgnoreExistingFeeds();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")?;
+    let tool = tool.with_tool_source("./local-packages")?;
+    let _tool = tool.with_tool_ignore_existing_feeds()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -264,13 +841,99 @@ await tool.withToolIgnoreFailedSources();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")
+    tool.with_tool_ignore_failed_sources()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tool := builder.AddDotnetTool("my-tool", "my-custom-tool").WithToolIgnoreFailedSources()
+
+	if err := tool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var tool = builder.addDotnetTool("my-tool", "my-custom-tool")
+        .withToolIgnoreFailedSources();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let tool = builder.add_dotnet_tool("my-tool", "my-custom-tool")?;
+    let _tool = tool.with_tool_ignore_failed_sources()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Practical example: Database migrations
 
 The following is a complete example using Entity Framework Core CLI to run database migrations:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'The PostgreSQL package used by this migrations example was not generated in the available Go SDK batch.',
+  rust: 'The PostgreSQL package used by this migrations example was not generated in the available Rust SDK batch.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -317,6 +980,44 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_postgres("postgres")
+    appdb = postgres.add_database("appdb")
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_reference(appdb)
+    migrations = builder.add_dotnet_tool("ef-migrate", "dotnet-ef")
+    migrations.with_args(["database", "update", "--project", "../Api"])
+    migrations.with_reference(appdb).wait_for(postgres)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var postgres = builder.addPostgres("postgres");
+    var appdb = postgres.addDatabase("appdb");
+    var api = builder.addProject("api", "../Api/Api.csproj").withReference(appdb);
+    var migrations = builder.addDotnetTool("ef-migrate", "dotnet-ef")
+        .withArgs(new String[] { "database", "update", "--project", "../Api" })
+        .withReference(appdb)
+        .waitFor(postgres);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Dashboard integration
@@ -351,7 +1052,7 @@ Be aware of the following limitations when using .NET tool resources:
 
 ## Suppress the experimental diagnostic
 
-The `ASPIREDOTNETTOOL` diagnostic applies to C# AppHosts only. The TypeScript AppHost SDK does not require any suppression.
+The `ASPIREDOTNETTOOL` diagnostic applies to C# AppHosts only. Generated TypeScript, Python, Go, Java, and Rust AppHost SDKs do not require suppression.
 
 ### Suppress in code
 

--- a/src/frontend/src/content/docs/integrations/dotnet/launch-profiles.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/launch-profiles.mdx
@@ -6,6 +6,7 @@ description: Learn how Aspire integrates with .NET launch profiles for C# AppHos
 
 import { Image } from 'astro:assets';
 import { Aside, Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import dotnetIcon from '@assets/icons/dotnet.svg';
 
 <Image
@@ -115,6 +116,9 @@ Other settings, such as `environmentVariables`, are passed to the application wi
 
 Ideally, you can align the launch profile names between the AppHost and its service projects so that switching profiles in the AppHost switches them across all coordinated projects at once. However, you can also specify which profile a particular project uses by passing `launchProfileName` to `AddProject`:
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -124,6 +128,121 @@ builder.AddProject<Projects.InventoryService>(
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addProject(
+  'inventoryservice',
+  '../InventoryService/InventoryService.csproj',
+  { launchProfileOrOptions: 'mylaunchprofile' }
+);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_project(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        launch_profile_or_options="mylaunchprofile",
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	inventory := builder.AddProject(
+		"inventoryservice",
+		"../InventoryService/InventoryService.csproj",
+		&aspire.AddProjectOptions{LaunchProfileOrOptions: "mylaunchprofile"},
+	)
+	if err := inventory.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var inventory = builder.addProject(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        "mylaunchprofile");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _inventory = builder.add_project(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        Some(json!("mylaunchprofile")),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding code launches the `inventoryservice` resource using the options from the `mylaunchprofile` launch profile. The launch profile precedence logic is as follows:
 
@@ -142,6 +261,14 @@ To force a service project to launch without a launch profile, set the `launchPr
 
 When adding an ASP.NET Core project to the AppHost, Aspire parses the _launchSettings.json_ file, selects the appropriate launch profile, and automatically generates endpoints in the application model based on the URLs in the `applicationUrl` field. To modify the automatically injected endpoints, use `WithEndpoint`:
 
+<AppHostTabs limitations={{
+  python: 'The endpoint mutation callback in this example has not been validated against the generated Python callback model.',
+  go: 'The endpoint mutation callback in this example has not been validated against the generated Go callback model.',
+  java: 'The endpoint mutation callback in this example has not been validated against the generated Java callback model.',
+  rust: 'The endpoint mutation callback in this example has not been validated against the generated Rust callback model.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -150,6 +277,29 @@ builder.AddProject<Projects.InventoryService>("inventoryservice")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder
+  .addProject(
+    'inventoryservice',
+    '../InventoryService/InventoryService.csproj'
+  )
+  .withEndpointCallback('https', async endpoint => {
+    await endpoint.isProxied.set(false);
+  });
+
+await builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding code disables the reverse proxy that Aspire deploys in front of the .NET application and allows the application to respond directly to requests over HTTP(S).
 

--- a/src/frontend/src/content/docs/integrations/dotnet/maui.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/maui.mdx
@@ -6,6 +6,7 @@ description: Learn how to use the Aspire .NET MAUI integration to orchestrate .N
 
 import { Image } from 'astro:assets';
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 import mauiIcon from '@assets/icons/maui-icon.png';
 
@@ -66,6 +67,15 @@ TypeScript AppHost support for this integration is not yet available.
 
 To orchestrate a .NET MAUI application in your AppHost, call `AddMauiProject` with the name and path to the `.csproj` file:
 
+<AppHostTabs limitations={{
+  typescript: 'Aspire.Hosting.Maui does not expose AddMauiProject in the generated TypeScript AppHost SDK.',
+  python: 'Aspire.Hosting.Maui does not expose AddMauiProject in the generated Python AppHost SDK.',
+  go: 'Aspire.Hosting.Maui does not expose AddMauiProject in the generated Go AppHost SDK.',
+  java: 'Aspire.Hosting.Maui does not expose AddMauiProject in the generated Java AppHost SDK.',
+  rust: 'Aspire.Hosting.Maui does not expose AddMauiProject in the generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -77,6 +87,9 @@ var mauiapp = builder.AddMauiProject("mauiapp", "../YourMauiApp/YourMauiApp.cspr
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 <Aside type="caution" title="Don't add a project reference">
 The .NET MAUI app is added here via its `.csproj` path passed to `AddMauiProject`. Don't add a `ProjectReference` from the AppHost project to the .NET MAUI project; this will cause the AppHost project to fail to build because their target frameworks are incompatible.
@@ -145,6 +158,15 @@ You can add multiple device configurations for the same MAUI project. Each devic
 
 The following example shows all platform configurations together in a single AppHost:
 
+<AppHostTabs limitations={{
+  typescript: 'Aspire.Hosting.Maui does not expose its project and device configuration operations in the generated TypeScript AppHost SDK.',
+  python: 'Aspire.Hosting.Maui does not expose its project and device configuration operations in the generated Python AppHost SDK.',
+  go: 'Aspire.Hosting.Maui does not expose its project and device configuration operations in the generated Go AppHost SDK.',
+  java: 'Aspire.Hosting.Maui does not expose its project and device configuration operations in the generated Java AppHost SDK.',
+  rust: 'Aspire.Hosting.Maui does not expose its project and device configuration operations in the generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -172,6 +194,9 @@ mauiapp.AddAndroidEmulator()
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Configure the .NET MAUI app
 

--- a/src/frontend/src/content/docs/integrations/dotnet/maui.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/maui.mdx
@@ -99,6 +99,15 @@ The .NET MAUI app is added here via its `.csproj` path passed to `AddMauiProject
 
 Each target platform requires a specific device configuration chained from the MAUI project resource:
 
+<AppHostTabs limitations={{
+  typescript: 'Aspire.Hosting.Maui does not expose platform-specific device configuration operations in the generated TypeScript AppHost SDK.',
+  python: 'Aspire.Hosting.Maui does not expose platform-specific device configuration operations in the generated Python AppHost SDK.',
+  go: 'Aspire.Hosting.Maui does not expose platform-specific device configuration operations in the generated Go AppHost SDK.',
+  java: 'Aspire.Hosting.Maui does not expose platform-specific device configuration operations in the generated Java AppHost SDK.',
+  rust: 'Aspire.Hosting.Maui does not expose platform-specific device configuration operations in the generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 <Tabs syncKey="platform">
 <TabItem label="Windows">
 
@@ -147,6 +156,9 @@ mauiapp.AddAndroidEmulator()
 
 </TabItem>
 </Tabs>
+
+</Fragment>
+</AppHostTabs>
 
 On Windows and Mac Catalyst, local service connectivity works directly through localhost without requiring Dev Tunnels. iOS Simulator and Android Emulator require Dev Tunnels; the `WithOtlpDevTunnel()` method creates a Dev Tunnel specifically for OpenTelemetry Protocol (OTLP) traffic so telemetry from mobile targets reaches the Aspire dashboard.
 

--- a/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
@@ -1,7 +1,7 @@
 ---
 title: Project resources
 seoTitle: "Add C# project resources to your Aspire AppHost"
-description: Learn how to add .NET projects as resources in your Aspire AppHost — with examples for both AppHost.cs (C#) and apphost.mts (TypeScript).
+description: Add .NET project resources from C#, TypeScript, Python, Go, Java, and Rust AppHosts, including references, launch profiles, endpoints, and replicas.
 ---
 
 import AppHostTabs from '@components/AppHostTabs.astro';
@@ -23,7 +23,7 @@ import proxyWithRandomPorts from '@assets/fundamentals/networking/proxy-with-ran
   data-zoom-off
 />
 
-This article is the reference for modeling .NET projects as first-class Aspire resources in your AppHost. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to add, configure, and connect a .NET project resource in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for modeling .NET projects as first-class Aspire resources in your AppHost. It shows the C# API and the generated TypeScript, Python, Go, Java, and Rust APIs that add, configure, and connect a .NET project resource.
 
 ## When to use project resources
 
@@ -33,7 +33,7 @@ Use project resources when you need to:
 - Connect the project to other Aspire resources with `withReference`, service discovery, and generated connection strings.
 - Reuse launch profile settings and ASP.NET Core endpoint discovery from `launchSettings.json`.
 
-In a **C# AppHost**, `AddProject<T>` references the target project through a generated `Projects.*` type, created from a `ProjectReference` in the AppHost `.csproj`. In a **TypeScript AppHost**, `addProject(name, path)` takes the path to the `.csproj` file directly — no generated type or project file reference is needed.
+In a **C# AppHost**, `AddProject<T>` references the target project through a generated `Projects.*` type, created from a `ProjectReference` in the AppHost `.csproj`. Generated guest-language SDKs take the path to the `.csproj` file directly, so no generated project type or AppHost project reference is needed.
 
 For single-file apps or quick experiments that don't need a `ProjectReference`, use [C# file-based apps](/integrations/dotnet/csharp-file-based-apps/) instead.
 
@@ -78,13 +78,96 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../ApiService/ApiService.csproj")
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _api = builder.add_project("api", "../ApiService/ApiService.csproj", None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Resource dependencies
 
 Project resources participate fully in the Aspire application model. You can reference other resources, flow connection strings and service discovery information, and expose endpoints like any other Aspire resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'The PostgreSQL package used by this dependency example was not generated in the available Go SDK batch.',
+  rust: 'The Redis and PostgreSQL packages used by this dependency example are not present in the available Rust SDK module.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -118,6 +201,41 @@ await builder.addProject("api", "../ApiService/ApiService.csproj")
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+    postgres = builder.add_postgres("postgres")
+    db = postgres.add_database("appdb")
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_reference(cache).with_reference(db).with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var cache = builder.addRedis("cache");
+    var db = builder.addPostgres("postgres").addDatabase("appdb");
+    var api = builder.addProject("api", "../ApiService/ApiService.csproj")
+        .withReference(cache)
+        .withReference(db)
+        .withExternalHttpEndpoints();
+
+    builder.build().run();
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -176,6 +294,98 @@ await builder.addProject("inventoryservice", "../InventoryService/InventoryServi
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    inventory = builder.add_project(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        launch_profile_or_options="https",
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	inventory := builder.AddProject("inventoryservice", "../InventoryService/InventoryService.csproj", &aspire.AddProjectOptions{LaunchProfileOrOptions: "https"})
+
+	if err := inventory.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var inventory = builder.addProject(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        "https");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _inventory = builder.add_project(
+        "inventoryservice",
+        "../InventoryService/InventoryService.csproj",
+        Some(json!("https")),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The `launchProfileName` argument has the highest precedence. When you don't specify it, Aspire selects the effective launch profile in this order:
@@ -187,7 +397,12 @@ The `launchProfileName` argument has the highest precedence. When you don't spec
 
 To force a project resource to run without a launch profile, pass `launchProfileName: null`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for explicitly disabling launch-profile selection for addProject.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for explicitly disabling launch-profile selection for addProject.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for explicitly disabling launch-profile selection for addProject.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for explicitly disabling launch-profile selection for addProject.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -223,6 +438,92 @@ await builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend
     .withHttpsEndpoint({ port: 7239 });
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+    frontend.with_http_endpoint(port=5066).with_https_endpoint(port=7239)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	httpPort, httpsPort := 5066.0, 7239.0
+	frontend := builder.AddProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: &httpPort}).WithHttpsEndpoint(&aspire.WithHttpsEndpointOptions{Port: &httpsPort})
+
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var frontend = builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+        .withHttpEndpoint(new WithHttpEndpointOptions().port(5066))
+        .withHttpsEndpoint(new WithHttpsEndpointOptions().port(7239));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj", None)?;
+    frontend.with_http_endpoint(Some(5066.0), None, None, None, None)?;
+    frontend.with_https_endpoint(Some(7239.0), None, None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 If there's no _launchSettings.json_ file or selected launch profile, project resources don't get HTTP or HTTPS bindings by default.
@@ -248,7 +549,12 @@ With a Kestrel endpoint configured, remove any `applicationUrl` from _launchSett
   AppHost throws an exception.
 </Aside>
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the addProject configure callback that changes launch-profile and Kestrel endpoint flags.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the addProject configure callback that changes launch-profile and Kestrel endpoint flags.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the addProject configure callback that changes launch-profile and Kestrel endpoint flags.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the addProject configure callback that changes launch-profile and Kestrel endpoint flags.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -281,7 +587,12 @@ await builder.build().run();
 
 For ASP.NET Core projects, Aspire reads the selected launch profile and can create endpoints from the `applicationUrl` field in _launchSettings.json_. You can then customize those endpoints with methods like `WithEndpoint`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK does not provide a validated mapping for the endpoint mutation callback used to set IsProxied.',
+  go: 'The generated Go AppHost SDK does not provide a validated mapping for the endpoint mutation callback used to set IsProxied.',
+  java: 'The generated Java AppHost SDK does not provide a validated mapping for the endpoint mutation callback used to set IsProxied.',
+  rust: 'The generated Rust AppHost SDK does not provide a validated mapping for the endpoint mutation callback used to set IsProxied.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -329,6 +640,92 @@ await builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend
     .withReplicas(2);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+    frontend.with_http_endpoint(port=5066).with_replicas(2)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	port := 5066.0
+	frontend := builder.AddProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: &port}).WithReplicas(2)
+
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var frontend = builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+        .withHttpEndpoint(new WithHttpEndpointOptions().port(5066))
+        .withReplicas(2);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj", None)?;
+    frontend.with_http_endpoint(Some(5066.0), None, None, None, None)?;
+    frontend.with_replicas(2.0)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The following diagram shows this setup:
@@ -360,6 +757,90 @@ await builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend
     .withHttpEndpoint({ port: 5066 });
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+    frontend.with_http_endpoint(port=5066)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	port := 5066.0
+	frontend := builder.AddProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: &port})
+
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var frontend = builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+        .withHttpEndpoint(new WithHttpEndpointOptions().port(5066));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj", None)?;
+    let _frontend = frontend.with_http_endpoint(Some(5066.0), None, None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Image
@@ -387,6 +868,89 @@ builder.AddProject<Projects.Networking_Frontend>("frontend")
 await builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
     .withHttpEndpoint();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+    frontend.with_http_endpoint()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	frontend := builder.AddProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj").WithHttpEndpoint()
+
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var frontend = builder.addProject("frontend", "../Networking_Frontend/Networking_Frontend.csproj")
+        .withHttpEndpoint();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_project("frontend", "../Networking_Frontend/Networking_Frontend.csproj", None)?;
+    let _frontend = frontend.with_http_endpoint(None, None, None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -428,6 +992,95 @@ await builder.addProject("apiservice", "../Networking.ApiService/Networking.ApiS
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("apiservice", "../Networking.ApiService/Networking.ApiService.csproj")
+    api.with_https_endpoint().with_https_endpoint(port=19227, name="admin").with_endpoints_in_env(["https"])
+    builder.run()
+````
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	adminPort := 19227.0
+	adminName := "admin"
+	api := builder.AddProject("apiservice", "../Networking.ApiService/Networking.ApiService.csproj").WithHttpsEndpoint().WithHttpsEndpoint(&aspire.WithHttpsEndpointOptions{Port: &adminPort, Name: &adminName}).WithEndpointsInEnvironment([]string{"https"})
+
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("apiservice", "../Networking.ApiService/Networking.ApiService.csproj")
+        .withHttpsEndpoint()
+        .withHttpsEndpoint(new WithHttpsEndpointOptions().port(19227).name("admin"))
+        .withEndpointsInEnvironment(new String[] { "https" });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("apiservice", "../Networking.ApiService/Networking.ApiService.csproj", None)?;
+    api.with_https_endpoint(None, None, None, None, None)?;
+    api.with_https_endpoint(Some(19227.0), None, Some("admin"), None, None)?;
+    api.with_endpoints_in_environment(vec!["https".to_string()])?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 This keeps the `admin` endpoint out of the environment variables while still defining it in the application model.
@@ -438,11 +1091,11 @@ This keeps the `admin` endpoint out of the environment variables while still def
 
 ## How project references work
 
-The C# and TypeScript AppHosts differ in how they reference .NET projects:
+The C# API and generated guest-language APIs differ in how they reference .NET projects:
 
 - **C# AppHost**: A `ProjectReference` in the AppHost `.csproj` causes the Aspire SDK to generate a `Projects.*` type during build. `AddProject<Projects.ApiService>("api")` uses that generated type to locate and launch the project. For the SDK-level build behavior behind this generation step, see [Aspire SDK](/get-started/aspire-sdk/).
 
-- **TypeScript AppHost**: No `ProjectReference` is needed. `addProject("api", "../ApiService/ApiService.csproj")` points directly to the `.csproj` file. The TypeScript SDK resolves the project path at startup.
+- **Generated guest-language AppHosts**: No `ProjectReference` is needed. Pass the `.csproj` path directly to the generated `addProject` equivalent. The SDK resolves the project path at startup.
 
 ## Exclude a project from orchestration
 
@@ -493,6 +1146,94 @@ const microservice2 = await builder.addProject("micro2", "../Microservice2/Prese
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    microservice1 = builder.add_project("micro1", "../Microservice1/Presentation.Api/Presentation.Api.csproj")
+    microservice2 = builder.add_project("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	microservice1 := builder.AddProject("micro1", "../Microservice1/Presentation.Api/Presentation.Api.csproj")
+	microservice2 := builder.AddProject("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj")
+
+	if err := microservice1.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	if err := microservice2.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var microservice1 = builder.addProject("micro1", "../Microservice1/Presentation.Api/Presentation.Api.csproj");
+    var microservice2 = builder.addProject("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let _microservice1 = builder.add_project("micro1", "../Microservice1/Presentation.Api/Presentation.Api.csproj", None)?;
+    let _microservice2 = builder.add_project("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj", None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
+++ b/src/frontend/src/content/docs/integrations/dotnet/project-resources.mdx
@@ -1177,12 +1177,11 @@ func main() {
 	}
 
 	microservice1 := builder.AddProject("micro1", "../Microservice1/Presentation.Api/Presentation.Api.csproj")
-	microservice2 := builder.AddProject("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj")
-
 	if err := microservice1.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}
 
+	microservice2 := builder.AddProject("micro2", "../Microservice2/Presentation.Api/Presentation.Api.csproj")
 	if err := microservice2.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/bun-apps.mdx
@@ -76,6 +76,68 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp := builder.AddBunApp("bun-api", "../bun-app", "server.ts")
+if err := bunApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var bunApp = builder.addBunApp("bun-api", "../bun-app", "server.ts");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The official package requires both paths. In TypeScript, replace the Toolkit options object with the official `appDirectory` and `scriptPath` arguments.
@@ -111,6 +173,72 @@ const bunApp = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
 await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")
+    bun_app.with_http_endpoint(port=3000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp := builder.AddBunApp("bun-api", "../bun-app", "server.ts")
+if err := bunApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp = bunApp.WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")})
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var bunApp = builder.addBunApp("bun-api", "../bun-app", "server.ts")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")?;
+bun_app.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -159,6 +287,72 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    bun_app = builder.add_bun_app("bun-api", "../bun-app", "src/http/server.ts")
+    bun_app.with_http_endpoint(port=3000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp := builder.AddBunApp("bun-api", "../bun-app", "src/http/server.ts")
+if err := bunApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp = bunApp.WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")})
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var bunApp = builder.addBunApp("bun-api", "../bun-app", "src/http/server.ts")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let bun_app = builder.add_bun_app("bun-api", "../bun-app", "src/http/server.ts")?;
+bun_app.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Install packages before startup
@@ -193,6 +387,72 @@ const bunApp = await builder.addBunApp('bun-api', '../bun-app', 'server.ts');
 await bunApp.withHttpEndpoint({ port: 3000, env: 'PORT' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")
+    bun_app.with_http_endpoint(port=3000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp := builder.AddBunApp("bun-api", "../bun-app", "server.ts")
+if err := bunApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+bunApp = bunApp.WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")})
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var bunApp = builder.addBunApp("bun-api", "../bun-app", "server.ts")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let bun_app = builder.add_bun_app("bun-api", "../bun-app", "server.ts")?;
+bun_app.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/frameworks/dapr/dapr-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/dapr/dapr-host.mdx
@@ -27,7 +27,12 @@ This article is the AppHost API reference for the [📦 CommunityToolkit.Aspire.
 
 ## Installation
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -69,7 +74,12 @@ The Dapr TypeScript exports are available, but the source test for referencing D
 
 Add Dapr, create state-store and pub/sub component resources, then reference the components from a sidecar:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -122,7 +132,12 @@ await builder.build().run();
 
 `AddDaprStateStore` and `AddDaprPubSub` create generic component resources. Use the generic component API when you need another Dapr component type:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -155,7 +170,12 @@ await builder.build().run();
 
 Use `DaprSidecarOptions` or its TypeScript equivalent to configure the app ID, app endpoint, Dapr endpoints, health probes, logging, metrics, component paths, and other `dapr run` settings:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -207,7 +227,12 @@ await builder.build().run();
 
 Use `WithMetadata` or `withMetadata` for static values. The hosting integration also exposes overloads for endpoint references, reference expressions, and parameters so metadata can follow Aspire-managed resources.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -260,7 +285,12 @@ Each Dapr sidecar is a hidden resource named from its app resource, such as `api
 
 Install [📦 CommunityToolkit.Aspire.Hosting.Azure.Dapr](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Azure.Dapr), then enable Dapr components on the Azure Container Apps environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The Aspire.Hosting.Dapr operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/deno/deno-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/deno/deno-get-started.mdx
@@ -40,7 +40,12 @@ The integration is a hosting integration: install it in the AppHost, then model 
 
 Add `CommunityToolkit.Aspire.Hosting.Deno` to your AppHost. Then add a Deno task or script resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/deno/deno-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/deno/deno-host.mdx
@@ -38,7 +38,12 @@ The Deno executable must be available on `PATH` when Aspire runs the resource.
 
 `AddDenoApp` / `addDenoApp` creates an executable resource that runs `deno run`, followed by permission flags, the script path, and application arguments.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -84,7 +89,12 @@ Script resources set `DENO_ENV` to `development` in the development environment 
 
 `AddDenoTask` / `addDenoTask` runs `deno task <taskName>`, using the task configuration in the resource's working directory.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -124,7 +134,12 @@ await builder.build().run();
 
 `WithDenoPackageInstallation` / `withDenoPackageInstallation` adds a `deno install` setup resource named `<resource-name>-deno-install`. The application waits for that setup resource to complete.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -160,7 +175,12 @@ In C#, an overload also accepts a callback that configures the installer resourc
 
 Deno resources are executable resources with endpoint, environment, argument, wait, and service-discovery support. Use the standard AppHost APIs to pass a listening port, configure additional environment variables, and define a probe:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Deno operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/dotnet/dotnet-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/dotnet/dotnet-host.mdx
@@ -21,7 +21,7 @@ import csharpIcon from '@assets/icons/csharp.svg';
   classOverride="float-inline-left icon"
 />
 
-This article is the reference for the Aspire Dotnet hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to add C# projects and file-based C# apps **by path** in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Dotnet hosting integration. It shows how to add C# projects and file-based C# apps **by path** from each AppHost language where the generated API can express the operation.
 
 If you're new to the Dotnet integration, start with the [Get started with the .NET / C# app integration](/integrations/frameworks/dotnet/dotnet-get-started/) guide.
 
@@ -31,7 +31,16 @@ If you're new to the Dotnet integration, start with the [Get started with the .N
 
 If your C# AppHost needs to reference the resource type directly — for example, to declare a strongly typed variable or a method parameter — import it from the `Aspire.Hosting.Dotnet` namespace, matching the pattern used by the Go, Python, and JavaScript hosting integrations:
 
-```csharp
+<AppHostTabs limitations={{
+  typescript: 'TypeScript AppHosts receive the generated DotnetProjectResource wrapper directly and do not use C# namespace imports or explicit generic resource-builder declarations.',
+  python: 'Python AppHosts receive the generated DotnetProjectResource wrapper directly and do not use C# namespace imports or explicit generic resource-builder declarations.',
+  go: 'Go AppHosts receive the generated DotnetProjectResource interface directly and do not use C# namespace imports or explicit generic resource-builder declarations.',
+  java: 'Java AppHosts receive the generated DotnetProjectResource class directly and do not use C# namespace imports or explicit generic resource-builder declarations.',
+  rust: 'Rust AppHosts receive the generated DotnetProjectResource wrapper directly and do not use C# namespace imports or explicit generic resource-builder declarations.',
+}}>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
 using Aspire.Hosting.Dotnet;
 
 var builder = DistributedApplication.CreateBuilder(args);
@@ -39,6 +48,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 IResourceBuilder<DotnetProjectResource> api =
     builder.AddDotnetProject("api", "../api/api.csproj");
 ```
+
+</Fragment>
+</AppHostTabs>
 
 :::note[Prerequisites]
 The **.NET SDK** must be available on the `PATH` of the machine running the AppHost. File-based C# apps (`.cs`) require **.NET 10 or later**.
@@ -93,6 +105,38 @@ This updates your `aspire.config.json` with the Dotnet hosting integration packa
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Dotnet
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Dotnet
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Dotnet
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Dotnet
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Add a C# project or file-based app by path
@@ -125,6 +169,74 @@ await api.withHttpEndpoint({ port: 8080 });
 await api.withExternalHttpEndpoints();
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_dotnet_project("api", "../api/api.csproj")
+    api.with_http_endpoint(port=8080)
+    api.with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddDotnetProject("api", "../api/api.csproj").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8080)}).WithExternalHttpEndpoints()
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addDotnetProject("api", "../api/api.csproj")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8080))
+    .withExternalHttpEndpoints();
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_dotnet_project("api", "../api/api.csproj", None)?;
+api.with_http_endpoint(Some(8080.0), None, None, None, None)?;
+api.with_external_http_endpoints()?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -161,13 +273,80 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_dotnet_project("inventoryservice", "../InventoryService.cs")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddDotnetProject("inventoryservice", "../InventoryService.cs")
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+builder.addDotnetProject("inventoryservice", "../InventoryService.cs");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let _api = builder.add_dotnet_project("inventoryservice", "../InventoryService.cs", None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Configure options
 
 Pass a configuration action to set additional options such as the launch profile:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python AppHost SDK cannot construct the ProjectResourceOptions handle required to set a launch profile for addDotnetProject.',
+  go: 'The generated Go AppHost SDK cannot construct the ProjectResourceOptions handle required to set a launch profile for addDotnetProject.',
+  java: 'The generated Java AppHost SDK cannot construct the ProjectResourceOptions handle required to set a launch profile for addDotnetProject.',
+  rust: 'The generated Rust AppHost SDK cannot construct the ProjectResourceOptions handle required to set a launch profile for addDotnetProject.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/go/go-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/go/go-get-started.mdx
@@ -71,7 +71,7 @@ architecture-beta
 
 2. ### Optionally try the Go AppHost templates
 
-   The `Aspire.Hosting.Go` integration works from C# and TypeScript AppHosts. Aspire also includes experimental Go AppHost and Go starter template support in the Aspire CLI. These templates use experimental Go AppHost APIs instead of the `Aspire.Hosting.Go` package.
+   The `Aspire.Hosting.Go` integration works from C#, TypeScript, Python, Go, Java, and Rust AppHosts. The generated Python, Go, Java, and Rust AppHost SDKs and the Go AppHost templates are experimental.
 
    <LinkButton
      variant="secondary"

--- a/src/frontend/src/content/docs/integrations/frameworks/go/go-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/go/go-host.mdx
@@ -22,7 +22,7 @@ import goLightIcon from '@assets/icons/go-light-icon.png';
   classOverride="float-inline-left icon"
 />
 
-This article is the reference for the Aspire Go hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to orchestrate Go applications in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Go hosting integration. It shows the equivalent generated APIs for TypeScript, Python, Go, Java, and Rust AppHosts alongside C# examples.
 
 If you're new to the Go integration, start with the [Get started with the Go integration](/integrations/frameworks/go/go-get-started/) guide.
 
@@ -83,6 +83,38 @@ This updates your `aspire.config.json` with the Go hosting integration package:
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add go
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add go
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add go
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add go
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Migrate from the Community Toolkit package
@@ -125,6 +157,74 @@ await api.withHttpEndpoint({ port: 8080, env: 'PORT' });
 await api.withExternalHttpEndpoints();
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_http_endpoint(port=8080, env="PORT")
+    api.with_external_http_endpoints()
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8080), Env: aspire.StringPtr("PORT")}).WithExternalHttpEndpoints()
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8080).env("PORT"))
+    .withExternalHttpEndpoints();
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_http_endpoint(Some(8080.0), None, None, Some("PORT"), None)?;
+api.with_external_http_endpoints()?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -212,6 +312,71 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api", package_path="./cmd/server")
+    api.with_http_endpoint(env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api", &aspire.AddGoAppOptions{PackagePath: aspire.StringPtr("./cmd/server")}).WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api", new AddGoAppOptions().packagePath("./cmd/server"))
+    .withHttpEndpoint(new WithHttpEndpointOptions().env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", Some("./cmd/server"), None, None, None, None)?;
+api.with_http_endpoint(None, None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The same `packagePath` is used for local run mode, headless Delve debugging, and publish-time `go build`.
@@ -258,6 +423,95 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app(
+        "api",
+        "./api",
+        package_path="./cmd/server",
+        build_tags=["netgo", "integration"],
+        ld_flags="-X main.version=1.2.3 -s -w",
+        gc_flags="all=-N -l",
+        race_detector=True,
+    )
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api", &aspire.AddGoAppOptions{
+	PackagePath: aspire.StringPtr("./cmd/server"),
+	BuildTags: []string{"netgo", "integration"},
+	LdFlags: aspire.StringPtr("-X main.version=1.2.3 -s -w"),
+	GcFlags: aspire.StringPtr("all=-N -l"),
+	RaceDetector: aspire.BoolPtr(true),
+})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api", new AddGoAppOptions()
+    .packagePath("./cmd/server")
+    .buildTags(new String[] { "netgo", "integration" })
+    .ldFlags("-X main.version=1.2.3 -s -w")
+    .gcFlags("all=-N -l")
+    .raceDetector(true));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let _api = builder.add_go_app(
+    "api",
+    "./api",
+    Some("./cmd/server"),
+    Some(vec!["netgo".into(), "integration".into()]),
+    Some("-X main.version=1.2.3 -s -w"),
+    Some("all=-N -l"),
+    Some(true),
+)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The options map to Go command-line flags:
@@ -297,6 +551,74 @@ await api.withAppArgs(['--config', 'dev.yaml']);
 await api.withHttpEndpoint({ env: 'PORT' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_app_args(["--config", "dev.yaml"])
+    api.with_http_endpoint(env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithAppArgs([]any{"--config", "dev.yaml"}).WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api")
+    .withAppArgs(new Object[] { "--config", "dev.yaml" })
+    .withHttpEndpoint(new WithHttpEndpointOptions().env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_app_args(vec![serde_json::json!("--config"), serde_json::json!("dev.yaml")])?;
+api.with_http_endpoint(None, None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -340,6 +662,77 @@ await api.withVetTool();
 await api.withHttpEndpoint({ env: 'PORT' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_mod_tidy().with_mod_vendor().with_mod_download().with_vet_tool()
+    api.with_http_endpoint(env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithModTidy().WithModVendor().WithModDownload().WithVetTool().WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api")
+    .withModTidy()
+    .withModVendor()
+    .withModDownload()
+    .withVetTool()
+    .withHttpEndpoint(new WithHttpEndpointOptions().env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_mod_tidy()?.with_mod_vendor()?.with_mod_download()?.with_vet_tool()?;
+api.with_http_endpoint(None, None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -399,6 +792,74 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_delve_server()
+    api.with_http_endpoint(port=8080, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithDelveServer().WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8080), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api")
+    .withDelveServer()
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8080).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_delve_server(None)?;
+api.with_http_endpoint(Some(8080.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 By default the Delve server accepts a single debugger client on port `2345`. To accept multiple
@@ -431,6 +892,93 @@ await api.withDelveServer({
     log: true,
     logOutput: 'rpc,dap,debugger',
 });
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_delve_server(options={
+        "AcceptMultiClient": True,
+        "ContinueOnStart": True,
+        "Log": True,
+        "LogOutput": "rpc,dap,debugger",
+    })
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithDelveServer(&aspire.DelveServerOptions{
+	AcceptMultiClient: aspire.BoolPtr(true),
+	ContinueOnStart: aspire.BoolPtr(true),
+	Log: aspire.BoolPtr(true),
+	LogOutput: aspire.StringPtr("rpc,dap,debugger"),
+})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var options = new DelveServerOptions();
+options.setAcceptMultiClient(true);
+options.setContinueOnStart(true);
+options.setLog(true);
+options.setLogOutput("rpc,dap,debugger");
+
+var api = builder.addGoApp("api", "./api").withDelveServer(options);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let options = DelveServerOptions {
+    accept_multi_client: Some(true),
+    continue_on_start: Some(true),
+    log: Some(true),
+    log_output: Some("rpc,dap,debugger".into()),
+    ..Default::default()
+};
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_delve_server(Some(options))?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -504,6 +1052,71 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_go_app("api", "./api")
+    api.with_go_private(["github.com/myorg"], "github.com")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddGoApp("api", "./api").WithGoPrivate([]string{"github.com/myorg"}, "github.com")
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addGoApp("api", "./api")
+    .withGoPrivate(new String[] { "github.com/myorg" }, "github.com");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_go_app("api", "./api", None, None, None, None, None)?;
+api.with_go_private(vec!["github.com/myorg".into()], "github.com", None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 <LearnMore>
@@ -513,7 +1126,7 @@ await builder.build().run();
 
 ## Experimental Go AppHost templates
 
-The `Aspire.Hosting.Go` integration can be used from C# and TypeScript AppHosts. Aspire also includes experimental Go AppHost and Go starter template support in the Aspire CLI. The Go AppHost templates use experimental Go AppHost APIs instead of the `Aspire.Hosting.Go` package. To enable Go AppHost language support for CLI templates, enable the Go feature flag:
+The `Aspire.Hosting.Go` integration can be used from C#, TypeScript, Python, Go, Java, and Rust AppHosts. The generated Python, Go, Java, and Rust AppHost SDKs are experimental. Aspire also includes experimental Go AppHost and Go starter templates in the Aspire CLI. To enable Go AppHost language support for CLI templates, enable the Go feature flag:
 
 ```bash title="Aspire CLI"
 aspire config set features:experimentalPolyglot:go true --global

--- a/src/frontend/src/content/docs/integrations/frameworks/java/java-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/java/java-get-started.mdx
@@ -40,7 +40,12 @@ Build helpers create setup resources that the executable application waits for d
 
 Add `CommunityToolkit.Aspire.Hosting.Java` to the AppHost, then configure an executable Java application. This short example runs a Spring Boot application through its Maven wrapper:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/java/java-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/java/java-host.mdx
@@ -41,7 +41,12 @@ Executable Java resources require the Java command and, when used, the Maven or 
 
 `WithMavenGoal` / `withMavenGoal` and `WithGradleTask` / `withGradleTask` replace the executable command with the respective wrapper in run mode. Maven defaults to `mvnw` (`mvnw.cmd` on Windows), and Gradle defaults to `gradlew` (`gradlew.bat` on Windows).
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -84,7 +89,12 @@ Do not combine a Maven goal or Gradle task with a JAR path; the integration reje
 
 Provide a JAR path relative to the resource working directory. The resource runs `java -jar <jarPath>` followed by the application arguments.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -132,7 +142,12 @@ The TypeScript export is named `addJavaAppWithJar`. The Java executable resource
 
 `WithMavenBuild` / `withMavenBuild` and `WithGradleBuild` / `withGradleBuild` add a child setup resource in run mode. The Java app waits for it to finish. Maven runs `clean package` by default and Gradle runs `clean build` by default; passing arguments replaces those defaults.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -171,7 +186,12 @@ await builder.build().run();
 
 Use `WithWrapperPath` / `withWrapperPath` before a build or launch method to use a wrapper at a relative or absolute path instead of the platform default.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -207,7 +227,12 @@ await builder.build().run();
 
 `WithJvmArgs` / `withJvmArgs` appends JVM options to `JAVA_TOOL_OPTIONS`, which works with JAR, Maven, Gradle, and container launches. `WithOtelAgent` / `withOtelAgent` configures the OTLP exporter; when you provide an agent JAR path, it also appends `-javaagent:<path>` to `JAVA_TOOL_OPTIONS`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -247,7 +272,12 @@ Download the agent JAR before configuring its path. `WithOtelAgent` without a pa
 
 `AddJavaContainerApp` / `addJavaContainerApp` models an existing container image and configures the OTLP exporter. Pass an optional image tag; configure endpoints and environment variables with standard container-resource APIs.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -286,7 +316,12 @@ await builder.build().run();
 
 Java executable and container resources support standard AppHost endpoints, environment variables, health checks, waits, and service discovery. Pass Spring Boot's listening port through an endpoint environment variable, add a health-check path, and reference the resource from consumers:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Java operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/javascript.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/javascript.mdx
@@ -21,7 +21,7 @@ import jsIcon from '@assets/icons/javascript.svg';
   data-zoom-off
 />
 
-This article is the reference for the Aspire JavaScript hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to orchestrate JavaScript and TypeScript applications in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire JavaScript hosting integration. It shows the equivalent generated APIs for TypeScript, Python, Go, Java, and Rust AppHosts alongside C# examples.
 
 ## Hosting integration
 
@@ -39,7 +39,7 @@ The integration exposes a number of app resource types:
 
 ## Framework examples
 
-The following TypeScript AppHost examples show validated ways to wire common JavaScript frameworks into Aspire for both local development and Docker Compose deployment. Each sample assumes:
+The following AppHost example shows validated ways to wire common JavaScript frameworks into Aspire for both local development and Docker Compose deployment. It assumes:
 
 - A backend API app lives in `./frameworks/api` and listens on the `PORT` environment variable.
 - The framework app lives in `./frameworks/<framework-name>`.
@@ -47,7 +47,12 @@ The following TypeScript AppHost examples show validated ways to wire common Jav
 
 For production deployment choices, see [Deploy JavaScript apps](/deployment/javascript-apps/).
 
-Start with a shared builder, Docker Compose deployment target, and API resource:
+The complete AppHost configuration is shown together because every framework resource shares the same builder, Docker Compose deployment target, and API resource:
+
+<AppHostTabs limitations={{
+  java: 'The generated Java SDK cannot pass a NodeAppResource to PublishAsStaticWebsite as the required IResourceWithServiceDiscovery type, so the static-site API proxy scenarios are not currently expressible in a Java AppHost.',
+}}>
+<Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
@@ -61,18 +66,459 @@ const api = await builder
   .withExternalHttpEndpoints();
 
 const apiEndpoint = await api.getEndpoint('http');
+
+await builder
+  .addViteApp('vite', './frameworks/vite', { runScriptName: 'dev' })
+  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('react', './frameworks/react', { runScriptName: 'dev' })
+  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('vue', './frameworks/vue', { runScriptName: 'dev' })
+  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('astro', './frameworks/astro', { runScriptName: 'dev' })
+  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('angular', './frameworks/angular', { runScriptName: 'dev' })
+  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
+  .withExternalHttpEndpoints();
+
+await builder
+  .addNextJsApp('nextjs', './frameworks/nextjs', { runScriptName: 'dev' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('nuxt', './frameworks/nuxt', { runScriptName: 'dev' })
+  .publishAsPackageScript({ scriptName: 'start' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withEnvironment('NUXT_API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('sveltekit', './frameworks/sveltekit', {
+    runScriptName: 'dev',
+  })
+  .publishAsNodeServer('build/index.js', { outputPath: 'build' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('tanstack-start', './frameworks/tanstack-start', {
+    runScriptName: 'dev',
+  })
+  .publishAsNodeServer('.output/server/index.mjs', { outputPath: '.output' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('astro-ssr', './frameworks/astro-ssr', {
+    runScriptName: 'dev',
+  })
+  .publishAsPackageScript({ scriptName: 'start' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('remix', './frameworks/remix', { runScriptName: 'dev' })
+  .publishAsPackageScript({
+    scriptName: 'start',
+    runScriptArguments: '-- --port "$PORT"',
+  })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder
+  .addViteApp('qwik', './frameworks/qwik', { runScriptName: 'dev' })
+  .publishAsPackageScript({ scriptName: 'start' })
+  .withEnvironment('API_URL', apiEndpoint)
+  .withExternalHttpEndpoints();
+
+await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddDockerComposeEnvironment("compose");
+
+var api = builder.AddNodeApp("api", "./frameworks/api", "server.js")
+    .WithHttpEndpoint(port: 3001, env: "PORT")
+    .WithExternalHttpEndpoints();
+
+var apiEndpoint = api.GetEndpoint("http");
+
+#pragma warning disable ASPIREJAVASCRIPT001
+builder.AddViteApp("vite", "./frameworks/vite", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("react", "./frameworks/react", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("vue", "./frameworks/vue", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("astro", "./frameworks/astro", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("angular", "./frameworks/angular", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+
+builder.AddNextJsApp("nextjs", "./frameworks/nextjs", runScriptName: "dev")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("nuxt", "./frameworks/nuxt", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithEnvironment("NUXT_API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("sveltekit", "./frameworks/sveltekit", runScriptName: "dev")
+    .PublishAsNodeServer(entryPoint: "build/index.js", outputPath: "build")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp(
+        "tanstack-start",
+        "./frameworks/tanstack-start",
+        runScriptName: "dev")
+    .PublishAsNodeServer(
+        entryPoint: ".output/server/index.mjs",
+        outputPath: ".output")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("astro-ssr", "./frameworks/astro-ssr", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("remix", "./frameworks/remix", runScriptName: "dev")
+    .PublishAsPackageScript(
+        scriptName: "start",
+        runScriptArguments: "-- --port \"$PORT\"")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+
+builder.AddViteApp("qwik", "./frameworks/qwik", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+#pragma warning restore ASPIREJAVASCRIPT001
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_docker_compose_env("compose")
+
+    api = builder.add_node_app("api", "./frameworks/api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    api.with_external_http_endpoints()
+    api_endpoint = api.get_endpoint("http")
+
+    for name in ("vite", "react", "vue", "astro", "angular"):
+        app = builder.add_vite_app(name, f"./frameworks/{name}")
+        app.publish_as_static_website(api_path="/api", api_target=api)
+        app.with_external_http_endpoints()
+
+    nextjs = builder.add_next_js_app("nextjs", "./frameworks/nextjs")
+    nextjs.with_environment("API_URL", api_endpoint)
+    nextjs.with_external_http_endpoints()
+
+    nuxt = builder.add_vite_app("nuxt", "./frameworks/nuxt")
+    nuxt.publish_as_package_script(script_name="start")
+    nuxt.with_environment("API_URL", api_endpoint)
+    nuxt.with_environment("NUXT_API_URL", api_endpoint)
+    nuxt.with_external_http_endpoints()
+
+    sveltekit = builder.add_vite_app("sveltekit", "./frameworks/sveltekit")
+    sveltekit.publish_as_node_server("build/index.js", output_path="build")
+    sveltekit.with_environment("API_URL", api_endpoint)
+    sveltekit.with_external_http_endpoints()
+
+    tanstack = builder.add_vite_app(
+        "tanstack-start", "./frameworks/tanstack-start"
+    )
+    tanstack.publish_as_node_server(
+        ".output/server/index.mjs", output_path=".output"
+    )
+    tanstack.with_environment("API_URL", api_endpoint)
+    tanstack.with_external_http_endpoints()
+
+    astro_ssr = builder.add_vite_app("astro-ssr", "./frameworks/astro-ssr")
+    astro_ssr.publish_as_package_script(script_name="start")
+    astro_ssr.with_environment("API_URL", api_endpoint)
+    astro_ssr.with_external_http_endpoints()
+
+    remix = builder.add_vite_app("remix", "./frameworks/remix")
+    remix.publish_as_package_script(
+        script_name="start",
+        run_script_arguments='-- --port "$PORT"',
+    )
+    remix.with_environment("API_URL", api_endpoint)
+    remix.with_external_http_endpoints()
+
+    qwik = builder.add_vite_app("qwik", "./frameworks/qwik")
+    qwik.publish_as_package_script(script_name="start")
+    qwik.with_environment("API_URL", api_endpoint)
+    qwik.with_external_http_endpoints()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+compose := builder.AddDockerComposeEnvironment("compose")
+if err := compose.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./frameworks/api", "server.js").
+    WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+        Port: aspire.Float64Ptr(3001),
+        Env:  aspire.StringPtr("PORT"),
+    }).
+    WithExternalHttpEndpoints()
+if err := api.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+apiEndpoint := api.GetEndpoint("http")
+var apiTarget aspire.ResourceWithServiceDiscovery = api
+
+for _, name := range []string{"vite", "react", "vue", "astro", "angular"} {
+    app := builder.AddViteApp(
+        name,
+        "./frameworks/"+name,
+        &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+    ).PublishAsStaticWebsite(&aspire.PublishAsStaticWebsiteOptions{
+        ApiPath:   aspire.StringPtr("/api"),
+        ApiTarget: &apiTarget,
+    }).WithExternalHttpEndpoints()
+    if err := app.Err(); err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+
+
+}
+
+nextjs := builder.AddNextJsApp(
+    "nextjs",
+    "./frameworks/nextjs",
+    &aspire.AddNextJsAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := nextjs.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+nuxt := builder.AddViteApp(
+    "nuxt",
+    "./frameworks/nuxt",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsPackageScript(&aspire.PublishAsPackageScriptOptions{
+    ScriptName: aspire.StringPtr("start"),
+}).WithEnvironment("API_URL", apiEndpoint).
+    WithEnvironment("NUXT_API_URL", apiEndpoint).
+    WithExternalHttpEndpoints()
+if err := nuxt.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+sveltekit := builder.AddViteApp(
+    "sveltekit",
+    "./frameworks/sveltekit",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsNodeServer(
+    "build/index.js",
+    &aspire.PublishAsNodeServerOptions{OutputPath: aspire.StringPtr("build")},
+).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := sveltekit.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+tanstack := builder.AddViteApp(
+    "tanstack-start",
+    "./frameworks/tanstack-start",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsNodeServer(
+    ".output/server/index.mjs",
+    &aspire.PublishAsNodeServerOptions{OutputPath: aspire.StringPtr(".output")},
+).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := tanstack.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+astroSSR := builder.AddViteApp(
+    "astro-ssr",
+    "./frameworks/astro-ssr",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsPackageScript(&aspire.PublishAsPackageScriptOptions{
+    ScriptName: aspire.StringPtr("start"),
+}).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := astroSSR.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+remix := builder.AddViteApp(
+    "remix",
+    "./frameworks/remix",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsPackageScript(&aspire.PublishAsPackageScriptOptions{
+    ScriptName:         aspire.StringPtr("start"),
+    RunScriptArguments: aspire.StringPtr(`-- --port "$PORT"`),
+}).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := remix.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+qwik := builder.AddViteApp(
+    "qwik",
+    "./frameworks/qwik",
+    &aspire.AddViteAppOptions{RunScriptName: aspire.StringPtr("dev")},
+).PublishAsPackageScript(&aspire.PublishAsPackageScriptOptions{
+    ScriptName: aspire.StringPtr("start"),
+}).WithEnvironment("API_URL", apiEndpoint).WithExternalHttpEndpoints()
+if err := qwik.Err(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+
+
+app, err := builder.Build()
+if err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+if err := app.Run(); err != nil {
+    log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+builder.add_docker_compose_environment("compose")?;
+
+let api = builder.add_node_app("api", "./frameworks/api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+api.with_external_http_endpoints()?;
+let api_endpoint = api.get_endpoint("http")?;
+let api_target =
+    IResourceWithServiceDiscovery::new(api.handle().clone(), api.client().clone());
+
+for name in ["vite", "react", "vue", "astro", "angular"] {
+    let app = builder.add_vite_app(
+        name,
+        &format!("./frameworks/{name}"),
+        Some("dev"),
+    )?;
+    app.publish_as_static_website(
+        Some("/api"),
+        Some(&api_target),
+        None,
+        None,
+        None,
+    )?;
+    app.with_external_http_endpoints()?;
+}
+
+let nextjs =
+    builder.add_next_js_app("nextjs", "./frameworks/nextjs", Some("dev"))?;
+nextjs.with_environment("API_URL", api_endpoint.handle().to_json())?;
+nextjs.with_external_http_endpoints()?;
+
+let nuxt = builder.add_vite_app("nuxt", "./frameworks/nuxt", Some("dev"))?;
+nuxt.publish_as_package_script(Some("start"), None)?;
+nuxt.with_environment("API_URL", api_endpoint.handle().to_json())?;
+nuxt.with_environment("NUXT_API_URL", api_endpoint.handle().to_json())?;
+nuxt.with_external_http_endpoints()?;
+
+let sveltekit =
+    builder.add_vite_app("sveltekit", "./frameworks/sveltekit", Some("dev"))?;
+sveltekit.publish_as_node_server("build/index.js", Some("build"))?;
+sveltekit.with_environment("API_URL", api_endpoint.handle().to_json())?;
+sveltekit.with_external_http_endpoints()?;
+
+let tanstack = builder.add_vite_app(
+    "tanstack-start",
+    "./frameworks/tanstack-start",
+    Some("dev"),
+)?;
+tanstack.publish_as_node_server(
+    ".output/server/index.mjs",
+    Some(".output"),
+)?;
+tanstack.with_environment("API_URL", api_endpoint.handle().to_json())?;
+tanstack.with_external_http_endpoints()?;
+
+let astro_ssr =
+    builder.add_vite_app("astro-ssr", "./frameworks/astro-ssr", Some("dev"))?;
+astro_ssr.publish_as_package_script(Some("start"), None)?;
+astro_ssr.with_environment("API_URL", api_endpoint.handle().to_json())?;
+astro_ssr.with_external_http_endpoints()?;
+
+let remix =
+    builder.add_vite_app("remix", "./frameworks/remix", Some("dev"))?;
+remix.publish_as_package_script(Some("start"), Some(r#"-- --port "$PORT""#))?;
+remix.with_environment("API_URL", api_endpoint.handle().to_json())?;
+remix.with_external_http_endpoints()?;
+
+let qwik = builder.add_vite_app("qwik", "./frameworks/qwik", Some("dev"))?;
+qwik.publish_as_package_script(Some("start"), None)?;
+qwik.with_environment("API_URL", api_endpoint.handle().to_json())?;
+qwik.with_external_http_endpoints()?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
+</AppHostTabs>
 
 ### Vite
 
 Plain Vite apps that produce static browser files use `addViteApp` and `publishAsStaticWebsite`. The `apiPath` / `apiTarget` options configure the deployed static website to proxy `/api` requests to the backend.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('vite', './frameworks/vite', { runScriptName: 'dev' })
-  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
-  .withExternalHttpEndpoints();
-```
 
 ```typescript title="Vite — src/weather.ts"
 export async function loadWeather() {
@@ -85,12 +531,6 @@ export async function loadWeather() {
 
 React apps created with Vite use the same static website pattern as other Vite browser apps.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('react', './frameworks/react', { runScriptName: 'dev' })
-  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
-  .withExternalHttpEndpoints();
-```
 
 ```tsx title="React — src/App.tsx"
 export async function loadWeather() {
@@ -103,12 +543,6 @@ export async function loadWeather() {
 
 Vue apps created with Vite also use `publishAsStaticWebsite`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('vue', './frameworks/vue', { runScriptName: 'dev' })
-  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
-  .withExternalHttpEndpoints();
-```
 
 ```vue title="Vue — src/App.vue"
 <script setup lang="ts">
@@ -121,23 +555,11 @@ const weather = await response.json();
 
 Static Astro apps use `addViteApp` and `publishAsStaticWebsite`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('astro', './frameworks/astro', { runScriptName: 'dev' })
-  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
-  .withExternalHttpEndpoints();
-```
 
 ### Angular
 
 Angular 17+ uses Vite internally. Use `addViteApp` with the Angular app's dev script, then publish the build output as a static website.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('angular', './frameworks/angular', { runScriptName: 'dev' })
-  .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
-  .withExternalHttpEndpoints();
-```
 
 ```javascript title="Angular — proxy.conf.js"
 const target = process.env.API_HTTPS || process.env.API_HTTP;
@@ -172,12 +594,6 @@ Next.js standalone apps use the dedicated `addNextJsApp` helper, not a generic V
 `AddNextJsApp` is marked `[Experimental]`. In C# AppHosts, suppress the `ASPIREJAVASCRIPT001` diagnostic when you use this API.
 :::
 
-```typescript title="apphost.mts"
-await builder
-  .addNextJsApp('nextjs', './frameworks/nextjs', { runScriptName: 'dev' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ```tsx title="Next.js — app/page.tsx"
 export default async function Home() {
@@ -200,14 +616,6 @@ export default async function Home() {
 
 Nuxt apps need `node_modules` at runtime for server-side rendering, so publish them with `publishAsPackageScript`. Set both `API_URL` for direct server-side code and `NUXT_API_URL` for Nuxt runtime config.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('nuxt', './frameworks/nuxt', { runScriptName: 'dev' })
-  .publishAsPackageScript({ scriptName: 'start' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withEnvironment('NUXT_API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ```typescript title="Nuxt — nuxt.config.ts"
 export default defineNuxtConfig({
@@ -237,13 +645,6 @@ export default defineEventHandler(async () => {
 
 SvelteKit with `@sveltejs/adapter-node` produces a self-contained Node server artifact, so publish it with `publishAsNodeServer`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('sveltekit', './frameworks/sveltekit', { runScriptName: 'dev' })
-  .publishAsNodeServer('build/index.js', { outputPath: 'build' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ```typescript title="SvelteKit — src/routes/+page.server.ts"
 import type { PageServerLoad } from './$types';
@@ -267,60 +668,24 @@ export const load: PageServerLoad = async ({ fetch }) => {
 
 TanStack Start uses Nitro's Node server output and works with `publishAsNodeServer`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('tanstack-start', './frameworks/tanstack-start', {
-    runScriptName: 'dev',
-  })
-  .publishAsNodeServer('.output/server/index.mjs', { outputPath: '.output' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ### Astro SSR
 
 Astro SSR apps using `@astrojs/node` need runtime dependencies, so publish them with `publishAsPackageScript`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('astro-ssr', './frameworks/astro-ssr', { runScriptName: 'dev' })
-  .publishAsPackageScript({ scriptName: 'start' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ### Remix
 
 Remix / React Router apps need `node_modules` at runtime. Pass the port argument through the package script so the server listens on Aspire's assigned port.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('remix', './frameworks/remix', { runScriptName: 'dev' })
-  .publishAsPackageScript({
-    scriptName: 'start',
-    runScriptArguments: '-- --port "$PORT"',
-  })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 ### Qwik City
 
 Qwik City apps need runtime dependencies and the Node server adapter, so publish them with `publishAsPackageScript`.
 
-```typescript title="apphost.mts"
-await builder
-  .addViteApp('qwik', './frameworks/qwik', { runScriptName: 'dev' })
-  .publishAsPackageScript({ scriptName: 'start' })
-  .withEnvironment('API_URL', apiEndpoint)
-  .withExternalHttpEndpoints();
-```
 
 After adding the framework resources your app needs, build and run the AppHost:
 
-```typescript title="apphost.mts"
-await builder.build().run();
-```
 
 ## Add JavaScript application
 
@@ -361,6 +726,84 @@ const frontend = await builder
   .withReference(api);
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    frontend = builder.add_java_script_app("frontend", "./frontend")
+    frontend.with_http_endpoint(port=3000, env="PORT").with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+frontend := builder.AddJavaScriptApp("frontend", "./frontend").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")}).WithReference(api)
+if err := frontend.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"));
+var frontend = builder.addJavaScriptApp("frontend", "./frontend")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"))
+    .withReference(api);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+let frontend = builder.add_java_script_app("frontend", "./frontend", None)?;
+frontend.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+frontend.with_reference(api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -409,6 +852,71 @@ const api = await builder
   .withHttpEndpoint({ port: 3000, env: 'PORT' });
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./api", "server.js")
+    api.with_http_endpoint(port=3000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./api", "server.js")?;
+api.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -466,6 +974,82 @@ const nextApp = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    next_app = builder.add_next_js_app("next-app", "./next-app")
+    next_app.with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+nextApp := builder.AddNextJsApp("next-app", "./next-app").WithReference(api)
+if err := nextApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"));
+var nextApp = builder.addNextJsApp("next-app", "./next-app")
+    .withReference(api);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+let next_app = builder.add_next_js_app("next-app", "./next-app", None)?;
+next_app.with_reference(api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 `AddNextJsApp` configures:
@@ -507,6 +1091,71 @@ var nextApp = builder.AddNextJsApp("next-app", "./next-app")
 const nextApp = await builder
   .addNextJsApp('next-app', './next-app')
   .disableBuildValidation();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    next_app = builder.add_next_js_app("next-app", "./next-app")
+    next_app.disable_build_validation()
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+nextApp := builder.AddNextJsApp("next-app", "./next-app").DisableBuildValidation()
+if err := nextApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var nextApp = builder.addNextJsApp("next-app", "./next-app")
+    .disableBuildValidation();
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let next_app = builder.add_next_js_app("next-app", "./next-app", None)?;
+let _next_app = next_app.disable_build_validation()?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -555,6 +1204,82 @@ const viteApp = await builder
   .withReference(api);
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    vite_app = builder.add_vite_app("vite-app", "./vite-app")
+    vite_app.with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+viteApp := builder.AddViteApp("vite-app", "./vite-app").WithReference(api)
+if err := viteApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"));
+var viteApp = builder.addViteApp("vite-app", "./vite-app")
+    .withReference(api);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+let vite_app = builder.add_vite_app("vite-app", "./vite-app", None)?;
+vite_app.with_reference(api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -639,6 +1364,79 @@ const customApp = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app")
+    custom_app = builder.add_java_script_app("custom-app", "./custom-app")
+    custom_app.with_npm(install_command="ci", install_args=["--legacy-peer-deps"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app")
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+customApp := builder.AddJavaScriptApp("custom-app", "./custom-app").WithNpm(&aspire.WithNpmOptions{InstallCommand: aspire.StringPtr("ci"), InstallArgs: []string{"--legacy-peer-deps"}})
+if err := customApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app");
+var customApp = builder.addJavaScriptApp("custom-app", "./custom-app")
+    .withNpm(new WithNpmOptions().installCommand("ci").installArgs(new String[] { "--legacy-peer-deps" }));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let _app = builder.add_java_script_app("app", "./app", None)?;
+let custom_app = builder.add_java_script_app("custom-app", "./custom-app", None)?;
+custom_app.with_npm(None, Some("ci"), Some(vec!["--legacy-peer-deps".into()]))?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 When publishing (production mode), Aspire automatically uses `npm ci` if `package-lock.json` exists, otherwise it uses `npm install` for deterministic builds.
@@ -679,6 +1477,80 @@ const customApp = await builder
   .withYarn({ installArgs: ['--immutable'] });
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app").with_yarn()
+    custom_app = builder.add_java_script_app("custom-app", "./custom-app")
+    custom_app.with_yarn(install_args=["--immutable"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithYarn()
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+customApp := builder.AddJavaScriptApp("custom-app", "./custom-app").WithYarn(&aspire.WithYarnOptions{InstallArgs: []string{"--immutable"}})
+if err := customApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app").withYarn();
+var customApp = builder.addJavaScriptApp("custom-app", "./custom-app")
+    .withYarn(new WithYarnOptions().installArgs(new String[] { "--immutable" }));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_yarn(None, None)?;
+let custom_app = builder.add_java_script_app("custom-app", "./custom-app", None)?;
+custom_app.with_yarn(None, Some(vec!["--immutable".into()]))?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -729,6 +1601,80 @@ const customApp = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app").with_pnpm()
+    custom_app = builder.add_java_script_app("custom-app", "./custom-app")
+    custom_app.with_pnpm(install_args=["--immutable" if "Pnpm" == "Yarn" else "--frozen-lockfile"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithPnpm()
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+customApp := builder.AddJavaScriptApp("custom-app", "./custom-app").WithPnpm(&aspire.WithPnpmOptions{InstallArgs: []string{"--frozen-lockfile"}})
+if err := customApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app").withPnpm();
+var customApp = builder.addJavaScriptApp("custom-app", "./custom-app")
+    .withPnpm(new WithPnpmOptions().installArgs(new String[] { "--frozen-lockfile" }));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_pnpm(None, None)?;
+let custom_app = builder.add_java_script_app("custom-app", "./custom-app", None)?;
+custom_app.with_pnpm(None, Some(vec!["--frozen-lockfile".into()]))?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 When publishing, Aspire uses `pnpm install --frozen-lockfile` if `pnpm-lock.yaml` exists, otherwise it uses `pnpm install`.
@@ -772,6 +1718,80 @@ const customApp = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_vite_app("app", "./app").with_bun()
+    custom_app = builder.add_vite_app("custom-app", "./custom-app")
+    custom_app.with_bun(install_args=["--frozen-lockfile"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddViteApp("app", "./app").WithBun()
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+customApp := builder.AddViteApp("custom-app", "./custom-app").WithBun(&aspire.WithBunOptions{InstallArgs: []string{"--frozen-lockfile"}})
+if err := customApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addViteApp("app", "./app").withBun();
+var customApp = builder.addViteApp("custom-app", "./custom-app")
+    .withBun(new WithBunOptions().installArgs(new String[] { "--frozen-lockfile" }));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_vite_app("app", "./app", None)?;
+app.with_bun(None, None)?;
+let custom_app = builder.add_vite_app("custom-app", "./custom-app", None)?;
+custom_app.with_bun(None, Some(vec!["--frozen-lockfile".into()]))?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 When publishing, Aspire uses `bun install --frozen-lockfile` if `bun.lock` or `bun.lockb` exists, otherwise it uses `bun install`.
@@ -809,6 +1829,73 @@ const app = await builder
   .withDockerfileBaseImage({ buildImage: 'oven/bun:1.1' });
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_vite_app("app", "./app")
+    app.with_bun().with_dockerfile_base_image(build_image="oven/bun:1.1")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddViteApp("app", "./app").WithBun().WithDockerfileBaseImage(&aspire.WithDockerfileBaseImageOptions{BuildImage: aspire.StringPtr("oven/bun:1.1")})
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addViteApp("app", "./app")
+    .withBun()
+    .withDockerfileBaseImage(new WithDockerfileBaseImageOptions().buildImage("oven/bun:1.1"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_vite_app("app", "./app", None)?;
+app.with_bun(None, None)?;
+app.with_dockerfile_base_image(Some("oven/bun:1.1"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -850,6 +1937,73 @@ const app = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app")
+    app.with_run_script("start").with_build_script("prod")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithRunScript("start").WithBuildScript("prod")
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app")
+    .withRunScript("start")
+    .withBuildScript("prod");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_run_script("start", None)?;
+app.with_build_script("prod", None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Pass arguments to scripts
@@ -883,6 +2037,73 @@ const app = await builder
   .withArgs(['--port', '3000', '--host']);
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app")
+    app.with_run_script("dev").with_args(["--port", "3000", "--host"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithRunScript("dev").WithArgs([]string{"--port", "3000", "--host"})
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app")
+    .withRunScript("dev")
+    .withArgs(new String[] { "--port", "3000", "--host" });
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_run_script("dev", None)?;
+app.with_args(vec!["--port".into(), "3000".into(), "--host".into()])?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -929,6 +2150,70 @@ const app = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app")
+    app.with_run_script("dev:custom")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithRunScript("dev:custom")
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app").withRunScript("dev:custom");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_run_script("dev:custom", None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Configure endpoints
@@ -967,6 +2252,71 @@ const app = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_java_script_app("app", "./app")
+    app.with_http_endpoint(port=3000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+app := builder.AddJavaScriptApp("app", "./app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3000), Env: aspire.StringPtr("PORT")})
+if err := app.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var app = builder.addJavaScriptApp("app", "./app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let app = builder.add_java_script_app("app", "./app", None)?;
+app.with_http_endpoint(Some(3000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 Common environment variables for JavaScript frameworks:
@@ -979,7 +2329,10 @@ Common environment variables for JavaScript frameworks:
 
 When you reference a resource that exposes a connection string, Aspire injects the connection string into the JavaScript app's environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'This example also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Go AppHost SDK.',
+  rust: 'This example also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1013,6 +2366,37 @@ await app.withReference(db);
 
 // After adding all resources, run the app...
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_postgres("postgres")
+    db = postgres.add_database("mydb")
+    app = builder.add_java_script_app("app", "./app")
+    app.with_http_endpoint(port=3000, env="PORT").with_reference(db)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var postgres = builder.addPostgres("postgres");
+var db = postgres.addDatabase("mydb");
+var app = builder.addJavaScriptApp("app", "./app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3000).env("PORT"))
+    .withReference(db);
+
+builder.build().run();
 ```
 
 </Fragment>
@@ -1060,6 +2444,71 @@ const viteApp = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    vite_app = builder.add_vite_app("vite-app", "./vite-app")
+    vite_app.with_vite_config("./vite.production.config.js")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+viteApp := builder.AddViteApp("vite-app", "./vite-app").WithViteConfig("./vite.production.config.js")
+if err := viteApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var viteApp = builder.addViteApp("vite-app", "./vite-app")
+    .withViteConfig("./vite.production.config.js");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let vite_app = builder.add_vite_app("vite-app", "./vite-app", None)?;
+vite_app.with_vite_config("./vite.production.config.js")?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The `WithViteConfig` / `withViteConfig` configuration accepts:
@@ -1101,6 +2550,73 @@ const viteApp = await builder
   .withHttpsDeveloperCertificate();
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    vite_app = builder.add_vite_app("vite-app", "./vite-app")
+    vite_app.with_https_endpoint(env="PORT").with_https_developer_certificate()
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+viteApp := builder.AddViteApp("vite-app", "./vite-app").WithHttpsEndpoint(&aspire.WithHttpsEndpointOptions{Env: aspire.StringPtr("PORT")}).WithHttpsDeveloperCertificate()
+if err := viteApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var viteApp = builder.addViteApp("vite-app", "./vite-app")
+    .withHttpsEndpoint(new WithHttpsEndpointOptions().env("PORT"))
+    .withHttpsDeveloperCertificate();
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let vite_app = builder.add_vite_app("vite-app", "./vite-app", None)?;
+vite_app.with_https_endpoint(None, None, None, Some("PORT"), None)?;
+vite_app.with_https_developer_certificate(None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -1151,6 +2667,87 @@ const viteApp = await builder
   .withEnvironment('VITE_API_BASE_URL', await api.getEndpoint('http'));
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT").with_external_http_endpoints()
+    vite_app = builder.add_vite_app("vite-app", "./vite-app")
+    vite_app.with_reference(api).with_environment("VITE_API_BASE_URL", api.get_endpoint("http"))
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")}).WithExternalHttpEndpoints()
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+viteApp := builder.AddViteApp("vite-app", "./vite-app").WithReference(api).WithEnvironment("VITE_API_BASE_URL", api.GetEndpoint("http"))
+if err := viteApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"))
+    .withExternalHttpEndpoints();
+var viteApp = builder.addViteApp("vite-app", "./vite-app")
+    .withReference(api)
+    .withEnvironment("VITE_API_BASE_URL", api.getEndpoint("http"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+api.with_external_http_endpoints()?;
+let endpoint = api.get_endpoint("http")?;
+let vite_app = builder.add_vite_app("vite-app", "./vite-app", None)?;
+vite_app.with_reference(api.handle().to_json(), None, None, None)?;
+vite_app.with_environment("VITE_API_BASE_URL", endpoint.handle().to_json())?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -1230,7 +2827,94 @@ To bridge this gap, pass the parameter to your API app as a standard environment
     ```
 
           </Fragment>
-          </AppHostTabs>
+
+    <Fragment slot="python">
+
+    ```python title="apphost.py"
+    from aspire_app import create_builder
+
+    with create_builder() as builder:
+        google_client_id = builder.add_parameter("google-client-id")
+        api = builder.add_node_app("api", "./api", "server.js")
+        api.with_http_endpoint(port=3001, env="PORT").with_environment("GOOGLE_CLIENT_ID", google_client_id)
+        frontend = builder.add_vite_app("frontend", "./frontend")
+        frontend.with_pnpm().with_reference(api)
+        builder.run()
+    ```
+
+    </Fragment>
+
+    <Fragment slot="go">
+
+    ```go title="apphost.go"
+    builder, err := aspire.CreateBuilder()
+    if err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+
+    googleClientID := builder.AddParameter("google-client-id")
+    if err := googleClientID.Err(); err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+
+    api := builder.AddNodeApp("api", "./api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")}).WithEnvironment("GOOGLE_CLIENT_ID", googleClientID)
+    if err := api.Err(); err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+
+    frontend := builder.AddViteApp("frontend", "./frontend").WithPnpm().WithReference(api)
+    if err := frontend.Err(); err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+
+    distributedApp, err := builder.Build()
+    if err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+    if err := distributedApp.Run(); err != nil {
+        log.Fatal(aspire.FormatError(err))
+    }
+    ```
+
+    </Fragment>
+
+    <Fragment slot="java">
+
+    ```java title="AppHost.java"
+    var builder = DistributedApplication.CreateBuilder();
+
+    var googleClientId = builder.addParameter("google-client-id");
+    var api = builder.addNodeApp("api", "./api", "server.js")
+        .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"))
+        .withEnvironment("GOOGLE_CLIENT_ID", googleClientId);
+    var frontend = builder.addViteApp("frontend", "./frontend")
+        .withPnpm()
+        .withReference(api);
+
+    builder.build().run();
+    ```
+
+    </Fragment>
+
+    <Fragment slot="rust">
+
+    ```rust title="apphost.rs"
+    let builder = create_builder(None)?;
+
+    let google_client_id = builder.add_parameter("google-client-id", None, None, None)?;
+    let api = builder.add_node_app("api", "./api", "server.js")?;
+    api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+    api.with_environment("GOOGLE_CLIENT_ID", google_client_id.handle().to_json())?;
+    let frontend = builder.add_vite_app("frontend", "./frontend", None)?;
+    frontend.with_pnpm(None, None)?;
+    frontend.with_reference(api.handle().to_json(), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    ```
+
+    </Fragment>
+    </AppHostTabs>
 
 2.  **Expose a config endpoint in the API**
 
@@ -1354,6 +3038,91 @@ const dashboard = await builder
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./apps/api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    frontend = builder.add_vite_app("frontend", "./apps/frontend")
+    frontend.with_pnpm().with_reference(api)
+    dashboard = builder.add_vite_app("dashboard", "./apps/dashboard")
+    dashboard.with_pnpm().with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./apps/api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+frontend := builder.AddViteApp("frontend", "./apps/frontend").WithPnpm().WithReference(api)
+if err := frontend.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+dashboard := builder.AddViteApp("dashboard", "./apps/dashboard").WithPnpm().WithReference(api)
+if err := dashboard.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./apps/api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"));
+var frontend = builder.addViteApp("frontend", "./apps/frontend").withPnpm().withReference(api);
+var dashboard = builder.addViteApp("dashboard", "./apps/dashboard").withPnpm().withReference(api);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./apps/api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+let frontend = builder.add_vite_app("frontend", "./apps/frontend", None)?.with_pnpm(None, None)?;
+frontend.with_reference(api.handle().to_json(), None, None, None)?;
+let dashboard = builder.add_vite_app("dashboard", "./apps/dashboard", None)?.with_pnpm(None, None)?;
+dashboard.with_reference(api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="note">
@@ -1411,6 +3180,84 @@ const frontend = await builder
   .withReference(api);
 
 // After adding all resources, run the app...
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_node_app("api", "./apps/api", "server.js")
+    api.with_http_endpoint(port=3001, env="PORT")
+    frontend = builder.add_java_script_app("frontend", "./apps/frontend")
+    frontend.with_pnpm().with_run_script("dev").with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.AddNodeApp("api", "./apps/api", "server.js").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(3001), Env: aspire.StringPtr("PORT")})
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+frontend := builder.AddJavaScriptApp("frontend", "./apps/frontend").WithPnpm().WithRunScript("dev").WithReference(api)
+if err := frontend.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var api = builder.addNodeApp("api", "./apps/api", "server.js")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(3001).env("PORT"));
+var frontend = builder.addJavaScriptApp("frontend", "./apps/frontend")
+    .withPnpm()
+    .withRunScript("dev")
+    .withReference(api);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let api = builder.add_node_app("api", "./apps/api", "server.js")?;
+api.with_http_endpoint(Some(3001.0), None, None, Some("PORT"), None)?;
+let frontend = builder.add_java_script_app("frontend", "./apps/frontend", None)?.with_pnpm(None, None)?.with_run_script("dev", None)?;
+frontend.with_reference(api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/frameworks/nodejs-extensions.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/nodejs-extensions.mdx
@@ -38,7 +38,12 @@ The extensions add:
 
 ## Hosting integration
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 <InstallPackage packageName="CommunityToolkit.Aspire.Hosting.JavaScript.Extensions" />
@@ -59,7 +64,12 @@ This command adds the package to `aspire.config.json` so Aspire can generate its
 
 `AddNxApp` / `addNxApp` models the workspace. Add each runnable project with `AddApp` / `addApp`, then decorate that child app with the official JavaScript resource APIs it needs.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -104,7 +114,12 @@ await builder.build().run();
 
 Use `AddTurborepoApp` / `addTurborepoApp` for a Turborepo workspace. The optional `filter` selects the workspace package to run.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.NodeJS.Extensions operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/orleans.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/orleans.mdx
@@ -21,7 +21,7 @@ import orleansIcon from '@assets/icons/microsoft-orleans.png';
   data-zoom-off
 />
 
-This article is the reference for the Aspire Orleans Hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model an Orleans cluster in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Orleans Hosting integration. It shows the equivalent generated APIs for TypeScript, Python, Go, Java, and Rust AppHosts alongside C# examples.
 
 [Orleans](https://github.com/dotnet/orleans) is a cross-platform framework for building distributed applications that are elastically scalable and fault-tolerant. Unlike other Aspire integrations, the Orleans integration doesn't create a container. Instead, the Orleans service is modeled as a resource in the AppHost and its configuration is propagated to any project that references it.
 
@@ -76,6 +76,38 @@ This updates your `aspire.config.json` with the Orleans hosting integration pack
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Orleans
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Orleans
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Orleans
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```bash title="Terminal"
+aspire add Aspire.Hosting.Orleans
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Add an Orleans resource
@@ -105,6 +137,68 @@ const builder = await createBuilder();
 const orleans = await builder.addOrleans("default");
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    orleans = builder.add_orleans("default")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+orleans := builder.AddOrleans("default")
+if err := orleans.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var orleans = builder.addOrleans("default");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let _orleans = builder.add_orleans("default")?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -160,13 +254,113 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage")
+    clustering_table = storage.add_tables("clustering")
+    grain_storage = storage.add_blobs("grainstate")
+
+    orleans = builder.add_orleans("default")
+    orleans.with_clustering(clustering_table).with_grain_storage("Default", grain_storage)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+storage := builder.AddAzureStorage("storage")
+if err := storage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+clusteringTable := storage.AddTables("clustering")
+if err := clusteringTable.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+grainStorage := storage.AddBlobs("grainstate")
+if err := grainStorage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+orleans := builder.AddOrleans("default").WithClustering(clusteringTable).WithGrainStorage("Default", grainStorage)
+if err := orleans.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var storage = builder.addAzureStorage("storage");
+var clusteringTable = storage.addTables("clustering");
+var grainStorage = storage.addBlobs("grainstate");
+var orleans = builder.addOrleans("default")
+    .withClustering(clusteringTable)
+    .withGrainStorage("Default", grainStorage);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let storage = builder.add_azure_storage("storage")?;
+let clustering_table = storage.add_tables("clustering")?;
+let grain_storage = storage.add_blobs("grainstate")?;
+let clustering_provider = IResourceWithConnectionString::new(
+    clustering_table.handle().clone(),
+    clustering_table.client().clone(),
+);
+let grain_provider = IResourceWithConnectionString::new(
+    grain_storage.handle().clone(),
+    grain_storage.client().clone(),
+);
+let orleans = builder.add_orleans("default")?
+    .with_clustering(&clustering_provider)?
+    .with_grain_storage("Default", &grain_provider)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 Any project that references the Orleans resource also inherits a reference to the `clusteringTable` resource automatically.
 
 ### Add an Orleans server project
 
-Add a project to your solution as an Orleans server (a silo). Reference the Orleans resource from the server project so that it receives the clustering and storage configuration. In TypeScript AppHosts, use `withOrleansReference` to configure a project as a silo:
+Add a project to your solution as an Orleans server (a silo). Reference the Orleans resource from the server project so that it receives the clustering and storage configuration. Generated guest AppHost SDKs use their language-specific form of `withOrleansReference` to configure a project as a silo:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -212,13 +406,126 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage")
+    clustering_table = storage.add_tables("clustering")
+    grain_storage = storage.add_blobs("grainstate")
+
+    orleans = builder.add_orleans("default")
+    orleans.with_clustering(clustering_table).with_grain_storage("Default", grain_storage)
+
+    server = builder.add_project("orleans-server", "../OrleansServer/OrleansServer.csproj")
+    server.with_orleans_reference(orleans)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+storage := builder.AddAzureStorage("storage")
+if err := storage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+clusteringTable := storage.AddTables("clustering")
+if err := clusteringTable.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+grainStorage := storage.AddBlobs("grainstate")
+if err := grainStorage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+orleans := builder.AddOrleans("default").WithClustering(clusteringTable).WithGrainStorage("Default", grainStorage)
+if err := orleans.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+server := builder.AddProject("orleans-server", "../OrleansServer/OrleansServer.csproj").WithOrleansReference(orleans)
+if err := server.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var storage = builder.addAzureStorage("storage");
+var clusteringTable = storage.addTables("clustering");
+var grainStorage = storage.addBlobs("grainstate");
+var orleans = builder.addOrleans("default")
+    .withClustering(clusteringTable)
+    .withGrainStorage("Default", grainStorage);
+var server = builder.addProject("orleans-server", "../OrleansServer/OrleansServer.csproj")
+    .withOrleansReference(orleans);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let storage = builder.add_azure_storage("storage")?;
+let clustering_table = storage.add_tables("clustering")?;
+let grain_storage = storage.add_blobs("grainstate")?;
+let clustering_provider = IResourceWithConnectionString::new(
+    clustering_table.handle().clone(),
+    clustering_table.client().clone(),
+);
+let grain_provider = IResourceWithConnectionString::new(
+    grain_storage.handle().clone(),
+    grain_storage.client().clone(),
+);
+let orleans = builder.add_orleans("default")?
+    .with_clustering(&clustering_provider)?
+    .with_grain_storage("Default", &grain_provider)?;
+let server = builder.add_project("orleans-server", "../OrleansServer/OrleansServer.csproj", None)?;
+server.with_orleans_reference(&orleans)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 When you reference the Orleans resource from a project, the dependent storage resources are also referenced transitively.
 
 ### Add an Orleans client project
 
-Orleans clients communicate with grains hosted in an Orleans cluster. For example, a frontend web app calls grains running on Orleans servers. Reference the Orleans resource using `asClient()` (or `AsClient()`) so the project is configured as a client rather than a silo. In TypeScript AppHosts, use `withOrleansClientReference` for Orleans client references:
+Orleans clients communicate with grains hosted in an Orleans cluster. For example, a frontend web app calls grains running on Orleans servers. Reference the Orleans resource using the language-specific form of `asClient` so the project is configured as a client rather than a silo. Generated guest AppHost SDKs use their language-specific form of `withOrleansClientReference` for Orleans client references:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -261,6 +568,121 @@ const client = await builder.addProject("orleans-client", "../OrleansClient/Orle
     .withOrleansClientReference(orleans.asClient());
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage")
+    clustering_table = storage.add_tables("clustering")
+    grain_storage = storage.add_blobs("grainstate")
+
+    orleans = builder.add_orleans("default")
+    orleans.with_clustering(clustering_table).with_grain_storage("Default", grain_storage)
+
+    client = builder.add_project("orleans-client", "../OrleansClient/OrleansClient.csproj")
+    client.with_orleans_client_reference(orleans.as_client())
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+storage := builder.AddAzureStorage("storage")
+if err := storage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+clusteringTable := storage.AddTables("clustering")
+if err := clusteringTable.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+grainStorage := storage.AddBlobs("grainstate")
+if err := grainStorage.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+orleans := builder.AddOrleans("default").WithClustering(clusteringTable).WithGrainStorage("Default", grainStorage)
+if err := orleans.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+orleansClient := orleans.AsClient()
+client := builder.AddProject("orleans-client", "../OrleansClient/OrleansClient.csproj").WithOrleansClientReference(orleansClient)
+if err := client.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var storage = builder.addAzureStorage("storage");
+var clusteringTable = storage.addTables("clustering");
+var grainStorage = storage.addBlobs("grainstate");
+var orleans = builder.addOrleans("default")
+    .withClustering(clusteringTable)
+    .withGrainStorage("Default", grainStorage);
+var client = builder.addProject("orleans-client", "../OrleansClient/OrleansClient.csproj")
+    .withOrleansClientReference(orleans.asClient());
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let storage = builder.add_azure_storage("storage")?;
+let clustering_table = storage.add_tables("clustering")?;
+let grain_storage = storage.add_blobs("grainstate")?;
+let clustering_provider = IResourceWithConnectionString::new(
+    clustering_table.handle().clone(),
+    clustering_table.client().clone(),
+);
+let grain_provider = IResourceWithConnectionString::new(
+    grain_storage.handle().clone(),
+    grain_storage.client().clone(),
+);
+let orleans = builder.add_orleans("default")?
+    .with_clustering(&clustering_provider)?
+    .with_grain_storage("Default", &grain_provider)?;
+let orleans_client = orleans.as_client()?;
+let client = builder.add_project("orleans-client", "../OrleansClient/OrleansClient.csproj", None)?;
+client.with_orleans_client_reference(&orleans_client)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/frameworks/perl/perl-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/perl/perl-get-started.mdx
@@ -63,7 +63,12 @@ Add `CommunityToolkit.Aspire.Hosting.Perl` to your AppHost. The [Perl hosting re
 
 Add a script resource and use a project-local module directory:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/perl/perl-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/perl/perl-host.mdx
@@ -29,7 +29,12 @@ This reference describes the Community Toolkit Perl hosting integration APIs for
 
 Add [📦 CommunityToolkit.Aspire.Hosting.Perl](https://www.nuget.org/packages/CommunityToolkit.Aspire.Hosting.Perl) to the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -78,7 +83,12 @@ Each `AddPerl*` / `addPerl*` method accepts a resource name, an application dire
 | `AddPerlModule` / `addPerlModule`         | `perl -M<moduleName> -e "<moduleName>->run()"` |
 | `AddPerlExecutable` / `addPerlExecutable` | Runs `<executablePath>` directly               |
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -119,7 +129,12 @@ All entrypoints require `perl` and `cpan` to be available. Aspire adds the stand
 
 Perl resources don't add an HTTP endpoint or health check automatically. For an API, configure the application to listen on a port and add the standard AppHost endpoint. Use normal resource APIs such as `WithArgs` / `withArgs`, `WithReference` / `withReference`, and `WaitFor` / `waitFor` to supply arguments and model dependencies.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -148,7 +163,12 @@ Every Perl resource configures OTLP export and sets `OTEL_TRACES_EXPORTER`, `OTE
 
 It sets `PERL5LIB` to `<path>/lib/perl5`, `PERL_LOCAL_LIB_ROOT` to `<path>`, `PERL_MM_OPT` to `INSTALL_BASE=<path>`, and `PERL_MB_OPT` to `--install_base <path>`. If CPAN is active, the integration changes to cpanm because CPAN doesn't support the needed `--local-lib` option.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -175,7 +195,12 @@ await worker.withLocalLib('local');
 
 `WithPerlCertificateTrust` / `withPerlCertificateTrust` is experimental. When Aspire provides a certificate bundle, it sets `SSL_CERT_FILE`, `PERL_LWP_SSL_CA_FILE`, and `MOJO_CA_FILE` on the app and its dependency installers.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -198,7 +223,12 @@ await api.withPerlCertificateTrust();
 
 The default package manager is CPAN. `WithPackage` / `withPackage` creates a child installer resource in run mode and makes the Perl app wait for it to complete. Use `force` to force an install and `skipTest` to skip package tests.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -231,7 +261,12 @@ await api.withPackage('Mojolicious', false, true);
 
 When the application directory contains `cpanfile`, `Makefile.PL`, or `Build.PL`, the integration automatically configures project dependency installation in run mode.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -276,7 +311,12 @@ The integration switches the command to the selected Perl executable, sets `PERL
 Perlbrew is Linux-only. On Windows, the resource displays a notification and fails before starting. Use a Windows Perl distribution instead.
 :::
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Perl operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/powershell/powershell-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/powershell/powershell-get-started.mdx
@@ -56,7 +56,12 @@ architecture-beta
 
    Add a named PowerShell pool, then add a script to it. The following script appears as a resource in the dashboard.
 
-   <AppHostTabs>
+   <AppHostTabs limitations={{
+     python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+     go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+     java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+     rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+   }}>
    <Fragment slot="csharp">
 
    ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/powershell/powershell-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/powershell/powershell-host.mdx
@@ -29,7 +29,12 @@ Add the `CommunityToolkit.Aspire.Hosting.PowerShell` package to your AppHost. Th
 
 ## Install the package
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -54,7 +59,12 @@ This adds the package to `aspire.config.json` and generates the TypeScript AppHo
 
 `AddPowerShell` / `addPowerShell` adds a runspace-pool resource. The resource name is shown in the dashboard. By default, the pool uses `ConstrainedLanguage` mode with one to five runspaces.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -95,7 +105,12 @@ Use the least-permissive language mode appropriate for the scripts you run. The 
 
 Use `WithArgs` / `withArgs` to bind values to a PowerShell `param()` block. The C# `object[]` overload accepts values of any type but is marked `[AspireExportIgnore]` because `object[]` isn't ATS-compatible. The exported TypeScript bridge accepts strings.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -141,7 +156,12 @@ The script resource implements the standard environment annotation interface, bu
 
 In C#, `WithReference` on the runspace pool makes a connection string available as a read-only PowerShell variable. By default, the variable name is the referenced resource name. Pass `connectionName` to choose a different variable name. `optional: true` allows the connection string to be unavailable.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -172,7 +192,12 @@ The pool resolves these variables before it opens. This is distinct from an envi
 
 Use `WaitFor` / `waitFor` for readiness dependencies. Each script automatically waits for its parent pool. Use `WaitForCompletion` / `waitForCompletion` when one script must finish before another script starts.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.PowerShell operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/python.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/python.mdx
@@ -89,6 +89,82 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    example = builder.add_project("example", "../ExampleProject/ExampleProject.csproj")
+    example.with_reference(python_app)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonApp("python-api", "../python-app", "main.py").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+example := builder.AddProject("example", "../ExampleProject/ExampleProject.csproj").WithReference(pythonApp)
+if err := example.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+var example = builder.addProject("example", "../ExampleProject/ExampleProject.csproj")
+    .withReference(pythonApp);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_app("python-api", "../python-app", "main.py")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+let example = builder.add_project("example", "../ExampleProject/ExampleProject.csproj", None)?;
+example.with_reference(python_app.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 `AddPythonApp` / `addPythonApp` requires:
@@ -135,6 +211,71 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_module("python-module", "../python-app", "mymodule")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonModule("python-module", "../python-app", "mymodule").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonModule("python-module", "../python-app", "mymodule")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_module("python-module", "../python-app", "mymodule")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 `AddPythonModule` / `addPythonModule` requires:
@@ -170,7 +311,7 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-// TypeScript: pass additional arguments via withArgs after creation
+// Pass additional arguments after creating the resource
 const python = await builder.addPythonExecutable(
   'python-tool',
   '../python-app',
@@ -179,6 +320,74 @@ const python = await builder.addPythonExecutable(
 await python.withArgs(['main:app', '--host', '0.0.0.0', '--port', '8000']);
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_executable("python-tool", "../python-app", "uvicorn")
+    python_app.with_args(["main:app", "--host", "0.0.0.0", "--port", "8000"])
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonExecutable("python-tool", "../python-app", "uvicorn").WithArgs([]string{"main:app", "--host", "0.0.0.0", "--port", "8000"})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonExecutable("python-tool", "../python-app", "uvicorn")
+    .withArgs(new String[] { "main:app", "--host", "0.0.0.0", "--port", "8000" });
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_executable("python-tool", "../python-app", "uvicorn")?;
+python_app.with_args(vec![
+    "main:app".into(), "--host".into(), "0.0.0.0".into(),
+    "--port".into(), "8000".into(),
+])?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -235,6 +444,82 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    example = builder.add_project("example", "../ExampleProject/ExampleProject.csproj")
+    example.with_reference(python_app)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+example := builder.AddProject("example", "../ExampleProject/ExampleProject.csproj").WithReference(pythonApp)
+if err := example.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+var example = builder.addProject("example", "../ExampleProject/ExampleProject.csproj")
+    .withReference(pythonApp);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+let example = builder.add_project("example", "../ExampleProject/ExampleProject.csproj", None)?;
+example.with_reference(python_app.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 `AddUvicornApp` / `addUvicornApp` requires:
@@ -282,6 +567,77 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    python_app.with_environment("UVICORN_WORKERS", "4")
+    python_app.with_environment("UVICORN_LOG_LEVEL", "info")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")}).WithEnvironment("UVICORN_WORKERS", "4").WithEnvironment("UVICORN_LOG_LEVEL", "info")
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"))
+    .withEnvironment("UVICORN_WORKERS", "4")
+    .withEnvironment("UVICORN_LOG_LEVEL", "info");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+python_app.with_environment("UVICORN_WORKERS", serde_json::json!("4"))?;
+python_app.with_environment("UVICORN_LOG_LEVEL", serde_json::json!("info"))?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 Common Uvicorn environment variables:
@@ -295,7 +651,7 @@ Common Uvicorn environment variables:
 
 The Python hosting integration automatically detects and uses a virtual environment in the project directory. By default, if a `requirements.txt` or `pyproject.toml` is found, Aspire creates and activates a virtual environment before starting the app.
 
-The official integration doesn't expose a C# or TypeScript API to disable virtual environment management. Use the default `.venv` location or specify a different path.
+The official integration doesn't expose an AppHost API to disable virtual environment management. Use the default `.venv` location or specify a different path.
 
 ### Custom virtual environment
 
@@ -329,6 +685,71 @@ const python = await builder.addPythonApp(
 await python.withVirtualEnvironment('../python-app/.venv');
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_virtual_env("../python-app/.venv")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonApp("python-api", "../python-app", "main.py").WithVirtualEnvironment("../python-app/.venv")
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withVirtualEnvironment("../python-app/.venv");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_app("python-api", "../python-app", "main.py")?;
+python_app.with_virtual_environment("../python-app/.venv", None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -373,6 +794,74 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_uv()
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithUv().WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withUv()
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_uv(None, None)?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### pip package manager
@@ -409,6 +898,74 @@ await python.withPip();
 await python.withHttpEndpoint({ port: 8000, env: 'PORT' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_pip()
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonApp("python-api", "../python-app", "main.py").WithPip().WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withPip()
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_app("python-api", "../python-app", "main.py")?;
+python_app.with_pip(None, None)?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -453,6 +1010,71 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Multiple endpoints
@@ -489,6 +1111,74 @@ await python.withHttpEndpoint({ port: 8000, env: 'HTTP_PORT', name: 'http' });
 await python.withHttpEndpoint({ port: 8443, env: 'HTTPS_PORT', name: 'https' });
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_http_endpoint(port=8000, env="HTTP_PORT", name="http")
+    python_app.with_http_endpoint(port=8443, env="HTTPS_PORT", name="https")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonApp("python-api", "../python-app", "main.py").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("HTTP_PORT"), Name: aspire.StringPtr("http")}).WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8443), Env: aspire.StringPtr("HTTPS_PORT"), Name: aspire.StringPtr("https")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("HTTP_PORT").name("http"))
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8443).env("HTTPS_PORT").name("https"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_app("python-api", "../python-app", "main.py")?;
+python_app.with_http_endpoint(Some(8000.0), None, Some("http"), Some("HTTP_PORT"), None)?;
+python_app.with_http_endpoint(Some(8443.0), None, Some("https"), Some("HTTPS_PORT"), None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -531,6 +1221,74 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_http_endpoint(port=8000, env="PORT")
+    python_app.with_http_health_check(path="/health")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")}).WithHttpHealthCheck(&aspire.WithHttpHealthCheckOptions{Path: aspire.StringPtr("/health")})
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"))
+    .withHttpHealthCheck(new WithHttpHealthCheckOptions().path("/health"));
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+python_app.with_http_health_check(Some("/health"), None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Environment variables
@@ -570,13 +1328,84 @@ await builder.build().run();
 ```
 
 </Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_environment("DEBUG", "true")
+    python_app.with_environment("LOG_LEVEL", "debug")
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddPythonApp("python-api", "../python-app", "main.py").WithEnvironment("DEBUG", "true").WithEnvironment("LOG_LEVEL", "debug")
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withEnvironment("DEBUG", "true")
+    .withEnvironment("LOG_LEVEL", "debug");
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_python_app("python-api", "../python-app", "main.py")?;
+python_app.with_environment("DEBUG", serde_json::json!("true"))?;
+python_app.with_environment("LOG_LEVEL", serde_json::json!("debug"))?;
+
+let app = builder.build()?;
+app.run(None)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Service discovery
 
 Reference other Aspire resources from a Python app using `WithReference`. Aspire injects the connection string as the `ConnectionStrings__<resourcename>` environment variable in the Python process:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  go: 'This example also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Go AppHost SDK.',
+  rust: 'This example also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -610,6 +1439,36 @@ const python = await builder.addPythonApp(
 await python.withReference(db);
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_postgres("postgres")
+    db = postgres.add_database("mydb")
+    python_app = builder.add_python_app("python-api", "../python-app", "main.py")
+    python_app.with_reference(db)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var postgres = builder.addPostgres("postgres");
+var db = postgres.addDatabase("mydb");
+var pythonApp = builder.addPythonApp("python-api", "../python-app", "main.py")
+    .withReference(db);
+
+builder.build().run();
 ```
 
 </Fragment>
@@ -659,6 +1518,74 @@ await python.withHttpsEndpoint({ port: 8443, env: 'PORT' });
 await python.withHttpsDeveloperCertificate();
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")
+    python_app.with_https_endpoint(port=8443, env="PORT")
+    python_app.with_https_developer_certificate()
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+pythonApp := builder.AddUvicornApp("python-api", "../python-app", "main:app").WithHttpsEndpoint(&aspire.WithHttpsEndpointOptions{Port: aspire.Float64Ptr(8443), Env: aspire.StringPtr("PORT")}).WithHttpsDeveloperCertificate()
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var pythonApp = builder.addUvicornApp("python-api", "../python-app", "main:app")
+    .withHttpsEndpoint(new WithHttpsEndpointOptions().port(8443).env("PORT"))
+    .withHttpsDeveloperCertificate();
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let python_app = builder.add_uvicorn_app("python-api", "../python-app", "main:app")?;
+python_app.with_https_endpoint(Some(8443.0), None, None, Some("PORT"), None)?;
+python_app.with_https_developer_certificate(None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>
@@ -746,6 +1673,98 @@ await frontend.withReference(internalApi);
 await frontend.withReference(publicApi);
 
 await builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    internal_api = builder.add_uvicorn_app("internal-api", "../internal-api", "main:app")
+    internal_api.with_http_endpoint(port=8001, env="PORT")
+    public_api = builder.add_uvicorn_app("public-api", "../public-api", "main:app")
+    public_api.with_http_endpoint(port=8000, env="PORT")
+    public_api.with_external_http_endpoints()
+    frontend = builder.add_project("frontend", "../WebFrontend/WebFrontend.csproj")
+    frontend.with_reference(internal_api).with_reference(public_api)
+    builder.run()
+```
+
+</Fragment>
+
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder, err := aspire.CreateBuilder()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+internalAPI := builder.AddUvicornApp("internal-api", "../internal-api", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8001), Env: aspire.StringPtr("PORT")})
+if err := internalAPI.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+publicAPI := builder.AddUvicornApp("public-api", "../public-api", "main:app").WithHttpEndpoint(&aspire.WithHttpEndpointOptions{Port: aspire.Float64Ptr(8000), Env: aspire.StringPtr("PORT")}).WithExternalHttpEndpoints()
+if err := publicAPI.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+frontend := builder.AddProject("frontend", "../WebFrontend/WebFrontend.csproj").WithReference(internalAPI).WithReference(publicAPI)
+if err := frontend.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+
+distributedApp, err := builder.Build()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := distributedApp.Run(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var internalApi = builder.addUvicornApp("internal-api", "../internal-api", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8001).env("PORT"));
+var publicApi = builder.addUvicornApp("public-api", "../public-api", "main:app")
+    .withHttpEndpoint(new WithHttpEndpointOptions().port(8000).env("PORT"))
+    .withExternalHttpEndpoints();
+var frontend = builder.addProject("frontend", "../WebFrontend/WebFrontend.csproj")
+    .withReference(internalApi)
+    .withReference(publicApi);
+
+builder.build().run();
+```
+
+</Fragment>
+
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+
+let internal_api = builder.add_uvicorn_app("internal-api", "../internal-api", "main:app")?;
+internal_api.with_http_endpoint(Some(8001.0), None, None, Some("PORT"), None)?;
+let public_api = builder.add_uvicorn_app("public-api", "../public-api", "main:app")?;
+public_api.with_http_endpoint(Some(8000.0), None, None, Some("PORT"), None)?;
+public_api.with_external_http_endpoints()?;
+let frontend = builder.add_project("frontend", "../WebFrontend/WebFrontend.csproj", None)?;
+frontend.with_reference(internal_api.handle().to_json(), None, None, None)?;
+frontend.with_reference(public_api.handle().to_json(), None, None, None)?;
+
+let app = builder.build()?;
+app.run(None)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/integrations/frameworks/rust/rust-get-started.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/rust/rust-get-started.mdx
@@ -59,7 +59,12 @@ architecture-beta
 
    Register the directory that contains your Rust project, then configure an endpoint for the port that the app reads from `PORT`.
 
-   <AppHostTabs>
+   <AppHostTabs limitations={{
+     python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+     go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+     java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+     rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+   }}>
    <Fragment slot="csharp">
 
    ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/rust/rust-host.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/rust/rust-host.mdx
@@ -29,7 +29,12 @@ Install [Rust and Cargo](https://www.rust-lang.org/tools/install). Install [Baco
 
 ## Install the package
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -54,7 +59,12 @@ This adds the package to `aspire.config.json` and generates the TypeScript AppHo
 
 `AddRustApp` / `addRustApp` starts `cargo run` in the supplied working directory. The path is resolved relative to the AppHost directory, so it normally contains the Rust project's `Cargo.toml`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -85,7 +95,12 @@ await builder.build().run();
 
 The optional `args` are appended after `cargo run`. For example, `--release` produces `cargo run --release`; use `--` before arguments intended for your Rust application. The working directory is normalized to the current platform after Aspire combines it with the AppHost directory.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -124,7 +139,12 @@ await builder.build().run();
 
 `AddBaconApp` / `addBaconApp` runs the [Bacon](https://dystroy.org/bacon/) CLI from the working directory. Without arguments it runs `bacon run`; supply `args` to use another Bacon command.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -160,7 +180,12 @@ await builder.build().run();
 
 Rust app resources support standard executable-resource configuration. Use `WithHttpEndpoint` / `withHttpEndpoint` to allocate a port and put it in an environment variable that the application reads. Use `WithHttpHealthCheck` / `withHttpHealthCheck` when the application exposes an HTTP health endpoint. `WithExternalHttpEndpoints` / `withExternalHttpEndpoints` makes an HTTP endpoint externally accessible.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Python AppHost SDK.',
+  go: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Go AppHost SDK.',
+  java: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Java AppHost SDK.',
+  rust: 'The CommunityToolkit.Aspire.Hosting.Rust operation in this example is not exposed by the generated Rust AppHost SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/frameworks/wpf-winforms.mdx
+++ b/src/frontend/src/content/docs/integrations/frameworks/wpf-winforms.mdx
@@ -5,6 +5,7 @@ description: Learn how to orchestrate WPF and Windows Forms desktop applications
 
 import { Image } from 'astro:assets';
 import { Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import dotnetIcon from '@assets/icons/dotnet.svg';
 
 <Image
@@ -24,11 +25,11 @@ WPF and Windows Forms applications require Windows and are **not** containerized
 
 ## Add WPF or Windows Forms to the AppHost
 
-No additional NuGet package is required. Add the desktop project reference to the AppHost and call `AddProject` to register it.
+No additional NuGet package is required. C# AppHosts reference the desktop project from the AppHost project; generated guest AppHosts identify it by project path. Use the language-specific `AddProject` API to register it.
 
 <Steps>
 
-1. **Add a project reference** from your AppHost `.csproj` to the WPF or Windows Forms project:
+1. **For a C# AppHost, add a project reference** from the AppHost `.csproj` to the WPF or Windows Forms project. Generated guest AppHosts don't have an AppHost `.csproj` and use the project path shown in the next step.
 
    ```xml title="AppHost.csproj"
    <ItemGroup>
@@ -37,6 +38,9 @@ No additional NuGet package is required. Add the desktop project reference to th
    ```
 
 1. **Register the project** in your AppHost and wire up any service references it needs:
+
+   <AppHostTabs>
+   <Fragment slot="csharp">
 
    ```csharp title="AppHost.cs"
    var builder = DistributedApplication.CreateBuilder(args);
@@ -50,6 +54,106 @@ No additional NuGet package is required. Add the desktop project reference to th
    // After adding all resources, run the app...
    builder.Build().Run();
    ```
+
+   </Fragment>
+   <Fragment slot="typescript">
+
+   ```typescript title="apphost.mts"
+   import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+   const builder = await createBuilder();
+
+   const api = await builder.addProject(
+     'api',
+     '../ApiService/ApiService.csproj'
+   );
+   const desktop = await builder.addProject(
+     'desktop',
+     '../MyWpfApp/MyWpfApp.csproj'
+   );
+   await desktop.withReference(api);
+   await desktop.waitFor(api);
+
+   await builder.build().run();
+   ```
+
+   </Fragment>
+   <Fragment slot="python">
+
+   ```python title="apphost.py"
+   from aspire_app import create_builder
+
+   with create_builder() as builder:
+       api = builder.add_project("api", "../ApiService/ApiService.csproj")
+       desktop = builder.add_project("desktop", "../MyWpfApp/MyWpfApp.csproj")
+       desktop.with_reference(api).wait_for(api)
+       builder.run()
+   ```
+
+   </Fragment>
+   <Fragment slot="go">
+
+   ```go title="apphost.go"
+   builder, err := aspire.CreateBuilder()
+   if err != nil {
+       log.Fatal(aspire.FormatError(err))
+   }
+
+   api := builder.AddProject("api", "../ApiService/ApiService.csproj")
+   if err := api.Err(); err != nil {
+       log.Fatal(aspire.FormatError(err))
+   }
+
+   desktop := builder.AddProject("desktop", "../MyWpfApp/MyWpfApp.csproj").
+       WithReference(api).
+       WaitFor(api)
+   if err := desktop.Err(); err != nil {
+       log.Fatal(aspire.FormatError(err))
+   }
+
+
+   app, err := builder.Build()
+   if err != nil {
+       log.Fatal(aspire.FormatError(err))
+   }
+   if err := app.Run(); err != nil {
+       log.Fatal(aspire.FormatError(err))
+   }
+   ```
+
+   </Fragment>
+   <Fragment slot="java">
+
+   ```java title="AppHost.java"
+   var builder = DistributedApplication.CreateBuilder();
+
+   var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+   var desktop = builder.addProject("desktop", "../MyWpfApp/MyWpfApp.csproj")
+       .withReference(api)
+       .waitFor(api);
+
+   builder.build().run();
+   ```
+
+   </Fragment>
+   <Fragment slot="rust">
+
+   ```rust title="apphost.rs"
+   let builder = create_builder(None)?;
+
+   let api = builder.add_project("api", "../ApiService/ApiService.csproj", None)?;
+   let desktop =
+       builder.add_project("desktop", "../MyWpfApp/MyWpfApp.csproj", None)?;
+   desktop.with_reference(api.handle().to_json(), None, None, None)?;
+   let api_resource = IResource::new(api.handle().clone(), api.client().clone());
+   desktop.wait_for(&api_resource, None)?;
+
+   let app = builder.build()?;
+   app.run(None)?;
+   ```
+
+   </Fragment>
+   </AppHostTabs>
 
    When you run the AppHost, the desktop application starts automatically as a process resource alongside all other registered services.
 
@@ -113,6 +217,11 @@ No additional NuGet package is required. Add the desktop project reference to th
 
 A common pattern is to register the desktop app only during local development and skip it in CI or staging environments. Use `builder.Environment.IsDevelopment()` to add the resource conditionally:
 
+<AppHostTabs limitations={{
+  go: 'This scenario also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Go AppHost SDK.',
+  rust: 'This scenario also requires Aspire.Hosting.PostgreSQL, which is not present in the restored generated Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -132,6 +241,76 @@ if (builder.Environment.IsDevelopment())
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres('postgres');
+const database = await postgres.addDatabase('mydb');
+const api = await builder.addProject(
+  'api',
+  '../ApiService/ApiService.csproj'
+);
+await api.withReference(database);
+
+if (await builder.environment().isDevelopment()) {
+  const desktop = await builder.addProject(
+    'desktop',
+    '../MyWpfApp/MyWpfApp.csproj'
+  );
+  await desktop.withReference(api);
+  await desktop.waitFor(api);
+}
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_postgres("postgres")
+    database = postgres.add_database("mydb")
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_reference(database)
+
+    if builder.env.is_development():
+        desktop = builder.add_project("desktop", "../MyWpfApp/MyWpfApp.csproj")
+        desktop.with_reference(api).wait_for(api)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var builder = DistributedApplication.CreateBuilder();
+
+var postgres = builder.addPostgres("postgres");
+var database = postgres.addDatabase("mydb");
+var api = builder.addProject("api", "../ApiService/ApiService.csproj")
+    .withReference(database);
+
+if (builder.environment().isDevelopment()) {
+    builder.addProject("desktop", "../MyWpfApp/MyWpfApp.csproj")
+        .withReference(api)
+        .waitFor(api);
+}
+
+builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Limitations
 

--- a/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
@@ -29,10 +29,10 @@ If you're new to the Apache Kafka integration, start with the [Get started with 
 To start building an Aspire app that uses Apache Kafka, install the [📦 Aspire.Hosting.Kafka](https://www.nuget.org/packages/Aspire.Hosting.Kafka) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -85,10 +85,10 @@ This updates your `aspire.config.json` with the Kafka hosting integration packag
 Once you've installed the hosting integration in your AppHost project, you can add a Kafka server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -145,10 +145,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add the [Kafka UI](https://hub.docker.com/r/kafbat/kafka-ui) sub-resource to the Kafka server resource to get a web interface for monitoring and managing your Kafka cluster during development:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -195,9 +195,9 @@ To change the host port the Kafka UI listens on, chain a call to `WithHostPort` 
 
 <AppHostTabs limitations={{
   rust: 'The generated Rust SDK\'s `with_kafka_ui` callback receives raw `Vec<Value limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>` arguments instead of a typed `KafkaUIContainerResource`, so this doc doesn\'t show calling `with_host_port` fluently from inside it. Configure the Kafka UI host port from another language, or reconstruct the resource from `KafkaUIContainerResource::new` using the callback\'s JSON handle.',
 }}>
 <Fragment slot="csharp">
@@ -244,10 +244,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the Kafka server resource to persist data outside the lifecycle of its container:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -291,10 +291,10 @@ The data volume is used to persist Kafka broker data outside the lifecycle of it
 Add a data bind mount to the Kafka server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -350,10 +350,10 @@ The Aspire Kafka integration deploys a container from the `confluentinc/confluen
 To use a full broker topology in non-development environments, switch to an externally managed Kafka cluster via a connection string:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -394,10 +394,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 By default, Aspire injects the Kafka connection information using variable names derived from the resource name (for example, `KAFKA_HOST`, `KAFKA_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs  limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -446,10 +446,10 @@ await builder.build().run();
 To reference an externally managed Kafka instance rather than spinning up a local container:
 
 <AppHostTabs  limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
@@ -20,7 +20,7 @@ import kafkaIcon from '@assets/icons/apache-kafka-icon.svg';
   data-zoom-off
 />
 
-This article is the reference for the Aspire Apache Kafka Hosting integration. It enumerates the AppHost APIs — with examples for both `AppHost.cs` and `apphost.mts` — that you use to model a Kafka resource in your [`AppHost`](/get-started/app-host/) project.
+This article is the reference for the Aspire Apache Kafka Hosting integration. It enumerates the AppHost APIs — with examples across all six supported AppHost languages — that you use to model a Kafka resource in your [`AppHost`](/get-started/app-host/) project.
 
 If you're new to the Apache Kafka integration, start with the [Get started with Apache Kafka integrations](/integrations/messaging/apache-kafka/apache-kafka-get-started/) guide. For how consuming apps read the connection information this page exposes, see [Connect to Apache Kafka](../apache-kafka-connect/).
 
@@ -28,7 +28,12 @@ If you're new to the Apache Kafka integration, start with the [Get started with 
 
 To start building an Aspire app that uses Apache Kafka, install the [📦 Aspire.Hosting.Kafka](https://www.nuget.org/packages/Aspire.Hosting.Kafka) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -36,7 +41,8 @@ aspire add kafka
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -57,7 +63,8 @@ aspire add kafka
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Kafka hosting integration package:
@@ -77,20 +84,29 @@ This updates your `aspire.config.json` with the Kafka hosting integration packag
 
 Once you've installed the hosting integration in your AppHost project, you can add a Kafka server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(kafka);
+.WithReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -103,6 +119,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -115,7 +132,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a Kafka resource from the AppHost, Aspire makes several properties available to the consuming project, such as the bootstrap server host and port. For a complete list of these properties and per-language connection examples, see [Connect to Apache Kafka](../apache-kafka-connect/).
+  When you reference a Kafka resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as the bootstrap server
+  host and port. For a complete list of these properties and per-language
+  connection examples, see [Connect to Apache Kafka](../apache-kafka-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Kafka" only="Kafka" />
@@ -124,21 +144,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add the [Kafka UI](https://hub.docker.com/r/kafbat/kafka-ui) sub-resource to the Kafka server resource to get a web interface for monitoring and managing your Kafka cluster during development:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithKafkaUI();
+.WithKafkaUI();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(kafka);
+.WithReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -152,6 +181,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -163,21 +193,31 @@ The Kafka UI is a free, open-source web UI to monitor and manage Apache Kafka cl
 
 To change the host port the Kafka UI listens on, chain a call to `WithHostPort` (or `withHostPort`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The generated Rust SDK\'s `with_kafka_ui` callback receives raw `Vec<Value limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>` arguments instead of a typed `KafkaUIContainerResource`, so this doc doesn\'t show calling `with_host_port` fluently from inside it. Configure the Kafka UI host port from another language, or reconstruct the resource from `KafkaUIContainerResource::new` using the callback\'s JSON handle.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithKafkaUI(kafkaUI => kafkaUI.WithHostPort(9100));
+.WithKafkaUI(kafkaUI => kafkaUI.WithHostPort(9100));
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(kafka);
+.WithReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -195,6 +235,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -202,21 +243,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the Kafka server resource to persist data outside the lifecycle of its container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(kafka);
+.WithReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -230,6 +280,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -239,23 +290,32 @@ The data volume is used to persist Kafka broker data outside the lifecycle of it
 
 Add a data bind mount to the Kafka server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var kafka = builder.AddKafka("kafka")
-    .WithDataBindMount(
-        source: "/Kafka/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/Kafka/Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(kafka);
+.WithReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -269,11 +329,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 ## Work with larger Kafka clusters
@@ -282,15 +349,23 @@ The Aspire Kafka integration deploys a container from the `confluentinc/confluen
 
 To use a full broker topology in non-development environments, switch to an externally managed Kafka cluster via a connection string:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var kafka = builder.ExecutionContext.IsRunMode
     ? builder.AddKafka("kafka").WithKafkaUI()
     : builder.AddConnectionString("kafka");
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -303,11 +378,11 @@ const kafka = await builder.addKafka("kafka");
 await kafka.withKafkaUI();
 
 await builder.addNodeApp("api", "./api", "index.js")
-    .withReference(kafka);
+.withReference(kafka);
 
 // After adding all resources, run the app...
-```
 
+```
 <Aside type="note">
     The TypeScript AppHost doesn't currently expose an `ExecutionContext.IsRunMode` equivalent. To conditionally connect to an existing broker from a TypeScript AppHost, use [`builder.addConnectionString(...)`](/get-started/app-host/) with a parameter and reference that connection string from your consuming apps instead.
 </Aside>
@@ -318,8 +393,14 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 By default, Aspire injects the Kafka connection information using variable names derived from the resource name (for example, `KAFKA_HOST`, `KAFKA_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs  limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -335,8 +416,10 @@ var app = builder.AddExecutable("my-app", "node", "app.js", ".")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -347,12 +430,14 @@ const kafkaHost = await kafka.host();
 const kafkaPort = await kafka.port();
 
 await builder.addNodeApp("my-app", "./app", "index.js")
-    .withReference(kafka)
-    .withEnvironment("BOOTSTRAP_SERVERS_HOST", kafkaHost)
-    .withEnvironment("BOOTSTRAP_SERVERS_PORT", kafkaPort);
+.withReference(kafka)
+.withEnvironment("BOOTSTRAP_SERVERS_HOST", kafkaHost)
+.withEnvironment("BOOTSTRAP_SERVERS_PORT", kafkaPort);
 
 await builder.build().run();
+
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -360,8 +445,14 @@ await builder.build().run();
 
 To reference an externally managed Kafka instance rather than spinning up a local container:
 
-<AppHostTabs>
+<AppHostTabs  limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -372,8 +463,10 @@ var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -385,7 +478,9 @@ const exampleProject = await builder.addProject("apiservice", "../ExampleProject
 await exampleProject.withReference(kafka);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -396,3 +491,4 @@ For the full reference of Kafka connection properties — and how consuming apps
 ## Hosting integration health checks
 
 The Kafka hosting integration automatically adds a health check for the Kafka server resource. The health check verifies that a Kafka producer with the specified connection name can connect and persist a topic to the Kafka server.
+```

--- a/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/apache-kafka/apache-kafka-host.mdx
@@ -194,11 +194,10 @@ The Kafka UI is a free, open-source web UI to monitor and manage Apache Kafka cl
 To change the host port the Kafka UI listens on, chain a call to `WithHostPort` (or `withHostPort`):
 
 <AppHostTabs limitations={{
-  rust: 'The generated Rust SDK\'s `with_kafka_ui` callback receives raw `Vec<Value limitations={{
   python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
   go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
   java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
-}}>` arguments instead of a typed `KafkaUIContainerResource`, so this doc doesn\'t show calling `with_host_port` fluently from inside it. Configure the Kafka UI host port from another language, or reconstruct the resource from `KafkaUIContainerResource::new` using the callback\'s JSON handle.',
+  rust: 'The generated Rust SDK\'s `with_kafka_ui` callback receives raw `Vec<Value>` arguments instead of a typed `KafkaUIContainerResource`, so this doc doesn\'t show calling `with_host_port` fluently from inside it. Configure the Kafka UI host port from another language, or reconstruct the resource from `KafkaUIContainerResource::new` using the callback\'s JSON handle.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-connect.mdx
@@ -43,7 +43,12 @@ Unlike the Aspire RabbitMQ resource, the LavinMQ resource doesn't expose a `Virt
 
 For an external broker, model the connection string in the AppHost instead of adding a LavinMQ container:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-connect.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-connect.mdx
@@ -44,10 +44,10 @@ Unlike the Aspire RabbitMQ resource, the LavinMQ resource doesn't expose a `Virt
 For an external broker, model the connection string in the AppHost instead of adding a LavinMQ container:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-host.mdx
@@ -26,7 +26,12 @@ This article is the AppHost API reference for the [📦 CommunityToolkit.Aspire.
 
 ## Installation
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -62,7 +67,12 @@ This adds the package to `aspire.config.json`. After `aspire restore`, `.aspire/
 
 ## Add a LavinMQ resource
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -107,7 +117,12 @@ The integration runs `docker.io/cloudamqp/lavinmq:2.1.0`. The AMQP endpoint uses
 
 Pass fixed host ports when another process needs stable endpoints:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -147,7 +162,12 @@ When you omit these parameters, the integration binds host ports `5672` and
 
 `WithDataVolume` and `withDataVolume` require a volume name and mount it at `/var/lib/lavinmq`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -180,7 +200,12 @@ await builder.build().run();
 
 Use a bind mount when you need direct access to broker files on the host:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -215,7 +240,12 @@ Both persistence methods accept an optional `isReadOnly` value. A read-only moun
 
 The resource exports its AMQP endpoint and connection expressions for use in custom AppHost expressions:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/lavinmq/lavinmq-host.mdx
@@ -27,10 +27,10 @@ This article is the AppHost API reference for the [📦 CommunityToolkit.Aspire.
 ## Installation
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -68,10 +68,10 @@ This adds the package to `aspire.config.json`. After `aspire restore`, `.aspire/
 ## Add a LavinMQ resource
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -118,10 +118,10 @@ The integration runs `docker.io/cloudamqp/lavinmq:2.1.0`. The AMQP endpoint uses
 Pass fixed host ports when another process needs stable endpoints:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -163,10 +163,10 @@ When you omit these parameters, the integration binds host ports `5672` and
 `WithDataVolume` and `withDataVolume` require a volume name and mount it at `/var/lib/lavinmq`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -201,10 +201,10 @@ await builder.build().run();
 Use a bind mount when you need direct access to broker files on the host:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -241,10 +241,10 @@ Both persistence methods accept an optional `isReadOnly` value. A read-only moun
 The resource exports its AMQP endpoint and connection expressions for use in custom AppHost expressions:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/messaging/nats/nats-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/nats/nats-host.mdx
@@ -30,10 +30,10 @@ If you're new to the NATS integration, start with the [Get started with NATS int
 To start building an Aspire app that uses NATS, install the [📦 Aspire.Hosting.Nats](https://www.nuget.org/packages/Aspire.Hosting.Nats) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the NATS hosting integration package
 Once you've installed the hosting integration in your AppHost project, you can add a NATS resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -149,10 +149,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 [JetStream](https://docs.nats.io/nats-concepts/jetstream) is NATS's built-in persistence engine that provides at-least-once delivery, replay, and stream retention. To enable JetStream on the NATS resource, use `WithJetStream` (or `withJetStream`):
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -194,10 +194,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the NATS resource to persist messages and JetStream state across container restarts:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -243,10 +243,10 @@ The data volume is used to persist the NATS data outside the lifecycle of its co
 Add a data bind mount to the NATS resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -304,10 +304,10 @@ Data bind mounts rely on the host machine's filesystem to persist NATS data acro
 When you want to explicitly provide the port and credentials used by the NATS container, you can pass them as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -355,10 +355,10 @@ When no `userName` or `password` parameters are provided, Aspire generates stron
 By default, Aspire injects the NATS connection information using variable names derived from the resource name (for example, `NATS_URI`, `NATS_HOST`, `NATS_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/messaging/nats/nats-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/nats/nats-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up NATS in the AppHost
-seoTitle: "Set up NATS in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up NATS in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire NATS Hosting integration to orchestrate and configure a NATS resource in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the NATS integration, start with the [Get started with NATS int
 
 To start building an Aspire app that uses NATS, install the [📦 Aspire.Hosting.Nats](https://www.nuget.org/packages/Aspire.Hosting.Nats) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add nats
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add nats
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the NATS hosting integration package:
@@ -78,20 +85,29 @@ This updates your `aspire.config.json` with the NATS hosting integration package
 
 Once you've installed the hosting integration in your AppHost project, you can add a NATS resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var nats = builder.AddNats("nats");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(nats);
+.WithReference(nats);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -104,6 +120,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -118,7 +135,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a NATS resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and credentials. For a complete list of these properties and per-language connection examples, see [Connect to NATS](../nats-connect/).
+  When you reference a NATS resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and credentials. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  NATS](../nats-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.Nats" />
@@ -127,21 +148,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 [JetStream](https://docs.nats.io/nats-concepts/jetstream) is NATS's built-in persistence engine that provides at-least-once delivery, replay, and stream retention. To enable JetStream on the NATS resource, use `WithJetStream` (or `withJetStream`):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var nats = builder.AddNats("nats")
-    .WithJetStream();
+.WithJetStream();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(nats);
+.WithReference(nats);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -155,6 +185,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -162,22 +193,31 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the NATS resource to persist messages and JetStream state across container restarts:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var nats = builder.AddNats("nats")
-    .WithJetStream()
-    .WithDataVolume(isReadOnly: false);
+.WithJetStream()
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(nats);
+.WithReference(nats);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -192,6 +232,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -201,24 +242,33 @@ The data volume is used to persist the NATS data outside the lifecycle of its co
 
 Add a data bind mount to the NATS resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var nats = builder.AddNats("nats")
-    .WithJetStream()
-    .WithDataBindMount(
-        source: @"C:\Nats\Data",
-        isReadOnly: false);
+.WithJetStream()
+.WithDataBindMount(
+source: @"C:\Nats\Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(nats);
+.WithReference(nats);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -233,11 +283,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist NATS data across container restarts. The data bind mount is mounted at the `C:\Nats\Data` on Windows (or `/Nats/Data` on Unix) path on the host machine in the NATS container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -246,8 +303,14 @@ Data bind mounts rely on the host machine's filesystem to persist NATS data acro
 
 When you want to explicitly provide the port and credentials used by the NATS container, you can pass them as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -257,12 +320,15 @@ var password = builder.AddParameter("natsPass", secret: true);
 var nats = builder.AddNats("nats", userName: userName, password: password);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(nats);
+.WithReference(nats);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -278,6 +344,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -287,27 +354,36 @@ When no `userName` or `password` parameters are provided, Aspire generates stron
 
 By default, Aspire injects the NATS connection information using variable names derived from the resource name (for example, `NATS_URI`, `NATS_HOST`, `NATS_PORT`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var nats = builder.AddNats("nats");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(nats)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["NATS_HOST"] = nats.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["NATS_PORT"] = nats.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["NATS_USER"] = nats.Resource.UserNameParameter;
-        context.EnvironmentVariables["NATS_PASSWORD"] = nats.Resource.PasswordParameter;
-    });
+.WithReference(nats)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["NATS_HOST"] = nats.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["NATS_PORT"] = nats.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["NATS_USER"] = nats.Resource.UserNameParameter;
+context.EnvironmentVariables["NATS_PASSWORD"] = nats.Resource.PasswordParameter;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -327,6 +403,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up RabbitMQ in the AppHost
-seoTitle: "Set up RabbitMQ in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up RabbitMQ in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire RabbitMQ Hosting integration to orchestrate and configure a RabbitMQ resource in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the RabbitMQ integration, start with the [Get started with Rabb
 
 To start building an Aspire app that uses RabbitMQ, install the [📦 Aspire.Hosting.RabbitMQ](https://www.nuget.org/packages/Aspire.Hosting.RabbitMQ) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add rabbitmq
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add rabbitmq
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the RabbitMQ hosting integration package:
@@ -75,27 +82,37 @@ This updates your `aspire.config.json` with the RabbitMQ hosting integration pac
 </AppHostTabs>
 
 <Aside type="tip">
-    If you'd rather connect to an existing RabbitMQ server, see [Connect to an existing RabbitMQ instance](#connect-to-an-existing-rabbitmq-instance) below.
+  If you'd rather connect to an existing RabbitMQ server, see [Connect to an
+  existing RabbitMQ instance](#connect-to-an-existing-rabbitmq-instance) below.
 </Aside>
 
 ## Add RabbitMQ server resource
 
 Once you've installed the hosting integration in your AppHost project, you can add a RabbitMQ server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var rabbitmq = builder.AddRabbitMQ("messaging");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -108,6 +125,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -122,7 +140,11 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a RabbitMQ resource from the AppHost, Aspire makes several properties available to the consuming project, such as connection URIs, hostnames, port numbers, and credentials. For a complete list of these properties and per-language connection examples, see [Connect to RabbitMQ](../rabbitmq-connect/).
+  When you reference a RabbitMQ resource from the AppHost, Aspire makes several
+  properties available to the consuming project, such as connection URIs,
+  hostnames, port numbers, and credentials. For a complete list of these
+  properties and per-language connection examples, see [Connect to
+  RabbitMQ](../rabbitmq-connect/).
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.RabbitMQ" />
@@ -131,21 +153,30 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 Add a data volume to the RabbitMQ server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var rabbitmq = builder.AddRabbitMQ("messaging")
-    .WithDataVolume(isReadOnly: false);
+.WithDataVolume(isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -159,6 +190,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -168,23 +200,32 @@ The data volume is used to persist RabbitMQ server data outside the lifecycle of
 
 Add a data bind mount to the RabbitMQ server resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var rabbitmq = builder.AddRabbitMQ("messaging")
-    .WithDataBindMount(
-        source: "/RabbitMQ/Data",
-        isReadOnly: false);
+.WithDataBindMount(
+source: "/RabbitMQ/Data",
+isReadOnly: false);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -198,11 +239,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist RabbitMQ server data across container restarts. The data bind mount is mounted at the `C:\RabbitMQ\Data` on Windows (or `/RabbitMQ/Data` on Unix) path on the host machine in the RabbitMQ server container. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -211,8 +259,14 @@ Data bind mounts rely on the host machine's filesystem to persist RabbitMQ serve
 
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters. Consider the following alternative examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -222,12 +276,15 @@ var password = builder.AddParameter("password", secret: true);
 var rabbitmq = builder.AddRabbitMQ("messaging", username, password);
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -243,6 +300,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -252,8 +310,14 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 
 To add the [RabbitMQ management plugin](https://www.rabbitmq.com/docs/management) as a sub-resource, call `WithManagementPlugin` (or `withManagementPlugin`). You'll need the credentials you configured to log in to the management UI:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -261,15 +325,18 @@ var username = builder.AddParameter("username", secret: true);
 var password = builder.AddParameter("password", secret: true);
 
 var rabbitmq = builder.AddRabbitMQ("messaging", username, password)
-    .WithManagementPlugin();
+.WithManagementPlugin();
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -286,6 +353,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -293,17 +361,26 @@ The RabbitMQ management plugin provides an HTTP-based API for management and mon
 
 To configure a custom host port for the management plugin, pass the `port` option:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var rabbitmq = builder.AddRabbitMQ("messaging")
     .WithManagementPlugin(port: 15672);
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 await rabbitmq.withManagementPlugin({ port: 15672 });
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -311,27 +388,36 @@ await rabbitmq.withManagementPlugin({ port: 15672 });
 
 By default, Aspire injects the RabbitMQ connection information using variable names derived from the resource name (for example, `MESSAGING_URI`, `MESSAGING_HOST`, `MESSAGING_PORT`, `MESSAGING_USERNAME`, `MESSAGING_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var rabbitmq = builder.AddRabbitMQ("messaging");
 
 var app = builder.AddExecutable("my-app", "node", "app.js", ".")
-    .WithReference(rabbitmq)
-    .WithEnvironment(context =>
-    {
-        context.EnvironmentVariables["RABBITMQ_HOST"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
-        context.EnvironmentVariables["RABBITMQ_PORT"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
-        context.EnvironmentVariables["RABBITMQ_USER"] = rabbitmq.Resource.UserNameParameter;
-        context.EnvironmentVariables["RABBITMQ_PASSWORD"] = rabbitmq.Resource.PasswordParameter;
-    });
+.WithReference(rabbitmq)
+.WithEnvironment(context =>
+{
+context.EnvironmentVariables["RABBITMQ_HOST"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Host);
+context.EnvironmentVariables["RABBITMQ_PORT"] = rabbitmq.Resource.PrimaryEndpoint.Property(EndpointProperty.Port);
+context.EnvironmentVariables["RABBITMQ_USER"] = rabbitmq.Resource.UserNameParameter;
+context.EnvironmentVariables["RABBITMQ_PASSWORD"] = rabbitmq.Resource.PasswordParameter;
+});
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, EndpointProperty } from './.aspire/modules/aspire.mjs';
 
@@ -351,6 +437,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -358,20 +445,29 @@ await builder.build().run();
 
 To reference an externally managed RabbitMQ instance instead of running one as a container, use `AddConnectionString`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var rabbitmq = builder.AddConnectionString("messaging");
 
 var exampleProject = builder.AddProject<Projects.ExampleProject>("apiservice")
-    .WithReference(rabbitmq);
+.WithReference(rabbitmq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -385,6 +481,7 @@ await builder.addNodeApp("my-app", "./app", "index.js")
 // After adding all resources, run the app...
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -394,7 +491,10 @@ With `AddConnectionString` and `addConnectionString`, Aspire resolves `messaging
 
 For the full reference of RabbitMQ resource connection properties — and how consuming apps in C#, TypeScript, Python, and Go read them — see [Connect to RabbitMQ](../rabbitmq-connect/).
 
-<span id="rabbitmq-4-3-queue-declaration-requirements" aria-hidden="true"></span>
+<span
+  id="rabbitmq-4-3-queue-declaration-requirements"
+  aria-hidden="true"
+></span>
 
 ## RabbitMQ 4.3 queue declaration requirements
 
@@ -409,7 +509,13 @@ If your application declares such queues, switch to one of the supported pattern
 For upstream details, see the [RabbitMQ 4.3.0 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.0).
 
 <Aside type="note">
-  Neither the Aspire RabbitMQ hosting integration (`Aspire.Hosting.RabbitMQ`) nor the client integration (`Aspire.RabbitMQ.Client`) declares queues for you. The hosting integration models and runs the RabbitMQ broker as a resource and exposes a connection string; the client integration registers an `IConnection` and wires up DI, configuration, telemetry, and health checks. Queue topology is entirely owned by your application code, so any queue declarations your app makes must comply with the RabbitMQ 4.3 requirements above.
+  Neither the Aspire RabbitMQ hosting integration (`Aspire.Hosting.RabbitMQ`)
+  nor the client integration (`Aspire.RabbitMQ.Client`) declares queues for you.
+  The hosting integration models and runs the RabbitMQ broker as a resource and
+  exposes a connection string; the client integration registers an `IConnection`
+  and wires up DI, configuration, telemetry, and health checks. Queue topology
+  is entirely owned by your application code, so any queue declarations your app
+  makes must comply with the RabbitMQ 4.3 requirements above.
 </Aside>
 
 ## Hosting integration health checks

--- a/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/messaging/rabbitmq/rabbitmq-host.mdx
@@ -30,10 +30,10 @@ If you're new to the RabbitMQ integration, start with the [Get started with Rabb
 To start building an Aspire app that uses RabbitMQ, install the [📦 Aspire.Hosting.RabbitMQ](https://www.nuget.org/packages/Aspire.Hosting.RabbitMQ) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -91,10 +91,10 @@ This updates your `aspire.config.json` with the RabbitMQ hosting integration pac
 Once you've installed the hosting integration in your AppHost project, you can add a RabbitMQ server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -154,10 +154,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 Add a data volume to the RabbitMQ server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -201,10 +201,10 @@ The data volume is used to persist RabbitMQ server data outside the lifecycle of
 Add a data bind mount to the RabbitMQ server resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -260,10 +260,10 @@ Data bind mounts rely on the host machine's filesystem to persist RabbitMQ serve
 When you want to explicitly provide the username and password used by the container image, you can provide these credentials as parameters. Consider the following alternative examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -311,10 +311,10 @@ When no `password` parameter is provided, Aspire generates a strong password aut
 To add the [RabbitMQ management plugin](https://www.rabbitmq.com/docs/management) as a sub-resource, call `WithManagementPlugin` (or `withManagementPlugin`). You'll need the credentials you configured to log in to the management UI:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -362,10 +362,10 @@ The RabbitMQ management plugin provides an HTTP-based API for management and mon
 To configure a custom host port for the management plugin, pass the `port` option:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -389,10 +389,10 @@ await rabbitmq.withManagementPlugin({ port: 15672 });
 By default, Aspire injects the RabbitMQ connection information using variable names derived from the resource name (for example, `MESSAGING_URI`, `MESSAGING_HOST`, `MESSAGING_PORT`, `MESSAGING_USERNAME`, `MESSAGING_PASSWORD`). If your consuming app expects a different set of environment variable names, pass individual connection properties from the AppHost:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -446,10 +446,10 @@ await builder.build().run();
 To reference an externally managed RabbitMQ instance instead of running one as a container, use `AddConnectionString`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
@@ -30,10 +30,10 @@ If you're new to the Seq integration, start with the [Get started with Seq integ
 To start building an Aspire app that uses Seq, install the [📦 Aspire.Hosting.Seq](https://www.nuget.org/packages/Aspire.Hosting.Seq) NuGet package:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -86,10 +86,10 @@ This updates your `aspire.config.json` with the Seq hosting integration package:
 Once you've installed the hosting integration in your AppHost project, you can add a Seq resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -164,10 +164,10 @@ Seq is an observability tool intended for local development and internal environ
 Add a data volume to the Seq resource to persist log data across container restarts:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -221,10 +221,10 @@ The data volume is used to persist the Seq data outside the lifecycle of its con
 Add a data bind mount to the Seq resource as shown in the following examples:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
+++ b/src/frontend/src/content/docs/integrations/observability/seq/seq-host.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up Seq in the AppHost
-seoTitle: "Set up Seq in the Aspire AppHost: hosting integration"
+seoTitle: 'Set up Seq in the Aspire AppHost: hosting integration'
 description: Learn how to use the Aspire Seq hosting integration to orchestrate and configure a Seq resource in an Aspire solution.
 ---
 
@@ -29,7 +29,12 @@ If you're new to the Seq integration, start with the [Get started with Seq integ
 
 To start building an Aspire app that uses Seq, install the [📦 Aspire.Hosting.Seq](https://www.nuget.org/packages/Aspire.Hosting.Seq) NuGet package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -37,7 +42,8 @@ aspire add seq
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 Or, choose a manual installation approach:
@@ -58,7 +64,8 @@ aspire add seq
 ```
 
 <LearnMore>
-  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the command reference.
+  Learn more about [`aspire add`](/reference/cli/commands/aspire-add/) in the
+  command reference.
 </LearnMore>
 
 This updates your `aspire.config.json` with the Seq hosting integration package:
@@ -78,24 +85,33 @@ This updates your `aspire.config.json` with the Seq hosting integration package:
 
 Once you've installed the hosting integration in your AppHost project, you can add a Seq resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var seq = builder.AddSeq("seq")
-    .ExcludeFromManifest()
-    .WithLifetime(ContainerLifetime.Persistent)
-    .WithEnvironment("ACCEPT_EULA", "Y");
+.ExcludeFromManifest()
+.WithLifetime(ContainerLifetime.Persistent)
+.WithEnvironment("ACCEPT_EULA", "Y");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(seq)
-    .WaitFor(seq);
+.WithReference(seq)
+.WaitFor(seq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -112,6 +128,7 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -126,7 +143,10 @@ await builder.addNodeApp("api", "./api", "index.js")
 </Steps>
 
 <Aside type="note">
-    When you reference a Seq resource from the AppHost, Aspire makes connection properties available to the consuming project, such as the URI, hostname, and port. For a complete list of these properties and per-language connection examples, see [Connect to Seq](../seq-connect/).
+  When you reference a Seq resource from the AppHost, Aspire makes connection
+  properties available to the consuming project, such as the URI, hostname, and
+  port. For a complete list of these properties and per-language connection
+  examples, see [Connect to Seq](../seq-connect/).
 </Aside>
 
 ### Accept the Seq End User License Agreement (EULA)
@@ -143,23 +163,31 @@ Seq is an observability tool intended for local development and internal environ
 
 Add a data volume to the Seq resource to persist log data across container restarts:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var seq = builder.AddSeq("seq")
-    .WithDataVolume()
-    .ExcludeFromManifest()
-    .WithLifetime(ContainerLifetime.Persistent)
-    .WithEnvironment("ACCEPT_EULA", "Y");
+.WithDataVolume()
+.ExcludeFromManifest()
+.WithLifetime(ContainerLifetime.Persistent)
+.WithEnvironment("ACCEPT_EULA", "Y");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(seq)
-    .WaitFor(seq);
+.WithReference(seq)
+.WaitFor(seq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 
@@ -192,25 +220,34 @@ The data volume is used to persist the Seq data outside the lifecycle of its con
 
 Add a data bind mount to the Seq resource as shown in the following examples:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var seq = builder.AddSeq("seq")
-    .WithDataBindMount(source: "/Seq/Data", isReadOnly: false)
-    .ExcludeFromManifest()
-    .WithLifetime(ContainerLifetime.Persistent)
-    .WithEnvironment("ACCEPT_EULA", "Y");
+.WithDataBindMount(source: "/Seq/Data", isReadOnly: false)
+.ExcludeFromManifest()
+.WithLifetime(ContainerLifetime.Persistent)
+.WithEnvironment("ACCEPT_EULA", "Y");
 
 var myService = builder.AddProject<Projects.ExampleProject>()
-    .WithReference(seq)
-    .WaitFor(seq);
+.WithReference(seq)
+.WaitFor(seq);
 
 // After adding all resources, run the app...
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder, ContainerLifetime } from './.aspire/modules/aspire.mjs';
 
@@ -228,11 +265,18 @@ await builder.addNodeApp("api", "./api", "index.js")
 
 // After adding all resources, run the app...
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-    Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have limited functionality compared to [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better performance, portability, and security, making them more suitable for production environments. However, bind mounts allow direct access and modification of files on the host system, ideal for development and testing where real-time changes are needed.
+  Data [bind mounts](https://docs.docker.com/engine/storage/bind-mounts/) have
+  limited functionality compared to
+  [volumes](https://docs.docker.com/engine/storage/volumes/), which offer better
+  performance, portability, and security, making them more suitable for
+  production environments. However, bind mounts allow direct access and
+  modification of files on the host system, ideal for development and testing
+  where real-time changes are needed.
 </Aside>
 
 Data bind mounts rely on the host machine's filesystem to persist Seq data across container restarts. The bind mount is mounted at `/data` in the Seq container, and maps to `C:\Seq\Data` on Windows (or `/Seq/Data` on Unix) on the host machine. For more information on data bind mounts, see [Docker docs: Bind mounts](https://docs.docker.com/engine/storage/bind-mounts).
@@ -241,8 +285,8 @@ Data bind mounts rely on the host machine's filesystem to persist Seq data acros
 
 The Seq container exposes two endpoints:
 
-| Endpoint | Default port | Description |
-| -------- | ------------ | ----------- |
+| Endpoint | Default port | Description                                                                        |
+| -------- | ------------ | ---------------------------------------------------------------------------------- |
 | `http`   | `5341`       | The primary ingestion and query endpoint used by consuming apps and the Seq web UI |
 
 When you call `.WithReference(seq)`, Aspire injects the `http` endpoint URI into the consuming app as the `SEQ_URI` environment variable (or `{RESOURCE}_URI` for other resource names).

--- a/src/frontend/src/content/docs/integrations/overview.mdx
+++ b/src/frontend/src/content/docs/integrations/overview.mdx
@@ -146,7 +146,12 @@ func main() {
 		log.Fatal(aspire.FormatError(err))
 	}
 
-	db := builder.AddPostgres("postgres").AddDatabase("appdb")
+	postgres := builder.AddPostgres("postgres")
+	if err := postgres.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	db := postgres.AddDatabase("appdb")
 	if err := db.Err(); err != nil {
 		log.Fatal(aspire.FormatError(err))
 	}

--- a/src/frontend/src/content/docs/integrations/overview.mdx
+++ b/src/frontend/src/content/docs/integrations/overview.mdx
@@ -96,14 +96,122 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const cache = await builder.addRedis("cache");
-const db = (await builder.addPostgres("postgres")).addDatabase("appdb");
+const cache = await builder.addRedis('cache');
+const db = (await builder.addPostgres('postgres')).addDatabase('appdb');
 
-const api = await builder.addProject("api", "../Api/Api.csproj");
+const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withReference(cache);
 await api.withReference(db);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+    db = builder.add_postgres("postgres").add_database("appdb")
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_reference(cache)
+    api.with_reference(db)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddRedis("cache")
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	db := builder.AddPostgres("postgres").AddDatabase("appdb")
+	if err := db.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj")
+	api.WithReference(cache).WithReference(db)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var cache = builder.addRedis("cache");
+    var db = builder.addPostgres("postgres").addDatabase("appdb");
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withReference(cache);
+    api.withReference(db);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_redis("cache", None, None)?;
+    let db = builder
+        .add_postgres("postgres", None, None, None)?
+        .add_database("appdb", None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_reference(cache.handle().to_json(), None, None, None)?;
+    api.with_reference(db.handle().to_json(), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -135,7 +243,7 @@ var redisConnectionString = Environment.GetEnvironmentVariable("ConnectionString
 
 ```typescript title="app.ts"
 // Read the environment variable directly
-const redisConnectionString = process.env["ConnectionStrings__cache"];
+const redisConnectionString = process.env['ConnectionStrings__cache'];
 ```
 
 </TabItem>

--- a/src/frontend/src/content/docs/integrations/reverse-proxies/yarp.mdx
+++ b/src/frontend/src/content/docs/integrations/reverse-proxies/yarp.mdx
@@ -26,7 +26,12 @@ This article is the reference for the Aspire YARP Hosting integration. It enumer
 
 The YARP hosting integration models a YARP resource as the `YarpResource` type. To access this type and APIs, install the [📦 Aspire.Hosting.Yarp](https://www.nuget.org/packages/Aspire.Hosting.Yarp) NuGet package in your AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```bash title="Terminal"
@@ -67,7 +72,12 @@ This updates your `aspire.config.json` with the YARP hosting integration package
 
 In your AppHost, add a YARP resource and configure routes programmatically:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -130,7 +140,12 @@ When Aspire adds a YARP resource to the AppHost, it creates a new containerized 
 
 The YARP integration provides a fluent API for configuring routes, clusters, and transforms programmatically:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -209,10 +224,19 @@ Routes define how incoming requests are matched and forwarded to backend service
 | Catch-all route for a resource | `AddRoute(resource)`              | `addCatchAllRoute(resource)`      |
 | Route for a resource           | `AddRoute(path, resource)`        | `addRoute(path, resource)`        |
 | Route for an external service  | `AddRoute(path, externalService)` | `addRoute(path, externalService)` |
-| Route for an endpoint          | `AddRoute(path, cluster)`         | `addRoute(path, cluster)`        |
+| Route for an endpoint          | `AddRoute(path, cluster)`         | `addRoute(path, cluster)`         |
 | Route for a URL destination    | `AddRoute(path, destination)`     | `addRoute(path, destination)`     |
 
 TypeScript AppHosts use unified route helpers. Pass any supported target to `addRoute(path, target)` or `addCatchAllRoute(target)`: a YARP cluster, endpoint, service-discovery resource, external service, or URL string.
+
+<AppHostTabs limitations={{
+  csharp: 'C# for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
+<Fragment slot="typescript">
 
 ```typescript title="apphost.mts"
 await gateway.withConfiguration(async (yarp) => {
@@ -223,20 +247,28 @@ await gateway.withConfiguration(async (yarp) => {
   );
   const endpointCluster = await yarp.addClusterFromEndpoint(httpEndpoint);
 
-  await yarp.addRoute('/from-cluster/{**catch-all}', endpointCluster);
-  await yarp.addRoute('/from-endpoint/{**catch-all}', httpEndpoint);
-  await yarp.addRoute('/from-resource/{**catch-all}', catalogService);
-  await yarp.addRoute('/from-external/{**catch-all}', externalApi);
-  await yarp.addRoute('/from-url/{**catch-all}', 'https://api.example.net');
-  await yarp.addCatchAllRoute(catalogService);
+await yarp.addRoute('/from-cluster/{**catch-all}', endpointCluster);
+await yarp.addRoute('/from-endpoint/{**catch-all}', httpEndpoint);
+await yarp.addRoute('/from-resource/{**catch-all}', catalogService);
+await yarp.addRoute('/from-external/{**catch-all}', externalApi);
+await yarp.addRoute('/from-url/{\*\*catch-all}', 'https://api.example.net');
+await yarp.addCatchAllRoute(catalogService);
 });
+
 ```
 
+</Fragment>
+</AppHostTabs>
 #### Transforms
 
 Transforms modify requests and responses as they pass through the proxy:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -272,7 +304,12 @@ Common transform methods include:
 
 To configure the host port that the YARP resource is exposed on, use the host port API:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -312,7 +349,12 @@ await builder.build().run();
 
 The YARP integration automatically works with service discovery when targeting resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -357,7 +399,12 @@ await builder.build().run();
 
 For external services, use `AddExternalService` or `addExternalService`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -403,7 +450,12 @@ await builder.build().run();
 
 YARP can serve static files alongside proxied routes. Use the static files API to enable static file serving:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -433,7 +485,12 @@ await builder.build().run();
 
 For building frontend applications, you can use a Docker multi-stage build:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -469,7 +526,12 @@ await builder.build().run();
 
 You can combine static file serving with dynamic routing:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -520,7 +582,12 @@ await builder.build().run();
 
 When both the YARP gateway and backend services use HTTPS, configure HTTPS endpoints using `WithHttpsEndpoint` or `withHttpsEndpoint` and the developer certificate. YARP can proxy HTTPS-to-HTTPS when the backend service exposes an HTTPS endpoint:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/reverse-proxies/yarp.mdx
+++ b/src/frontend/src/content/docs/integrations/reverse-proxies/yarp.mdx
@@ -27,10 +27,10 @@ This article is the reference for the Aspire YARP Hosting integration. It enumer
 The YARP hosting integration models a YARP resource as the `YarpResource` type. To access this type and APIs, install the [📦 Aspire.Hosting.Yarp](https://www.nuget.org/packages/Aspire.Hosting.Yarp) NuGet package in your AppHost project:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -73,10 +73,10 @@ This updates your `aspire.config.json` with the YARP hosting integration package
 In your AppHost, add a YARP resource and configure routes programmatically:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -141,10 +141,10 @@ When Aspire adds a YARP resource to the AppHost, it creates a new containerized 
 The YARP integration provides a fluent API for configuring routes, clusters, and transforms programmatically:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -230,11 +230,11 @@ Routes define how incoming requests are matched and forwarded to backend service
 TypeScript AppHosts use unified route helpers. Pass any supported target to `addRoute(path, target)` or `addCatchAllRoute(target)`: a YARP cluster, endpoint, service-discovery resource, external service, or URL string.
 
 <AppHostTabs limitations={{
-  csharp: 'C# for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  python: 'Python for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this standalone AppHost scenario has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  csharp: 'C# for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  python: 'Python for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this standalone AppHost scenario has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="typescript">
 
@@ -264,10 +264,10 @@ await yarp.addCatchAllRoute(catalogService);
 Transforms modify requests and responses as they pass through the proxy:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -305,10 +305,10 @@ Common transform methods include:
 To configure the host port that the YARP resource is exposed on, use the host port API:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -350,10 +350,10 @@ await builder.build().run();
 The YARP integration automatically works with service discovery when targeting resources:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -400,10 +400,10 @@ await builder.build().run();
 For external services, use `AddExternalService` or `addExternalService`:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -451,10 +451,10 @@ await builder.build().run();
 YARP can serve static files alongside proxied routes. Use the static files API to enable static file serving:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -486,10 +486,10 @@ await builder.build().run();
 For building frontend applications, you can use a Docker multi-stage build:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -527,10 +527,10 @@ await builder.build().run();
 You can combine static file serving with dynamic routing:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -583,10 +583,10 @@ await builder.build().run();
 When both the YARP gateway and backend services use HTTPS, configure HTTPS endpoints using `WithHttpsEndpoint` or `withHttpsEndpoint` and the developer certificate. YARP can proxy HTTPS-to-HTTPS when the backend service exposes an HTTPS endpoint:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/src/content/docs/integrations/security/keycloak.mdx
+++ b/src/frontend/src/content/docs/integrations/security/keycloak.mdx
@@ -41,27 +41,36 @@ The Keycloak hosting integration models the server as the `KeycloakResource` typ
 
 In your AppHost, call `AddKeycloak` to add and return a Keycloak resource builder:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080);
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 var webfrontend = builder.AddProject<Projects.Web>("webfrontend")
-    .WithExternalHttpEndpoints()
-    .WithReference(keycloak)
-    .WithReference(apiService)
-    .WaitFor(apiService);
+.WithExternalHttpEndpoints()
+.WithReference(keycloak)
+.WithReference(apiService)
+.WaitFor(apiService);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -81,6 +90,7 @@ await webfrontend.waitFor(apiService);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -116,22 +126,31 @@ When the AppHost runs, the password is stored in the AppHost's secret store in t
 
 To add a data volume to the Keycloak resource, call the `WithDataVolume` method on the Keycloak resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithDataVolume();
+.WithDataVolume();
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -146,6 +165,7 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -160,22 +180,31 @@ The data volume is used to persist the Keycloak data outside the lifecycle of it
 
 To add a data bind mount to the Keycloak resource, call the `WithDataBindMount` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithDataBindMount(@"C:\Keycloak\Data");
+.WithDataBindMount(@"C:\Keycloak\Data");
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -190,6 +219,7 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -203,8 +233,14 @@ await builder.build().run();
 
 When you want to explicitly provide the admin username and password used by the container image, you can provide these credentials as parameters:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -214,13 +250,16 @@ var password = builder.AddParameter("password", secret: true);
 var keycloak = builder.AddKeycloak("keycloak", 8080, username, password);
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -241,6 +280,7 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -250,22 +290,31 @@ For more information on providing parameters, see [External parameters](/get-sta
 
 To import a realm into Keycloak, call the `WithRealmImport` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithRealmImport("./Realms");
+.WithRealmImport("./Realms");
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -280,6 +329,7 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -310,22 +360,31 @@ FROM quay.io/keycloak/keycloak:25.0.0
 COPY ./realms/*.json /opt/keycloak/data/import/
 ```
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithDockerfile("./keycloak");
+.WithDockerfile("./keycloak");
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -340,10 +399,16 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```text title="Directory layout"
@@ -388,22 +453,31 @@ to manage realm configuration separately from your application deployment.
 
 Keycloak containers can export telemetry to your OTLP collector using the `WithOtlpExporter` method:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var keycloak = builder.AddKeycloak("keycloak", 8080)
-    .WithOtlpExporter();
+.WithOtlpExporter();
 
 var apiService = builder.AddProject<Projects.ApiService>("apiservice")
-    .WithReference(keycloak)
-    .WaitFor(keycloak);
+.WithReference(keycloak)
+.WaitFor(keycloak);
 
 builder.Build().Run();
+
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -418,6 +492,7 @@ await apiService.waitFor(keycloak);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -434,7 +509,12 @@ The [📦 CommunityToolkit.Aspire.Hosting.Keycloak.Extensions](https://www.nuget
   prerelease={true}
 />
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -565,7 +645,12 @@ builder.Services.AddAuthentication()
 
 For production deployments, consider using connection strings:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/integrations/security/keycloak.mdx
+++ b/src/frontend/src/content/docs/integrations/security/keycloak.mdx
@@ -42,10 +42,10 @@ The Keycloak hosting integration models the server as the `KeycloakResource` typ
 In your AppHost, call `AddKeycloak` to add and return a Keycloak resource builder:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -127,10 +127,10 @@ When the AppHost runs, the password is stored in the AppHost's secret store in t
 To add a data volume to the Keycloak resource, call the `WithDataVolume` method on the Keycloak resource:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -181,10 +181,10 @@ The data volume is used to persist the Keycloak data outside the lifecycle of it
 To add a data bind mount to the Keycloak resource, call the `WithDataBindMount` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -234,10 +234,10 @@ await builder.build().run();
 When you want to explicitly provide the admin username and password used by the container image, you can provide these credentials as parameters:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -291,10 +291,10 @@ For more information on providing parameters, see [External parameters](/get-sta
 To import a realm into Keycloak, call the `WithRealmImport` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -361,10 +361,10 @@ COPY ./realms/*.json /opt/keycloak/data/import/
 ```
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -404,10 +404,10 @@ await builder.build().run();
 </AppHostTabs>
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -454,10 +454,10 @@ to manage realm configuration separately from your application deployment.
 Keycloak containers can export telemetry to your OTLP collector using the `WithOtlpExporter` method:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -510,10 +510,10 @@ The [📦 CommunityToolkit.Aspire.Hosting.Keycloak.Extensions](https://www.nuget
 />
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 
@@ -646,10 +646,10 @@ builder.Services.AddAuthentication()
 For production deployments, consider using connection strings:
 
 <AppHostTabs limitations={{
-  python: 'Python for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  go: 'Go for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  java: 'Java for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
-  rust: 'Rust for this exact AppHost operation sequence has not been validated against the generated Aspire 13.6.0-preview.1.26458.6 SDK.',
+  python: 'Python for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  go: 'Go for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  java: 'Java for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
+  rust: 'Rust for this exact AppHost operation sequence has not been validated against the daily generated SDK used for this documentation.',
 }}>
 <Fragment slot="csharp">
 

--- a/src/frontend/tests/unit/apphost-languages.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-languages.vitest.test.ts
@@ -78,6 +78,10 @@ function getMdxFiles(directory: string): string[] {
   return files;
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 describe('AppHost language registry', () => {
   test('keeps the canonical order and enables only the established languages initially', () => {
     expect(appHostLanguageConfig.languages.map((language) => language.id)).toEqual([
@@ -263,6 +267,94 @@ describe('AppHost language registry', () => {
       }
     }
     expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
+  });
+
+  test('cloud and AI Go AppHost resources check errors before use', () => {
+    const violations: string[] = [];
+    const goFencePattern = /```go[^\n]*\n(?<code>[\s\S]*?)```/g;
+
+    for (const directory of integrationParityDirectories) {
+      for (const file of getMdxFiles(directory)) {
+        const source = fs.readFileSync(file, 'utf8');
+
+        for (const match of source.matchAll(goFencePattern)) {
+          const code = match.groups?.code ?? '';
+          const lines = code.split(/\r?\n/);
+
+          for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+            const assignment = lines[lineIndex].match(
+              /^\s*(?<variable>[A-Za-z_]\w*)\s*:=\s*(?<expression>.+)$/
+            );
+            if (!assignment?.groups) {
+              continue;
+            }
+
+            const variable = assignment.groups.variable;
+            let expression = assignment.groups.expression;
+            let statementEnd = lineIndex;
+            let parenthesisDepth =
+              (expression.match(/\(/g) ?? []).length - (expression.match(/\)/g) ?? []).length;
+
+            while (
+              statementEnd + 1 < lines.length &&
+              (parenthesisDepth > 0 || expression.trimEnd().endsWith('.'))
+            ) {
+              statementEnd += 1;
+              expression += `\n${lines[statementEnd]}`;
+              parenthesisDepth +=
+                (lines[statementEnd].match(/\(/g) ?? []).length -
+                (lines[statementEnd].match(/\)/g) ?? []).length;
+            }
+
+            const createsGeneratedResource =
+              /\b(?:builder|[A-Za-z_]\w*)\.Add[A-Z]\w*\s*\(/.test(expression) &&
+              !/\bbuilder\.AddProject\s*\(/.test(expression);
+            if (!createsGeneratedResource) {
+              lineIndex = statementEnd;
+              continue;
+            }
+
+            const resourceCreationCount = (expression.match(/\.(?:Add[A-Z]\w*)\s*\(/g) ?? [])
+              .length;
+            if (resourceCreationCount > 1) {
+              violations.push(
+                `${path.relative(docsDirectory, file)}:${
+                  source.slice(0, (match.index ?? 0) + match[0].indexOf(code)).split('\n').length +
+                  lineIndex
+                } chains generated resources without exposing each parent for an Err check`
+              );
+            }
+
+            const escapedVariable = escapeRegExp(variable);
+            const errorPattern = new RegExp(`\\b${escapedVariable}\\.Err\\s*\\(`);
+            const usagePattern = new RegExp(`\\b${escapedVariable}\\b`);
+
+            for (let nextLine = statementEnd + 1; nextLine < lines.length; nextLine += 1) {
+              const candidate = lines[nextLine].trim();
+              if (!candidate || candidate.startsWith('//')) {
+                continue;
+              }
+              if (errorPattern.test(candidate)) {
+                break;
+              }
+              if (usagePattern.test(candidate) || /\bbuilder\.Build\s*\(/.test(candidate)) {
+                violations.push(
+                  `${path.relative(docsDirectory, file)}:${
+                    source.slice(0, (match.index ?? 0) + match[0].indexOf(code)).split('\n')
+                      .length + lineIndex
+                  } uses ${variable} before checking ${variable}.Err()`
+                );
+                break;
+              }
+            }
+
+            lineIndex = statementEnd;
+          }
+        }
+      }
+    }
+
     expect(violations).toEqual([]);
   });
 });

--- a/src/frontend/tests/unit/apphost-languages.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-languages.vitest.test.ts
@@ -209,39 +209,54 @@ describe('AppHost language registry', () => {
     expect(violations).toEqual([]);
   });
 
-  test('cloud and AI AppHost builder examples use AppHost tabs', () => {
+  test('cloud and AI AppHost code uses language containers', () => {
     const violations: string[] = [];
-    const appHostTabsPattern = /<AppHostTabs\b[\s\S]*?<\/AppHostTabs>/g;
-    const codeFencePattern = /```(?<language>\w+)[^\n]*\n(?<code>[\s\S]*?)```/g;
+    const appHostContainerPattern =
+      /<(?:AppHostTabs|AppHostLanguagePivot)\b[\s\S]*?<\/(?:AppHostTabs|AppHostLanguagePivot)>/g;
+    const codeFencePattern = /```(?<language>\w+)(?<metadata>[^\n]*)\n(?<code>[\s\S]*?)```/g;
     const appHostBuilderPatterns = [
       /DistributedApplication\.CreateBuilder\s*\(/,
       /\bcreateBuilder\s*\(/,
       /\bcreate_builder\s*\(/,
       /\baspire\.CreateBuilder\s*\(/,
     ];
+    const appHostFileTitlePattern =
+      /\btitle\s*=\s*(['"])(?:apphost\.mts|AppHost\.cs|apphost\.py|apphost\.go|AppHost\.java|apphost\.rs)\1/i;
 
     for (const directory of integrationParityDirectories) {
       for (const file of getMdxFiles(directory)) {
         const source = fs.readFileSync(file, 'utf8');
-        const tabRanges = [...source.matchAll(appHostTabsPattern)].map((match) => ({
+        const containerRanges = [...source.matchAll(appHostContainerPattern)].map((match) => ({
           start: match.index ?? 0,
           end: (match.index ?? 0) + match[0].length,
         }));
 
         for (const match of source.matchAll(codeFencePattern)) {
           const code = match.groups?.code ?? '';
-          if (!appHostBuilderPatterns.some((pattern) => pattern.test(code))) {
+          const metadata = match.groups?.metadata ?? '';
+          const isBuilderExample = appHostBuilderPatterns.some((pattern) => pattern.test(code));
+          const isAppHostFile = appHostFileTitlePattern.test(metadata);
+          const isPackageDirectives = code
+            .trim()
+            .split(/\r?\n/)
+            .filter(Boolean)
+            .every((line) => line.trimStart().startsWith('#:package '));
+          const isProjectFile =
+            match.groups?.language.toLowerCase() === 'xml' ||
+            /\btitle\s*=\s*(['"])[^'"]+\.(?:csproj|fsproj|vbproj)\1/i.test(metadata);
+
+          if ((!isBuilderExample && !isAppHostFile) || isPackageDirectives || isProjectFile) {
             continue;
           }
 
           const index = match.index ?? 0;
-          const inAppHostTabs = tabRanges.some(
+          const inLanguageContainer = containerRanges.some(
             (range) => index >= range.start && index < range.end
           );
-          if (!inAppHostTabs) {
+          if (!inLanguageContainer) {
             const line = source.slice(0, index).split('\n').length;
             violations.push(
-              `${path.relative(docsDirectory, file)}:${line} has a standalone AppHost builder example`
+              `${path.relative(docsDirectory, file)}:${line} has a standalone AppHost code example`
             );
           }
         }

--- a/src/frontend/tests/unit/apphost-languages.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-languages.vitest.test.ts
@@ -14,6 +14,10 @@ import { renderAppHostTabsInMarkdown } from '../../config/apphost-language-markd
 const testsDirectory = path.dirname(fileURLToPath(import.meta.url));
 const componentsDirectory = path.resolve(testsDirectory, '..', '..', 'src', 'components');
 const docsDirectory = path.resolve(testsDirectory, '..', '..', 'src', 'content', 'docs');
+const integrationParityDirectories = [
+  path.join(docsDirectory, 'integrations', 'ai'),
+  path.join(docsDirectory, 'integrations', 'cloud'),
+];
 const excludedTopLevel = new Set([
   'da',
   'de',
@@ -56,6 +60,21 @@ function getActiveEnglishDocs(): string[] {
   }
 
   visit(docsDirectory);
+  return files;
+}
+
+function getMdxFiles(directory: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const resolved = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...getMdxFiles(resolved));
+    } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+      files.push(resolved);
+    }
+  }
+
   return files;
 }
 
@@ -153,6 +172,83 @@ describe('AppHost language registry', () => {
     expect(builderClientSource).toContain("template?.dataset.variantKind === 'limitation'");
     expect(builderClientSource).not.toContain("type AppHostLanguage = 'csharp' | 'typescript'");
     expect(homeSource).not.toContain("type AppHostLanguage = 'csharp' | 'typescript'");
+  });
+
+  test('cloud and AI AppHost tabs account for all six languages', () => {
+    const violations: string[] = [];
+    const appHostTabsPattern =
+      /<AppHostTabs\b(?<attributes>[\s\S]*?)>(?<content>[\s\S]*?)<\/AppHostTabs>/g;
+
+    for (const directory of integrationParityDirectories) {
+      for (const file of getMdxFiles(directory)) {
+        const source = fs.readFileSync(file, 'utf8');
+        let tabIndex = 0;
+
+        for (const match of source.matchAll(appHostTabsPattern)) {
+          tabIndex += 1;
+          const attributes = match.groups?.attributes ?? '';
+          const content = match.groups?.content ?? '';
+
+          for (const language of appHostLanguageConfig.languages) {
+            const slotPattern = new RegExp(
+              `<Fragment\\b[^>]*\\bslot\\s*=\\s*(['"])${language.id}\\1`,
+              'i'
+            );
+            const limitationPattern = new RegExp(`\\b${language.id}\\s*:`, 'i');
+
+            if (!slotPattern.test(content) && !limitationPattern.test(attributes)) {
+              violations.push(
+                `${path.relative(docsDirectory, file)} AppHostTabs #${tabIndex} does not account for ${language.id}`
+              );
+            }
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test('cloud and AI AppHost builder examples use AppHost tabs', () => {
+    const violations: string[] = [];
+    const appHostTabsPattern = /<AppHostTabs\b[\s\S]*?<\/AppHostTabs>/g;
+    const codeFencePattern = /```(?<language>\w+)[^\n]*\n(?<code>[\s\S]*?)```/g;
+    const appHostBuilderPatterns = [
+      /DistributedApplication\.CreateBuilder\s*\(/,
+      /\bcreateBuilder\s*\(/,
+      /\bcreate_builder\s*\(/,
+      /\baspire\.CreateBuilder\s*\(/,
+    ];
+
+    for (const directory of integrationParityDirectories) {
+      for (const file of getMdxFiles(directory)) {
+        const source = fs.readFileSync(file, 'utf8');
+        const tabRanges = [...source.matchAll(appHostTabsPattern)].map((match) => ({
+          start: match.index ?? 0,
+          end: (match.index ?? 0) + match[0].length,
+        }));
+
+        for (const match of source.matchAll(codeFencePattern)) {
+          const code = match.groups?.code ?? '';
+          if (!appHostBuilderPatterns.some((pattern) => pattern.test(code))) {
+            continue;
+          }
+
+          const index = match.index ?? 0;
+          const inAppHostTabs = tabRanges.some(
+            (range) => index >= range.start && index < range.end
+          );
+          if (!inAppHostTabs) {
+            const line = source.slice(0, index).split('\n').length;
+            violations.push(
+              `${path.relative(docsDirectory, file)}:${line} has a standalone AppHost builder example`
+            );
+          }
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+    expect(violations).toEqual([]);
   });
 });
 

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -7,60 +7,67 @@ import { appHostLanguageConfig } from '../../src/utils/apphost-languages';
 
 const testsDirectory = path.dirname(fileURLToPath(import.meta.url));
 const docsDirectory = path.resolve(testsDirectory, '..', '..', 'src', 'content', 'docs');
-const integrationDirectory = path.join(docsDirectory, 'integrations');
-const scopedCategories = [
-  'frameworks',
+const integrationsDirectory = path.join(docsDirectory, 'integrations');
+const scopedPaths = [
+  'caching',
   'compute',
-  'dotnet',
-  'devtools',
   'custom-integrations',
+  'databases',
+  'devtools',
+  'dotnet',
+  'frameworks',
+  'messaging',
+  'observability',
+  'reverse-proxies',
+  'security',
 ];
-const appHostBuilderPattern =
-  /\b(?:DistributedApplication\.CreateBuilder|createBuilder|create_builder|aspire\.CreateBuilder)\s*\(/;
 
-function getMdxFiles(directory: string): string[] {
-  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const resolved = path.join(directory, entry.name);
-    if (entry.isDirectory()) {
-      return getMdxFiles(resolved);
+function getScopedDocs(): string[] {
+  const files = [path.join(integrationsDirectory, 'overview.mdx')];
+
+  function visit(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const resolved = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(resolved);
+      } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+        files.push(resolved);
+      }
     }
+  }
 
-    return entry.isFile() && entry.name.endsWith('.mdx') ? [resolved] : [];
-  });
+  for (const scopedPath of scopedPaths) {
+    visit(path.join(integrationsDirectory, scopedPath));
+  }
+
+  return files;
 }
 
-function getScopedMdxFiles(): string[] {
-  return scopedCategories.flatMap((category) =>
-    getMdxFiles(path.join(integrationDirectory, category))
+function getAppHostTabs(source: string): RegExpMatchArray[] {
+  return Array.from(
+    source.matchAll(/<AppHostTabs(?<attributes>[^>]*)>(?<content>[\s\S]*?)<\/AppHostTabs>/g)
   );
 }
 
 describe('integration AppHost language parity', () => {
-  test('accounts for all six AppHost languages in the assigned categories', () => {
+  test('accounts for every AppHost language in the scoped integration docs', () => {
     const violations: string[] = [];
 
-    for (const file of getScopedMdxFiles()) {
+    for (const file of getScopedDocs()) {
       const source = fs.readFileSync(file, 'utf8');
-      const appHostTabs = source.matchAll(
-        /<AppHostTabs\b(?<attributes>[\s\S]*?)>(?<content>[\s\S]*?)<\/AppHostTabs>/g
-      );
+      const appHostTabs = getAppHostTabs(source);
 
-      for (const match of appHostTabs) {
+      for (const [index, match] of appHostTabs.entries()) {
         const attributes = match.groups?.attributes ?? '';
         const content = match.groups?.content ?? '';
-        const line = source.slice(0, match.index).split('\n').length;
 
         for (const language of appHostLanguageConfig.languages) {
-          const hasSlot = new RegExp(
-            String.raw`\bslot\s*=\s*(['"])${language.id}\1`
-          ).test(content);
-          const hasLimitation = new RegExp(
-            String.raw`\b${language.id}\s*:`
-          ).test(attributes);
+          const hasSlot = new RegExp(`<Fragment\\s+slot=(['"])${language.id}\\1`).test(content);
+          const hasLimitation = new RegExp(`\\b${language.id}\\s*:`).test(attributes);
 
           if (!hasSlot && !hasLimitation) {
             violations.push(
-              `${path.relative(docsDirectory, file)}:${line} is missing ${language.id}`
+              `${path.relative(docsDirectory, file)} AppHostTabs ${index + 1} omits ${language.id}`
             );
           }
         }
@@ -70,34 +77,112 @@ describe('integration AppHost language parity', () => {
     expect(violations).toEqual([]);
   });
 
-  test('wraps standalone AppHost builder examples for language accounting', () => {
+  test('uses safe generated SDK patterns in Go and Rust examples', () => {
     const violations: string[] = [];
 
-    for (const file of getScopedMdxFiles()) {
+    for (const file of getScopedDocs()) {
       const source = fs.readFileSync(file, 'utf8');
-      const appHostTabRanges = Array.from(
-        source.matchAll(/<AppHostTabs\b[\s\S]*?<\/AppHostTabs>/g),
-        (match) => ({
-          start: match.index,
-          end: match.index + match[0].length,
-        })
-      );
 
-      for (const codeFence of source.matchAll(
-        /```(?<language>csharp|typescript|python|go|java|rust)\b[^\n]*\n(?<code>[\s\S]*?)```/g
-      )) {
-        if (!appHostBuilderPattern.test(codeFence.groups?.code ?? '')) {
-          continue;
+      for (const [tabIndex, tab] of getAppHostTabs(source).entries()) {
+        const content = tab.groups?.content ?? '';
+        const goFences = content.matchAll(/```go\b[^\n]*\n(?<code>[\s\S]*?)```/g);
+
+        for (const fence of goFences) {
+          const code = fence.groups?.code ?? '';
+          for (const resourceCall of code.matchAll(/builder(?:\s*\.\s*)?Add[A-Z]\w*\s*\(/g)) {
+            if (resourceCall.index === undefined) {
+              continue;
+            }
+
+            const lineStart = code.lastIndexOf('\n', resourceCall.index) + 1;
+            const linePrefix = code.slice(lineStart, resourceCall.index);
+            if (!linePrefix.includes(':=')) {
+              violations.push(
+                `${path.relative(docsDirectory, file)} AppHostTabs ${tabIndex + 1} does not assign a Go resource for an immediate Err() check`
+              );
+            }
+          }
+
+          const assignments = Array.from(
+            code.matchAll(/^\s*(?<resource>\w+)\s*:=\s*builder(?:\s*\.\s*)?Add[A-Z]\w*\s*\(/gm)
+          );
+
+          for (const assignment of assignments) {
+            const resource = assignment.groups?.resource;
+            if (!resource || assignment.index === undefined) {
+              continue;
+            }
+
+            const remainder = code.slice(assignment.index + assignment[0].length);
+            const nextOperation = remainder.search(
+              /^\s*(?:\w+(?:\s*,\s*\w+)?\s*:=|app\s*,\s*err\s*:=\s*builder\.Build\(\))/m
+            );
+            const immediateBlock =
+              nextOperation === -1 ? remainder : remainder.slice(0, nextOperation);
+            const escapedResource = resource.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+            if (
+              !new RegExp(
+                `if\\s+err\\s*:=\\s*${escapedResource}\\.Err\\(\\);\\s*err\\s*!=\\s*nil`
+              ).test(immediateBlock)
+            ) {
+              violations.push(
+                `${path.relative(docsDirectory, file)} AppHostTabs ${tabIndex + 1} does not immediately check ${resource}.Err()`
+              );
+            }
+          }
         }
 
-        const isAccountedFor = appHostTabRanges.some(
-          (range) => codeFence.index >= range.start && codeFence.index < range.end
-        );
+        const rustFences = content.matchAll(/```rust\b[^\n]*\n(?<code>[\s\S]*?)```/g);
+        for (const fence of rustFences) {
+          const code = fence.groups?.code ?? '';
+          let referenceIndex = code.indexOf('.with_reference(');
 
-        if (!isAccountedFor) {
-          const line = source.slice(0, codeFence.index).split('\n').length;
+          while (referenceIndex !== -1) {
+            const referenceEnd = code.indexOf('?;', referenceIndex);
+            const referenceCall = code.slice(
+              referenceIndex,
+              referenceEnd === -1 ? undefined : referenceEnd
+            );
+
+            if (!referenceCall.includes('.handle().to_json()')) {
+              violations.push(
+                `${path.relative(docsDirectory, file)} AppHostTabs ${tabIndex + 1} passes a Rust reference without handle().to_json()`
+              );
+            }
+
+            referenceIndex = code.indexOf('.with_reference(', referenceIndex + 1);
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test('does not leave AppHost source fences outside AppHostTabs', () => {
+    const violations: string[] = [];
+
+    for (const file of getScopedDocs()) {
+      const source = fs.readFileSync(file, 'utf8');
+      const withoutAppHostTabs = source.replace(/<AppHostTabs[^>]*>[\s\S]*?<\/AppHostTabs>/g, '');
+      const sourceFences = withoutAppHostTabs.matchAll(
+        /```(?<language>csharp|typescript|python|go|java|rust)\b(?<metadata>[^\n]*)\n(?<code>[\s\S]*?)```/g
+      );
+
+      for (const match of sourceFences) {
+        const metadata = match.groups?.metadata ?? '';
+        const code = match.groups?.code ?? '';
+        const isAppHostFence =
+          /\btitle=(['"])[^'"]*apphost\.[^'"]*\1/i.test(metadata) ||
+          /DistributedApplication\.CreateBuilder|createBuilder\(\)|create_builder\(|CreateBuilder\(\)/.test(
+            code
+          );
+
+        if (isAppHostFence) {
+          const line = source.slice(0, match.index).split('\n').length;
           violations.push(
-            `${path.relative(docsDirectory, file)}:${line} has a standalone ${codeFence.groups?.language} AppHost builder fence`
+            `${path.relative(docsDirectory, file)}:${line} has a standalone AppHost source fence`
           );
         }
       }

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -9,7 +9,9 @@ const testsDirectory = path.dirname(fileURLToPath(import.meta.url));
 const docsDirectory = path.resolve(testsDirectory, '..', '..', 'src', 'content', 'docs');
 const integrationsDirectory = path.join(docsDirectory, 'integrations');
 const scopedPaths = [
+  'ai',
   'caching',
+  'cloud',
   'compute',
   'custom-integrations',
   'databases',

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -165,21 +165,37 @@ describe('integration AppHost language parity', () => {
 
     for (const file of getScopedDocs()) {
       const source = fs.readFileSync(file, 'utf8');
-      const withoutAppHostTabs = source.replace(/<AppHostTabs[^>]*>[\s\S]*?<\/AppHostTabs>/g, '');
-      const sourceFences = withoutAppHostTabs.matchAll(
-        /```(?<language>csharp|typescript|python|go|java|rust)\b(?<metadata>[^\n]*)\n(?<code>[\s\S]*?)```/g
+      const withoutAppHostWrappers = source
+        .replace(/<AppHostTabs[^>]*>[\s\S]*?<\/AppHostTabs>/g, '')
+        .replace(/<AppHostLanguagePivot[^>]*>[\s\S]*?<\/AppHostLanguagePivot>/g, '');
+      const sourceFences = withoutAppHostWrappers.matchAll(
+        /```(?<language>csharp|typescript|python|go|java|rust|xml)\b(?<metadata>[^\n]*)\n(?<code>[\s\S]*?)```/g
       );
 
       for (const match of sourceFences) {
+        const language = match.groups?.language ?? '';
         const metadata = match.groups?.metadata ?? '';
         const code = match.groups?.code ?? '';
+        const titleMatch = metadata.match(/\btitle=(?:"(?<double>[^"]+)"|'(?<single>[^']+)'|(?<bare>\S+))/);
+        const title =
+          titleMatch?.groups?.double ??
+          titleMatch?.groups?.single ??
+          titleMatch?.groups?.bare ??
+          '';
+        const nonemptyLines = code
+          .split(/\r?\n/)
+          .map((line) => line.trim())
+          .filter(Boolean);
+        const isPackageDirectiveOnly =
+          nonemptyLines.length > 0 && nonemptyLines.every((line) => line.startsWith('#:package '));
+        const isProjectFile = language === 'xml' || /\.(?:csproj|fsproj|vbproj)$/i.test(title);
         const isAppHostFence =
-          /\btitle=(['"])[^'"]*apphost\.[^'"]*\1/i.test(metadata) ||
+          /(?:^|[\\/])apphost\.(?:cs|mts|ts|py|go|java|rs)$/i.test(title) ||
           /DistributedApplication\.CreateBuilder|createBuilder\(\)|create_builder\(|CreateBuilder\(\)/.test(
             code
           );
 
-        if (isAppHostFence) {
+        if (isAppHostFence && !isPackageDirectiveOnly && !isProjectFile) {
           const line = source.slice(0, match.index).split('\n').length;
           violations.push(
             `${path.relative(docsDirectory, file)}:${line} has a standalone AppHost source fence`

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'vitest';
+
+import { appHostLanguageConfig } from '../../src/utils/apphost-languages';
+
+const testsDirectory = path.dirname(fileURLToPath(import.meta.url));
+const docsDirectory = path.resolve(testsDirectory, '..', '..', 'src', 'content', 'docs');
+const integrationDirectory = path.join(docsDirectory, 'integrations');
+const scopedCategories = [
+  'frameworks',
+  'compute',
+  'dotnet',
+  'devtools',
+  'custom-integrations',
+];
+const appHostBuilderPattern =
+  /\b(?:DistributedApplication\.CreateBuilder|createBuilder|create_builder|aspire\.CreateBuilder)\s*\(/;
+
+function getMdxFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const resolved = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      return getMdxFiles(resolved);
+    }
+
+    return entry.isFile() && entry.name.endsWith('.mdx') ? [resolved] : [];
+  });
+}
+
+function getScopedMdxFiles(): string[] {
+  return scopedCategories.flatMap((category) =>
+    getMdxFiles(path.join(integrationDirectory, category))
+  );
+}
+
+describe('integration AppHost language parity', () => {
+  test('accounts for all six AppHost languages in the assigned categories', () => {
+    const violations: string[] = [];
+
+    for (const file of getScopedMdxFiles()) {
+      const source = fs.readFileSync(file, 'utf8');
+      const appHostTabs = source.matchAll(
+        /<AppHostTabs\b(?<attributes>[\s\S]*?)>(?<content>[\s\S]*?)<\/AppHostTabs>/g
+      );
+
+      for (const match of appHostTabs) {
+        const attributes = match.groups?.attributes ?? '';
+        const content = match.groups?.content ?? '';
+        const line = source.slice(0, match.index).split('\n').length;
+
+        for (const language of appHostLanguageConfig.languages) {
+          const hasSlot = new RegExp(
+            String.raw`\bslot\s*=\s*(['"])${language.id}\1`
+          ).test(content);
+          const hasLimitation = new RegExp(
+            String.raw`\b${language.id}\s*:`
+          ).test(attributes);
+
+          if (!hasSlot && !hasLimitation) {
+            violations.push(
+              `${path.relative(docsDirectory, file)}:${line} is missing ${language.id}`
+            );
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  test('wraps standalone AppHost builder examples for language accounting', () => {
+    const violations: string[] = [];
+
+    for (const file of getScopedMdxFiles()) {
+      const source = fs.readFileSync(file, 'utf8');
+      const appHostTabRanges = Array.from(
+        source.matchAll(/<AppHostTabs\b[\s\S]*?<\/AppHostTabs>/g),
+        (match) => ({
+          start: match.index,
+          end: match.index + match[0].length,
+        })
+      );
+
+      for (const codeFence of source.matchAll(
+        /```(?<language>csharp|typescript|python|go|java|rust)\b[^\n]*\n(?<code>[\s\S]*?)```/g
+      )) {
+        if (!appHostBuilderPattern.test(codeFence.groups?.code ?? '')) {
+          continue;
+        }
+
+        const isAccountedFor = appHostTabRanges.some(
+          (range) => codeFence.index >= range.start && codeFence.index < range.end
+        );
+
+        if (!isAccountedFor) {
+          const line = source.slice(0, codeFence.index).split('\n').length;
+          violations.push(
+            `${path.relative(docsDirectory, file)}:${line} has a standalone ${codeFence.groups?.language} AppHost builder fence`
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -51,6 +51,10 @@ function getAppHostTabs(source: string): RegExpMatchArray[] {
   );
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 describe('integration AppHost language parity', () => {
   test('accounts for every AppHost language in the scoped integration docs', () => {
     const violations: string[] = [];
@@ -91,47 +95,76 @@ describe('integration AppHost language parity', () => {
 
         for (const fence of goFences) {
           const code = fence.groups?.code ?? '';
-          for (const resourceCall of code.matchAll(/builder(?:\s*\.\s*)?Add[A-Z]\w*\s*\(/g)) {
-            if (resourceCall.index === undefined) {
-              continue;
-            }
+          const lines = code.split(/\r?\n/);
 
-            const lineStart = code.lastIndexOf('\n', resourceCall.index) + 1;
-            const linePrefix = code.slice(lineStart, resourceCall.index);
-            if (!linePrefix.includes(':=')) {
-              violations.push(
-                `${path.relative(docsDirectory, file)} AppHostTabs ${tabIndex + 1} does not assign a Go resource for an immediate Err() check`
-              );
-            }
-          }
-
-          const assignments = Array.from(
-            code.matchAll(/^\s*(?<resource>\w+)\s*:=\s*builder(?:\s*\.\s*)?Add[A-Z]\w*\s*\(/gm)
-          );
-
-          for (const assignment of assignments) {
-            const resource = assignment.groups?.resource;
-            if (!resource || assignment.index === undefined) {
-              continue;
-            }
-
-            const remainder = code.slice(assignment.index + assignment[0].length);
-            const nextOperation = remainder.search(
-              /^\s*(?:\w+(?:\s*,\s*\w+)?\s*:=|app\s*,\s*err\s*:=\s*builder\.Build\(\))/m
+          for (let lineIndex = 0; lineIndex < lines.length; lineIndex += 1) {
+            const assignment = lines[lineIndex].match(
+              /^\s*(?<variable>[A-Za-z_]\w*)\s*:=\s*(?<expression>.+)$/
             );
-            const immediateBlock =
-              nextOperation === -1 ? remainder : remainder.slice(0, nextOperation);
-            const escapedResource = resource.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            if (!assignment?.groups) {
+              continue;
+            }
 
-            if (
-              !new RegExp(
-                `if\\s+err\\s*:=\\s*${escapedResource}\\.Err\\(\\);\\s*err\\s*!=\\s*nil`
-              ).test(immediateBlock)
+            const variable = assignment.groups.variable;
+            let expression = assignment.groups.expression;
+            let statementEnd = lineIndex;
+            let parenthesisDepth =
+              (expression.match(/\(/g) ?? []).length -
+              (expression.match(/\)/g) ?? []).length;
+
+            while (
+              statementEnd + 1 < lines.length &&
+              (parenthesisDepth > 0 || expression.trimEnd().endsWith('.'))
             ) {
+              statementEnd += 1;
+              expression += `\n${lines[statementEnd]}`;
+              parenthesisDepth +=
+                (lines[statementEnd].match(/\(/g) ?? []).length -
+                (lines[statementEnd].match(/\)/g) ?? []).length;
+            }
+
+            const createsGeneratedResource =
+              /\b(?:builder|[A-Za-z_]\w*)\.Add[A-Z]\w*\s*\(/.test(expression) &&
+              !/\bbuilder\.AddProject\s*\(/.test(expression);
+            if (!createsGeneratedResource) {
+              lineIndex = statementEnd;
+              continue;
+            }
+
+            const resourceCreationCount = (
+              expression.match(/\.(?:Add[A-Z]\w*)\s*\(/g) ?? []
+            ).length;
+            if (resourceCreationCount > 1) {
               violations.push(
-                `${path.relative(docsDirectory, file)} AppHostTabs ${tabIndex + 1} does not immediately check ${resource}.Err()`
+                `${path.relative(docsDirectory, file)} AppHostTabs ${
+                  tabIndex + 1
+                } chains generated Go resources without exposing each parent for an Err() check`
               );
             }
+
+            const escapedVariable = escapeRegExp(variable);
+            const errorPattern = new RegExp(`\\b${escapedVariable}\\.Err\\s*\\(`);
+            const usagePattern = new RegExp(`\\b${escapedVariable}\\b`);
+
+            for (let nextLine = statementEnd + 1; nextLine < lines.length; nextLine += 1) {
+              const candidate = lines[nextLine].trim();
+              if (!candidate || candidate.startsWith('//')) {
+                continue;
+              }
+              if (errorPattern.test(candidate)) {
+                break;
+              }
+              if (usagePattern.test(candidate) || /\bbuilder\.Build\s*\(/.test(candidate)) {
+                violations.push(
+                  `${path.relative(docsDirectory, file)} AppHostTabs ${
+                    tabIndex + 1
+                  } uses ${variable} before checking ${variable}.Err()`
+                );
+                break;
+              }
+            }
+
+            lineIndex = statementEnd;
           }
         }
 

--- a/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
+++ b/src/frontend/tests/unit/integration-apphost-language-parity.vitest.test.ts
@@ -193,7 +193,7 @@ describe('integration AppHost language parity', () => {
         const isProjectFile = language === 'xml' || /\.(?:csproj|fsproj|vbproj)$/i.test(title);
         const isAppHostFence =
           /(?:^|[\\/])apphost\.(?:cs|mts|ts|py|go|java|rs)$/i.test(title) ||
-          /DistributedApplication\.CreateBuilder|createBuilder\(\)|create_builder\(|CreateBuilder\(\)/.test(
+          /\b(?:DistributedApplication\.(?:CreateBuilder|createBuilder)|aspire\.CreateBuilder|createBuilder|create_builder)\s*\(/.test(
             code
           );
 


### PR DESCRIPTION
Stack 2/5. Depends on #1634.

Adds six-language AppHost coverage across 124 active-English integration pages spanning framework, compute, .NET, devtools, custom, cloud, AI, data, caching, database, messaging, and service categories. All six languages are represented by verified examples or explicit, support-aware limitations.

This stack includes immediate Go `Err()` checks, Rust handle serialization, support-aware limitation wording, unified fence audits, and MDX repairs. Python, Go, Java, and Rust remain disabled until stack 5.

Focused validation: the integration AppHost language parity Vitest suite passes (3 tests), and `git diff --check` passes. No local production build was run.