### PR TITLE
Add six-language core and diagnostics documentation

### DIFF
--- a/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/certificate-configuration.mdx
@@ -41,10 +41,10 @@ Many of the certificate features in Aspire rely on a development certificate. Be
 
 The preferred way to manage the development certificate is to use the [Aspire CLI](/get-started/install-cli/). When you run `aspire run` in an interactive session, the CLI automatically ensures the development certificate is created and trusted. No additional manual steps are required.
 
-For non-C# AppHosts (such as [TypeScript](/app-host/typescript-apphost/) or Python AppHosts), the `dotnet` first-run experience that normally creates the HTTPS development certificate never runs, because these AppHosts launch a prebuilt native binary instead of invoking `dotnet`. The Aspire CLI fills this gap when `aspire run` starts and no development certificate exists:
+For generated TypeScript, Python, Go, Java, and Rust AppHosts, the `dotnet` first-run experience that normally creates the HTTPS development certificate never runs, because these AppHosts launch a prebuilt native binary instead of invoking `dotnet`. The Aspire CLI fills this gap when `aspire run` starts and no development certificate exists:
 
-- In an interactive session—and on Linux, where establishing trust doesn't require a prompt—the CLI creates *and* trusts the certificate, just as it does for C# AppHosts.
-- In a non-interactive session on macOS or Windows (for example, in CI), the CLI can't show the macOS Keychain password prompt or the Windows trust dialog, so it *generates* the certificate without trusting it. This lets servers such as Kestrel load the certificate from the personal store, even though it isn't trusted. If the certificate can't be generated, a warning is displayed and the run continues.
+- In an interactive session—and on Linux, where establishing trust doesn't require a prompt—the CLI creates _and_ trusts the certificate, just as it does for C# AppHosts.
+- In a non-interactive session on macOS or Windows (for example, in CI), the CLI can't show the macOS Keychain password prompt or the Windows trust dialog, so it _generates_ the certificate without trusting it. This lets servers such as Kestrel load the certificate from the personal store, even though it isn't trusted. If the certificate can't be generated, a warning is displayed and the run continues.
 
 To opt out of automatic certificate generation, set the `ASPIRE_CLI_GENERATE_HTTPS_CERTIFICATE` environment variable to `false`. This mirrors the .NET SDK's `DOTNET_GENERATE_ASPNET_CERTIFICATE` opt-out:
 
@@ -85,19 +85,20 @@ aspire certs trust
 <Aside type="note" title="Linux certificate trust">
   On Linux, the development certificate is exported to `~/.aspnet/dev-certs/trust`, but applications using OpenSSL won't discover it unless the `SSL_CERT_DIR` environment variable includes that path. You can set `SSL_CERT_DIR` in your shell profile (~/.bashrc, ~/.zshrc, ~/.profile, etc.):
 
-  ```bash title="~/.bashrc, ~/.zshrc, or ~/.profile"
-  # Confirm /usr/lib/ssl/certs is the correct certificate directory for
-  # your Linux distribution. Common alternatives include:
-  #   /etc/ssl/certs
-  #   /etc/pki/tls/certs
-  if [ -z "$SSL_CERT_DIR" ]; then
-      export SSL_CERT_DIR="/usr/lib/ssl/certs:$HOME/.aspnet/dev-certs/trust"
-  else
-      export SSL_CERT_DIR="$SSL_CERT_DIR:$HOME/.aspnet/dev-certs/trust"
-  fi
-  ```
+```bash title="~/.bashrc, ~/.zshrc, or ~/.profile"
+# Confirm /usr/lib/ssl/certs is the correct certificate directory for
+# your Linux distribution. Common alternatives include:
+#   /etc/ssl/certs
+#   /etc/pki/tls/certs
+if [ -z "$SSL_CERT_DIR" ]; then
+    export SSL_CERT_DIR="/usr/lib/ssl/certs:$HOME/.aspnet/dev-certs/trust"
+else
+    export SSL_CERT_DIR="$SSL_CERT_DIR:$HOME/.aspnet/dev-certs/trust"
+fi
+```
 
-  You may need to reload your profile or start a new terminal session for the change to take effect.
+You may need to reload your profile or start a new terminal session for the change to take effect.
+
 </Aside>
 
 ### Developer certificate for DCP communication
@@ -141,8 +142,16 @@ You can control this behavior using the HTTPS endpoint APIs described below.
 
 To explicitly configure a resource to use the development certificate for its HTTPS endpoints:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_uvicorn_app or add_vite_app, which this development-certificate example requires.',
+    go: 'The generated Go SDK does not include AddUvicornApp or AddViteApp, which this development-certificate example requires.',
+    java: 'The generated Java SDK does not include addUvicornApp or addViteApp, which this development-certificate example requires.',
+    rust: 'The generated Rust SDK does not include add_uvicorn_app or add_vite_app, which this development-certificate example requires.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -157,24 +166,31 @@ var pythonApp = builder.AddUvicornApp("api", "../api", "app:main")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 // Explicitly use the developer certificate
-const nodeApp = await builder.addViteApp("frontend", "../frontend")
-    .withHttpsDeveloperCertificate();
+const nodeApp = await builder
+  .addViteApp('frontend', '../frontend')
+  .withHttpsDeveloperCertificate();
 
 // Use developer certificate with an encrypted private key
-const certPassword = await builder.addParameter("cert-password", { secret: true });
-const pythonApp = await builder.addUvicornApp("api", "../api", "app:main")
-    .withHttpsDeveloperCertificate({ password: certPassword });
+const certPassword = await builder.addParameter('cert-password', {
+  secret: true,
+});
+const pythonApp = await builder
+  .addUvicornApp('api', '../api', 'app:main')
+  .withHttpsDeveloperCertificate({ password: certPassword });
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -189,8 +205,16 @@ The `WithHttpsDeveloperCertificate` method:
 
 To configure a resource to use a specific X.509 certificate for HTTPS endpoints:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose with_https_certificate for supplying certificate and key parameters.',
+    go: 'The generated Go SDK does not expose WithHttpsCertificate for supplying certificate and key parameters.',
+    java: 'The generated Java SDK does not expose withHttpsCertificate for supplying certificate and key parameters.',
+    rust: 'The generated Rust SDK does not expose with_https_certificate for supplying certificate and key parameters.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 using System.Security.Cryptography.X509Certificates;
 
@@ -210,19 +234,22 @@ builder.AddNpmApp("frontend", "../frontend")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const api = await builder.addContainer("api", {
-  image: "my-api",
-  tag: "latest",
+const api = await builder.addContainer('api', {
+  image: 'my-api',
+  tag: 'latest',
 });
 
-api.createExecutionConfiguration()
+api
+  .createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withHttpsCertificateConfig(async () => ({
@@ -233,6 +260,7 @@ api.createExecutionConfiguration()
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -246,8 +274,16 @@ The certificate must:
 
 To prevent Aspire from configuring any HTTPS certificate for a resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK supports without_https_certificate, but it does not include add_redis for the resource used in this example.',
+    go: 'The generated Go SDK supports WithoutHttpsCertificate, but it does not include AddRedis for the resource used in this example.',
+    java: 'The generated Java SDK supports withoutHttpsCertificate, but it does not include addRedis for the resource used in this example.',
+    rust: 'The generated Rust SDK supports without_https_certificate, but it does not include add_redis for the resource used in this example.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -257,19 +293,21 @@ var redis = builder.AddRedis("cache")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 // Disable automatic HTTPS certificate configuration
-const redis = await builder.addRedis("cache")
-    .withoutHttpsCertificate();
+const redis = await builder.addRedis('cache').withoutHttpsCertificate();
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -283,8 +321,14 @@ Use `WithoutHttpsCertificate` when:
 
 For resources that need custom certificate configuration logic, use `WithHttpsCertificateConfiguration` to specify how certificate files should be passed to the resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose with_https_certificate_configuration.',
+    rust: 'The generated Rust SDK emits this callback as Fn(Vec<Value>) -> Value, so its typed certificate context cannot be used safely.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -315,30 +359,76 @@ builder.AddContainer("api", "my-api:latest")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder, refExpr } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const api = await builder.addContainer("api", {
-  image: "myimage",
-  tag: "latest",
+const api = await builder.addContainer('api', {
+  image: 'myimage',
+  tag: 'latest',
 });
 
-api.createExecutionConfiguration()
+api
+  .createExecutionConfiguration()
   .withArgumentsConfig()
   .withEnvironmentVariablesConfig()
   .withCertificateTrustConfig(async () => ({
     certificateBundlePath: refExpr`/certs/ca-bundle.crt`,
     certificateDirectoriesPath: refExpr`/certs`,
-    rootCertificatesPath: "/etc/ssl/certs",
+    rootCertificatesPath: '/etc/ssl/certs',
     isContainer: true,
   }));
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+api := builder.
+	AddContainer("api", "my-api:latest").
+	WithHttpsCertificateConfiguration(
+		func(ctx aspire.HttpsCertificateConfigurationCallbackAnnotationContext) {
+			arguments := ctx.Arguments()
+			_ = arguments.Add("--tls-cert")
+			_ = arguments.Add(ctx.CertificatePath())
+			_ = arguments.Add("--tls-key")
+			_ = arguments.Add(ctx.KeyPath())
+
+			environment := ctx.Environment()
+			_ = environment.Set("TLS_CERT_FILE", ctx.CertificatePath())
+			_ = environment.Set("TLS_KEY_FILE", ctx.KeyPath())
+			_ = environment.Set("TLS_PFX_FILE", ctx.PfxPath())
+		},
+	)
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var api = builder.addContainer("api", "my-api:latest");
+api.withHttpsCertificateConfiguration(ctx -> {
+    ctx.arguments().add("--tls-cert");
+    ctx.arguments().add(ctx.certificatePath());
+    ctx.arguments().add("--tls-key");
+    ctx.arguments().add(ctx.keyPath());
+
+    ctx.environment().set("TLS_CERT_FILE", ctx.certificatePath());
+    ctx.environment().set("TLS_KEY_FILE", ctx.keyPath());
+    ctx.environment().set("TLS_PFX_FILE", ctx.pfxPath());
+});
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -377,8 +467,16 @@ You can control this behavior per resource using the `WithDeveloperCertificateTr
 
 To explicitly enable or disable development certificate trust for a specific resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_node_app or add_python_app.',
+    go: 'The generated Go SDK does not include AddNodeApp or AddPythonApp.',
+    java: 'The generated Java SDK does not include addNodeApp or addPythonApp.',
+    rust: 'The generated Rust SDK does not include add_node_app or add_python_app.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -392,23 +490,28 @@ var pythonApp = builder.AddPythonApp("api", "../api", "main.py")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 // Explicitly enable development certificate trust
-const nodeApp = await builder.addNodeApp("frontend", "../frontend", "index.js")
-    .withDeveloperCertificateTrust(true);
+const nodeApp = await builder
+  .addNodeApp('frontend', '../frontend', 'index.js')
+  .withDeveloperCertificateTrust(true);
 
 // Disable development certificate trust
-const pythonApp = await builder.addPythonApp("api", "../api", "main.py")
-    .withDeveloperCertificateTrust(false);
+const pythonApp = await builder
+  .addPythonApp('api', '../api', 'main.py')
+  .withDeveloperCertificateTrust(false);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -417,6 +520,17 @@ await builder.build().run();
 Certificate authority collections allow you to bundle custom certificates and make them available to resources. You create a collection using the `AddCertificateAuthorityCollection` method and then reference it from resources that need to trust those certificates.
 
 #### Create and use a certificate authority collection
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not export certificate authority collection APIs or X.509 certificate collection values.',
+    python: 'The generated Python SDK does not export certificate authority collection APIs or X.509 certificate collection values.',
+    go: 'The generated Go SDK does not export certificate authority collection APIs or X.509 certificate collection values.',
+    java: 'The generated Java SDK does not export certificate authority collection APIs or X.509 certificate collection values.',
+    rust: 'The generated Rust SDK does not export certificate authority collection APIs or X.509 certificate collection values.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 using System.Security.Cryptography.X509Certificates;
@@ -438,9 +552,8 @@ builder.AddNpmApp("my-project", "../myapp")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 In the preceding example, the certificate bundle is created with custom certificates and then applied to a Node.js application, enabling it to trust those certificates.
 
@@ -465,8 +578,16 @@ Attempts to append the configured certificates to the default trusted certificat
 
 This is the default scope for most resources. For Python resources, only <abbr title="OpenTelemetry" data-tooltip-placement="top">OTEL</abbr> trust configuration will be applied in this mode.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK supports with_certificate_trust_scope, but it does not include add_node_app for this resource.',
+    go: 'The generated Go SDK supports WithCertificateTrustScope, but it does not include AddNodeApp for this resource.',
+    java: 'The generated Java SDK supports withCertificateTrustScope, but it does not include addNodeApp for this resource.',
+    rust: 'The generated Rust SDK supports with_certificate_trust_scope, but it does not include add_node_app for this resource.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -475,18 +596,25 @@ builder.AddNodeApp("api", "../api")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, CertificateTrustScope } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  CertificateTrustScope,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addNodeApp("api", "../api", "index.js")
-    .withCertificateTrustScope(CertificateTrustScope.Append);
+await builder
+  .addNodeApp('api', '../api', 'index.js')
+  .withCertificateTrustScope(CertificateTrustScope.Append);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -496,24 +624,35 @@ await builder.build().run();
 </Aside>
 
 <Aside type="note" title="Linux system trust preservation">
-  On Linux, executable resources configured with Append mode preserve access
-  to the system's OpenSSL certificate roots in addition to Aspire's generated
+  On Linux, executable resources configured with Append mode preserve access to
+  the system's OpenSSL certificate roots in addition to Aspire's generated
   development certificate. If `SSL_CERT_DIR` is set in the AppHost process
   environment, Aspire adds those directories after its generated certificate
   directory. An explicitly empty value is preserved by not inferring system
   directories. If `SSL_CERT_DIR` is unset, Aspire adds any well-known system
   certificate directories that exist on the machine (for example,
   `/etc/ssl/certs`) after its own. Aspire reads this value from the AppHost
-  process environment, not from an individual resource's configured
-  environment. This avoids a scenario where Linux workloads launched with
-  `dotnet run` or an IDE lose OpenSSL's implicit system certificate roots and
-  fail outbound HTTPS requests once Aspire configures the resource with only
-  its generated certificate directory.
+  process environment, not from an individual resource's configured environment.
+  This avoids a scenario where Linux workloads launched with `dotnet run` or an
+  IDE lose OpenSSL's implicit system certificate roots and fail outbound HTTPS
+  requests once Aspire configures the resource with only its generated
+  certificate directory.
 </Aside>
 
 #### Override mode
 
 Attempts to override a resource to only trust the configured certificates, replacing the default trusted certificates entirely. This mode is useful when you need strict control over which certificates are trusted.
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK exports the Override trust scope, but it does not export certificate authority collection APIs.',
+    python: 'The generated Python SDK exports the Override trust scope, but it does not export certificate authority collection APIs.',
+    go: 'The generated Go SDK exports the Override trust scope, but it does not export certificate authority collection APIs.',
+    java: 'The generated Java SDK exports the Override trust scope, but it does not export certificate authority collection APIs.',
+    rust: 'The generated Rust SDK exports the Override trust scope, but it does not export certificate authority collection APIs.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -528,9 +667,8 @@ builder.AddPythonModule("api", "./api", "uvicorn")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 #### System mode
 
@@ -538,8 +676,16 @@ Attempts to combine the configured certificates with the default system root cer
 
 This is the default scope for Python projects because Python only has mechanisms to fully override certificate trust.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK supports with_certificate_trust_scope, but it does not include add_python_app for this resource.',
+    go: 'The generated Go SDK supports WithCertificateTrustScope, but it does not include AddPythonApp for this resource.',
+    java: 'The generated Java SDK supports withCertificateTrustScope, but it does not include addPythonApp for this resource.',
+    rust: 'The generated Rust SDK supports with_certificate_trust_scope, but it does not include add_python_app for this resource.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -548,18 +694,25 @@ builder.AddPythonApp("worker", "../worker", "main.py")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, CertificateTrustScope } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  CertificateTrustScope,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addPythonApp("worker", "../worker", "main.py")
-    .withCertificateTrustScope(CertificateTrustScope.System);
+await builder
+  .addPythonApp('worker', '../worker', 'main.py')
+  .withCertificateTrustScope(CertificateTrustScope.System);
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -571,6 +724,7 @@ This is the default scope for .NET projects on Windows, as there's no way to aut
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -579,18 +733,61 @@ builder.AddContainer("service", "myimage")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, CertificateTrustScope } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  CertificateTrustScope,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-await builder.addContainer("service", { image: "myimage", tag: "latest" })
-    .withCertificateTrustScope(CertificateTrustScope.None);
+await builder
+  .addContainer('service', { image: 'myimage', tag: 'latest' })
+  .withCertificateTrustScope(CertificateTrustScope.None);
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+service = builder.add_container("service", "myimage")
+service.with_certificate_trust_scope("None")
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+service := builder.
+	AddContainer("service", "myimage").
+	WithCertificateTrustScope(aspire.CertificateTrustScopeNone)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var service = builder.addContainer("service", "myimage");
+service.withCertificateTrustScope(CertificateTrustScope.NONE);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let service = builder.add_container(
+    "service",
+    serde_json::json!("myimage"),
+)?;
+service.with_certificate_trust_scope(CertificateTrustScope::None)?;
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -602,8 +799,16 @@ For advanced scenarios, you can specify custom certificate trust behavior using 
 
 Use `WithCertificateTrustConfiguration` to customize how certificate trust is configured for a resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose with_certificate_trust_configuration.',
+    go: 'The generated Go SDK does not expose WithCertificateTrustConfiguration.',
+    java: 'The generated Java SDK does not expose withCertificateTrustConfiguration.',
+    rust: 'The generated Rust SDK does not expose with_certificate_trust_configuration.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -625,6 +830,7 @@ builder.AddContainer("api", "myimage")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
 <Aside type="note">
@@ -647,6 +853,9 @@ Default implementations are provided for Node.js, Python, and container resource
 
 For container resources, you can customize where certificates are stored and accessed using `WithContainerCertificatePaths`:
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -659,9 +868,130 @@ builder.AddContainer("api", "myimage")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder
+  .addContainer('api', { image: 'myimage', tag: 'latest' })
+  .withContainerCertificatePaths({
+    customCertificatesDestination: '/custom/certs/path',
+    defaultCertificateBundlePaths: ['/etc/ssl/certs/ca-certificates.crt'],
+    defaultCertificateDirectoryPaths: ['/etc/ssl/certs'],
+  });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_container("api", "myimage")
+    api.with_container_certificate_paths(
+        custom_certificates_destination="/custom/certs/path",
+        default_certificate_bundle_paths=["/etc/ssl/certs/ca-certificates.crt"],
+        default_certificate_dir_paths=["/etc/ssl/certs"],
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddContainer("api", "myimage").
+		WithContainerCertificatePaths(&aspire.WithContainerCertificatePathsOptions{
+			CustomCertificatesDestination: aspire.StringPtr("/custom/certs/path"),
+			DefaultCertificateBundlePaths: []string{"/etc/ssl/certs/ca-certificates.crt"},
+			DefaultCertificateDirectoryPaths: []string{"/etc/ssl/certs"},
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addContainer("api", "myimage");
+    api.withContainerCertificatePaths(
+        new WithContainerCertificatePathsOptions()
+            .customCertificatesDestination("/custom/certs/path")
+            .defaultCertificateBundlePaths(
+                new String[] { "/etc/ssl/certs/ca-certificates.crt" })
+            .defaultCertificateDirectoryPaths(
+                new String[] { "/etc/ssl/certs" }));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_container("api", serde_json::json!("myimage"))?;
+    api.with_container_certificate_paths(
+        Some("/custom/certs/path"),
+        Some(vec!["/etc/ssl/certs/ca-certificates.crt".to_string()]),
+        Some(vec!["/etc/ssl/certs".to_string()]),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 The `WithContainerCertificatePaths` API accepts three optional parameters:
 
@@ -683,8 +1013,16 @@ This section demonstrates common patterns for configuring HTTPS endpoints and ce
 
 A typical scenario is configuring a Node.js service to serve HTTPS traffic while also enabling it to send telemetry to the dashboard:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_node_app, so this Node.js HTTPS and telemetry example is unavailable.',
+    go: 'The generated Go SDK does not include AddNodeApp, so this Node.js HTTPS and telemetry example is unavailable.',
+    java: 'The generated Java SDK does not include addNodeApp, so this Node.js HTTPS and telemetry example is unavailable.',
+    rust: 'The generated Rust SDK does not include add_node_app, so this Node.js HTTPS and telemetry example is unavailable.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -696,8 +1034,10 @@ var frontend = builder.AddNpmApp("frontend", "../frontend")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -705,18 +1045,31 @@ const builder = await createBuilder();
 
 // Configure the service to use developer certificate for HTTPS endpoints
 // and trust the developer certificate for outbound connections (like dashboard telemetry)
-const frontend = await builder.addNodeApp("frontend", "../frontend", "index.js")
-    .withHttpsDeveloperCertificate()         // Server cert for HTTPS endpoints
-    .withDeveloperCertificateTrust(true);    // Client trust for dashboard
+const frontend = await builder
+  .addNodeApp('frontend', '../frontend', 'index.js')
+  .withHttpsDeveloperCertificate() // Server cert for HTTPS endpoints
+  .withDeveloperCertificateTrust(true); // Client trust for dashboard
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
 ### Enable HTTPS with custom certificates
 
 When working with corporate or custom CA certificates, you can configure both server and client certificates:
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not export custom X.509 server certificate or certificate authority collection APIs.',
+    python: 'The generated Python SDK does not export custom X.509 server certificate or certificate authority collection APIs.',
+    go: 'The generated Go SDK does not export custom X.509 server certificate or certificate authority collection APIs.',
+    java: 'The generated Java SDK does not export custom X.509 server certificate or certificate authority collection APIs.',
+    rust: 'The generated Rust SDK does not export custom X.509 server certificate or certificate authority collection APIs.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 using System.Security.Cryptography.X509Certificates;
@@ -739,16 +1092,23 @@ builder.AddContainer("api", "my-api:latest")
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  This API is not yet available in TypeScript AppHosts.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 ### Configure Redis with TLS
 
 Redis resources can be configured to use HTTPS (TLS) for secure connections:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_redis, so this Redis TLS example is unavailable.',
+    go: 'The generated Go SDK does not include AddRedis, so this Redis TLS example is unavailable.',
+    java: 'The generated Java SDK does not include addRedis, so this Redis TLS example is unavailable.',
+    rust: 'The generated Rust SDK does not include add_redis, so this Redis TLS example is unavailable.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -762,23 +1122,26 @@ var redisNoTls = builder.AddRedis("cache-notls")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 // Configure Redis to use the developer certificate for TLS
-const redis = await builder.addRedis("cache")
-    .withHttpsDeveloperCertificate();
+const redis = await builder.addRedis('cache').withHttpsDeveloperCertificate();
 
 // Or disable TLS entirely
-const redisNoTls = await builder.addRedis("cache-notls")
-    .withoutHttpsCertificate();
+const redisNoTls = await builder
+  .addRedis('cache-notls')
+  .withoutHttpsCertificate();
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
@@ -786,8 +1149,16 @@ await builder.build().run();
 
 To disable both HTTPS endpoint configuration and certificate trust for a resource that manages its own certificates:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK supports certificate trust scope and disabling HTTPS configuration, but it does not include add_python_module for this example.',
+    go: 'The generated Go SDK supports certificate trust scope and disabling HTTPS configuration, but it does not include AddPythonModule for this example.',
+    java: 'The generated Java SDK supports certificate trust scope and disabling HTTPS configuration, but it does not include addPythonModule for this example.',
+    rust: 'The generated Rust SDK supports certificate trust scope and disabling HTTPS configuration, but it does not include add_python_module for this example.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -798,20 +1169,27 @@ builder.AddPythonModule("api", "./api", "uvicorn")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
-import { createBuilder, CertificateTrustScope } from './.aspire/modules/aspire.mjs';
+import {
+  createBuilder,
+  CertificateTrustScope,
+} from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
 // Disable all automatic certificate configuration
-await builder.addPythonModule("api", "./api", "uvicorn")
-    .withoutHttpsCertificate()             // No server cert config
-    .withCertificateTrustScope(CertificateTrustScope.None);    // No client trust config
+await builder
+  .addPythonModule('api', './api', 'uvicorn')
+  .withoutHttpsCertificate() // No server cert config
+  .withCertificateTrustScope(CertificateTrustScope.None); // No client trust config
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 

--- a/src/frontend/src/content/docs/app-host/configuration.mdx
+++ b/src/frontend/src/content/docs/app-host/configuration.mdx
@@ -95,6 +95,90 @@ In TypeScript AppHosts, profiles live in `aspire.config.json`:
 }
 ```
 </AppHostLanguagePivot>
+<AppHostLanguagePivot id="python">
+In Python AppHosts, profiles live in `aspire.config.json`:
+
+```json title="aspire.config.json"
+{
+  "appHost": {
+    "path": "apphost.py",
+    "language": "python"
+  },
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:17134;http://localhost:15170",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+      }
+    }
+  }
+}
+```
+</AppHostLanguagePivot>
+<AppHostLanguagePivot id="go">
+In Go AppHosts, profiles live in `aspire.config.json`:
+
+```json title="aspire.config.json"
+{
+  "appHost": {
+    "path": "apphost.go",
+    "language": "go"
+  },
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:17134;http://localhost:15170",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+      }
+    }
+  }
+}
+```
+</AppHostLanguagePivot>
+<AppHostLanguagePivot id="java">
+In Java AppHosts, profiles live in `aspire.config.json`:
+
+```json title="aspire.config.json"
+{
+  "appHost": {
+    "path": "AppHost.java",
+    "language": "java"
+  },
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:17134;http://localhost:15170",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+      }
+    }
+  }
+}
+```
+</AppHostLanguagePivot>
+<AppHostLanguagePivot id="rust">
+In Rust AppHosts, profiles live in `aspire.config.json`:
+
+```json title="aspire.config.json"
+{
+  "appHost": {
+    "path": "apphost.rs",
+    "language": "rust"
+  },
+  "profiles": {
+    "https": {
+      "applicationUrl": "https://localhost:17134;http://localhost:15170",
+      "environmentVariables": {
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21030",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22057"
+      }
+    }
+  }
+}
+```
+</AppHostLanguagePivot>
 
 <Aside type="note">
   Configuration described on this page is for the Aspire AppHost project. To

--- a/src/frontend/src/content/docs/app-host/container-files.mdx
+++ b/src/frontend/src/content/docs/app-host/container-files.mdx
@@ -25,7 +25,14 @@ The `WithContainerFiles` extension method creates or updates files and directori
 
 Use the inline entries overload to declaratively define files and directories using `ContainerFileSystemItem` objects. This is useful when file contents are known at build time or can be expressed as string literals.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK exposes only handle-backed ContainerFileSystemItem types, so inline file and directory entries cannot be constructed in a Python AppHost.',
+    go: 'The generated Go SDK does not generate constructible ContainerFile and ContainerDirectory value types, so inline entries cannot be supplied from a Go AppHost.',
+    java: 'The generated Java SDK does not generate constructible ContainerFile and ContainerDirectory value types, so inline entries cannot be supplied from a Java AppHost.',
+    rust: 'The generated Rust SDK represents container file-system items as handle-backed marker types, so inline entries cannot be constructed in a Rust AppHost.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -106,6 +113,38 @@ await api.publishWithContainerFiles(frontend, "./wwwroot");
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+container = builder.add_container("myapp", "myapp:latest")
+container.with_container_files("/app/config", "./config-files")
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+container := builder.
+	AddContainer("myapp", "myapp:latest").
+	WithContainerFiles("/app/config", "./config-files")
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var container = builder.addContainer("myapp", "myapp:latest");
+container.withContainerFiles("/app/config", "./config-files");
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let container = builder.add_container(
+    "myapp",
+    serde_json::json!("myapp:latest"),
+)?;
+container.with_container_files(
+    "/app/config",
+    "./config-files",
+    None,
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 Unless the source path is a rooted (absolute) path, it's interpreted as relative to the AppHost project directory. All files in the source directory are copied to the destination path in the container at startup.
@@ -114,7 +153,14 @@ Unless the source path is a rooted (absolute) path, it's interpreted as relative
 
 Use the callback overload to generate files dynamically when the container starts. The callback receives a `ContainerFileSystemCallbackContext` that provides access to the `IServiceProvider` and the resource's `IResource` model, enabling you to resolve services or inspect the app model.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The Python callback exists, but its required ContainerFileSystemItem results are handle-backed and cannot be constructed by AppHost code.',
+    go: 'The Go callback exists, but the generated SDK does not provide constructible container file-system item values for its result.',
+    java: 'The Java callback exists, but the generated SDK does not provide constructible container file-system item values for its result.',
+    rust: 'The Rust callback is emitted as an untyped JSON callback and container file-system items remain marker types, so this example is not expressible safely.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -159,6 +205,15 @@ The `WithContainerFiles` API uses a type hierarchy rooted at the abstract `Conta
 
 `ContainerFile` represents a standard file. Set either `Contents` (a string) or `SourcePath` (an absolute path on the host) to provide the file data — the two are mutually exclusive.
 
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK does not expose constructible ContainerFile values; use the supported high-level container-file APIs instead.',
+  python: 'The Python SDK generates ContainerFile as a handle-backed type that cannot be constructed directly.',
+  go: 'The Go SDK does not generate ContainerFile as a constructible value.',
+  java: 'The Java SDK does not generate ContainerFile as a constructible value.',
+  rust: 'The Rust SDK generates ContainerFile as a handle-backed marker that cannot be constructed directly.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 // File with inline contents
 var configYaml = new ContainerFile
@@ -175,7 +230,19 @@ var dataCsv = new ContainerFile
 };
 ```
 
+</Fragment>
+</AppHostTabs>
+
 Set `ContinueOnError` to `true` to allow the container to start even if creating this particular file fails:
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK does not expose constructible ContainerFile values or ContinueOnError.',
+  python: 'The Python SDK generates ContainerFile as a handle-backed type that cannot be constructed directly.',
+  go: 'The Go SDK does not generate ContainerFile as a constructible value.',
+  java: 'The Java SDK does not generate ContainerFile as a constructible value.',
+  rust: 'The Rust SDK generates ContainerFile as a handle-backed marker that cannot be constructed directly.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var optionalJson = new ContainerFile
@@ -186,9 +253,21 @@ var optionalJson = new ContainerFile
 };
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### ContainerDirectory
 
 `ContainerDirectory` represents a directory that can contain nested `ContainerFileSystemItem` entries, allowing you to build arbitrary directory trees.
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK does not expose constructible ContainerDirectory or ContainerFile values.',
+  python: 'The Python SDK generates these container-file-system types as handle-backed values that cannot be constructed directly.',
+  go: 'The Go SDK does not generate ContainerDirectory or ContainerFile as constructible values.',
+  java: 'The Java SDK does not generate ContainerDirectory or ContainerFile as constructible values.',
+  rust: 'The Rust SDK generates these container-file-system types as handle-backed markers that cannot be constructed directly.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var certsDir = new ContainerDirectory
@@ -216,7 +295,19 @@ var certsDir = new ContainerDirectory
 };
 ```
 
+</Fragment>
+</AppHostTabs>
+
 You can also populate a `ContainerDirectory` from files on disk using the static `GetFileSystemItemsFromPath` method:
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK does not expose ContainerDirectory.GetFileSystemItemsFromPath.',
+  python: 'The Python SDK does not expose a constructible ContainerDirectory or the filesystem enumeration helper.',
+  go: 'The Go SDK does not expose a constructible ContainerDirectory or the filesystem enumeration helper.',
+  java: 'The Java SDK does not expose a constructible ContainerDirectory or the filesystem enumeration helper.',
+  rust: 'The Rust SDK does not expose a constructible ContainerDirectory or the filesystem enumeration helper.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var assetsDir = new ContainerDirectory
@@ -228,11 +319,21 @@ var assetsDir = new ContainerDirectory
 };
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### ContainerOpenSSLCertificateFile
 
 `ContainerOpenSSLCertificateFile` represents a PEM-encoded public certificate. In addition to placing the certificate file in the container, Aspire automatically creates an OpenSSL-compatible symlink (`[subject hash].[n]`) in the same directory — equivalent to running `openssl rehash`. This enables containers that use OpenSSL for certificate validation to discover the certificate automatically.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'ContainerOpenSSLCertificateFile is generated as a handle-backed type and cannot be constructed in a Python AppHost.',
+    go: 'ContainerOpenSSLCertificateFile is not generated as a constructible Go value, so this inline certificate entry is unavailable.',
+    java: 'ContainerOpenSSLCertificateFile is not generated as a constructible Java value, so this inline certificate entry is unavailable.',
+    rust: 'ContainerOpenSSLCertificateFile is represented by a marker type and cannot be constructed in a Rust AppHost.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddContainer("myapp", "myapp:latest")
@@ -260,7 +361,14 @@ All `WithContainerFiles` overloads accept optional parameters to control file ow
 
 The `defaultOwner` and `defaultGroup` parameters set the default UID and GID applied to all created files and directories. Both default to `0` (root) when not specified. You can override ownership on individual items using the `Owner` and `Group` properties on any `ContainerFileSystemItem`.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'Per-entry owner and group values require constructible ContainerFile entries, which the generated Python SDK does not provide.',
+    go: 'Per-entry owner and group values require constructible ContainerFile entries, which the generated Go SDK does not provide.',
+    java: 'Per-entry owner and group values require constructible ContainerFile entries, which the generated Java SDK does not provide.',
+    rust: 'Per-entry owner and group values require constructible container file-system items, which are marker types in the generated Rust SDK.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddContainer("myapp", "myapp:latest")
@@ -306,7 +414,14 @@ The default umask is `0022`, which results in:
 
 You can set `Mode` directly on individual items to override the umask-based default:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK exposes ContainerFilesOptions, but explicit per-entry modes require ContainerFile values that AppHost code cannot construct.',
+    go: 'The generated Go SDK exposes ContainerFilesOptions, but explicit per-entry modes require ContainerFile values that it does not generate.',
+    java: 'The generated Java SDK exposes ContainerFilesOptions, but explicit per-entry modes require ContainerFile values that it does not generate.',
+    rust: 'The generated Rust SDK exposes ContainerFilesOptions, but explicit per-entry modes require marker-typed file-system items that AppHost code cannot construct.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddContainer("myapp", "myapp:latest")
@@ -345,7 +460,14 @@ A key use case is embedding single-page application (SPA) or static JavaScript f
 
 ### Embed a frontend in a backend
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_vite_app, so this Vite build-output example cannot be defined from a Python AppHost.',
+    go: 'The generated Go SDK does not include AddViteApp, so this Vite build-output example cannot be defined from a Go AppHost.',
+    java: 'The generated Java SDK does not include addViteApp, so this Vite build-output example cannot be defined from a Java AppHost.',
+    rust: 'The generated Rust SDK does not include add_vite_app, so this Vite build-output example cannot be defined from a Rust AppHost.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -384,7 +506,14 @@ In this example:
 
 You can also embed frontend assets into a dedicated reverse proxy container:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_vite_app, add_yarp, or publish_with_static_files.',
+    go: 'The generated Go SDK does not include AddViteApp, AddYarp, or PublishWithStaticFiles.',
+    java: 'The generated Java SDK does not include addViteApp, addYarp, or publishWithStaticFiles.',
+    rust: 'The generated Rust SDK does not include add_vite_app, add_yarp, or publish_with_static_files.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -421,7 +550,14 @@ This produces a self-contained Nginx container that serves the frontend applicat
 
 By default, the source resource exports files from its container based on its configured output paths. Use `WithContainerFilesSource` to specify which path inside the source container to copy from:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK supports with_container_files_source, but it does not include add_vite_app for creating the source resource used here.',
+    go: 'The generated Go SDK supports WithContainerFilesSource, but it does not include AddViteApp for creating the source resource used here.',
+    java: 'The generated Java SDK supports withContainerFilesSource, but it does not include addViteApp for creating the source resource used here.',
+    rust: 'The generated Rust SDK supports with_container_files_source, but it does not include add_vite_app for creating the source resource used here.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var frontend = builder.AddViteApp("frontend", "../frontend")

--- a/src/frontend/src/content/docs/app-host/container-registry.mdx
+++ b/src/frontend/src/content/docs/app-host/container-registry.mdx
@@ -32,7 +32,11 @@ Use the `AddContainerRegistry` method to configure a generic container registry 
 
 The following example configures a container registry and associates it with a project resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK exposes with_container_registry only with an IResource marker argument, but does not provide a public conversion from ContainerRegistryResource to that marker type.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -63,6 +67,55 @@ await api.withContainerRegistry(registry);
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    registry = builder.add_container_registry(
+        "myregistry", "registry.example.com"
+    )
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_container_registry(registry)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registry := builder.AddContainerRegistry(
+	"myregistry",
+	"registry.example.com",
+)
+if err := registry.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registry = builder.addContainerRegistry(
+    "myregistry",
+    AspireUnion.of("registry.example.com"));
+
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding code:
@@ -75,7 +128,11 @@ The preceding code:
 
 To push images to DockerHub, specify `docker.io` as the registry endpoint:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -98,13 +155,46 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withContainerRegistry(registry);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+registry = builder.add_container_registry("dockerhub", "docker.io")
+api = builder.add_project("api", "../Api/Api.csproj")
+api.with_container_registry(registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registry := builder.AddContainerRegistry("dockerhub", "docker.io")
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registry = builder.addContainerRegistry(
+    "dockerhub", AspireUnion.of("docker.io"));
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### GitHub Container Registry example
 
 To push images to GitHub Container Registry (GHCR):
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -127,13 +217,46 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withContainerRegistry(registry);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+registry = builder.add_container_registry("ghcr", "ghcr.io")
+api = builder.add_project("api", "../Api/Api.csproj")
+api.with_container_registry(registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registry := builder.AddContainerRegistry("ghcr", "ghcr.io")
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registry = builder.addContainerRegistry(
+    "ghcr", AspireUnion.of("ghcr.io"));
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Private registry example
 
 For private registries, provide the full registry URL:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -160,6 +283,41 @@ const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withContainerRegistry(registry);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+registry = builder.add_container_registry(
+    "private-registry", "registry.mycompany.com:5000"
+)
+api = builder.add_project("api", "../Api/Api.csproj")
+api.with_container_registry(registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registry := builder.AddContainerRegistry(
+	"private-registry",
+	"registry.mycompany.com:5000",
+)
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registry = builder.addContainerRegistry(
+    "private-registry",
+    AspireUnion.of("registry.mycompany.com:5000"));
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Authentication and credentials
@@ -170,7 +328,11 @@ Container registries typically require authentication for pushing images. You ca
 
 Parameters allow you to provide registry configuration dynamically:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK represents parameter-valued registry arguments as untyped JSON and cannot convert ContainerRegistryResource to the IResource marker required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -204,6 +366,54 @@ const registry = await builder.addContainerRegistry(
 const api = await builder.addProject("api", "../Api/Api.csproj");
 await api.withContainerRegistry(registry);
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+registry_endpoint = builder.add_parameter("registry-endpoint")
+registry_repository = builder.add_parameter("registry-repository")
+
+registry = builder.add_container_registry(
+    "myregistry",
+    registry_endpoint,
+    repository=registry_repository,
+)
+api = builder.add_project("api", "../Api/Api.csproj")
+api.with_container_registry(registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registryEndpoint := builder.AddParameter("registry-endpoint")
+registryRepository := builder.AddParameter("registry-repository")
+
+registry := builder.AddContainerRegistry(
+	"myregistry",
+	registryEndpoint,
+	&aspire.AddContainerRegistryOptions{
+		Repository: registryRepository,
+	},
+)
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registryEndpoint = builder.addParameter("registry-endpoint");
+var registryRepository = builder.addParameter("registry-repository");
+
+var registry = builder.addContainerRegistry(
+    "myregistry", registryEndpoint, registryRepository);
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -259,7 +469,14 @@ Azure Container Registry (ACR) provides first-class integration with Aspire, wit
 
 Aspire 13.1 introduces explicit container registry configuration for Azure Container Apps environments:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_azure_container_app_environment.',
+    go: 'The generated Go SDK does not include AddAzureContainerAppEnvironment.',
+    java: 'The generated Java SDK does not include addAzureContainerAppEnvironment.',
+    rust: 'The generated Rust SDK does not include add_azure_container_app_environment.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -307,7 +524,14 @@ In the preceding example:
 
 To use an existing Azure Container Registry, call the `PublishAsExisting` method when you add the ACR:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the Azure Container Registry and Container Apps environment integration APIs used here.',
+    go: 'The generated Go SDK does not include the Azure Container Registry and Container Apps environment integration APIs used here.',
+    java: 'The generated Java SDK does not include the Azure Container Registry and Container Apps environment integration APIs used here.',
+    rust: 'The generated Rust SDK does not include the Azure Container Registry and Container Apps environment integration APIs used here.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -411,7 +635,11 @@ The `deploy` step includes building, pushing, and deploying all resources.
 
 You can configure different registries for different resources:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -446,13 +674,73 @@ const internalApi = await builder.addProject("internal-api", "../InternalApi/Int
 await internalApi.withContainerRegistry(privateRegistry);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+public_registry = builder.add_container_registry("dockerhub", "docker.io")
+private_registry = builder.add_container_registry(
+    "private", "registry.company.com"
+)
+
+public_api = builder.add_project(
+    "public-api", "../PublicApi/PublicApi.csproj"
+)
+public_api.with_container_registry(public_registry)
+
+internal_api = builder.add_project(
+    "internal-api", "../InternalApi/InternalApi.csproj"
+)
+internal_api.with_container_registry(private_registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+publicRegistry := builder.AddContainerRegistry("dockerhub", "docker.io")
+privateRegistry := builder.AddContainerRegistry(
+	"private",
+	"registry.company.com",
+)
+
+publicAPI := builder.
+	AddProject("public-api", "../PublicApi/PublicApi.csproj").
+	WithContainerRegistry(publicRegistry)
+internalAPI := builder.
+	AddProject("internal-api", "../InternalApi/InternalApi.csproj").
+	WithContainerRegistry(privateRegistry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var publicRegistry = builder.addContainerRegistry(
+    "dockerhub", AspireUnion.of("docker.io"));
+var privateRegistry = builder.addContainerRegistry(
+    "private", AspireUnion.of("registry.company.com"));
+
+var publicApi = builder.addProject(
+    "public-api", "../PublicApi/PublicApi.csproj");
+publicApi.withContainerRegistry(publicRegistry);
+
+var internalApi = builder.addProject(
+    "internal-api", "../InternalApi/InternalApi.csproj");
+internalApi.withContainerRegistry(privateRegistry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Parameterized registry configuration
 
 You can use parameters when you need flexible deployment across environments:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK represents parameter-valued registry arguments as untyped JSON and cannot convert ContainerRegistryResource to the IResource marker required by with_container_registry.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -497,6 +785,61 @@ await worker.withContainerRegistry(registry);
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+registry_endpoint = builder.add_parameter("registry-endpoint")
+registry_repository = builder.add_parameter("registry-repository")
+registry = builder.add_container_registry(
+    "container-registry",
+    registry_endpoint,
+    repository=registry_repository,
+)
+
+api = builder.add_project("api", "../Api/Api.csproj")
+api.with_container_registry(registry)
+worker = builder.add_project("worker", "../Worker/Worker.csproj")
+worker.with_container_registry(registry)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+registryEndpoint := builder.AddParameter("registry-endpoint")
+registryRepository := builder.AddParameter("registry-repository")
+registry := builder.AddContainerRegistry(
+	"container-registry",
+	registryEndpoint,
+	&aspire.AddContainerRegistryOptions{
+		Repository: registryRepository,
+	},
+)
+
+api := builder.
+	AddProject("api", "../Api/Api.csproj").
+	WithContainerRegistry(registry)
+worker := builder.
+	AddProject("worker", "../Worker/Worker.csproj").
+	WithContainerRegistry(registry)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var registryEndpoint = builder.addParameter("registry-endpoint");
+var registryRepository = builder.addParameter("registry-repository");
+var registry = builder.addContainerRegistry(
+    "container-registry", registryEndpoint, registryRepository);
+
+var api = builder.addProject("api", "../Api/Api.csproj");
+api.withContainerRegistry(registry);
+var worker = builder.addProject("worker", "../Worker/Worker.csproj");
+worker.withContainerRegistry(registry);
+```
+
+</Fragment>
 </AppHostTabs>
 
 Configure the parameters in your AppHost configuration:
@@ -521,7 +864,14 @@ export Parameters__registry_repository="myorg"
 
 The following code constitutes a complete AppHost example with Azure Container Apps and ACR:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the Azure Container Apps environment or Redis integration APIs used by this complete example.',
+    go: 'The generated Go SDK does not include the Azure Container Apps environment or Redis integration APIs used by this complete example.',
+    java: 'The generated Java SDK does not include the Azure Container Apps environment or Redis integration APIs used by this complete example.',
+    rust: 'The generated Rust SDK does not include the Azure Container Apps environment or Redis integration APIs used by this complete example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/app-host/container-registry.mdx
+++ b/src/frontend/src/content/docs/app-host/container-registry.mdx
@@ -32,11 +32,7 @@ Use the `AddContainerRegistry` method to configure a generic container registry 
 
 The following example configures a container registry and associates it with a project resource:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK exposes with_container_registry only with an IResource marker argument, but does not provide a public conversion from ContainerRegistryResource to that marker type.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -116,6 +112,24 @@ api.withContainerRegistry(registry);
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry = builder.add_container_registry(
+    "myregistry",
+    serde_json::json!("registry.example.com"),
+    None,
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding code:
@@ -128,11 +142,7 @@ The preceding code:
 
 To push images to DockerHub, specify `docker.io` as the registry endpoint:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -184,17 +194,31 @@ api.withContainerRegistry(registry);
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry = builder.add_container_registry(
+    "dockerhub",
+    serde_json::json!("docker.io"),
+    None,
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### GitHub Container Registry example
 
 To push images to GitHub Container Registry (GHCR):
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -246,17 +270,31 @@ api.withContainerRegistry(registry);
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry = builder.add_container_registry(
+    "ghcr",
+    serde_json::json!("ghcr.io"),
+    None,
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Private registry example
 
 For private registries, provide the full registry URL:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -318,6 +356,24 @@ api.withContainerRegistry(registry);
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry = builder.add_container_registry(
+    "private-registry",
+    serde_json::json!("registry.mycompany.com:5000"),
+    None,
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Authentication and credentials
@@ -328,11 +384,7 @@ Container registries typically require authentication for pushing images. You ca
 
 Parameters allow you to provide registry configuration dynamically:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK represents parameter-valued registry arguments as untyped JSON and cannot convert ContainerRegistryResource to the IResource marker required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -412,6 +464,37 @@ var registry = builder.addContainerRegistry(
     "myregistry", registryEndpoint, registryRepository);
 var api = builder.addProject("api", "../Api/Api.csproj");
 api.withContainerRegistry(registry);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry_endpoint = builder.add_parameter(
+    "registry-endpoint",
+    None,
+    None,
+    None,
+)?;
+let registry_repository = builder.add_parameter(
+    "registry-repository",
+    None,
+    None,
+    None,
+)?;
+
+let registry = builder.add_container_registry(
+    "myregistry",
+    serialize_handle(&registry_endpoint),
+    Some(serialize_handle(&registry_repository)),
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
 ```
 
 </Fragment>
@@ -635,11 +718,7 @@ The `deploy` step includes building, pushing, and deploying all resources.
 
 You can configure different registries for different resources:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK cannot pass a ContainerRegistryResource to the IResource marker parameter required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -730,17 +809,51 @@ internalApi.withContainerRegistry(privateRegistry);
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let public_registry = builder.add_container_registry(
+    "dockerhub",
+    serde_json::json!("docker.io"),
+    None,
+)?;
+let private_registry = builder.add_container_registry(
+    "private",
+    serde_json::json!("registry.company.com"),
+    None,
+)?;
+let public_registry_resource = IResource::new(
+    public_registry.handle().clone(),
+    public_registry.client().clone(),
+);
+let private_registry_resource = IResource::new(
+    private_registry.handle().clone(),
+    private_registry.client().clone(),
+);
+
+let public_api = builder.add_project(
+    "public-api",
+    "../PublicApi/PublicApi.csproj",
+    None,
+)?;
+public_api.with_container_registry(&public_registry_resource)?;
+
+let internal_api = builder.add_project(
+    "internal-api",
+    "../InternalApi/InternalApi.csproj",
+    None,
+)?;
+internal_api.with_container_registry(&private_registry_resource)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Parameterized registry configuration
 
 You can use parameters when you need flexible deployment across environments:
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK represents parameter-valued registry arguments as untyped JSON and cannot convert ContainerRegistryResource to the IResource marker required by with_container_registry.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -837,6 +950,42 @@ var api = builder.addProject("api", "../Api/Api.csproj");
 api.withContainerRegistry(registry);
 var worker = builder.addProject("worker", "../Worker/Worker.csproj");
 worker.withContainerRegistry(registry);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let registry_endpoint = builder.add_parameter(
+    "registry-endpoint",
+    None,
+    None,
+    None,
+)?;
+let registry_repository = builder.add_parameter(
+    "registry-repository",
+    None,
+    None,
+    None,
+)?;
+let registry = builder.add_container_registry(
+    "container-registry",
+    serialize_handle(&registry_endpoint),
+    Some(serialize_handle(&registry_repository)),
+)?;
+let registry_resource = IResource::new(
+    registry.handle().clone(),
+    registry.client().clone(),
+);
+
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+api.with_container_registry(&registry_resource)?;
+let worker = builder.add_project(
+    "worker",
+    "../Worker/Worker.csproj",
+    None,
+)?;
+worker.with_container_registry(&registry_resource)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/app-host/eventing.mdx
+++ b/src/frontend/src/content/docs/app-host/eventing.mdx
@@ -25,9 +25,13 @@ The following events are available in the AppHost and occur in the following ord
 
 ### Subscribe to AppHost events
 
-To subscribe to built-in AppHost events, use the typed API available for each event. C# provides builder extension methods for selected events and the lower-level `Eventing.Subscribe<T>()` API for others. TypeScript provides named subscription methods:
+To subscribe to built-in AppHost events, use the typed API available for each event. C# provides builder extension methods for selected events and the lower-level `Eventing.Subscribe<T>()` API for others. TypeScript, Python, Go, and Java provide named subscription methods. The generated Rust callbacks are currently untyped, as noted in the language limitation below.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK emits AppHost event callbacks as Fn(Vec<Value>) -> Value instead of typed event callbacks, so a type-safe equivalent is not available.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -74,6 +78,47 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.subscribe_before_start(
+        lambda event: print("BeforeStartEvent")
+    )
+    builder.subscribe_after_resources_created(
+        lambda event: print("AfterResourcesCreatedEvent")
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder.SubscribeBeforeStart(func(event aspire.BeforeStartEvent) {
+	log.Println("BeforeStartEvent")
+})
+builder.SubscribeAfterResourcesCreated(
+	func(event aspire.AfterResourcesCreatedEvent) {
+		log.Println("AfterResourcesCreatedEvent")
+	},
+)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+builder.subscribeBeforeStart(
+    event -> System.out.println("BeforeStartEvent"));
+builder.subscribeAfterResourcesCreated(
+    event -> System.out.println("AfterResourcesCreatedEvent"));
+```
+
+</Fragment>
 </AppHostTabs>
 
 The following C# builder-level helper methods are available for AppHost events:
@@ -88,6 +133,17 @@ For the full API surface, see the [C# `DistributedApplicationEventingExtensions`
 and the [TypeScript `Aspire.Hosting` API reference](/reference/api/typescript/aspire.hosting/).
 
 If you need to subscribe via `IDistributedApplicationEventing` directly (for example, inside an `IDistributedApplicationEventingSubscriber`), you can use the lower-level `Eventing.Subscribe<T>()` API:
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not export the generic Eventing.Subscribe<TEvent>() API. Use the named subscription methods instead.',
+    python: 'The generated Python SDK does not export the generic Eventing.Subscribe<TEvent>() API. Use the named subscription methods instead.',
+    go: 'The generated Go SDK does not export the generic Eventing.Subscribe<TEvent>() API. Use the named subscription methods instead.',
+    java: 'The generated Java SDK does not export the generic Eventing.Subscribe<TEvent>() API. Use the named subscription methods instead.',
+    rust: 'The generated Rust SDK does not export the generic Eventing.Subscribe<TEvent>() API, and its generated event callbacks are untyped.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 builder.Eventing.Subscribe<BeforeStartEvent>(
@@ -107,12 +163,15 @@ builder.Eventing.Subscribe<AfterResourcesCreatedEvent>(
     });
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="note">
-  TypeScript AppHosts don't expose the generic
+  Generated TypeScript, Python, Go, Java, and Rust AppHosts don't expose the generic
   `builder.Eventing.Subscribe<TEvent>()` API. Use the named callback APIs
-  generated for each supported event, such as `subscribeBeforeStart`,
-  `subscribeAfterResourcesCreated`, `addEventingSubscriber`, and resource
-  callbacks like `onResourceReady`.
+  generated for each supported event, using the language's naming convention,
+  such as `subscribeBeforeStart`, `subscribe_before_start`, or
+  `SubscribeBeforeStart`.
 </Aside>
 
 <Aside type="caution">
@@ -165,7 +224,14 @@ In addition to the AppHost events, you can also subscribe to resource events. Re
 
 To subscribe to resource events, use the convenience-based extension methods. After you have a distributed application builder instance, and a resource builder, walk up to the instance and chain a call to the desired event API:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'This resource-event example uses add_redis, which is not included in the generated Python SDK.',
+    go: 'This resource-event example uses AddRedis, which is not included in the generated Go SDK.',
+    java: 'This resource-event example uses addRedis, which is not included in the generated Java SDK.',
+    rust: 'This resource-event example uses add_redis, which is not included in the generated Rust SDK; Rust event callbacks are also emitted as untyped JSON callbacks.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -346,6 +412,13 @@ The default behavior is `EventDispatchBehavior.BlockingSequential`. To override 
 
 In some cases, such as extension libraries, you may need to access lifecycle events from a service rather than directly from the Aspire application model. You can implement `IDistributedApplicationEventingSubscriber` and register the service with `AddEventingSubscriber` (or `TryAddEventingSubscriber` if you want to avoid duplicate registrations).
 
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK emits eventing subscriber callbacks as Fn(Vec<Value>) -> Value instead of typed registration and event callbacks.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Eventing;
 using Aspire.Hosting.Lifecycle;
@@ -389,29 +462,112 @@ internal sealed class LifecycleLoggerSubscriber(ILogger<LifecycleLoggerSubscribe
 }
 ```
 
-<Aside type="note">
-  C# eventing subscriber service classes are specific to the C# AppHost hosting
-  model. TypeScript AppHosts can register callback-based subscribers with
-  `addEventingSubscriber` or `tryAddEventingSubscriber`.
-</Aside>
+</Fragment>
+<Fragment slot="typescript">
 
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-builder.addEventingSubscriber(async (events) => {
-  events.onBeforeStart(async () => {
+await builder.addEventingSubscriber(async (events) => {
+  await events.onBeforeStart(async () => {
     console.log('1. BeforeStartEvent');
   });
 
-  events.onAfterResourcesCreated(async () => {
+  await events.onAfterResourcesCreated(async () => {
     console.log('3. AfterResourcesCreatedEvent');
   });
 });
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    def subscribe(events):
+        events.on_before_start(
+            lambda event: print("1. BeforeStartEvent")
+        )
+        events.on_after_resources_created(
+            lambda event: print("3. AfterResourcesCreatedEvent")
+        )
+
+    builder.add_eventing_subscriber(subscribe)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	err = builder.AddEventingSubscriber(
+		func(events aspire.EventingSubscriberRegistrationContext) {
+			events.OnBeforeStart(func(event aspire.BeforeStartEvent) {
+				log.Print("1. BeforeStartEvent")
+			})
+			events.OnAfterResourcesCreated(
+				func(event aspire.AfterResourcesCreatedEvent) {
+					log.Print("3. AfterResourcesCreatedEvent")
+				},
+			)
+		},
+	)
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addEventingSubscriber(events -> {
+        events.onBeforeStart(
+            event -> System.out.println("1. BeforeStartEvent"));
+        events.onAfterResourcesCreated(
+            event -> System.out.println("3. AfterResourcesCreatedEvent"));
+    });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 The subscriber approach keeps builder code minimal while still letting you respond to the same lifecycle moments as inline subscriptions:
 
@@ -434,6 +590,17 @@ If you're migrating from the deprecated `IDistributedApplicationLifecycleHook` i
 
 **Before (deprecated):**
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not use the deprecated IDistributedApplicationLifecycleHook class model.',
+    python: 'The generated Python SDK does not use the deprecated IDistributedApplicationLifecycleHook class model.',
+    go: 'The generated Go SDK does not use the deprecated IDistributedApplicationLifecycleHook class model.',
+    java: 'The generated Java SDK does not use the deprecated IDistributedApplicationLifecycleHook class model.',
+    rust: 'The generated Rust SDK does not use the deprecated IDistributedApplicationLifecycleHook class model.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="OldLifecycleHook.cs"
 public class MyHook : IDistributedApplicationLifecycleHook
 {
@@ -450,7 +617,21 @@ public class MyHook : IDistributedApplicationLifecycleHook
 builder.Services.TryAddLifecycleHook<MyHook>();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 **After (recommended):**
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK supports callback-based eventing subscribers, but it does not export the C# IDistributedApplicationEventingSubscriber service class model.',
+    python: 'The generated Python SDK supports callback-based eventing subscribers, but it does not export the C# IDistributedApplicationEventingSubscriber service class model.',
+    go: 'The generated Go SDK supports callback-based eventing subscribers, but it does not export the C# IDistributedApplicationEventingSubscriber service class model.',
+    java: 'The generated Java SDK supports callback-based eventing subscribers, but it does not export the C# IDistributedApplicationEventingSubscriber service class model.',
+    rust: 'The generated Rust SDK does not export the C# IDistributedApplicationEventingSubscriber service class model, and its callback-based subscriber API is untyped.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="NewEventingSubscriber.cs"
 public class MySubscriber : IDistributedApplicationEventingSubscriber
@@ -474,6 +655,9 @@ public class MySubscriber : IDistributedApplicationEventingSubscriber
 builder.Services.TryAddEventingSubscriber<MySubscriber>();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 <Aside type="caution">
   The `IDistributedApplicationLifecycleHook` interface is deprecated as of
   Aspire 9.0 and will be removed in a future release. Migrate to
@@ -493,7 +677,11 @@ When publishing your application (generating deployment manifests), these events
 | `BeforePublishEvent` | Before publishing begins   | Validate or modify resources before manifest generation |
 | `AfterPublishEvent`  | After publishing completes | Perform cleanup or post-publish actions                 |
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK emits publishing callbacks as Fn(Vec<Value>) -> Value instead of typed event callbacks, so a type-safe equivalent is not available.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -530,6 +718,40 @@ await builder.subscribeAfterPublish(async (event) => {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+builder.subscribe_before_publish(
+    lambda event: print("Publishing application")
+)
+builder.subscribe_after_publish(
+    lambda event: print("Publish completed")
+)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+builder.SubscribeBeforePublish(func(event aspire.BeforePublishEvent) {
+	log.Println("Publishing application")
+})
+builder.SubscribeAfterPublish(func(event aspire.AfterPublishEvent) {
+	log.Println("Publish completed")
+})
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+builder.subscribeBeforePublish(
+    event -> System.out.println("Publishing application"));
+builder.subscribeAfterPublish(
+    event -> System.out.println("Publish completed"));
+```
+
+</Fragment>
 </AppHostTabs>
 
 <LearnMore>
@@ -541,7 +763,14 @@ await builder.subscribeAfterPublish(async (event) => {
 
 The `ResourceStoppedEvent` is raised when a resource stops execution:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'This resource-stopped example uses add_redis, which is not included in the generated Python SDK.',
+    go: 'This resource-stopped example uses AddRedis, which is not included in the generated Go SDK.',
+    java: 'This resource-stopped example uses addRedis, which is not included in the generated Java SDK.',
+    rust: 'This resource-stopped example uses add_redis, which is not included in the generated Rust SDK; Rust event callbacks are also emitted as untyped JSON callbacks.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/app-host/executable-resources.mdx
+++ b/src/frontend/src/content/docs/app-host/executable-resources.mdx
@@ -314,12 +314,7 @@ const app = await builder.addExecutable("app", "node", ".", ["app.js"])
 
 Here's a complete example using the [Vercel CLI](https://vercel.com/docs/cli) to host a frontend application with a backend API:
 
-<AppHostTabs
-  limitations={{
-    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so API_URL cannot be assigned from the AppHost.',
-    rust: 'The generated Rust SDK cannot convert an EndpointReference into the untyped Value required by with_environment, so the API_URL assignment is not type-safe.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -353,6 +348,26 @@ const frontend = await builder.addExecutable("vercel-dev", "vercel", ".", ["dev"
     .withHttpEndpoint({ port: 3000, name: "http" });
 
 await builder.build().run();
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "./Api/Api.csproj")
+    api.with_external_http_endpoints()
+
+    frontend = builder.add_executable(
+        "vercel-dev",
+        "vercel",
+        ".",
+        ["dev", "--listen", "3000"],
+    )
+    frontend.with_env("API_URL", api.get_endpoint("http"))
+    frontend.with_http_endpoint(port=3000, name="http")
+
+    builder.run()
 ```
 </Fragment>
 <Fragment slot="go">
@@ -389,18 +404,50 @@ frontend.withHttpEndpoint(
     new WithHttpEndpointOptions().port(3000.0).name("http"));
 ```
 </Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "./Api/Api.csproj", None)?;
+    api.with_external_http_endpoints()?;
+
+    let frontend = builder.add_executable(
+        "vercel-dev",
+        "vercel",
+        ".",
+        vec!["dev", "--listen", "3000"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    )?;
+    let api_endpoint = api.get_endpoint("http")?;
+    frontend.with_environment("API_URL", serialize_handle(&api_endpoint))?;
+    frontend.with_http_endpoint(
+        Some(3000.0),
+        None,
+        Some("http"),
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+</Fragment>
 </AppHostTabs>
 
 ## Configure endpoints
 
 Executable resources can expose HTTP endpoints that other resources can reference:
 
-<AppHostTabs
-  limitations={{
-    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so BASE_URL cannot be assigned from the AppHost.',
-    rust: 'The generated Rust SDK cannot convert an EndpointReference into the untyped Value required by with_environment, so the BASE_URL assignment is not type-safe.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -426,6 +473,27 @@ const frontend = await builder.addExecutable("webpack-dev", "npx", ".", ["webpac
 // Another service can reference the frontend
 const e2eTests = await builder.addExecutable("playwright", "npx", ".", ["playwright", "test"])
     .withEnvironment("BASE_URL", frontend.getEndpoint("http"));
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_executable(
+        "webpack-dev",
+        "npx",
+        ".",
+        ["webpack", "serve", "--port", "8080", "--host", "0.0.0.0"],
+    )
+    frontend.with_http_endpoint(port=8080, name="http")
+
+    e2e_tests = builder.add_executable(
+        "playwright", "npx", ".", ["playwright", "test"]
+    )
+    e2e_tests.with_env("BASE_URL", frontend.get_endpoint("http"))
+
+    builder.run()
 ```
 </Fragment>
 <Fragment slot="go">
@@ -463,17 +531,67 @@ var e2eTests = builder.addExecutable(
 e2eTests.withEnvironment("BASE_URL", frontend.getEndpoint("http"));
 ```
 </Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_executable(
+        "webpack-dev",
+        "npx",
+        ".",
+        vec![
+            "webpack",
+            "serve",
+            "--port",
+            "8080",
+            "--host",
+            "0.0.0.0",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+    )?;
+    frontend.with_http_endpoint(
+        Some(8080.0),
+        None,
+        Some("http"),
+        None,
+        None,
+    )?;
+
+    let e2e_tests = builder.add_executable(
+        "playwright",
+        "npx",
+        ".",
+        vec!["playwright", "test"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+    )?;
+    let frontend_endpoint = frontend.get_endpoint("http")?;
+    e2e_tests.with_environment(
+        "BASE_URL",
+        serialize_handle(&frontend_endpoint),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+</Fragment>
 </AppHostTabs>
 
 ## Environment configuration
 
 Configure environment variables for your executable:
 
-<AppHostTabs
-  limitations={{
-    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so this environment assignment example is unavailable.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -499,6 +617,26 @@ const app = await builder.addExecutable("api", "uvicorn", ".", ["main:app", "--r
     .withEnvironment("DEBUG", "true")
     .withEnvironment("LOG_LEVEL", "info")
     .withEnvironment("START_TIME", new Date().toISOString());
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from datetime import datetime, timezone
+
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    app = builder.add_executable(
+        "api",
+        "uvicorn",
+        ".",
+        ["main:app", "--reload", "--host", "0.0.0.0"],
+    )
+    app.with_env("DEBUG", "true")
+    app.with_env("LOG_LEVEL", "info")
+    app.with_env("START_TIME", datetime.now(timezone.utc).isoformat())
+
+    builder.run()
 ```
 </Fragment>
 <Fragment slot="go">

--- a/src/frontend/src/content/docs/app-host/executable-resources.mdx
+++ b/src/frontend/src/content/docs/app-host/executable-resources.mdx
@@ -406,6 +406,7 @@ frontend.withHttpEndpoint(
 </Fragment>
 <Fragment slot="rust">
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;
@@ -533,6 +534,7 @@ e2eTests.withEnvironment("BASE_URL", frontend.getEndpoint("http"));
 </Fragment>
 <Fragment slot="rust">
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;

--- a/src/frontend/src/content/docs/app-host/executable-resources.mdx
+++ b/src/frontend/src/content/docs/app-host/executable-resources.mdx
@@ -59,6 +59,97 @@ const pythonApp = await builder.addExecutable("api", "python", ".", ["-m", "uvic
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    node_app = builder.add_executable(
+        "frontend", "node", ".", ["server.js"]
+    )
+
+    python_app = builder.add_executable(
+        "api",
+        "python",
+        ".",
+        [
+            "-m",
+            "uvicorn",
+            "main:app",
+            "--reload",
+            "--host",
+            "0.0.0.0",
+            "--port",
+            "8000",
+        ],
+    )
+
+    builder.run()
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+nodeApp := builder.AddExecutable(
+	"frontend",
+	"node",
+	".",
+	[]string{"server.js"},
+)
+pythonApp := builder.AddExecutable(
+	"api",
+	"python",
+	".",
+	[]string{
+		"-m", "uvicorn", "main:app", "--reload",
+		"--host", "0.0.0.0", "--port", "8000",
+	},
+)
+if err := nodeApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+if err := pythonApp.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var nodeApp = builder.addExecutable(
+    "frontend", "node", ".", new String[] { "server.js" });
+
+var pythonApp = builder.addExecutable(
+    "api",
+    "python",
+    ".",
+    new String[] {
+        "-m", "uvicorn", "main:app", "--reload",
+        "--host", "0.0.0.0", "--port", "8000"
+    });
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let node_app = builder.add_executable(
+    "frontend",
+    "node",
+    ".",
+    vec!["server.js".to_string()],
+)?;
+
+let python_app = builder.add_executable(
+    "api",
+    "python",
+    ".",
+    vec![
+        "-m", "uvicorn", "main:app", "--reload",
+        "--host", "0.0.0.0", "--port", "8000",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect(),
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 This code demonstrates setting up a basic executable resource. The first example runs a Node.js server script, while the second starts a Python application using Uvicorn with specific configuration options passed as arguments directly to the `AddExecutable` method.
@@ -89,13 +180,59 @@ const builder = await createBuilder();
 const app = await builder.addExecutable("vercel-dev", "vercel", ".", ["dev", "--listen", "3000"]);
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+app = builder.add_executable(
+    "vercel-dev", "vercel", ".", ["dev", "--listen", "3000"]
+)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+app := builder.AddExecutable(
+	"vercel-dev",
+	"vercel",
+	".",
+	[]string{"dev", "--listen", "3000"},
+)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var app = builder.addExecutable(
+    "vercel-dev",
+    "vercel",
+    ".",
+    new String[] { "dev", "--listen", "3000" });
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let app = builder.add_executable(
+    "vercel-dev",
+    "vercel",
+    ".",
+    vec!["dev", "--listen", "3000"]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 ### Resource dependencies with environment variables
 
 For arguments that depend on other resources, use environment variables:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the Redis and PostgreSQL integration APIs used by this dependency example.',
+    go: 'The generated Go SDK does not include the Redis and PostgreSQL integration APIs used by this dependency example.',
+    java: 'The generated Java SDK does not include the Redis and PostgreSQL integration APIs used by this dependency example.',
+    rust: 'The generated Rust SDK does not include the Redis and PostgreSQL integration APIs used by this dependency example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -130,7 +267,14 @@ When one resource depends on another, `WithReference` passes along environment v
 
 For more control over how connection information is passed to your executable:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_redis, which supplies the endpoint used by this environment example.',
+    go: 'The generated Go SDK does not include AddRedis, which supplies the endpoint used by this environment example.',
+    java: 'The generated Java SDK does not include addRedis, which supplies the endpoint used by this environment example.',
+    rust: 'The generated Rust SDK does not include add_redis, which supplies the endpoint used by this environment example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -170,7 +314,12 @@ const app = await builder.addExecutable("app", "node", ".", ["app.js"])
 
 Here's a complete example using the [Vercel CLI](https://vercel.com/docs/cli) to host a frontend application with a backend API:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so API_URL cannot be assigned from the AppHost.',
+    rust: 'The generated Rust SDK cannot convert an EndpointReference into the untyped Value required by with_environment, so the API_URL assignment is not type-safe.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -206,13 +355,52 @@ const frontend = await builder.addExecutable("vercel-dev", "vercel", ".", ["dev"
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+api := builder.
+	AddProject("api", "./Api/Api.csproj").
+	WithExternalHttpEndpoints()
+frontend := builder.
+	AddExecutable(
+		"vercel-dev",
+		"vercel",
+		".",
+		[]string{"dev", "--listen", "3000"},
+	).
+	WithEnvironment("API_URL", api.GetEndpoint("http")).
+	WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+		Port: aspire.Float64Ptr(3000),
+		Name: aspire.StringPtr("http"),
+	})
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var api = builder.addProject("api", "./Api/Api.csproj");
+api.withExternalHttpEndpoints();
+
+var frontend = builder.addExecutable(
+    "vercel-dev",
+    "vercel",
+    ".",
+    new String[] { "dev", "--listen", "3000" });
+frontend.withEnvironment("API_URL", api.getEndpoint("http"));
+frontend.withHttpEndpoint(
+    new WithHttpEndpointOptions().port(3000.0).name("http"));
+```
+</Fragment>
 </AppHostTabs>
 
 ## Configure endpoints
 
 Executable resources can expose HTTP endpoints that other resources can reference:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so BASE_URL cannot be assigned from the AppHost.',
+    rust: 'The generated Rust SDK cannot convert an EndpointReference into the untyped Value required by with_environment, so the BASE_URL assignment is not type-safe.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -240,13 +428,52 @@ const e2eTests = await builder.addExecutable("playwright", "npx", ".", ["playwri
     .withEnvironment("BASE_URL", frontend.getEndpoint("http"));
 ```
 </Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+frontend := builder.
+	AddExecutable(
+		"webpack-dev",
+		"npx",
+		".",
+		[]string{"webpack", "serve", "--port", "8080", "--host", "0.0.0.0"},
+	).
+	WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+		Port: aspire.Float64Ptr(8080),
+		Name: aspire.StringPtr("http"),
+	})
+e2eTests := builder.
+	AddExecutable("playwright", "npx", ".", []string{"playwright", "test"}).
+	WithEnvironment("BASE_URL", frontend.GetEndpoint("http"))
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var frontend = builder.addExecutable(
+    "webpack-dev",
+    "npx",
+    ".",
+    new String[] {
+        "webpack", "serve", "--port", "8080", "--host", "0.0.0.0"
+    });
+frontend.withHttpEndpoint(
+    new WithHttpEndpointOptions().port(8080.0).name("http"));
+
+var e2eTests = builder.addExecutable(
+    "playwright", "npx", ".", new String[] { "playwright", "test" });
+e2eTests.withEnvironment("BASE_URL", frontend.getEndpoint("http"));
+```
+</Fragment>
 </AppHostTabs>
 
 ## Environment configuration
 
 Configure environment variables for your executable:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK documents with_environment but does not emit the method on executable resources, so this environment assignment example is unavailable.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -274,19 +501,68 @@ const app = await builder.addExecutable("api", "uvicorn", ".", ["main:app", "--r
     .withEnvironment("START_TIME", new Date().toISOString());
 ```
 </Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+app := builder.
+	AddExecutable(
+		"api",
+		"uvicorn",
+		".",
+		[]string{"main:app", "--reload", "--host", "0.0.0.0"},
+	).
+	WithEnvironment("DEBUG", "true").
+	WithEnvironment("LOG_LEVEL", "info").
+	WithEnvironment("START_TIME", time.Now().UTC().Format(time.RFC3339))
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var app = builder.addExecutable(
+    "api",
+    "uvicorn",
+    ".",
+    new String[] { "main:app", "--reload", "--host", "0.0.0.0" });
+app.withEnvironment("DEBUG", "true");
+app.withEnvironment("LOG_LEVEL", "info");
+app.withEnvironment("START_TIME", Instant.now().toString());
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let app = builder.add_executable(
+    "api",
+    "uvicorn",
+    ".",
+    vec!["main:app", "--reload", "--host", "0.0.0.0"]
+        .into_iter()
+        .map(str::to_string)
+        .collect(),
+)?;
+app.with_environment("DEBUG", serde_json::json!("true"))?;
+app.with_environment("LOG_LEVEL", serde_json::json!("info"))?;
+app.with_environment(
+    "START_TIME",
+    serde_json::json!("2026-09-09T14:13:47Z"),
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
-### `withEnvironment` API unification in Aspire 13.3
+### Environment API unification in Aspire 13.3
 
-Aspire 13.3 unified non-C# AppHost environment assignment behind a single `withEnvironment(name, value)` pattern. The public TypeScript API accepts plain strings, reference expressions, endpoint references, parameter resources, supported resources that expose connection strings, expression values, and awaitable forms of supported values.
+Aspire 13.3 unified generated AppHost environment assignment behind one operation, named `withEnvironment` or `WithEnvironment` according to the generated language. Generated SDKs accept the supported string, reference, endpoint, parameter, resource, and expression value forms exposed by each language's type system.
 
-When upgrading to Aspire 13.3, replace every earlier per-kind environment helper call with `withEnvironment(name, value)`. The 13.3 TypeScript SDK doesn't generate compatibility aliases for those helpers.
+When upgrading to Aspire 13.3, replace earlier per-kind environment helper calls with the unified environment method. The generated SDKs don't provide compatibility aliases for those helpers.
 
 ## Publishing with PublishAsDockerFile
 
 For production deployment, executable resources need to be containerized. Use the `PublishAsDockerFile` method to specify how the executable should be packaged:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK emits publish_as_docker_file with an untyped Fn(Vec<Value>) -> Value callback, so a type-safe empty configuration callback is not available.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -304,6 +580,36 @@ const builder = await createBuilder();
 
 const app = await builder.addExecutable("frontend", "npm", ".", ["start", "--port", "3000"])
     .publishAsDockerFile(async () => {});
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+app = builder.add_executable(
+    "frontend", "npm", ".", ["start", "--port", "3000"]
+)
+app.publish_as_docker_file(lambda container: None)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+app := builder.
+	AddExecutable(
+		"frontend",
+		"npm",
+		".",
+		[]string{"start", "--port", "3000"},
+	).
+	PublishAsDockerFile(func(container aspire.ContainerResource) {})
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var app = builder.addExecutable(
+    "frontend",
+    "npm",
+    ".",
+    new String[] { "start", "--port", "3000" });
+app.publishAsDockerFile(container -> {});
 ```
 </Fragment>
 </AppHostTabs>
@@ -326,7 +632,11 @@ CMD ["npm", "start"]
 
 Then reference it in your AppHost:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK emits publish_as_docker_file with an untyped Fn(Vec<Value>) -> Value callback, so Dockerfile build arguments cannot be configured type-safely.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -343,6 +653,28 @@ const builder = await createBuilder();
 
 const app = await builder.addExecutable("frontend", "npm", ".", ["start"])
     .publishAsDockerFile(async () => {});
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+app = builder.add_executable(
+    "frontend", "npm", ".", ["start"]
+)
+app.publish_as_docker_file(lambda container: None)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+app := builder.
+	AddExecutable("frontend", "npm", ".", []string{"start"}).
+	PublishAsDockerFile(func(container aspire.ContainerResource) {})
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var app = builder.addExecutable(
+    "frontend", "npm", ".", new String[] { "start" });
+app.publishAsDockerFile(container -> {});
 ```
 </Fragment>
 </AppHostTabs>

--- a/src/frontend/src/content/docs/app-host/hot-reload-and-watch.mdx
+++ b/src/frontend/src/content/docs/app-host/hot-reload-and-watch.mdx
@@ -14,7 +14,7 @@ Aspire has two levels of watch behavior:
 1. **AppHost watch** - watches the AppHost itself so changes to the application model restart the AppHost-managed application.
 2. **Resource watch and hot reload** - depend on the application or framework backing each resource.
 
-Aspire's CLI watch support is centered on the AppHost. Aspire supports two AppHost languages, C# and TypeScript, and `defaultWatchEnabled` applies to the AppHost-managed application regardless of which AppHost language you use.
+Aspire's CLI watch support is centered on the AppHost. `defaultWatchEnabled` applies to the AppHost-managed application regardless of which supported AppHost language you use.
 
 When watch mode is enabled, Aspire owns the file-watching loop for the AppHost-managed application. File changes cause Aspire to restart the application topology so the updated AppHost model and resources are applied.
 
@@ -49,7 +49,7 @@ To see the current value and available feature flags, run:
 aspire config list --all
 ```
 
-Watch mode is useful when you want Aspire to restart the AppHost-managed application for you after AppHost changes. It supports both C# and TypeScript AppHosts and is a restart-based workflow, not the same experience as runtime-specific or IDE-specific hot reload.
+Watch mode is useful when you want Aspire to restart the AppHost-managed application for you after AppHost changes. It supports every AppHost language and is a restart-based workflow, not the same experience as runtime-specific or IDE-specific hot reload.
 
 ## AppHost language guidance
 
@@ -84,6 +84,54 @@ Use this workflow when changes affect:
 - The AppHost model in `apphost.mts`.
 - Resource configuration, endpoints, parameters, or integration setup.
 - Multiple services that need to be restarted together under Aspire orchestration.
+
+```bash title="Aspire CLI"
+aspire config set features.defaultWatchEnabled true
+aspire run
+```
+
+</Fragment>
+<Fragment slot="python">
+
+For a Python AppHost, `defaultWatchEnabled` watches `apphost.py`. When AppHost code changes, Aspire restarts the AppHost-managed application so the updated model is applied.
+
+Resource processes keep their runtime-specific development behavior. Use this workflow for AppHost model, endpoint, parameter, and integration changes; use each resource's own reload or rebuild workflow for application source changes.
+
+```bash title="Aspire CLI"
+aspire config set features.defaultWatchEnabled true
+aspire run
+```
+
+</Fragment>
+<Fragment slot="go">
+
+For a Go AppHost, `defaultWatchEnabled` watches `apphost.go`. When AppHost code changes, Aspire rebuilds and restarts the AppHost-managed application so the updated model is applied.
+
+Resource processes keep their runtime-specific development behavior. Use this workflow for AppHost model, endpoint, parameter, and integration changes; use each resource's own reload or rebuild workflow for application source changes.
+
+```bash title="Aspire CLI"
+aspire config set features.defaultWatchEnabled true
+aspire run
+```
+
+</Fragment>
+<Fragment slot="java">
+
+For a Java AppHost, `defaultWatchEnabled` watches `AppHost.java`. When AppHost code changes, Aspire rebuilds and restarts the AppHost-managed application so the updated model is applied.
+
+Resource processes keep their runtime-specific development behavior. Use this workflow for AppHost model, endpoint, parameter, and integration changes; use each resource's own reload or rebuild workflow for application source changes.
+
+```bash title="Aspire CLI"
+aspire config set features.defaultWatchEnabled true
+aspire run
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+For a Rust AppHost, `defaultWatchEnabled` watches `apphost.rs`. When AppHost code changes, Aspire rebuilds and restarts the AppHost-managed application so the updated model is applied.
+
+Resource processes keep their runtime-specific development behavior. Use this workflow for AppHost model, endpoint, parameter, and integration changes; use each resource's own reload or rebuild workflow for application source changes.
 
 ```bash title="Aspire CLI"
 aspire config set features.defaultWatchEnabled true

--- a/src/frontend/src/content/docs/app-host/migrate-from-docker-compose.mdx
+++ b/src/frontend/src/content/docs/app-host/migrate-from-docker-compose.mdx
@@ -97,7 +97,14 @@ volumes:
 
 **Aspire equivalent:**
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this complete migration example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this complete migration example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this complete migration example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this complete migration example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -213,7 +220,14 @@ volumes:
 
 **Aspire equivalent:**
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL and Redis integration APIs used by this Dockerfile migration example.',
+    go: 'The generated Go SDK does not include the PostgreSQL and Redis integration APIs used by this Dockerfile migration example.',
+    java: 'The generated Java SDK does not include the PostgreSQL and Redis integration APIs used by this Dockerfile migration example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL and Redis integration APIs used by this Dockerfile migration example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -308,7 +322,14 @@ services:
 
 **Aspire approach:**
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL and Redis integration APIs required by this parameter migration example.',
+    go: 'The generated Go SDK does not include the PostgreSQL and Redis integration APIs required by this parameter migration example.',
+    java: 'The generated Java SDK does not include the PostgreSQL and Redis integration APIs required by this parameter migration example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL and Redis integration APIs required by this parameter migration example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -364,7 +385,14 @@ await builder.build().run();
 If your application expects URL-format variables like `DATABASE_URL` or `REDIS_URL`, construct them manually using the `WithEnvironment` callback:
 </Aside>
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'This validation example depends on PostgreSQL integration resources, which are not present in the generated Python SDK.',
+    go: 'This validation example depends on PostgreSQL integration resources, which are not present in the generated Go SDK.',
+    java: 'This validation example depends on PostgreSQL integration resources, which are not present in the generated Java SDK.',
+    rust: 'This validation example depends on PostgreSQL integration resources, which are not present in the generated Rust SDK.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var dbPassword = builder.AddParameter("dbPassword", secret: true);
@@ -456,6 +484,67 @@ const worker = await builder.addContainer("worker", { image: "myworker", tag: "l
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+app = builder.add_container("app", "myapp:latest")
+app.with_volume("/data", name="app-data", is_read_only=True)
+app.with_bind_mount("./config", "/app/config", is_read_only=True)
+worker = builder.add_container("worker", "myworker:latest")
+worker.with_volume("/shared", name="app-data")
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+app := builder.
+	AddContainer("app", &aspire.AddContainerOptions{
+		Image: "myapp",
+		Tag:   aspire.StringPtr("latest"),
+	}).
+	WithVolume("/data", &aspire.WithVolumeOptions{
+		Name:       aspire.StringPtr("app-data"),
+		IsReadOnly: aspire.BoolPtr(true),
+	}).
+	WithBindMount("./config", "/app/config", &aspire.WithBindMountOptions{
+		IsReadOnly: aspire.BoolPtr(true),
+	})
+worker := builder.
+	AddContainer("worker", "myworker:latest").
+	WithVolume("/shared", &aspire.WithVolumeOptions{
+		Name: aspire.StringPtr("app-data"),
+	})
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var app = builder.addContainer("app", "myapp:latest");
+app.withVolume(
+    "/data",
+    new WithVolumeOptions().name("app-data").isReadOnly(true));
+app.withBindMount("./config", "/app/config", true);
+var worker = builder.addContainer("worker", "myworker:latest");
+worker.withVolume("/shared", new WithVolumeOptions().name("app-data"));
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let app = builder.add_container("app", serde_json::json!("myapp:latest"))?;
+app.with_volume("/data", Some("app-data"), Some(true))?;
+app.with_bind_mount("./config", "/app/config", Some(true))?;
+let worker = builder.add_container(
+    "worker",
+    serde_json::json!("myworker:latest"),
+)?;
+worker.with_volume("/shared", Some("app-data"), None)?;
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -561,7 +650,14 @@ Aspire generates .NET-style connection strings (`ConnectionStrings__*`) rather t
 
 **Solution**: If your application expects specific URL formats, construct them manually using `WithEnvironment()`:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'This reference-expression example depends on PostgreSQL integration resources, which are not present in the generated Python SDK.',
+    go: 'This reference-expression example depends on PostgreSQL integration resources, which are not present in the generated Go SDK.',
+    java: 'This reference-expression example depends on PostgreSQL integration resources, which are not present in the generated Java SDK.',
+    rust: 'This reference-expression example depends on PostgreSQL integration resources, which are not present in the generated Rust SDK.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var dbPassword = builder.AddParameter("dbPassword", secret: true);
@@ -615,6 +711,40 @@ const api = await builder.addProject("api", "./Api/Api.csproj", "https")
     .waitFor(database);       // Startup ordering
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+api = builder.add_project("api", "./Api/Api.csproj")
+api.with_reference(database)
+api.wait_for(database)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+api := builder.
+	AddProject("api", "./Api/Api.csproj").
+	WithReference(database).
+	WaitFor(database)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var api = builder.addProject("api", "./Api/Api.csproj");
+api.withReference(database);
+api.waitFor(database);
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let api = builder.add_project("api", "./Api/Api.csproj", None)?;
+api.with_reference(serialize_handle(&database), None, None, None)?;
+
+let database_resource = IResource::new(
+    database.handle().clone(),
+    database.client().clone(),
+);
+api.wait_for(&database_resource, None)?;
+```
+</Fragment>
 </AppHostTabs>
 
 #### Volume mounting issues
@@ -629,7 +759,14 @@ Aspire automatically assigns random ports by default.
 
 **Solution**: Use `WithHostPort()` or `WithHttpEndpoint(port:)` for static port mapping:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include add_redis or the Redis-specific host-port helper.',
+    go: 'The generated Go SDK does not include AddRedis or the Redis-specific WithHostPort helper.',
+    java: 'The generated Java SDK does not include addRedis or the Redis-specific withHostPort helper.',
+    rust: 'The generated Rust SDK does not include add_redis or the Redis-specific with_host_port helper.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var redis = builder.AddRedis("cache")
@@ -663,11 +800,46 @@ const api = await builder.addProject("api", "./Api/Api.csproj", "https")
     .withHttpHealthCheck("/health");
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+api = builder.add_project("api", "./Api/Api.csproj")
+api.with_http_health_check(path="/health")
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+api := builder.
+	AddProject("api", "./Api/Api.csproj").
+	WithHttpHealthCheck(&aspire.WithHttpHealthCheckOptions{
+		Path: aspire.StringPtr("/health"),
+	})
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var api = builder.addProject("api", "./Api/Api.csproj");
+api.withHttpHealthCheck(
+    new WithHttpHealthCheckOptions().path("/health"));
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let api = builder.add_project("api", "./Api/Api.csproj", None)?;
+api.with_http_health_check(Some("/health"), None, None)?;
+```
+</Fragment>
 </AppHostTabs>
 
 For custom container health checks that need shell commands (like RabbitMQ), register a custom health check and associate it with the resource:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK can associate a named health check with a resource, but it does not expose the service-registration API needed to define that custom check.',
+    go: 'The generated Go SDK can associate a named health check with a resource, but it does not expose the service-registration API needed to define that custom check.',
+    java: 'The generated Java SDK can associate a named health check with a resource, but it does not expose the service-registration API needed to define that custom check.',
+    rust: 'The generated Rust SDK can associate a named health check with a resource, but it does not expose the service-registration API needed to define that custom check.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.Services.AddHealthChecks()

--- a/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
+++ b/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
@@ -211,7 +211,7 @@ with create_builder() as builder:
     cache = builder.add_container("long-lived-cache", "my-cache-image")
     cache.with_persistent_lifetime()
     cache.with_explicit_start()
-    cache.with_environment_callback(
+    cache.with_env_callback(
         lambda context: context.env.set("CACHE_SIZE", "512mb")
     )
 

--- a/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
+++ b/src/frontend/src/content/docs/app-host/resource-lifetimes.mdx
@@ -5,7 +5,6 @@ description: Learn how session, persistent, resource-scoped, and parent-process 
 
 import AppHostTabs from '@components/AppHostTabs.astro';
 
-
 import { Image } from 'astro:assets';
 import LearnMore from '@components/LearnMore.astro';
 import persistentContainer from '@assets/whats-new/aspire-9/persistent-container.png';
@@ -88,6 +87,16 @@ Starting in Aspire 13.5, `WithExplicitStart()` also affects when execution confi
 
 For session-scoped resources (the default lifetime), Aspire defers Developer Control Plane (DCP) registration until you manually start the resource from the dashboard. This means execution configuration callbacks — such as `WithEnvironment(context => ...)` — are **not** evaluated during AppHost startup. They run only when the resource is manually started.
 
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python environment callback is synchronous, so it cannot express the asynchronous GetApiKeyAsync operation in this example.',
+    go: 'The generated Go environment callback is synchronous, so it cannot express the asynchronous GetApiKeyAsync operation in this example.',
+    java: 'The generated Java environment callback is synchronous, so it cannot express the asynchronous GetApiKeyAsync operation in this example.',
+    rust: 'The generated Rust environment callback is emitted as Fn(Vec<Value>) -> Value instead of a typed EnvironmentCallbackContext callback.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -104,6 +113,33 @@ var job = builder.AddExecutable("batch-job", "dotnet", ".", "run", "--project", 
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+declare function getApiKeyAsync(): Promise<string>;
+
+// The callback below is NOT evaluated during AppHost startup.
+// It runs only when the resource is manually started from the dashboard.
+await builder
+  .addExecutable('batch-job', 'dotnet', '.', ['run', '--project', 'BatchJob'])
+  .withExplicitStart()
+  .withEnvironmentCallback(async (context) => {
+    // Prompt or compute dynamic configuration at start time
+    const environment = await context.environment();
+    await environment.set('API_KEY', await getApiKeyAsync());
+  });
+
+await builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
+
 :::note[Placeholder API used for demonstration]
 `GetApiKeyAsync` is a placeholder used to demonstrate deferred, callback-based configuration. Its implementation isn't shown because the relevant behavior is retrieving a value when the callback runs and assigning that value to an environment variable on the target resource.
 :::
@@ -111,6 +147,13 @@ builder.Build().Run();
 ### Persistent explicit-start resources
 
 For persistent resources, Aspire must register the resource with the Developer Control Plane (DCP) immediately at startup so it can discover any existing running instance. However, when you manually start a persistent explicit-start resource, Aspire patches the existing DCP resource to start it rather than deleting and recreating it. This means the execution configuration callbacks run once during startup registration and are **not** re-evaluated when you manually start the resource.
+
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust environment callback is emitted as Fn(Vec<Value>) -> Value instead of a typed EnvironmentCallbackContext callback.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -131,11 +174,129 @@ var cache = builder.AddContainer("long-lived-cache", "my-cache-image")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+// Persistent explicit-start resources are registered at startup to detect existing instances.
+// The callback runs during startup registration — not again when manually started.
+await builder
+  .addContainer('long-lived-cache', {
+    image: 'my-cache-image',
+    tag: 'latest',
+  })
+  .withPersistentLifetime()
+  .withExplicitStart()
+  .withEnvironmentCallback(async (context) => {
+    const environment = await context.environment();
+    await environment.set('CACHE_SIZE', '512mb');
+  });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    # Persistent explicit-start resources are registered at startup to detect
+    # existing instances. The callback runs during startup registration.
+    cache = builder.add_container("long-lived-cache", "my-cache-image")
+    cache.with_persistent_lifetime()
+    cache.with_explicit_start()
+    cache.with_environment_callback(
+        lambda context: context.env.set("CACHE_SIZE", "512mb")
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	// Persistent explicit-start resources are registered at startup to detect
+	// existing instances. The callback runs during startup registration.
+	cache := builder.
+		AddContainer("long-lived-cache", "my-cache-image").
+		WithPersistentLifetime().
+		WithExplicitStart().
+		WithEnvironmentCallback(func(context aspire.EnvironmentCallbackContext) {
+			if err := context.Environment().Set("CACHE_SIZE", "512mb"); err != nil {
+				log.Fatal(aspire.FormatError(err))
+			}
+		})
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    // Persistent explicit-start resources are registered at startup to detect
+    // existing instances. The callback runs during startup registration.
+    var cache = builder.addContainer("long-lived-cache", "my-cache-image");
+    cache.withPersistentLifetime();
+    cache.withExplicitStart();
+    cache.withEnvironmentCallback(
+        context -> context.environment().set("CACHE_SIZE", "512mb"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## Configure a persistent container
 
 For new code, configure a persistent container with `WithPersistentLifetime()`:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this persistent-container example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this persistent-container example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this persistent-container example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this persistent-container example.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -216,6 +377,61 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    worker = builder.add_executable("worker", "node", "../worker", ["server.js"])
+    worker.with_http_endpoint(port=5050, target_port=5050)
+    worker.with_persistent_lifetime()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+worker := builder.
+	AddExecutable("worker", "node", "../worker", []string{"server.js"}).
+	WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+		Port:       aspire.Float64Ptr(5050),
+		TargetPort: aspire.Float64Ptr(5050),
+	}).
+	WithPersistentLifetime()
+if err := worker.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var worker = builder.addExecutable(
+    "worker", "node", "../worker", new String[] { "server.js" });
+worker.withHttpEndpoint(
+    new WithHttpEndpointOptions().port(5050.0).targetPort(5050.0));
+worker.withPersistentLifetime();
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let worker = builder.add_executable(
+    "worker",
+    "node",
+    "../worker",
+    vec!["server.js".to_string()],
+)?;
+worker.with_http_endpoint(Some(5050.0), Some(5050.0), None, None, None)?;
+worker.with_persistent_lifetime()?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding example configures a concrete `port` so the endpoint address is explicit. If you omit the public `port`, Aspire allocates one before the executable starts and reuses it from user secrets on later AppHost runs when user secrets are available.
@@ -251,6 +467,47 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_persistent_lifetime()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+api := builder.
+	AddProject("api", "../ApiService/ApiService.csproj").
+	WithPersistentLifetime()
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+api.withPersistentLifetime();
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let api = builder.add_project("api", "../ApiService/ApiService.csproj", None)?;
+api.with_persistent_lifetime()?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 Persistent project and executable resources are run by Aspire's orchestrator so it can manage their lifecycle consistently. Persistent project and executable resources don't support replicas.
@@ -259,7 +516,14 @@ Persistent project and executable resources are run by Aspire's orchestrator so 
 
 Use `WithLifetimeOf` when a companion resource should follow another resource's lifetime. This is useful when a sidecar, helper process, or supporting service should become persistent only when its source resource is persistent.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'This WithLifetimeOf example depends on a PostgreSQL integration resource, which is not present in the generated Python SDK.',
+    go: 'This WithLifetimeOf example depends on a PostgreSQL integration resource, which is not present in the generated Go SDK.',
+    java: 'This withLifetimeOf example depends on a PostgreSQL integration resource, which is not present in the generated Java SDK.',
+    rust: 'This with_lifetime_of example depends on a PostgreSQL integration resource, which is not present in the generated Rust SDK.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -343,6 +607,62 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+import os
+
+parent_process_id = int(os.environ["RESOURCE_PARENT_PROCESS_ID"])
+worker = builder.add_executable(
+"scoped-worker", "node", "../worker", ["server.js"]
+)
+worker.with_parent_process_lifetime(parent_process_id)
+
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+parentProcessID, err := strconv.ParseFloat(
+	os.Getenv("RESOURCE_PARENT_PROCESS_ID"),
+	64,
+)
+if err != nil {
+	log.Fatal(err)
+}
+worker := builder.
+	AddExecutable("scoped-worker", "node", "../worker", []string{"server.js"}).
+	WithParentProcessLifetime(parentProcessID)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var parentProcessId = Double.parseDouble(
+    System.getenv("RESOURCE_PARENT_PROCESS_ID"));
+var worker = builder.addExecutable(
+    "scoped-worker", "node", "../worker", new String[] { "server.js" });
+worker.withParentProcessLifetime(parentProcessId);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let parent_process_id = std::env::var("RESOURCE_PARENT_PROCESS_ID")?
+    .parse::<f64>()?;
+let worker = builder.add_executable(
+    "scoped-worker",
+    "node",
+    "../worker",
+    vec!["server.js".to_string()],
+)?;
+worker.with_parent_process_lifetime(parent_process_id)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The parent process ID must be greater than zero and identify a running process.
@@ -353,7 +673,14 @@ The older container-specific lifetime API is still supported. Use `WithLifetime(
 
 For new code, prefer the shared `WithPersistentLifetime()` and `WithSessionLifetime()` APIs because they work consistently across containers, executables, and projects.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this container-specific lifetime example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this container-specific lifetime example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this container-specific lifetime example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this container-specific lifetime example.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -415,7 +742,14 @@ For example, if you have a service named `"postgres"` in an AppHost project loca
 
 For advanced scenarios, you can set a custom container name using the `WithContainerName` method:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this custom-container-name example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this custom-container-name example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this custom-container-name example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this custom-container-name example.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -483,7 +817,14 @@ For persistent executable and project resources, stop the running process with y
 
 For **databases and other stateful services**, use both APIs together so you get fast startup (the container stays running) _and_ data safety (a volume protects data even if the container is recreated):
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this persistence and data-volume example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this persistence and data-volume example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this persistence and data-volume example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this persistence and data-volume example.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
+++ b/src/frontend/src/content/docs/app-host/typescript-apphost.mdx
@@ -491,7 +491,7 @@ aspire update
 
 ## See also
 
-- [Build your first app](/get-started/first-app/?lang=typescript)
+- [Build your first app](/get-started/first-app/?aspire-lang=typescript)
 - [AppHost overview](/get-started/app-host/)
 - [Multi-language architecture](/architecture/multi-language-architecture/)
 - [aspire doctor command](/reference/cli/commands/aspire-doctor/)

--- a/src/frontend/src/content/docs/app-host/with-terminal.mdx
+++ b/src/frontend/src/content/docs/app-host/with-terminal.mdx
@@ -38,6 +38,92 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    agent = builder.add_executable("agent", "my-agent", ".", [])
+    agent.with_terminal()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	agent := builder.
+		AddExecutable("agent", "my-agent", ".", []string{}).
+		WithTerminal()
+	if err := agent.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var agent = builder.addExecutable(
+        "agent", "my-agent", ".", new String[] {});
+    agent.withTerminal();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let agent = builder.add_executable("agent", "my-agent", ".", vec![])?;
+    agent.with_terminal()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 Once the app is running, open the resource's terminal page in the dashboard—or run `aspire terminal attach agent`—to interact with the process just as you would in a local shell.
@@ -120,8 +206,58 @@ await builder.build().run();
 ```
 
 <Aside type="note">
-In TypeScript AppHosts, `withTerminal()` currently applies the default options shown above. Configurable options are coming to the non-C# API as `WithTerminal` is finalized (tracked by [microsoft/aspire#18105](https://github.com/microsoft/aspire/issues/18105)).
+In TypeScript AppHosts, `withTerminal()` currently applies the default options shown above. Configurable options are coming to the generated AppHost SDKs as `WithTerminal` is finalized (tracked by [microsoft/aspire#18105](https://github.com/microsoft/aspire/issues/18105)).
 </Aside>
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    agent = builder.add_executable("agent", "my-agent", ".", [])
+    agent.with_terminal()
+
+    builder.run()
+```
+
+Python AppHosts currently apply the default terminal options. The generated SDK doesn't expose configurable columns, rows, or terminal-host visibility.
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+agent := builder.
+	AddExecutable("agent", "my-agent", ".", []string{}).
+	WithTerminal()
+if err := agent.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+Go AppHosts currently apply the default terminal options. The generated SDK doesn't expose configurable columns, rows, or terminal-host visibility.
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var agent = builder.addExecutable(
+    "agent", "my-agent", ".", new String[] {});
+agent.withTerminal();
+```
+
+Java AppHosts currently apply the default terminal options. The generated SDK doesn't expose configurable columns, rows, or terminal-host visibility.
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let agent = builder.add_executable("agent", "my-agent", ".", vec![])?;
+agent.with_terminal()?;
+```
+
+Rust AppHosts currently apply the default terminal options. The generated SDK doesn't expose configurable columns, rows, or terminal-host visibility.
 
 </Fragment>
 </AppHostTabs>
@@ -130,7 +266,14 @@ In TypeScript AppHosts, `withTerminal()` currently applies the default options s
 
 Each replica of a resource gets its own independent terminal session. Aspire creates one terminal host per parent replica, so requesting three replicas yields three separate terminals. The order of `WithReplicas` and `WithTerminal` does not matter—the final replica count is always honored:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose WithReplicas for executable resources, so this executable-replica example is not available.',
+    go: 'The generated Go SDK does not expose WithReplicas for executable resources, so this executable-replica example is not available.',
+    java: 'The generated Java SDK does not expose withReplicas for executable resources, so this executable-replica example is not available.',
+    rust: 'The generated Rust SDK does not expose with_replicas for executable resources, so this executable-replica example is not available.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/app-host/with-terminal.mdx
+++ b/src/frontend/src/content/docs/app-host/with-terminal.mdx
@@ -268,6 +268,7 @@ Each replica of a resource gets its own independent terminal session. Aspire cre
 
 <AppHostTabs
   limitations={{
+    typescript: 'The generated TypeScript SDK does not expose withReplicas for executable resources, so this executable-replica example is not available.',
     python: 'The generated Python SDK does not expose WithReplicas for executable resources, so this executable-replica example is not available.',
     go: 'The generated Go SDK does not expose WithReplicas for executable resources, so this executable-replica example is not available.',
     java: 'The generated Java SDK does not expose withReplicas for executable resources, so this executable-replica example is not available.',
@@ -286,21 +287,6 @@ var agent = builder.AddExecutable("agent", "my-agent", ".")
     .WithTerminal();
 
 builder.Build().Run();
-```
-
-</Fragment>
-<Fragment slot="typescript">
-
-```typescript title="apphost.ts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-
-const builder = await createBuilder();
-
-const agent = await builder.addExecutable("agent", "my-agent", ".")
-    .withReplicas(3)
-    .withTerminal();
-
-await builder.build().run();
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/app-host/withdockerfile.mdx
+++ b/src/frontend/src/content/docs/app-host/withdockerfile.mdx
@@ -576,11 +576,7 @@ container.with_build_arg(
 
 The value parameter on the `WithBuildArg` method can be a literal value (`boolean`, `string`, `int`) or it can be a resource builder for a [parameter resource](/fundamentals/external-parameters/). The following code replaces the `GO_VERSION` with a parameter value that can be specified at deployment time.
 
-<AppHostTabs
-  limitations={{
-    rust: 'The generated Rust SDK accepts an untyped Value for with_build_arg but does not provide a public conversion from ParameterResource to that Value.',
-  }}
->
+<AppHostTabs>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -626,6 +622,26 @@ var goVersion = builder.addParameter("goversion");
 var container = builder.addDockerfile(
     "mygoapp", "relative/context/path");
 container.withBuildArg("GO_VERSION", goVersion);
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let go_version = builder.add_parameter(
+    "goversion",
+    None,
+    None,
+    None,
+)?;
+let container = builder.add_dockerfile(
+    "mygoapp",
+    "relative/context/path",
+    None,
+    None,
+)?;
+container.with_build_arg(
+    "GO_VERSION",
+    serialize_handle(&go_version),
+)?;
 ```
 </Fragment>
 </AppHostTabs>

--- a/src/frontend/src/content/docs/app-host/withdockerfile.mdx
+++ b/src/frontend/src/content/docs/app-host/withdockerfile.mdx
@@ -57,6 +57,37 @@ const container = await builder.addDockerfile(
     "mycontainer", "relative/context/path");
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+container = builder.add_dockerfile(
+    "mycontainer", "relative/context/path"
+)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+container := builder.AddDockerfile(
+	"mycontainer",
+	"relative/context/path",
+)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var container = builder.addDockerfile(
+    "mycontainer", "relative/context/path");
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let container = builder.add_dockerfile(
+    "mycontainer",
+    "relative/context/path",
+    None,
+    None,
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 Unless the context path argument is a rooted path the context path is interpreted as being relative to the AppHost project directory.
@@ -90,6 +121,65 @@ const container = (await builder.executionContext.isRunMode())
           "mycontainer", "relative/context/path", "Dockerfile.release");
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+dockerfile_path = (
+    "Dockerfile.debug"
+    if builder.execution_context.is_run_mode
+    else "Dockerfile.release"
+)
+container = builder.add_dockerfile(
+    "mycontainer",
+    "relative/context/path",
+    dockerfile_path=dockerfile_path,
+)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+isRunMode, err := builder.ExecutionContext().IsRunMode()
+if err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+dockerfilePath := "Dockerfile.release"
+if isRunMode {
+	dockerfilePath = "Dockerfile.debug"
+}
+container := builder.AddDockerfile(
+	"mycontainer",
+	"relative/context/path",
+	&aspire.AddDockerfileOptions{
+		DockerfilePath: aspire.StringPtr(dockerfilePath),
+	},
+)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var dockerfilePath = builder.executionContext().isRunMode()
+    ? "Dockerfile.debug"
+    : "Dockerfile.release";
+var options = new AddDockerfileOptions()
+    .dockerfilePath(dockerfilePath);
+var container = builder.addDockerfile(
+    "mycontainer", "relative/context/path", options);
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let dockerfile_path = if builder.execution_context()?.is_run_mode()? {
+    "Dockerfile.debug"
+} else {
+    "Dockerfile.release"
+};
+let container = builder.add_dockerfile(
+    "mycontainer",
+    "relative/context/path",
+    Some(dockerfile_path),
+    None,
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 ## Customize existing container resources
@@ -98,7 +188,14 @@ When using `AddDockerfile` the return value is an `IResourceBuilder<ContainerRes
 
 Using the `WithDockerfile` extension method it's possible to take an existing Aspire component (like PostgreSQL, Redis, or SQL Server) and replace its default container image with a custom one built from your own Dockerfile. This allows you to continue using the strongly typed resource types and their specific extension methods while customizing the underlying container.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not include the PostgreSQL integration APIs used by this WithDockerfile example.',
+    go: 'The generated Go SDK does not include the PostgreSQL integration APIs used by this WithDockerfile example.',
+    java: 'The generated Java SDK does not include the PostgreSQL integration APIs used by this WithDockerfile example.',
+    rust: 'The generated Rust SDK does not include the PostgreSQL integration APIs used by this WithDockerfile example.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -197,6 +294,26 @@ await builder.addDockerfileBuilder("frontend", "../frontend", configureDockerfil
 await builder.build().run();
 ```
 </Fragment>
+<Fragment slot="python">
+
+The generated Python SDK exposes this operation as `builder.add_dockerfile_builder(name, context_path, callback, stage="runtime")`, with a typed `DockerfileBuilderCallbackContext`.
+
+</Fragment>
+<Fragment slot="go">
+
+The generated Go SDK exposes this operation as `builder.AddDockerfileBuilder(name, contextPath, callback, &aspire.AddDockerfileBuilderOptions{Stage: aspire.StringPtr("runtime")})`.
+
+</Fragment>
+<Fragment slot="java">
+
+The generated Java SDK exposes this operation as `builder.addDockerfileBuilder(name, contextPath, callback, "runtime")`.
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust SDK includes `add_dockerfile_builder`, but its callback is emitted as `Fn(Vec<Value>) -> Value` rather than a typed `DockerfileBuilderCallbackContext`, so the fluent builder example isn't type-safe in Rust.
+
+</Fragment>
 </AppHostTabs>
 
 `WithDockerfileBuilder` applies a generated Dockerfile to an existing container resource. The image name provided when the resource is created is replaced by the generated Dockerfile build during publish:
@@ -246,6 +363,26 @@ await builder
 
 await builder.build().run();
 ```
+</Fragment>
+<Fragment slot="python">
+
+Use `container.with_dockerfile_builder("../frontend", callback, stage="runtime")`. The callback receives a typed `DockerfileBuilderCallbackContext`.
+
+</Fragment>
+<Fragment slot="go">
+
+Use `container.WithDockerfileBuilder("../frontend", callback, &aspire.WithDockerfileBuilderOptions{Stage: aspire.StringPtr("runtime")})`.
+
+</Fragment>
+<Fragment slot="java">
+
+Use `container.withDockerfileBuilder("../frontend", callback, "runtime")`.
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust SDK includes `with_dockerfile_builder`, but its callback is emitted as `Fn(Vec<Value>) -> Value` rather than a typed `DockerfileBuilderCallbackContext`.
+
 </Fragment>
 </AppHostTabs>
 
@@ -300,6 +437,26 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+Use `builder.add_dockerfile_factory("myapp", "../myapp", callback)`. The Python callback receives `DockerfileFactoryContext` and returns the Dockerfile text as `str`.
+
+</Fragment>
+<Fragment slot="go">
+
+Use `builder.AddDockerfileFactory("myapp", "../myapp", callback)`. The Go callback has the signature `func(aspire.DockerfileFactoryContext) string`.
+
+</Fragment>
+<Fragment slot="java">
+
+Use `builder.addDockerfileFactory("myapp", "../myapp", callback)`. The Java callback receives `DockerfileFactoryContext` and returns `String`.
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust SDK includes `add_dockerfile_factory`, but its callback is emitted as `Fn(Vec<Value>) -> Value` rather than a typed context returning `String`.
+
+</Fragment>
 </AppHostTabs>
 
 `WithDockerfileFactory` applies a factory-generated Dockerfile to an existing container resource:
@@ -342,6 +499,18 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+Use `container.with_dockerfile_factory("../myapp", callback)`. The callback receives `DockerfileFactoryContext` and returns the Dockerfile text as `str`.
+</Fragment>
+<Fragment slot="go">
+Use `container.WithDockerfileFactory("../myapp", callback)`. The callback has the signature `func(aspire.DockerfileFactoryContext) string`.
+</Fragment>
+<Fragment slot="java">
+Use `container.withDockerfileFactory("../myapp", callback)`. The callback receives `DockerfileFactoryContext` and returns `String`.
+</Fragment>
+<Fragment slot="rust">
+The generated Rust SDK includes `with_dockerfile_factory`, but its callback is emitted as `Fn(Vec<Value>) -> Value` rather than a typed context returning `String`.
+</Fragment>
 </AppHostTabs>
 
 ## Pass build arguments
@@ -367,11 +536,51 @@ const container = await builder.addDockerfile("mygoapp", "relative/context/path"
 await container.withBuildArg("GO_VERSION", "1.22");
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+container = builder.add_dockerfile(
+    "mygoapp", "relative/context/path"
+)
+container.with_build_arg("GO_VERSION", "1.22")
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+container := builder.
+	AddDockerfile("mygoapp", "relative/context/path").
+	WithBuildArg("GO_VERSION", "1.22")
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var container = builder.addDockerfile(
+    "mygoapp", "relative/context/path");
+container.withBuildArg("GO_VERSION", "1.22");
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let container = builder.add_dockerfile(
+    "mygoapp",
+    "relative/context/path",
+    None,
+    None,
+)?;
+container.with_build_arg(
+    "GO_VERSION",
+    serde_json::json!("1.22"),
+)?;
+```
+</Fragment>
 </AppHostTabs>
 
 The value parameter on the `WithBuildArg` method can be a literal value (`boolean`, `string`, `int`) or it can be a resource builder for a [parameter resource](/fundamentals/external-parameters/). The following code replaces the `GO_VERSION` with a parameter value that can be specified at deployment time.
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK accepts an untyped Value for with_build_arg but does not provide a public conversion from ParameterResource to that Value.',
+  }}
+>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -392,6 +601,31 @@ const goVersion = await builder.addParameter("goversion");
 
 const container = await builder.addDockerfile("mygoapp", "relative/context/path");
 await container.withBuildArg("GO_VERSION", goVersion);
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+go_version = builder.add_parameter("goversion")
+container = builder.add_dockerfile(
+    "mygoapp", "relative/context/path"
+)
+container.with_build_arg("GO_VERSION", go_version)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+goVersion := builder.AddParameter("goversion")
+container := builder.
+	AddDockerfile("mygoapp", "relative/context/path").
+	WithBuildArg("GO_VERSION", goVersion)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var goVersion = builder.addParameter("goversion");
+var container = builder.addDockerfile(
+    "mygoapp", "relative/context/path");
+container.withBuildArg("GO_VERSION", goVersion);
 ```
 </Fragment>
 </AppHostTabs>
@@ -444,6 +678,55 @@ const accessToken = await builder.addParameter("accesstoken", { secret: true });
 
 const container = await builder.addDockerfile("myapp", "relative/context/path");
 await container.withBuildSecret("ACCESS_TOKEN", accessToken);
+```
+</Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+access_token = builder.add_parameter(
+    "accesstoken", secret=True
+)
+container = builder.add_dockerfile(
+    "myapp", "relative/context/path"
+)
+container.with_build_secret("ACCESS_TOKEN", access_token)
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+accessToken := builder.AddParameter(
+	"accesstoken",
+	&aspire.AddParameterOptions{Secret: aspire.BoolPtr(true)},
+)
+container := builder.
+	AddDockerfile("myapp", "relative/context/path").
+	WithBuildSecret("ACCESS_TOKEN", accessToken)
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+var accessToken = builder.addParameter(
+    "accesstoken",
+    new AddParameterOptions().secret(true));
+var container = builder.addDockerfile(
+    "myapp", "relative/context/path");
+container.withBuildSecret("ACCESS_TOKEN", accessToken);
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let access_token = builder.add_parameter(
+    "accesstoken",
+    None,
+    None,
+    Some(true),
+)?;
+let container = builder.add_dockerfile(
+    "myapp",
+    "relative/context/path",
+    None,
+    None,
+)?;
+container.with_build_secret("ACCESS_TOKEN", &access_token)?;
 ```
 </Fragment>
 </AppHostTabs>

--- a/src/frontend/src/content/docs/architecture/resource-api-patterns.mdx
+++ b/src/frontend/src/content/docs/architecture/resource-api-patterns.mdx
@@ -33,7 +33,14 @@ An `AddX(...)` method executes:
 
 ### Signature pattern
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK exposes resource-creation methods, but not the .NET extension-method authoring pattern shown here.',
+    go: 'The generated Go SDK exposes resource-creation methods, but not the .NET extension-method authoring pattern shown here.',
+    java: 'The generated Java SDK exposes resource-creation methods, but not the .NET extension-method authoring pattern shown here.',
+    rust: 'The generated Rust SDK exposes resource-creation methods, but not the .NET extension-method authoring pattern shown here.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -90,7 +97,55 @@ const resource = await builder.addRedis("name" /*, optional params */);
 <Fragment slot="typescript">
 
 ```typescript
-resource.withEndpoint({ port: hostPort, targetPort: containerPort, name: endpointName });
+await resource.withEndpoint({ port: hostPort, targetPort: containerPort, name: endpointName });
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_endpoint(
+    port=host_port,
+    target_port=container_port,
+    name=endpoint_name,
+)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithEndpoint(&aspire.WithEndpointOptions{
+	Port:       aspire.Float64Ptr(float64(hostPort)),
+	TargetPort: aspire.Float64Ptr(float64(containerPort)),
+	Name:       aspire.StringPtr(endpointName),
+})
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
+resource.withEndpoint(new WithEndpointOptions()
+    .port(hostPort)
+    .targetPort(containerPort)
+    .name(endpointName));
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust
+resource.with_endpoint(
+    Some(host_port),
+    Some(container_port),
+    None,
+    Some(endpoint_name),
+    None,
+    None,
+    None,
+    None,
+)?;
 ```
 
 </Fragment>
@@ -109,7 +164,35 @@ resource.withEndpoint({ port: hostPort, targetPort: containerPort, name: endpoin
 <Fragment slot="typescript">
 
 ```typescript
+await resource.withHealthCheck(healthCheckKey);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_health_check(health_check_key)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithHealthCheck(healthCheckKey)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
 resource.withHealthCheck(healthCheckKey);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust
+resource.with_health_check(health_check_key)?;
 ```
 
 </Fragment>
@@ -129,8 +212,43 @@ resource.withHealthCheck(healthCheckKey);
 <Fragment slot="typescript">
 
 ```typescript
+await resource.withImage(imageName, { tag: imageTag });
+await resource.withImageRegistry(registryUrl);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_image(image_name, tag=image_tag)
+resource.with_image_registry(registry_url)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithImage(
+	imageName,
+	&aspire.WithImageOptions{Tag: aspire.StringPtr(imageTag)},
+)
+resource.WithImageRegistry(registryURL)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
 resource.withImage(imageName, imageTag);
 resource.withImageRegistry(registryUrl);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust
+resource.with_image(image_name, Some(image_tag))?;
+resource.with_image_registry(registry_url)?;
 ```
 
 </Fragment>
@@ -150,8 +268,40 @@ resource.withImageRegistry(registryUrl);
 <Fragment slot="typescript">
 
 ```typescript
+await resource.withEntrypoint("/bin/sh");
+await resource.withArgs(["--flag", "value"]);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_entrypoint("/bin/sh")
+resource.with_args(["--flag", "value"])
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithEntrypoint("/bin/sh")
+resource.WithArgs([]string{"--flag", "value"})
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
 resource.withEntrypoint("/bin/sh");
-resource.withArgs(["--flag", "value"]);
+resource.withArgs(new String[] { "--flag", "value" });
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust
+resource.with_entrypoint("/bin/sh")?;
+resource.with_args(vec!["--flag".to_string(), "value".to_string()])?;
 ```
 
 </Fragment>
@@ -159,7 +309,11 @@ resource.withArgs(["--flag", "value"]);
 
 **Environment variables**:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK accepts only serde_json::Value for with_environment, so it cannot pass an arbitrary typed value provider directly.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -170,6 +324,27 @@ resource.withArgs(["--flag", "value"]);
 <Fragment slot="typescript">
 
 ```typescript
+await resource.withEnvironment("ENV_VAR", value);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_env("ENV_VAR", value)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithEnvironment("ENV_VAR", value)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
 resource.withEnvironment("ENV_VAR", value);
 ```
 
@@ -178,7 +353,11 @@ resource.withEnvironment("ENV_VAR", value);
 
 **Event subscriptions**:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust event callbacks use Vec<Value> -> Value rather than typed event contexts, so this typed event-handling pattern cannot be expressed safely.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -189,8 +368,42 @@ builder.Eventing.Subscribe<EventType>(resource, handler);
 <Fragment slot="typescript">
 
 ```typescript
-builder.addEventingSubscriber(async (context) => {
+await builder.addEventingSubscriber(async (context) => {
     context.onBeforeStart(async (event) => {
+        // Handle event
+    });
+});
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+def subscribe(context):
+    context.on_before_start(lambda event: None)
+
+builder.add_eventing_subscriber(subscribe)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+if err := builder.AddEventingSubscriber(func(context aspire.EventingSubscriberRegistrationContext) {
+	context.OnBeforeStart(func(event aspire.BeforeStartEvent) {
+		// Handle event
+	})
+}); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
+builder.addEventingSubscriber(context -> {
+    context.onBeforeStart(event -> {
         // Handle event
     });
 });
@@ -214,7 +427,14 @@ builder.addEventingSubscriber(async (context) => {
 
 ### Signature pattern
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose custom annotation types or a public annotation-attachment API.',
+    go: 'The generated Go SDK does not expose custom annotation types or a public annotation-attachment API.',
+    java: 'The generated Java SDK does not expose custom annotation types or a public annotation-attachment API.',
+    rust: 'The generated Rust SDK does not expose custom annotation types or a public annotation-attachment API.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -251,7 +471,14 @@ Annotations are **public** metadata types implementing `IResourceAnnotation`. Th
 
 ### Definition and attachment
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose custom annotation types or a public annotation-attachment API.',
+    go: 'The generated Go SDK does not expose custom annotation types or a public annotation-attachment API.',
+    java: 'The generated Java SDK does not expose custom annotation types or a public annotation-attachment API.',
+    rust: 'The generated Rust SDK does not expose custom annotation types or a public annotation-attachment API.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -301,7 +528,11 @@ Custom value objects defer evaluation and allow the framework to discover depend
 
 ### Attaching to resources
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust SDK accepts only serde_json::Value for with_environment, so it cannot pass a typed resource or value-provider handle directly.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp
@@ -313,13 +544,41 @@ builder.WithEnvironment(context =>
 <Fragment slot="typescript">
 
 ```typescript
+await resource.withEnvironment("REDIS_CONNECTION_STRING", redis);
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python
+resource.with_env("REDIS_CONNECTION_STRING", redis)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go
+resource.WithEnvironment("REDIS_CONNECTION_STRING", redis)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java
 resource.withEnvironment("REDIS_CONNECTION_STRING", redis);
 ```
 
 </Fragment>
 </AppHostTabs>
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK exposes BicepOutputReference as a handle-backed type, but does not support implementing custom value-provider types.',
+    go: 'The generated Go SDK exposes BicepOutputReference as a handle-backed type, but does not support implementing custom value-provider types.',
+    java: 'The generated Java SDK exposes BicepOutputReference as a handle-backed type, but does not support implementing custom value-provider types.',
+    rust: 'The generated Rust SDK exposes BicepOutputReference as a handle-backed type, but does not support implementing custom value-provider types.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="Example: BicepOutputReference"
@@ -344,7 +603,14 @@ In the TypeScript SDK, `BicepOutputReference` and the value provider interfaces 
 </Fragment>
 </AppHostTabs>
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python SDK does not expose .NET extension-method overloads or EnvironmentVariableAnnotation construction.',
+    go: 'The generated Go SDK does not expose .NET extension-method overloads or EnvironmentVariableAnnotation construction.',
+    java: 'The generated Java SDK does not expose .NET extension-method overloads or EnvironmentVariableAnnotation construction.',
+    rust: 'The generated Rust SDK does not expose .NET extension-method overloads or EnvironmentVariableAnnotation construction.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp

--- a/src/frontend/src/content/docs/architecture/resource-hierarchies.mdx
+++ b/src/frontend/src/content/docs/architecture/resource-hierarchies.mdx
@@ -70,6 +70,17 @@ In Aspire, configuration, connectivity details, and dependencies between distrib
 
 Aspire represents these relationships through a **heterogeneous Directed Acyclic Graph (<abbr title="Directed Acyclic Graph" data-tooltip-placement="top">DAG</abbr>)**. This graph tracks not only dependency ordering but also how **structured values** are passed between resources at multiple abstraction levels: configuration, connection, and runtime behavior.
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK in the verified core scenario does not include both addPostgres and addNpmApp.',
+    python: 'The generated Python SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+    go: 'The generated Go SDK in the verified core scenario does not include AddPostgres or AddNpmApp.',
+    java: 'The generated Java SDK in the verified core scenario does not include addPostgres or addNpmApp.',
+    rust: 'The generated Rust SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -79,6 +90,9 @@ var web = builder.AddNpmApp("web").WithReference(api);
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ```mermaid
 architecture-beta
@@ -193,6 +207,15 @@ Aspire evaluates the model in **two distinct modes**:
 
 **Example — Using `ReferenceExpression`:**
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript uses createReferenceExpression with generated resource values rather than the C# ReferenceExpression.Create API shown here.',
+  python: 'The Python SDK does not expose the C# ReferenceExpression.Create interpolation API.',
+  go: 'The Go SDK does not expose the C# ReferenceExpression.Create interpolation API.',
+  java: 'The Java SDK does not expose the C# ReferenceExpression.Create interpolation API.',
+  rust: 'The Rust SDK does not expose the C# ReferenceExpression.Create interpolation API.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var ep = api.GetEndpoint("http");
 
@@ -202,6 +225,9 @@ builder.WithEnvironment("HEALTH_URL",
     )
 );
 ```
+
+</Fragment>
+</AppHostTabs>
 
 _Publish manifest excerpt:_
 
@@ -222,6 +248,15 @@ HEALTH_URL=https://localhost:5000/health
 
 ### Alternate pattern using `ExecutionContext`
 
+<AppHostTabs limitations={{
+  typescript: 'TypeScript exposes execution-context mode checks, but this C# fallback uses ReferenceExpression.Create and direct interpolation shapes that are not projected identically.',
+  python: 'Python exposes an execution-context mode property, but not the C# ReferenceExpression.Create fallback shown here.',
+  go: 'Go exposes execution-context mode checks, but not the C# ReferenceExpression.Create fallback shown here.',
+  java: 'Java exposes execution-context mode checks, but not the C# ReferenceExpression.Create fallback shown here.',
+  rust: 'Rust exposes execution-context mode checks, but not the C# ReferenceExpression.Create fallback shown here.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var ep = api.GetEndpoint("http");
 
@@ -236,6 +271,9 @@ else
         ReferenceExpression.Create($"{ep}/health")); // structured
 }
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ### Pattern used by `IResourceWithConnectionString`
 
@@ -279,6 +317,9 @@ These properties are dynamically resolved during the application's startup seque
 
 Resources supporting endpoints should implement `IResourceWithEndpoints`, enabling the use of `GetEndpoint(name)` to retrieve an `EndpointReference`. This is implemented on the built-in `ProjectResource`, `ContainerResource` and `ExecutableResource`. It allows endpoints to be programmatically accessed and passed between resources.
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="Example — Endpoint Access and Resolution"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -290,6 +331,135 @@ var endpoint = redis.GetEndpoint("tcp");
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const redis = await builder.addContainer('redis', 'redis');
+await redis.withEndpoint({ name: 'tcp', targetPort: 6379 });
+
+const endpoint = await redis.getEndpoint('tcp');
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_container("redis", "redis")
+    redis.with_endpoint(name="tcp", target_port=6379)
+
+    endpoint = redis.get_endpoint("tcp")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.
+		AddContainer("redis", "redis").
+		WithEndpoint(&aspire.WithEndpointOptions{
+			Name:       aspire.StringPtr("tcp"),
+			TargetPort: aspire.Float64Ptr(6379),
+		})
+	if err := redis.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	endpoint := redis.GetEndpoint("tcp")
+	if err := endpoint.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var redis = builder.addContainer("redis", "redis");
+    redis.withEndpoint(new WithEndpointOptions()
+        .name("tcp")
+        .targetPort(6379));
+
+    var endpoint = redis.getEndpoint("tcp");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let redis = builder.add_container("redis", serde_json::json!("redis"))?;
+    redis.with_endpoint(
+        None,
+        Some(6379.0),
+        None,
+        Some("tcp"),
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    let endpoint = redis.get_endpoint("tcp")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ### What does "allocated" mean?
 
@@ -310,6 +480,17 @@ Use the `IsAllocated` property on an `EndpointReference` to check whether an end
 ### Accessing Allocated Endpoints Safely
 
 Endpoint resolution happens during the startup sequence of the `DistributedApplication`. To safely access endpoint values (e.g., `Url`, `Host`, `Port`), you must wait until endpoints are allocated. Aspire provides eventing APIs, such as `AfterEndpointsAllocatedEvent`, to access endpoints after allocation. These APIs ensure code executes only when endpoints are ready.
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not emit AfterEndpointsAllocatedEvent subscriptions.',
+    python: 'The generated Python SDK does not emit AfterEndpointsAllocatedEvent subscriptions.',
+    go: 'The generated Go SDK does not emit AfterEndpointsAllocatedEvent subscriptions.',
+    java: 'The generated Java SDK does not emit AfterEndpointsAllocatedEvent subscriptions.',
+    rust: 'The generated Rust SDK does not emit AfterEndpointsAllocatedEvent subscriptions.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="Example — Checking Allocation and Using Eventing"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -346,6 +527,9 @@ builder.Eventing.Subscribe<AfterEndpointsAllocatedEvent>(
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 The preceding code will output different results depending on whether the application is running in **run mode** or **publish mode**:
 
 **Run Mode**:
@@ -375,6 +559,13 @@ This section covers how to reference endpoints from other resources in Aspire, a
 
 The `WithReference` API allows you to pass an endpoint reference directly to a target resource.
 
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust with_reference method accepts serde_json::Value and does not provide a typed EndpointReference overload.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -387,11 +578,119 @@ builder.AddProject<Projects.Worker>("worker")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const redis = await builder.addContainer('redis', 'redis');
+await redis.withEndpoint({ name: 'tcp', targetPort: 6379 });
+
+await builder
+  .addProject('worker', '../Worker/Worker.csproj')
+  .withReference(await redis.getEndpoint('tcp'));
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_container("redis", "redis")
+    redis.with_endpoint(name="tcp", target_port=6379)
+
+    worker = builder.add_project("worker", "../Worker/Worker.csproj")
+    worker.with_reference(redis.get_endpoint("tcp"))
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.
+		AddContainer("redis", "redis").
+		WithEndpoint(&aspire.WithEndpointOptions{
+			Name:       aspire.StringPtr("tcp"),
+			TargetPort: aspire.Float64Ptr(6379),
+		})
+
+	worker := builder.
+		AddProject("worker", "../Worker/Worker.csproj").
+		WithReference(redis.GetEndpoint("tcp"))
+
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var redis = builder.addContainer("redis", "redis");
+    redis.withEndpoint(new WithEndpointOptions()
+        .name("tcp")
+        .targetPort(6379));
+
+    builder.addProject("worker", "../Worker/Worker.csproj")
+        .withReference(redis.getEndpoint("tcp"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 `WithReference` is optimized for applications that use service discovery.
 
 ### Using `WithEnvironment`
 
 The `WithEnvironment` API exposes endpoint details as environment variables, enabling runtime configuration.
+
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust with_environment method accepts serde_json::Value and does not provide a typed EndpointReference overload.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="Example — Passing Redis Endpoint as Environment Variable"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -405,6 +704,107 @@ builder.AddProject<Worker>("worker")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const redis = await builder.addContainer('redis', 'redis');
+await redis.withEndpoint({ name: 'tcp', targetPort: 6379 });
+
+await builder
+  .addProject('worker', '../Worker/Worker.csproj')
+  .withEnvironment('RedisUrl', await redis.getEndpoint('tcp'));
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_container("redis", "redis")
+    redis.with_endpoint(name="tcp", target_port=6379)
+
+    worker = builder.add_project("worker", "../Worker/Worker.csproj")
+    worker.with_env("RedisUrl", redis.get_endpoint("tcp"))
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.
+		AddContainer("redis", "redis").
+		WithEndpoint(&aspire.WithEndpointOptions{
+			Name:       aspire.StringPtr("tcp"),
+			TargetPort: aspire.Float64Ptr(6379),
+		})
+
+	worker := builder.
+		AddProject("worker", "../Worker/Worker.csproj").
+		WithEnvironment("RedisUrl", redis.GetEndpoint("tcp"))
+
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var redis = builder.addContainer("redis", "redis");
+    redis.withEndpoint(new WithEndpointOptions()
+        .name("tcp")
+        .targetPort(6379));
+
+    builder.addProject("worker", "../Worker/Worker.csproj")
+        .withEnvironment("RedisUrl", redis.getEndpoint("tcp"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 `WithEnvironment` gives full control over the configuration names injected into the target resource.
 
 ## `EndpointReferenceExpression` — Accessing Endpoint Parts
@@ -417,7 +817,11 @@ In C#, call `endpoint.Property(...)` to get that field. In TypeScript AppHosts, 
 | Only one part (e.g., host)              | C#: `endpoint.Property(EndpointProperty.Host)`<br />TypeScript: `await endpoint.property(EndpointProperty.Host)` |
 | Compose multiple parts into one setting | Build a `ReferenceExpression` (see dedicated section).                                                           |
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    rust: 'The generated Rust with_environment method accepts serde_json::Value and does not provide a typed EndpointReferenceExpression overload.',
+  }}
+>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -454,6 +858,66 @@ await builder
   .withEnvironment('REDIS_PORT', redisPort);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_container("redis", "redis")
+    redis.with_endpoint(name="tcp", target_port=6379)
+
+    endpoint = redis.get_endpoint("tcp")
+    redis_host = endpoint.property("Host")
+    redis_port = endpoint.property("Port")
+
+    worker = builder.add_project("worker", "../Worker/Worker.csproj")
+    worker.with_env("REDIS_HOST", redis_host)
+    worker.with_env("REDIS_PORT", redis_port)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+redis := builder.
+	AddContainer("redis", "redis").
+	WithEndpoint(&aspire.WithEndpointOptions{
+		Name:       aspire.StringPtr("tcp"),
+		TargetPort: aspire.Float64Ptr(6379),
+	})
+
+endpoint := redis.GetEndpoint("tcp")
+redisHost := endpoint.Property(aspire.EndpointPropertyHost)
+redisPort := endpoint.Property(aspire.EndpointPropertyPort)
+
+worker := builder.
+	AddProject("worker", "../Worker/Worker.csproj").
+	WithEnvironment("REDIS_HOST", redisHost).
+	WithEnvironment("REDIS_PORT", redisPort)
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var redis = builder.addContainer("redis", "redis");
+redis.withEndpoint(new WithEndpointOptions()
+    .name("tcp")
+    .targetPort(6379));
+
+var endpoint = redis.getEndpoint("tcp");
+var redisHost = endpoint.property(EndpointProperty.HOST);
+var redisPort = endpoint.property(EndpointProperty.PORT);
+
+builder.addProject("worker", "../Worker/Worker.csproj")
+    .withEnvironment("REDIS_HOST", redisHost)
+    .withEnvironment("REDIS_PORT", redisPort);
 ```
 
 </Fragment>
@@ -521,6 +985,17 @@ Starting with Aspire 13.2, you can explicitly control endpoint resolution contex
 
 Use the `Caller` property to resolve an endpoint from the perspective of a specific calling resource:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not expose ValueProviderContext or a caller-aware endpoint value overload.',
+    python: 'The generated Python SDK does not expose ValueProviderContext or a caller-aware endpoint value overload.',
+    go: 'The generated Go SDK does not expose ValueProviderContext or a caller-aware endpoint value overload.',
+    java: 'The generated Java SDK does not expose ValueProviderContext or a caller-aware endpoint value overload.',
+    rust: 'The generated Rust SDK does not expose ValueProviderContext or a caller-aware endpoint value overload.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="Resolve endpoint from a resource's perspective"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -539,11 +1014,25 @@ var url = await endpoint.GetValueAsync(new ValueProviderContext {
 // e.g., "cache:6379" using the resource name as the hostname
 ```
 
+</Fragment>
+</AppHostTabs>
+
 This is particularly useful when you need to pass connection information between resources that may be running in different contexts (containers vs. host processes).
 
 #### Resolve from a specific network
 
 Use the `Network` property to resolve an endpoint from the perspective of a specific network:
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not expose ValueProviderContext, KnownNetworkIdentifiers, or a network-aware endpoint value overload.',
+    python: 'The generated Python SDK does not expose ValueProviderContext, KnownNetworkIdentifiers, or a network-aware endpoint value overload.',
+    go: 'The generated Go SDK does not expose ValueProviderContext, KnownNetworkIdentifiers, or a network-aware endpoint value overload.',
+    java: 'The generated Java SDK does not expose ValueProviderContext, KnownNetworkIdentifiers, or a network-aware endpoint value overload.',
+    rust: 'The generated Rust SDK does not expose ValueProviderContext, KnownNetworkIdentifiers, or a network-aware endpoint value overload.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="Resolve endpoint from a network's perspective"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -561,6 +1050,9 @@ var url = await endpoint.GetValueAsync(new ValueProviderContext {
 // The URL will be appropriate for the container network
 // e.g., "cache:6379" using the resource name as the hostname
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The `KnownNetworkIdentifiers` class provides predefined network identifiers:
 
@@ -580,6 +1072,17 @@ The `KnownNetworkIdentifiers` class provides predefined network identifiers:
 The following code demonstrates how to set environment variables for a project that needs to communicate with other resources like Grafana and Keycloak. It ensures that the URLs are correctly resolved based on the execution context (run mode vs. publish mode).
 
 With Aspire 13.2, you can simplify this using `ValueProviderContext`:
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not expose ValueProviderContext, and the tested core module does not include addKeycloak.',
+    python: 'The generated Python SDK does not expose ValueProviderContext, and the tested core module does not include add_keycloak.',
+    go: 'The generated Go SDK does not expose ValueProviderContext, and the tested core module does not include AddKeycloak.',
+    java: 'The generated Java SDK does not expose ValueProviderContext, and the tested core module does not include addKeycloak.',
+    rust: 'The generated Rust SDK does not expose ValueProviderContext, and the tested core module does not include add_keycloak.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="Simplified with ValueProviderContext (Aspire 13.2+)"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -615,7 +1118,21 @@ var api = builder.AddProject<Projects.Api>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 **Before Aspire 13.2**, you would need to manually construct the URL:
+
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not expose the endpoint callback context used by this legacy C# URL-construction pattern, and the tested core module does not include addKeycloak.',
+    python: 'The generated Python SDK does not expose the endpoint callback context used by this legacy C# URL-construction pattern, and the tested core module does not include add_keycloak.',
+    go: 'The generated Go SDK does not expose the endpoint callback context used by this legacy C# URL-construction pattern, and the tested core module does not include AddKeycloak.',
+    java: 'The generated Java SDK does not expose the endpoint callback context used by this legacy C# URL-construction pattern, and the tested core module does not include addKeycloak.',
+    rust: 'The generated Rust SDK does not expose a typed endpoint callback context for this legacy C# URL-construction pattern, and the tested core module does not include add_keycloak.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="Manual URL construction (pre-13.2)"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -651,3 +1168,6 @@ var api = builder.AddProject<Projects.Api>("api")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>

--- a/src/frontend/src/content/docs/architecture/resource-model.mdx
+++ b/src/frontend/src/content/docs/architecture/resource-model.mdx
@@ -5,6 +5,7 @@ description: "Learn how Aspire's resource model represents distributed apps as a
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 
 Aspire's AppHost represents a collection of resources, known as the "resource model". This model allows developers to define and manage the various components and services that make up their applications, providing a unified way to interact with these resources throughout the development lifecycle.
@@ -15,6 +16,17 @@ The resource model is a **directed acyclic graph (<abbr title="Directed Acyclic 
 
 A quick example that shows the basic usage:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK in the verified core scenario does not include both addPostgres and addNpmApp.',
+    python: 'The generated Python SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+    go: 'The generated Go SDK in the verified core scenario does not include AddPostgres or AddNpmApp.',
+    java: 'The generated Java SDK in the verified core scenario does not include addPostgres or addNpmApp.',
+    rust: 'The generated Rust SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -24,6 +36,9 @@ var web = builder.AddNpmApp("web", "../web").WithReference(api);
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding `AppHost` code defines an architecture with three resources:
 
@@ -51,7 +66,7 @@ architecture-beta
 </Steps>
 
 <LearnMore>
-Prefer writing your AppHost in TypeScript? Start with [Build your first Aspire app](/get-started/first-app/?lang=typescript).
+Prefer writing your AppHost in TypeScript? Start with [Build your first Aspire app](/get-started/first-app/?aspire-lang=typescript).
 </LearnMore>
 
 ## Resource basics
@@ -103,6 +118,17 @@ This pattern improves the developer experience by:
 
 To continue from the previous example, here's how you can add resources and wire them together in the `AppHost`:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK in the verified core scenario does not include both addPostgres and addNpmApp.',
+    python: 'The generated Python SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+    go: 'The generated Go SDK in the verified core scenario does not include AddPostgres or AddNpmApp.',
+    java: 'The generated Java SDK in the verified core scenario does not include addPostgres or addNpmApp.',
+    rust: 'The generated Rust SDK in the verified core scenario does not include add_postgres or add_npm_app.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp '.WithReference' title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -112,6 +138,9 @@ var web = builder.AddNpmApp("web", "../web").WithReference(api);
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding example:
 

--- a/src/frontend/src/content/docs/dashboard/enable-browser-telemetry/blazor-webassembly.mdx
+++ b/src/frontend/src/content/docs/dashboard/enable-browser-telemetry/blazor-webassembly.mdx
@@ -5,8 +5,6 @@ description: Enable browser telemetry for Blazor WebAssembly apps with Aspire's 
 
 import AppHostTabs from '@components/AppHostTabs.astro';
 
-
-
 Blazor WebAssembly apps run .NET in the browser, so they need a startup path that makes telemetry configuration available before the WebAssembly runtime starts. Starting with Aspire 13.4, you can use the Aspire Blazor hosting integration instead of configuring a Blazor WebAssembly app like a generic JavaScript browser app that sends OTLP directly to the dashboard.
 
 The Blazor hosting integration configures same-origin gateway or host routes for service calls and OTLP telemetry. The browser sends telemetry to a relative `/_otlp` path, or the app-prefixed equivalent such as `/app/_otlp`, and the gateway or host forwards it to the Aspire dashboard. This avoids CORS setup for the dashboard and keeps dashboard OTLP headers on the server-side proxy instead of putting them in browser-visible configuration.
@@ -15,7 +13,12 @@ The Blazor hosting integration configures same-origin gateway or host routes for
 
 For a standalone Blazor WebAssembly project, add the WASM project resource, reference any backend services from it, and bind it to a Blazor Gateway. Configure the gateway with HTTP/protobuf OTLP export because browser-based clients can't use OTLP/gRPC.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Blazor WebAssembly project, Blazor Gateway, OTLP exporter, or Blazor client attachment APIs.',
+  go: 'The generated Go SDK does not export Blazor WebAssembly project, Blazor Gateway, OTLP exporter, or Blazor client attachment APIs.',
+  java: 'The generated Java SDK does not export Blazor WebAssembly project, Blazor Gateway, OTLP exporter, or Blazor client attachment APIs.',
+  rust: 'The generated Rust SDK does not export Blazor WebAssembly project, Blazor Gateway, OTLP exporter, or Blazor client attachment APIs.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -72,6 +75,17 @@ The gateway exposes browser-safe configuration under the app path, such as `/app
 
 For a Blazor Web App that hosts an Interactive WebAssembly client, configure the host project to proxy API calls and telemetry for the WebAssembly client:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript SDK does not export ProxyBlazorService or ProxyBlazorTelemetry for hosted Blazor WebAssembly projects.',
+    python: 'The generated Python SDK does not export ProxyBlazorService or ProxyBlazorTelemetry for hosted Blazor WebAssembly projects.',
+    go: 'The generated Go SDK does not export ProxyBlazorService or ProxyBlazorTelemetry for hosted Blazor WebAssembly projects.',
+    java: 'The generated Java SDK does not export ProxyBlazorService or ProxyBlazorTelemetry for hosted Blazor WebAssembly projects.',
+    rust: 'The generated Rust SDK does not export ProxyBlazorService or ProxyBlazorTelemetry for hosted Blazor WebAssembly projects.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -84,9 +98,8 @@ builder.AddProject<Projects.BlazorWeb>("blazorapp")
 builder.Build().Run();
 ```
 
-:::note
-`ProxyBlazorService` and `ProxyBlazorTelemetry` are C# AppHost APIs in Aspire 13.4. They aren't exported to TypeScript AppHosts yet.
-:::
+</Fragment>
+</AppHostTabs>
 
 The AppHost emits YARP reverse proxy configuration and a Blazor client configuration response for the host project. In the host app, load the reverse proxy configuration and map the proxy routes:
 

--- a/src/frontend/src/content/docs/dashboard/telemetry-after-deployment.mdx
+++ b/src/frontend/src/content/docs/dashboard/telemetry-after-deployment.mdx
@@ -4,6 +4,7 @@ description: Understand how telemetry and the Aspire dashboard work after you de
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 
 The Aspire dashboard is designed for local development and short-term diagnostics. It stores telemetry in memory, which means telemetry is lost when the dashboard restarts and there are built-in limits on how much data it retains. After deploying your app to a production environment, you need to configure a persistent telemetry backend.
@@ -52,6 +53,40 @@ For more information about how Aspire configures OpenTelemetry, see [Aspire tele
 
 Add the Application Insights resource to your AppHost project:
 
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Azure Application Insights integration APIs used in this example.',
+  go: 'The verified Go SDK does not include the Azure Application Insights integration APIs used in this example.',
+  java: 'The verified Java SDK does not include the Azure Application Insights integration APIs used in this example.',
+  rust: 'The verified Rust SDK does not include the Azure Application Insights integration APIs used in this example.',
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const insights = await builder.addAzureApplicationInsights('app-insights');
+
+const apiService = await builder.addProject(
+  'apiservice',
+  '../MyApp.ApiService/MyApp.ApiService.csproj'
+);
+await apiService.withReference(insights);
+
+const webFrontend = await builder.addProject(
+  'webfrontend',
+  '../MyApp.Web/MyApp.Web.csproj'
+);
+await webFrontend.withReference(insights);
+await webFrontend.withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -66,6 +101,9 @@ builder.AddProject<Projects.MyApp_Web>("webfrontend")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 When you reference Application Insights, Aspire automatically configures the `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable for each service. The `Azure.Monitor.OpenTelemetry.AspNetCore` package uses the `UseAzureMonitor()` method to read this variable and send telemetry to Application Insights.
 

--- a/src/frontend/src/content/docs/deployment/app-lifecycle.mdx
+++ b/src/frontend/src/content/docs/deployment/app-lifecycle.mdx
@@ -37,12 +37,17 @@ Each phase uses the same `AppHost` configuration, but each phase answers a diffe
 
 ### Example application
 
-The following example uses a C# AppHost, but the same workflow shape applies to TypeScript AppHosts.
+The workflow shape applies to every AppHost language. The complete Docker Compose example is currently available for C# and TypeScript because the daily Python, Go, Java, and Rust generated SDKs don't expose the required Docker Compose and SQL Server integration APIs.
 
 Consider [this example](https://github.com/BethMassi/VolumeMount/). You have a distributed application that consists of a Blazor web project that relies on a SQL Server database with a persistent data volume as well as a persistent writable file volume to capture user file uploads.
 You want to distribute your Blazor app as a Docker container image via the GitHub Container Registry. You need the [Aspire.Hosting.Docker](/integrations/compute/docker/) and [Aspire.Hosting.SqlServer](/integrations/databases/sql-server/sql-server-get-started/) integrations.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose the Docker Compose and SQL Server integration APIs required by this example.',
+  go: 'The daily Go generated SDK does not expose the Docker Compose and SQL Server integration APIs required by this example.',
+  java: 'The daily Java generated SDK does not expose the Docker Compose and SQL Server integration APIs required by this example.',
+  rust: 'The daily Rust generated SDK does not expose the Docker Compose and SQL Server integration APIs required by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -436,9 +441,9 @@ After the workflow completes, you have everything needed for production deployme
 | **Release**      | CI/CD workflow (i.e. GitHub Actions) | Publish to staging/ production | Cloud/Server                                         | Container     | Container |
 
 <Aside type="tip">
-  This example uses a C# AppHost, but the same workflow shape applies to
-  TypeScript AppHosts. Replace `.csproj` references with your `apphost.mts` path
-  as needed.
+  The lifecycle commands and CI/CD phases apply to every AppHost language. Use
+  the AppHost file and runtime setup for your selected language; the deployment
+  target must also be available in that language's generated SDK.
 </Aside>
 
 The AppHost is the **single source of truth** for your application architecture. Each phase above uses the exact same AppHost configuration. This eliminates configuration drift between development and deployment. It defines things your distributed application needs like:

--- a/src/frontend/src/content/docs/deployment/azure/app-service.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/app-service.mdx
@@ -43,7 +43,12 @@ The Aspire CLI adds the [📦 Aspire.Hosting.Azure.AppService](https://www.nuget
 
 Then add the App Service environment in your AppHost and a supported web app or API resource. App Service environments automatically target supported project resources and Dockerfile-backed web containers:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_azure_app_service_environment, so this App Service environment cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddAzureAppServiceEnvironment, so this App Service environment cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addAzureAppServiceEnvironment, so this App Service environment cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_azure_app_service_environment, so this App Service environment cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -108,7 +113,12 @@ Azure App Service redirects HTTP traffic to HTTPS at the platform level. To matc
 
 This behavior is enabled by default. If you intentionally need generated endpoint URLs and connection strings to preserve `http://`, disable the upgrade on the App Service environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the App Service environment or with_https_upgrade APIs.',
+  go: 'The generated Go SDK does not export the App Service environment or WithHttpsUpgrade APIs.',
+  java: 'The generated Java SDK does not export the App Service environment or withHttpsUpgrade APIs.',
+  rust: 'The generated Rust SDK does not export the App Service environment or with_https_upgrade APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -175,7 +185,12 @@ App Service exposes one health check path per website. If you configure multiple
 
 Use `PublishAsAzureAppServiceWebsite` when you want to customize the generated website or deployment slot. It isn't required for a standard App Service deployment.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export publish_as_azure_app_service_website or its website customization callback.',
+  go: 'The generated Go SDK does not export PublishAsAzureAppServiceWebsite or its website customization callback.',
+  java: 'The generated Java SDK does not export publishAsAzureAppServiceWebsite or its website customization callback.',
+  rust: 'The generated Rust SDK does not export publish_as_azure_app_service_website or its website customization callback.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -224,7 +239,12 @@ await builder.build().run();
 
 When you use deployment slots, production website customizations and slot customizations are configured separately.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export App Service deployment-slot configuration or publish_as_azure_app_service_website slot callbacks.',
+  go: 'The generated Go SDK does not export App Service deployment-slot configuration or PublishAsAzureAppServiceWebsite slot callbacks.',
+  java: 'The generated Java SDK does not export App Service deployment-slot configuration or publishAsAzureAppServiceWebsite slot callbacks.',
+  rust: 'The generated Rust SDK does not export App Service deployment-slot configuration or publish_as_azure_app_service_website slot callbacks.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -274,7 +294,12 @@ await builder.build().run();
 
 Azure App Service application settings accept only letters, numbers, and underscores. If a connection name contains dashes and you intentionally want to bypass App Service name validation for that website, call `SkipEnvironmentVariableNameChecks()` after `PublishAsAzureAppServiceWebsite`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export publish_as_azure_app_service_website or skip_environment_variable_name_checks.',
+  go: 'The generated Go SDK does not export PublishAsAzureAppServiceWebsite or SkipEnvironmentVariableNameChecks.',
+  java: 'The generated Java SDK does not export publishAsAzureAppServiceWebsite or skipEnvironmentVariableNameChecks.',
+  rust: 'The generated Rust SDK does not export publish_as_azure_app_service_website or skip_environment_variable_name_checks.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddProject<Projects.Api>("api")
@@ -320,7 +345,12 @@ For Azure authentication, shared Azure settings, and `Parameters__*` inputs, see
 
 The Azure App Service environment includes the Aspire Dashboard by default, so you can inspect logs, traces, metrics, and topology for the deployed compute resources after deployment. Managed Azure backing services aren't shown as dashboard resources there. If you don't want to deploy it, disable it on the environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the App Service environment or with_dashboard deployment setting.',
+  go: 'The generated Go SDK does not export the App Service environment or WithDashboard deployment setting.',
+  java: 'The generated Java SDK does not export the App Service environment or withDashboard deployment setting.',
+  rust: 'The generated Rust SDK does not export the App Service environment or with_dashboard deployment setting.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -347,7 +377,12 @@ await appServiceEnv.withDashboard(false);
 
 Enable Azure Application Insights on the App Service environment when you want Aspire to provision monitoring resources and flow the connection string into your deployed websites:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export App Service environment Application Insights configuration.',
+  go: 'The generated Go SDK does not export App Service environment Application Insights configuration.',
+  java: 'The generated Java SDK does not export App Service environment Application Insights configuration.',
+  rust: 'The generated Rust SDK does not export App Service environment Application Insights configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -380,7 +415,12 @@ await appServiceEnv.withAzureApplicationInsights();
 
 Use deployment slots when you want to deploy the websites in your environment into a staging slot before swapping into production:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export App Service deployment-slot configuration.',
+  go: 'The generated Go SDK does not export App Service deployment-slot configuration.',
+  java: 'The generated Java SDK does not export App Service deployment-slot configuration.',
+  rust: 'The generated Rust SDK does not export App Service deployment-slot configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/azure/azure-developer-cli.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/azure-developer-cli.mdx
@@ -41,7 +41,12 @@ This page does not duplicate `azd`'s full operational workflow. For install, ini
 
 The `aspire deploy` path and `azd` use different resource naming schemes by default. If you're upgrading from an existing `azd` deployment to `aspire deploy`, use `WithAzdResourceNaming()` to preserve the original naming convention. This avoids creating duplicate Azure resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Azure Container Apps environment or azd resource-naming APIs.',
+  go: 'The generated Go SDK does not export Azure Container Apps environment or azd resource-naming APIs.',
+  java: 'The generated Java SDK does not export Azure Container Apps environment or azd resource-naming APIs.',
+  rust: 'The generated Rust SDK does not export Azure Container Apps environment or azd resource-naming APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/azure/azure-security-best-practices.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/azure-security-best-practices.mdx
@@ -45,7 +45,12 @@ If you're staying on the default public model, focus on identities, secrets, RBA
 
 For Azure Container Apps, a common production pattern is to place the environment in a delegated subnet and put private endpoints for backing Azure services in a separate subnet:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Azure virtual network, delegated subnet, private endpoint, or Container Apps environment APIs.',
+  go: 'The generated Go SDK does not export Azure virtual network, delegated subnet, private endpoint, or Container Apps environment APIs.',
+  java: 'The generated Java SDK does not export Azure virtual network, delegated subnet, private endpoint, or Container Apps environment APIs.',
+  rust: 'The generated Rust SDK does not export Azure virtual network, delegated subnet, private endpoint, or Container Apps environment APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -111,7 +116,12 @@ For service-specific requirements such as Service Bus Premium tier support and A
 
 Store sensitive configuration data and secrets in Azure Key Vault instead of source control or container images:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_azure_key_vault, so this Key Vault resource and reference cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddAzureKeyVault, so this Key Vault resource and reference cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addAzureKeyVault, so this Key Vault resource and reference cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_azure_key_vault, so this Key Vault resource and reference cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -145,7 +155,12 @@ For more information, see [Aspire Azure Key Vault integration](/integrations/clo
 
 For more granular control over permissions and role assignments, attach a user-assigned managed identity to the compute resource that needs it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Azure user-assigned identity resource or attachment APIs.',
+  go: 'The generated Go SDK does not export Azure user-assigned identity resource or attachment APIs.',
+  java: 'The generated Java SDK does not export Azure user-assigned identity resource or attachment APIs.',
+  rust: 'The generated Rust SDK does not export Azure user-assigned identity resource or attachment APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -179,7 +194,12 @@ For detailed guidance, see [Aspire Azure user-assigned managed identity integrat
 
 Use the deployed Aspire Dashboard to inspect the compute resources that Aspire places in Azure Container Apps or Azure App Service, then use Application Insights and Azure Monitor alerts to detect suspicious behavior, repeated failures, or unusual traffic patterns after deployment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_azure_application_insights, so this monitoring resource cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddAzureApplicationInsights, so this monitoring resource cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addAzureApplicationInsights, so this monitoring resource cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_azure_application_insights, so this monitoring resource cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/azure/container-apps.mdx
+++ b/src/frontend/src/content/docs/deployment/azure/container-apps.mdx
@@ -44,7 +44,12 @@ Learn more about the `aspire add` command in the [reference docs](/reference/cli
 
 Then add the Azure Container Apps environment in your AppHost and a web app you want to place in that environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_azure_container_app_environment, so this deployment environment cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddAzureContainerAppEnvironment, so this deployment environment cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addAzureContainerAppEnvironment, so this deployment environment cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_azure_container_app_environment, so this deployment environment cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -120,7 +125,12 @@ Azure Container Apps uses an Envoy-based HTTP edge proxy for HTTP ingress:
 
 To match the deployed serving scheme, Aspire upgrades external HTTP endpoints in an Azure Container Apps environment to HTTPS when it generates endpoint URLs and service discovery connection strings for dependent resources. If you intentionally need generated endpoint URLs and connection strings to preserve `http://`, disable the upgrade on the environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the Container Apps environment or with_https_upgrade APIs.',
+  go: 'The generated Go SDK does not export the Container Apps environment or WithHttpsUpgrade APIs.',
+  java: 'The generated Java SDK does not export the Container Apps environment or withHttpsUpgrade APIs.',
+  rust: 'The generated Rust SDK does not export the Container Apps environment or with_https_upgrade APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -197,7 +207,12 @@ Probe traffic stays on the internal container network. If a probe is associated 
 
 Use `PublishAsAzureContainerApp` when you want to customize the generated Container App resource for a project, container, or executable. It isn't required for a standard Container Apps deployment.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export publish_as_azure_container_app or its Container App customization callback.',
+  go: 'The generated Go SDK does not export PublishAsAzureContainerApp or its Container App customization callback.',
+  java: 'The generated Java SDK does not export publishAsAzureContainerApp or its Container App customization callback.',
+  rust: 'The generated Rust SDK does not export publish_as_azure_container_app or its Container App customization callback.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -236,7 +251,12 @@ await builder.build().run();
 
 Use `ConfigureCustomDomain` when you want Aspire to configure a custom domain and managed certificate on the generated Container App.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Azure Container App publishing or custom-domain configuration APIs.',
+  go: 'The generated Go SDK does not export Azure Container App publishing or custom-domain configuration APIs.',
+  java: 'The generated Java SDK does not export Azure Container App publishing or custom-domain configuration APIs.',
+  rust: 'The generated Rust SDK does not export Azure Container App publishing or custom-domain configuration APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -295,6 +315,52 @@ const api = await builder.addProject("api", "../Api/Api.csproj", "http");
 await api.withExternalHttpEndpoints();
 ```
 </Fragment>
+<Fragment slot="python">
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj", launch_profile_or_options="http")
+    api.with_external_http_endpoints()
+    builder.run()
+```
+</Fragment>
+<Fragment slot="go">
+```go title="apphost.go"
+api := builder.AddProject("api", "../Api/Api.csproj", &aspire.AddProjectOptions{
+	LaunchProfileOrOptions: "http",
+})
+api.WithExternalHttpEndpoints()
+if err := api.Err(); err != nil {
+	log.Fatal(aspire.FormatError(err))
+}
+```
+</Fragment>
+<Fragment slot="java">
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var api = builder.addProject("api", "../Api/Api.csproj", "http");
+    api.withExternalHttpEndpoints();
+    builder.build().run();
+}
+```
+</Fragment>
+<Fragment slot="rust">
+```rust title="apphost.rs"
+let builder = create_builder(None)?;
+let api = builder.add_project(
+    "api",
+    "../Api/Api.csproj",
+    Some(serde_json::json!("http")),
+)?;
+api.with_external_http_endpoints()?;
+let app = builder.build()?;
+app.run(None)?;
+```
+</Fragment>
 </AppHostTabs>
 
 ## Optional environment settings
@@ -303,7 +369,12 @@ await api.withExternalHttpEndpoints();
 
 By default, Aspire provisions an Azure Container Registry for the environment. If you want to use a shared or explicitly named registry instead, add an Azure Container Registry resource and attach it to the environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Azure Container Registry resources or Container Apps environment registry attachment.',
+  go: 'The generated Go SDK exports a generic container registry, but not Azure Container Registry resources or Container Apps environment registry attachment.',
+  java: 'The generated Java SDK exports a generic container registry, but not Azure Container Registry resources or Container Apps environment registry attachment.',
+  rust: 'The generated Rust SDK exports a generic container registry, but not Azure Container Registry resources or Container Apps environment registry attachment.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -335,7 +406,12 @@ For more information, see [Azure Container Registry integration](/integrations/c
 
 The Azure Container Apps environment includes the Aspire Dashboard by default. It helps you inspect the compute resources deployed into that environment. Managed Azure backing services aren't shown as dashboard resources there. If you don't want to deploy it, disable it on the environment:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the Container Apps environment or with_dashboard deployment setting.',
+  go: 'The generated Go SDK does not export the Container Apps environment or WithDashboard deployment setting.',
+  java: 'The generated Java SDK does not export the Container Apps environment or withDashboard deployment setting.',
+  rust: 'The generated Rust SDK does not export the Container Apps environment or with_dashboard deployment setting.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/custom-deployments.mdx
+++ b/src/frontend/src/content/docs/deployment/custom-deployments.mdx
@@ -138,7 +138,12 @@ The preceding code:
 
 In your AppHost, you can add the `ComputeEnvironmentResource` to the application model like this:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not support defining and registering custom resource types or deployment callbacks.',
+  go: 'The daily Go generated SDK does not support defining and registering custom resource types or deployment callbacks.',
+  java: 'The daily Java generated SDK does not support defining and registering custom resource types or deployment callbacks.',
+  rust: 'The daily Rust generated SDK does not support defining and registering custom resource types or deployment callbacks.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/deploy-with-aspire.mdx
+++ b/src/frontend/src/content/docs/deployment/deploy-with-aspire.mdx
@@ -16,7 +16,12 @@ Deployment behavior doesn't live outside the AppHost. It comes from resources in
 
 ### Resources add pipeline steps
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose the Docker Compose environment capability used in this example.',
+  go: 'The daily Go generated SDK does not expose the Docker Compose environment capability used in this example.',
+  java: 'The daily Java generated SDK does not expose the Docker Compose environment capability used in this example.',
+  rust: 'The daily Rust generated SDK does not expose the Docker Compose environment capability used in this example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -92,7 +97,12 @@ Parameters are the external values the pipeline needs from outside the AppHost, 
 
 Parameters connect AppHost code to pipeline behavior. In the publish path, the target preserves that requirement in emitted artifacts so another tool or manual step can provide the value later. In the deploy path, Aspire resolves the value internally while it generates and applies the deployment.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK supports parameters and environment variables, but not the Docker Compose environment required by this pipeline example.',
+  go: 'The daily Go generated SDK supports parameters and environment variables, but not the Docker Compose environment required by this pipeline example.',
+  java: 'The daily Java generated SDK supports parameters and environment variables, but not the Docker Compose environment required by this pipeline example.',
+  rust: 'The daily Rust generated SDK supports parameters and environment variables, but not the Docker Compose environment required by this pipeline example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/docker-compose.mdx
+++ b/src/frontend/src/content/docs/deployment/docker-compose.mdx
@@ -61,7 +61,12 @@ When Podman is the active runtime, Aspire uses `podman-compose` (or the Docker C
 
 To deploy with Docker Compose, add a Docker Compose environment resource to your AppHost using `AddDockerComposeEnvironment`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose the Docker Compose environment capability.',
+  go: 'The daily Go generated SDK does not expose the Docker Compose environment capability.',
+  java: 'The daily Java generated SDK does not expose the Docker Compose environment capability.',
+  rust: 'The daily Rust generated SDK does not expose the Docker Compose environment capability.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs" {3}
 var builder = DistributedApplication.CreateBuilder(args);
@@ -227,7 +232,12 @@ Docker Compose deployments can build images from Dockerfiles that are generated 
   [`ASPIREDOCKERFILEBUILDER001`](/diagnostics/aspiredockerfilebuilder001/) when you choose to use them.
 </Aside>
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python generates Dockerfile builder APIs, but the daily SDK does not expose the Docker Compose environment required by this deployment example.',
+  go: 'Go generates Dockerfile builder APIs, but the daily SDK does not expose the Docker Compose environment required by this deployment example.',
+  java: 'Java generates Dockerfile builder APIs, but the daily SDK does not expose the Docker Compose environment required by this deployment example.',
+  rust: 'Rust generates Dockerfile builder APIs, but the daily SDK does not expose the Docker Compose environment required by this deployment example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.ApplicationModel.Docker;
@@ -305,7 +315,12 @@ The Docker hosting integration captures environment variables from your app mode
 
 For advanced scenarios, use `ConfigureEnvFile` to customize the generated `.env` file:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose environment-file customization.',
+  go: 'The daily Go generated SDK does not expose Docker Compose environment-file customization.',
+  java: 'The daily Java generated SDK does not expose Docker Compose environment-file customization.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose environment-file customization.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Docker;
@@ -350,7 +365,12 @@ This is useful when you need to add custom environment variables to the generate
 
 Use `ConfigureComposeFile` to customize the generated `docker-compose.yml` model before Aspire writes it to disk:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose file customization.',
+  go: 'The daily Go generated SDK does not expose Docker Compose file customization.',
+  java: 'The daily Java generated SDK does not expose Docker Compose file customization.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose file customization.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -394,7 +414,12 @@ await builder.build().run();
 
 To customize the generated Docker Compose service for a specific resource, use the `PublishAsDockerComposeService` method. This is optional — all resources are automatically included in the Docker Compose output. Use this method only when you need to modify the generated service definition:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose service publishing or service-model customization.',
+  go: 'The daily Go generated SDK does not expose Docker Compose service publishing or service-model customization.',
+  java: 'The daily Java generated SDK does not expose Docker Compose service publishing or service-model customization.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose service publishing or service-model customization.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -445,7 +470,12 @@ The `configure` callback receives the `DockerComposeServiceResource` and the gen
 
 Use `GetHostAddressExpression` when you need the host name that another Docker Compose service should use for an endpoint. In Docker Compose deployments, this expression resolves to the generated service name on the Compose network.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose the Docker Compose host-address expression capability.',
+  go: 'The daily Go generated SDK does not expose the Docker Compose host-address expression capability.',
+  java: 'The daily Java generated SDK does not expose the Docker Compose host-address expression capability.',
+  rust: 'The daily Rust generated SDK does not expose the Docker Compose host-address expression capability.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -499,6 +529,90 @@ const container = await builder.addContainer('mycontainer', { image: 'myimage', 
 await container.withImagePullPolicy(ImagePullPolicy.Always);
 ```
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    container = builder.add_container("mycontainer", "myimage:latest")
+    container.with_image_pull_policy("Always")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	container := builder.AddContainer("mycontainer", "myimage:latest").
+		WithImagePullPolicy(aspire.ImagePullPolicyAlways)
+	if err := container.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addContainer("mycontainer", "myimage:latest")
+        .withImagePullPolicy(ImagePullPolicy.ALWAYS);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let container =
+        builder.add_container("mycontainer", serde_json::json!("myimage:latest"))?;
+    container.with_image_pull_policy(ImagePullPolicy::Always)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 When you publish resources to a Docker Compose environment, the `ImagePullPolicy` is automatically mapped to the Docker Compose [`pull_policy`](https://docs.docker.com/reference/compose-file/services/#pull_policy) field:
@@ -524,7 +638,12 @@ When deploying containers, you can customize how container images are named, tag
 
 Use `WithRemoteImageName` and `WithRemoteImageTag` to customize the image reference:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python generates remote image naming APIs, but the daily SDK does not expose the Docker Compose publishing capability used to make this resource deployable.',
+  go: 'Go generates remote image naming APIs, but the daily SDK does not expose the Docker Compose publishing capability used to make this resource deployable.',
+  java: 'Java generates remote image naming APIs, but the daily SDK does not expose the Docker Compose publishing capability used to make this resource deployable.',
+  rust: 'Rust generates remote image naming APIs, but the daily SDK does not expose the Docker Compose publishing capability used to make this resource deployable.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -560,7 +679,12 @@ await api.withRemoteImageTag('v1.0.0');
 
 For more complex scenarios, use `WithImagePushOptions` to register a callback that dynamically configures push options:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python generates image-push callback APIs, but not the Docker Compose publishing capability required by this example; its generated callback surface also lacks the typed setters shown here.',
+  go: 'Go generates image-push callback APIs, but the daily SDK does not expose the Docker Compose publishing capability required by this example.',
+  java: 'Java generates image-push callback APIs, but the daily SDK does not expose the Docker Compose publishing capability required by this example.',
+  rust: 'Rust generates image-push callback APIs, but the daily SDK does not expose the Docker Compose publishing capability required by this example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -610,7 +734,12 @@ Multiple callbacks can be registered on the same resource, and they are invoked 
 
 Use the `AddContainerRegistry` method to define a container registry and `WithContainerRegistry` to associate resources with it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python generates container registry APIs, but the daily SDK does not expose Docker Compose service publishing for the project resource in this example.',
+  go: 'Go generates container registry APIs, but the daily SDK does not expose Docker Compose service publishing for the project resource in this example.',
+  java: 'Java generates container registry APIs, but the daily SDK does not expose Docker Compose service publishing for the project resource in this example.',
+  rust: 'Rust generates container registry APIs, but the daily SDK does not expose Docker Compose service publishing for the project resource in this example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -662,7 +791,12 @@ await api.withContainerRegistry(registry);
 
 For more flexible configuration in CI/CD pipelines, use parameters with environment variables:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose configuration-backed parameters or Docker Compose service publishing used by this example.',
+  go: 'Go generates configuration-backed parameters, but the daily SDK does not expose Docker Compose service publishing used by this example.',
+  java: 'Java generates configuration-backed parameters, but the daily SDK does not expose Docker Compose service publishing used by this example.',
+  rust: 'Rust generates configuration-backed parameters, but the daily SDK does not expose Docker Compose service publishing used by this example.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);

--- a/src/frontend/src/content/docs/deployment/environments.mdx
+++ b/src/frontend/src/content/docs/deployment/environments.mdx
@@ -474,9 +474,7 @@ Common environment variable conventions by framework and ecosystem:
 
 Use [parameters](/fundamentals/external-parameters/) to externalize values that change between environments, such as SKU tiers, replica counts, or API endpoints:
 
-<AppHostTabs limitations={{
-  rust: 'The daily Rust generated SDK exposes parameters and environment injection separately, but its marker-type projection cannot pass a ParameterResource to with_environment.',
-}}>
+<AppHostTabs>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -580,6 +578,32 @@ void main(String[] args) throws Exception {
         .withEnvironment("API_KEY", apiKey);
 
     builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+    let api_key = builder.add_parameter(
+        "apiKey",
+        None,
+        None,
+        Some(true),
+    )?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_environment("API_KEY", serialize_handle(&api_key))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
 }
 ```
 

--- a/src/frontend/src/content/docs/deployment/environments.mdx
+++ b/src/frontend/src/content/docs/deployment/environments.mdx
@@ -108,6 +108,120 @@ if (await env.isEnvironment('Testing')) {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    env = builder.env
+
+    if env.is_development():
+        # Development-specific configuration
+        pass
+
+    # The daily Python SDK exposes Development, Staging, and Production checks,
+    # but not the custom is_environment(name) helper.
+    builder.run()
+```
+
+The daily Python generated SDK exposes `is_development()`, `is_staging()`, and `is_production()`, but it doesn't currently expose the custom `is_environment(name)` check.
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.Environment()
+	isDevelopment, err := env.IsDevelopment()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if isDevelopment {
+		// Development-specific configuration
+	}
+
+	isTesting, err := env.IsEnvironment("Testing")
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if isTesting {
+		// Testing-specific configuration
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+    var env = builder.environment();
+
+    if (env.isDevelopment()) {
+        // Development-specific configuration
+    }
+
+    if (env.isEnvironment("Testing")) {
+        // Testing-specific configuration
+    }
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+    let env = builder.environment()?;
+
+    if env.is_development()? {
+        // Development-specific configuration
+    }
+
+    if env.is_environment("Testing")? {
+        // Testing-specific configuration
+    }
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The following convenience methods are available:
@@ -119,11 +233,13 @@ The following convenience methods are available:
 | `IsProduction()` / `isProduction()`           | `Production`                       |
 | `IsEnvironment(name)` / `isEnvironment(name)` | Any custom name                    |
 
+Go, Java, and Rust expose all four checks using their generated naming conventions. Python currently exposes only the three named-environment checks.
+
 ## Common patterns
 
 ### Set environment variables on child resources
 
-Your services often need to know which environment they're running in. Different frameworks use different environment variables — use `WithEnvironment` to set the appropriate one for each service:
+Your services often need to know which environment they're running in. Different frameworks use different environment variables — use the generated environment-variable method (`WithEnvironment`, `withEnvironment`, `with_env`, or `with_environment`) to set the appropriate one for each service:
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -182,6 +298,154 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    is_development = builder.env.is_development()
+    dotnet_environment = "Development" if is_development else "Production"
+    app_environment = "development" if is_development else "production"
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_env("DOTNET_ENVIRONMENT", dotnet_environment)
+
+    frontend = builder.add_container("frontend", "node:22-alpine")
+    frontend.with_env("NODE_ENV", app_environment)
+
+    worker = builder.add_container("worker", "myorg/worker:latest")
+    worker.with_env("APP_ENV", app_environment)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	isDevelopment, err := builder.Environment().IsDevelopment()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	dotnetEnvironment := "Production"
+	appEnvironment := "production"
+	if isDevelopment {
+		dotnetEnvironment = "Development"
+		appEnvironment = "development"
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithEnvironment("DOTNET_ENVIRONMENT", dotnetEnvironment)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	frontend := builder.AddContainer("frontend", "node:22-alpine").
+		WithEnvironment("NODE_ENV", appEnvironment)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	worker := builder.AddContainer("worker", "myorg/worker:latest").
+		WithEnvironment("APP_ENV", appEnvironment)
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+    var isDevelopment = builder.environment().isDevelopment();
+    var dotnetEnvironment = isDevelopment ? "Development" : "Production";
+    var appEnvironment = isDevelopment ? "development" : "production";
+
+    builder.addProject("api", "../Api/Api.csproj")
+        .withEnvironment("DOTNET_ENVIRONMENT", dotnetEnvironment);
+
+    builder.addContainer("frontend", "node:22-alpine")
+        .withEnvironment("NODE_ENV", appEnvironment);
+
+    builder.addContainer("worker", "myorg/worker:latest")
+        .withEnvironment("APP_ENV", appEnvironment);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+    let is_development = builder.environment()?.is_development()?;
+    let dotnet_environment = if is_development {
+        "Development"
+    } else {
+        "Production"
+    };
+    let app_environment = if is_development {
+        "development"
+    } else {
+        "production"
+    };
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_environment(
+        "DOTNET_ENVIRONMENT",
+        serde_json::json!(dotnet_environment),
+    )?;
+
+    let frontend =
+        builder.add_container("frontend", serde_json::json!("node:22-alpine"))?;
+    frontend.with_environment("NODE_ENV", serde_json::json!(app_environment))?;
+
+    let worker =
+        builder.add_container("worker", serde_json::json!("myorg/worker:latest"))?;
+    worker.with_environment("APP_ENV", serde_json::json!(app_environment))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 Common environment variable conventions by framework and ecosystem:
@@ -199,17 +463,20 @@ Common environment variable conventions by framework and ecosystem:
 | Java (Spring)   | `SPRING_PROFILES_ACTIVE`   | `dev`, `test`, `prod`                  |
 
 <Aside type="tip">
-  `AddNodeApp` automatically sets `NODE_ENV` to `development` or `production`
-  based on whether the AppHost environment is `Development`. If you need a
-  different value (such as `staging`), override it with an explicit
-  `WithEnvironment("NODE_ENV", ...)` call as shown above.
+  In C# and TypeScript AppHosts, the Node.js resource automatically sets
+  `NODE_ENV` to `development` or `production` based on whether the AppHost
+  environment is `Development`. Override it explicitly when you need another
+  value. The daily Python, Go, Java, and Rust SDKs don't expose the Node.js
+  resource, so their examples set `NODE_ENV` on a container.
 </Aside>
 
 ### Use parameters for per-environment values
 
 Use [parameters](/fundamentals/external-parameters/) to externalize values that change between environments, such as SKU tiers, replica counts, or API endpoints:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The daily Rust generated SDK exposes parameters and environment injection separately, but its marker-type projection cannot pass a ParameterResource to with_environment.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -237,6 +504,83 @@ const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withEnvironment('API_KEY', apiKey);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api_key = builder.add_parameter("apiKey", secret=True)
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_env("API_KEY", api_key)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secret := true
+	apiKey := builder.AddParameter("apiKey", &aspire.AddParameterOptions{
+		Secret: &secret,
+	})
+	if err := apiKey.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithEnvironment("API_KEY", apiKey)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+    var apiKey = builder.addParameter(
+        "apiKey",
+        new AddParameterOptions().secret(true)
+    );
+
+    builder.addProject("api", "../Api/Api.csproj")
+        .withEnvironment("API_KEY", apiKey);
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -305,7 +649,12 @@ Environment variables take the highest priority, so they override any values fro
 
 Use the [execution context](#environment-vs-execution-context) for choices that differ between local orchestration and publish/deploy workflows. For example, use a local Redis container in run mode and an Azure Managed Redis resource when publishing:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose the Azure Managed Redis capability required for the publish-mode branch.',
+  go: 'The daily Go generated SDK does not expose Redis or Azure Managed Redis capabilities required by this example.',
+  java: 'The daily Java generated SDK does not expose Redis or Azure Managed Redis capabilities required by this example.',
+  rust: 'The daily Rust generated SDK does not expose Redis or Azure Managed Redis capabilities required by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/deployment/environments.mdx
+++ b/src/frontend/src/content/docs/deployment/environments.mdx
@@ -585,6 +585,7 @@ void main(String[] args) throws Exception {
 <Fragment slot="rust">
 
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;

--- a/src/frontend/src/content/docs/deployment/javascript-apps.mdx
+++ b/src/frontend/src/content/docs/deployment/javascript-apps.mdx
@@ -61,7 +61,12 @@ flowchart LR
     App --> Frontend["Vite build output"]
 ```
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Node.js or Vite resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Node.js or Vite resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Node.js or Vite resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Node.js or Vite resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -139,7 +144,12 @@ flowchart LR
     YARP --> Frontend["Frontend routes"]
 ```
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Node.js, Vite, or YARP resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Node.js, Vite, or YARP resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Node.js, Vite, or YARP resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Node.js, Vite, or YARP resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -201,7 +211,12 @@ await builder.build().run();
 
 If your gateway or BFF needs to know about the frontend dev server during local development, gate that wiring to run mode only:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python exposes execution-context checks, but the daily generated SDK does not expose Vite or YARP resource capabilities.',
+  go: 'Go exposes execution-context checks, but the daily generated SDK does not expose Vite or YARP resource capabilities.',
+  java: 'Java exposes execution-context checks, but the daily generated SDK does not expose Vite or YARP resource capabilities.',
+  rust: 'Rust exposes execution-context checks, but the daily generated SDK does not expose Vite or YARP resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -274,7 +289,12 @@ Use `PublishAsStaticWebsite` when the framework produces static files and you wa
 
 Choose this shape instead of `PublishWithStaticFiles(...)` when you do not already have a gateway or BFF resource that should own the public route table. If you already have an explicit YARP resource for gateway or BFF behavior, keep using `PublishWithStaticFiles(...)` on that resource.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose, Node.js, Vite, or static-website publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose, Node.js, Vite, or static-website publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose, Node.js, Vite, or static-website publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose, Node.js, Vite, or static-website publishing capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -365,7 +385,12 @@ Use `PublishAsNodeServer` for frameworks that produce a self-contained Node.js s
 
 Choose this method instead of `PublishAsPackageScript` when the build output does not need a production `node_modules` install at runtime. The resulting image can be smaller because it copies the server artifact rather than the full application with production dependencies.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose, Node.js, Vite, or Node-server publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose, Node.js, Vite, or Node-server publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose, Node.js, Vite, or Node-server publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose, Node.js, Vite, or Node-server publishing capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -426,7 +451,12 @@ Use `PublishAsPackageScript` for SSR frameworks that start production by running
 
 Choose this method instead of `PublishAsNodeServer` when the production server imports packages from `node_modules` at runtime or the framework's recommended production command is a package script.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose, Node.js, Vite, or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose, Node.js, Vite, or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose, Node.js, Vite, or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose, Node.js, Vite, or package-script publishing capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -490,6 +520,14 @@ The generated container sets `HOST=0.0.0.0` and `HOSTNAME=0.0.0.0` so the server
 - **pnpm**: The runtime stage runs `corepack enable pnpm && pnpm --version` before the entrypoint, so pnpm is available when the start script executes. Without this step, the container fails at startup with exit code 127 because pnpm is not included in the base `node:alpine` image.
 - **Bun**: The runtime stage reuses the Bun build image rather than switching to a Node.js image, because `bun run <script>` requires the Bun runtime at startup.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose, JavaScript app, pnpm, or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose, JavaScript app, pnpm, or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose, JavaScript app, pnpm, or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose, JavaScript app, pnpm, or package-script publishing capabilities.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs — pnpm package-script publish"
 #pragma warning disable ASPIREJAVASCRIPT001
 
@@ -505,6 +543,27 @@ var frontend = builder
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts — pnpm package-script publish"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+await builder.addDockerComposeEnvironment('compose');
+
+await builder
+  .addJavaScriptApp('frontend', '../NodeFrontend')
+  .withPnpm()
+  .publishAsPackageScript({ scriptName: 'start' })
+  .withExternalHttpEndpoints();
+
+await builder.build().run();
+```
+
+</Fragment>
+</AppHostTabs>
+
 The generated Dockerfile for the pnpm case includes:
 
 ```dockerfile
@@ -518,7 +577,12 @@ Use `AddNextJsApp` for Next.js apps that use [standalone output](https://nextjs.
 
 Choose this method instead of `AddJavaScriptApp(...).PublishAsPackageScript(...)` for Next.js standalone deployments. Use the more general package-script publish method for frameworks where the production server should be started through the package manager and the framework does not have a dedicated Aspire resource.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose, Node.js, or Next.js resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose, Node.js, or Next.js resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose, Node.js, or Next.js resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose, Node.js, or Next.js resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -603,7 +667,12 @@ flowchart TD
 
 This is a natural model for many SPA teams, especially when they already think in terms of "static site + API". It can work, but it is not the primary Aspire deployment story for `AddViteApp` and `AddJavaScriptApp`.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Node.js or Vite resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Node.js or Vite resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Node.js or Vite resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Node.js or Vite resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -657,7 +726,12 @@ This shape pushes more work onto the browser/frontend boundary:
 
 The following example looks reasonable, but it is a trap in publish/deploy:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Node.js or Vite resource capabilities, so this unsupported deployment shape cannot be reproduced from Python.',
+  go: 'The daily Go generated SDK does not expose Node.js or Vite resource capabilities, so this unsupported deployment shape cannot be reproduced from Go.',
+  java: 'The daily Java generated SDK does not expose Node.js or Vite resource capabilities, so this unsupported deployment shape cannot be reproduced from Java.',
+  rust: 'The daily Rust generated SDK does not expose Node.js or Vite resource capabilities, so this unsupported deployment shape cannot be reproduced from Rust.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -762,6 +836,14 @@ The SSR examples below assume the AppHost captures the backend endpoint with `ap
 
 The AppHost snippets in this section assume this shared setup:
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Docker Compose or Node.js resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Docker Compose or Node.js resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Docker Compose or Node.js resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Docker Compose or Node.js resource capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -776,12 +858,40 @@ const api = await builder
 const apiEndpoint = await api.getEndpoint('http');
 ```
 
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+#pragma warning disable ASPIREJAVASCRIPT001
+
+var builder = DistributedApplication.CreateBuilder(args);
+builder.AddDockerComposeEnvironment("compose");
+
+var api = builder
+    .AddNodeApp("api", "./frameworks/api", "server.js")
+    .WithHttpEndpoint(port: 3001, env: "PORT")
+    .WithExternalHttpEndpoints();
+
+var apiEndpoint = api.GetEndpoint("http");
+```
+
+</Fragment>
+</AppHostTabs>
+
 #### Nuxt
 
 - **Directory structure**: Nuxt 4 places pages in `app/pages/`, not a root `pages/` directory.
 - **Environment variables**: Nuxt maps [`runtimeConfig`](https://nuxt.com/docs/getting-started/configuration#runtime-config) keys to env vars with a `NUXT_` prefix. To pass the backend URL, set `NUXT_API_URL` on the resource so Nuxt sees it as `runtimeConfig.apiUrl`. You can also set `API_URL` for code that reads `process.env.API_URL` directly.
 - **Server API routes**: The recommended pattern for calling external APIs from Nuxt is a [server API route](https://nuxt.com/docs/guide/directory-structure/server) (`server/api/<name>.ts`) that uses `useRuntimeConfig()`, consumed from a page via [`useAsyncData`](https://nuxt.com/docs/api/composables/use-async-data).
 - **Publish method**: Always use `PublishAsPackageScript` for Nuxt. The Nitro `.output/` looks self-contained, but server-side data fetching via `useAsyncData` / `useFetch` fails without the full `node_modules` available at runtime.
+
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or package-script publishing capabilities.',
+}}>
+<Fragment slot="typescript">
 
 ```typescript title="AppHost — apphost.mts"
 await builder
@@ -791,6 +901,21 @@ await builder
   .withEnvironment('NUXT_API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("nuxt", "./frameworks/nuxt", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithEnvironment("NUXT_API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```typescript title="Nuxt — nuxt.config.ts"
 export default defineNuxtConfig({
@@ -823,6 +948,14 @@ export default defineEventHandler(async () => {
 - **Environment variables**: Use `process.env.API_URL`, not `import.meta.env.API_URL`. `import.meta.env` values are resolved at build time and baked into the output.
 - **Runtime dependencies**: The built `entry.mjs` imports unbundled `@astrojs/*` packages, so SSR Astro must use `PublishAsPackageScript`. The [official Docker recipe](https://docs.astro.build/en/recipes/docker/#multi-stage-build-using-ssr) confirms `node_modules` must be copied into the runtime image.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or package-script publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('astro-ssr', './frameworks/astro-ssr', { runScriptName: 'dev' })
@@ -830,6 +963,20 @@ await builder
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("astro-ssr", "./frameworks/astro-ssr", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```javascript title="Astro SSR — astro.config.mjs"
 import { defineConfig } from 'astro/config';
@@ -866,6 +1013,14 @@ const weather = response.ok ? await response.json() : [];
 - **Server-side data**: Use a [`+page.server.ts`](https://svelte.dev/docs/kit/load) `load` function for server-side fetching. `process.env.API_URL` is available inside the load function.
 - **Output shape**: The `build/` directory is fully self-contained, so no `node_modules` are required at runtime. This makes SvelteKit a good fit for `PublishAsNodeServer`.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or Node-server publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or Node-server publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or Node-server publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or Node-server publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('sveltekit', './frameworks/sveltekit', { runScriptName: 'dev' })
@@ -873,6 +1028,20 @@ await builder
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("sveltekit", "./frameworks/sveltekit", runScriptName: "dev")
+    .PublishAsNodeServer(entryPoint: "build/index.js", outputPath: "build")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```javascript title="SvelteKit — svelte.config.js"
 import adapter from '@sveltejs/adapter-node';
@@ -911,12 +1080,33 @@ export const load: PageServerLoad = async ({ fetch }) => {
 - **Copy shape**: The standalone build produces three directories that must be copied separately into the runtime image: `.next/standalone/` (server + bundled deps), `.next/static/` (client assets), and `public/` (static files). `AddNextJsApp` handles this automatically; see the [official with-docker example](https://github.com/vercel/next.js/tree/canary/examples/with-docker) if you need to do it manually.
 - **Server components**: Default App Router components are [server components](https://nextjs.org/docs/app/getting-started/server-and-client-components). Use `async` directly in the component body to fetch data; no special loader pattern is needed.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Next.js resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Next.js resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Next.js resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Next.js resource capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addNextJsApp('nextjs', './frameworks/nextjs', { runScriptName: 'dev' })
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddNextJsApp("nextjs", "./frameworks/nextjs", runScriptName: "dev")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```typescript title="Next.js — next.config.ts"
 import type { NextConfig } from 'next';
@@ -951,6 +1141,14 @@ export default async function Home() {
 - **Server functions**: Use [`createServerFn`](https://tanstack.com/start/latest/docs/framework/react/server-functions) for server-side data loading from route loaders.
 - **Environment variables**: `process.env.API_URL` is available inside server functions at runtime.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or Node-server publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or Node-server publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or Node-server publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or Node-server publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('tanstack-start', './frameworks/tanstack-start', {
@@ -960,6 +1158,25 @@ await builder
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp(
+        "tanstack-start",
+        "./frameworks/tanstack-start",
+        runScriptName: "dev")
+    .PublishAsNodeServer(
+        entryPoint: ".output/server/index.mjs",
+        outputPath: ".output")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```tsx title="TanStack Start — src/routes/index.tsx"
 import { createFileRoute } from '@tanstack/react-router';
@@ -987,6 +1204,14 @@ export const Route = createFileRoute('/')({
 - **Server binary**: `react-router-serve` lives in `node_modules`; it's not bundled into the build output. This is why Remix needs `PublishAsPackageScript` rather than `PublishAsNodeServer`. See the [React Router deployment guide](https://reactrouter.com/start/framework/deploying) and the [`node-custom-server` template](https://github.com/remix-run/react-router-templates/tree/main/node-custom-server) for production server patterns.
 - **Port binding**: Pass `-- --port "$PORT"` as `runScriptArguments` so the server listens on Aspire's assigned port.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or package-script publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('remix', './frameworks/remix', { runScriptName: 'dev' })
@@ -997,6 +1222,22 @@ await builder
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("remix", "./frameworks/remix", runScriptName: "dev")
+    .PublishAsPackageScript(
+        scriptName: "start",
+        runScriptArguments: "-- --port \"$PORT\"")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```json title="Remix — package.json"
 {
@@ -1031,6 +1272,14 @@ export async function loader() {
 - **Build steps**: Requires both `npm run build.client` and `npm run build.server`. The default `npm run build` runs both via `qwik build`.
 - **SSR data loading**: Use [`routeLoader$`](https://qwik.dev/docs/route-loader/) for server-side data loading. Read the backend URL via `process.env['API_URL']`.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or package-script publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or package-script publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or package-script publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or package-script publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('qwik', './frameworks/qwik', { runScriptName: 'dev' })
@@ -1038,6 +1287,20 @@ await builder
   .withEnvironment('API_URL', apiEndpoint)
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("qwik", "./frameworks/qwik", runScriptName: "dev")
+    .PublishAsPackageScript(scriptName: "start")
+    .WithEnvironment("API_URL", apiEndpoint)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```json title="Qwik City — package.json"
 {
@@ -1091,12 +1354,33 @@ export const useWeatherData = routeLoader$(async () => {
 - **Dev proxy**: Angular doesn't expose `vite.config.ts`. Use a [`proxy.conf.js`](https://angular.dev/tools/cli/serve) (not `.json`) that reads `process.env.API_HTTP`, referenced from `angular.json` under `serve.options.proxyConfig`.
 - **Output path**: Set [`outputPath`](https://angular.dev/reference/configs/workspace-config) in `angular.json` to `{ "base": "dist", "browser": "" }` so the production build writes directly to `dist/` for `PublishAsStaticWebsite`.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or static-website publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or static-website publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or static-website publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or static-website publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('angular', './frameworks/angular', { runScriptName: 'dev' })
   .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("angular", "./frameworks/angular", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```javascript title="Angular — proxy.conf.js"
 const target = process.env.API_HTTPS || process.env.API_HTTP;
@@ -1146,12 +1430,33 @@ module.exports = {
 - **API calls**: Use the `apiPath` / `apiTarget` options on `PublishAsStaticWebsite` so the backend is reachable through YARP. Don't use `VITE_*` env vars for runtime API URLs; they're baked at build time.
 - **Dev proxy**: Add [`server.proxy`](https://vite.dev/config/server-options.html#server-proxy) in `vite.config.ts` reading `process.env.API_HTTP` to forward `/api/*` to the backend in dev mode.
 
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Vite or static-website publishing capabilities.',
+  go: 'The daily Go generated SDK does not expose Vite or static-website publishing capabilities.',
+  java: 'The daily Java generated SDK does not expose Vite or static-website publishing capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Vite or static-website publishing capabilities.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="AppHost — apphost.mts"
 await builder
   .addViteApp('react', './frameworks/react', { runScriptName: 'dev' })
   .publishAsStaticWebsite({ apiPath: '/api', apiTarget: api })
   .withExternalHttpEndpoints();
 ```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost — AppHost.cs"
+builder
+    .AddViteApp("react", "./frameworks/react", runScriptName: "dev")
+    .PublishAsStaticWebsite(apiPath: "/api", apiTarget: api)
+    .WithExternalHttpEndpoints();
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```typescript title="Vite / React / Vue — vite.config.ts"
 import { defineConfig } from 'vite';
@@ -1231,15 +1536,103 @@ const builder = await createBuilder();
 
 // Add resources...
 
-builder.pipeline.disableBuildOnlyContainerValidation();
+builder.pipeline().disableBuildOnlyContainerValidation();
 
 await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    # Add resources...
+
+    builder.pipeline.disable_build_only_container_validation()
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	// Add resources...
+
+	pipeline := builder.Pipeline().DisableBuildOnlyContainerValidation()
+	if err := pipeline.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    // Add resources...
+
+    builder.pipeline().disableBuildOnlyContainerValidation();
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    // Add resources...
+
+    builder
+        .pipeline()?
+        .disable_build_only_container_validation()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
-The `DisableBuildOnlyContainerValidation` method is marked experimental with the `ASPIREPIPELINES001` diagnostic.
+In C#, `DisableBuildOnlyContainerValidation` is marked experimental with the `ASPIREPIPELINES001` diagnostic. The generated AppHost SDKs expose the same pipeline capability without that C# compile-time diagnostic.
 
 `AddNextJsApp` is different because it represents the Next.js standalone-server publish model directly. Use it when the app is a Next.js app with `output: "standalone"` rather than modeling the app with `AddJavaScriptApp` and choosing a generic package-script publish method.
 
@@ -1256,7 +1649,12 @@ To resolve the conflict, choose one of the following options:
 - **Remove or rename the Dockerfile** so Aspire generates a new one that runs your requested script as the container entrypoint.
 - **Override the container entrypoint explicitly** by calling `PublishAsDockerFile(...)` and configuring the entrypoint directly on the container resource. This keeps the existing Dockerfile and gives you full control over what runs:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python exposes generic Dockerfile publishing and entrypoint APIs, but the daily generated SDK does not expose the JavaScript app resource required by this example.',
+  go: 'Go exposes generic Dockerfile publishing and entrypoint APIs, but the daily generated SDK does not expose the JavaScript app resource required by this example.',
+  java: 'Java exposes generic Dockerfile publishing and entrypoint APIs, but the daily generated SDK does not expose the JavaScript app resource required by this example.',
+  rust: 'Rust exposes generic Dockerfile publishing and entrypoint APIs, but the daily generated SDK does not expose the JavaScript app resource required by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-gateway-aks.mdx
@@ -412,7 +412,12 @@ The `parentRefs` in the `ClusterIssuer` specifies `kind: Gateway` without a spec
 
 Add a Kubernetes Gateway to your AppHost project to expose your frontend service through AGC. The gateway configuration includes the gateway class, ALB annotations, routing, hostname, and TLS settings.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes environment or Gateway resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes environment or Gateway resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes environment or Gateway resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes environment or Gateway resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -680,7 +685,12 @@ Deploying without TLS exposes all traffic in plaintext. This is only appropriate
 
 To deploy without TLS, omit `WithTls()` from your Gateway configuration:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes Gateway resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -724,7 +734,12 @@ Deploying without a hostname means the Gateway accepts traffic for **any** hostn
 
 To deploy without a hostname, omit `WithHostname()` and `WithTls()`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes Gateway resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes Gateway resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress-aks.mdx
@@ -565,7 +565,12 @@ Define your Kubernetes environment, container registry, and ingress in the
 AppHost project. The example below uses parameters so that environment-specific
 values are supplied at deploy time.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes environment, Helm, or Ingress resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes environment, Helm, or Ingress resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes environment, Helm, or Ingress resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes environment, Helm, or Ingress resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -770,7 +775,12 @@ testing scenarios.
 
 Remove the `WithTls` call and the `cert-manager.io/cluster-issuer` annotation:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes Ingress resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp
@@ -816,7 +826,12 @@ the domain. The AGC-assigned FQDN uses a wildcard certificate managed by Azure.
 
 Remove the `WithHostname`, `WithTls`, and cert-manager annotation calls:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes Ingress resource capabilities.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp

--- a/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes-ingress.mdx
@@ -70,7 +70,12 @@ When you use `AddIngress()` or `AddGateway()`, Aspire generates additional Kuber
 
 Use `WithPath` on an Ingress (or `WithRoute` on a Gateway) to forward traffic for a URL path to one of your Aspire services. Each call adds a rule to the generated `Ingress` (or `HTTPRoute`) resource pointing at the named endpoint's backing Kubernetes service.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes environment or Ingress resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes environment or Ingress resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes environment or Ingress resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes environment or Ingress resource capabilities.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var k8s = builder.AddKubernetesEnvironment("k8s");
@@ -137,7 +142,12 @@ When you configure TLS with `WithTls()`, Aspire handles the initial bootstrappin
 
 Aspire's Ingress and Gateway APIs accept parameters, allowing you to reuse the same AppHost across multiple deployment environments (development, staging, production) with different hostnames, TLS secrets, and controller configurations:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The daily Python generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  go: 'The daily Go generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  java: 'The daily Java generated SDK does not expose Kubernetes Ingress resource capabilities.',
+  rust: 'The daily Rust generated SDK does not expose Kubernetes Ingress resource capabilities.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var hostname = builder.AddParameter("hostname");

--- a/src/frontend/src/content/docs/deployment/kubernetes/aks.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/aks.mdx
@@ -43,7 +43,12 @@ The Aspire CLI adds the [📦 Aspire.Hosting.Azure.Kubernetes](https://www.nuget
 
 Then add the AKS environment in your AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_azure_kubernetes_environment, so an AKS deployment environment cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddAzureKubernetesEnvironment, so an AKS deployment environment cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addAzureKubernetesEnvironment, so an AKS deployment environment cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_azure_kubernetes_environment, so an AKS deployment environment cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs" {3}
 var builder = DistributedApplication.CreateBuilder(args);
@@ -92,7 +97,12 @@ Aspire builds your container images, pushes them to ACR, generates Helm charts, 
 
 Customize the system node pool VM size and scaling using `WithSystemNodePool`:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS system node-pool configuration.',
+  go: 'The generated Go SDK does not export AKS system node-pool configuration.',
+  java: 'The generated Java SDK does not export AKS system node-pool configuration.',
+  rust: 'The generated Rust SDK does not export AKS system node-pool configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddAzureKubernetesEnvironment("aks")
@@ -111,7 +121,12 @@ await aks.withSystemNodePool('Standard_D4s_v5', 1, 5);
 
 Add additional node pools for workload isolation or specialized hardware, then use `WithNodePool` to schedule workloads on them:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS node-pool resources or workload scheduling to them.',
+  go: 'The generated Go SDK does not export AKS node-pool resources or workload scheduling to them.',
+  java: 'The generated Java SDK does not export AKS node-pool resources or workload scheduling to them.',
+  rust: 'The generated Rust SDK does not export AKS node-pool resources or workload scheduling to them.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var aks = builder.AddAzureKubernetesEnvironment("aks");
@@ -235,7 +250,12 @@ Feature registration can take several minutes the first time. For the latest pre
 
 AGC requires a dedicated subnet for its frontend that is delegated to `Microsoft.ServiceNetworking/trafficControllers`. The AKS node subnet and the AGC subnet must not overlap, and the AKS service CIDR defaults to `10.0.0.0/16` — pick a VNet range that avoids it.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the Azure virtual-network, subnet, or AKS subnet-attachment APIs used here.',
+  go: 'The generated Go SDK does not export the Azure virtual-network, subnet, or AKS subnet-attachment APIs used here.',
+  java: 'The generated Java SDK does not export the Azure virtual-network, subnet, or AKS subnet-attachment APIs used here.',
+  rust: 'The generated Rust SDK does not export the Azure virtual-network, subnet, or AKS subnet-attachment APIs used here.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREAZURE003 // AddSubnet is evaluation-only
@@ -268,7 +288,12 @@ The AGC frontend subnet must be **/24 or larger**. The AKS node pool subnet shou
 
 `AddLoadBalancer` returns a typed handle that gateways and ingresses attach to. Behind the scenes it delegates the supplied subnet to AGC, grants the controller's managed identity `Network Contributor` on the subnet, and applies the `ApplicationLoadBalancer` custom resource once the `azure-alb-external` GatewayClass is ready in the cluster.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS Application Gateway for Containers load-balancer resources.',
+  go: 'The generated Go SDK does not export AKS Application Gateway for Containers load-balancer resources.',
+  java: 'The generated Java SDK does not export AKS Application Gateway for Containers load-balancer resources.',
+  rust: 'The generated Rust SDK does not export AKS Application Gateway for Containers load-balancer resources.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var publicLb = aks.AddLoadBalancer("public", albSubnet);
@@ -289,7 +314,12 @@ Each AGC `ApplicationLoadBalancer` caps at five frontends (Gateways or Ingresses
 
 `AddGateway` declares a Kubernetes Gateway API `Gateway`. `WithLoadBalancer` attaches it to the AGC ALB you just created and defaults the `gatewayClassName` to `azure-alb-external`. `WithRoute` adds an `HTTPRoute` that forwards a path to the named endpoint on one of your services.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS Gateway API resources, load-balancer attachment, or route configuration.',
+  go: 'The generated Go SDK does not export AKS Gateway API resources, load-balancer attachment, or route configuration.',
+  java: 'The generated Java SDK does not export AKS Gateway API resources, load-balancer attachment, or route configuration.',
+  rust: 'The generated Rust SDK does not export AKS Gateway API resources, load-balancer attachment, or route configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var api = builder.AddProject<Projects.MyApi>("api")
@@ -333,7 +363,12 @@ This first deploy serves plain HTTP only. Continue to the next step before expos
 
 `AddCertManager` installs the upstream cert-manager Helm chart with the CRDs and Gateway API watcher enabled and the `--force-conflicts` flag set so AKS's Azure Policy add-on doesn't break subsequent upgrades. `AddIssuer` adds a typed `ClusterIssuer` parented to that installation, and `WithTls(issuer)` on a gateway adds an HTTPS listener that cert-manager will populate with a real certificate.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS cert-manager, issuer, Gateway, or TLS configuration APIs.',
+  go: 'The generated Go SDK does not export AKS cert-manager, issuer, Gateway, or TLS configuration APIs.',
+  java: 'The generated Java SDK does not export AKS cert-manager, issuer, Gateway, or TLS configuration APIs.',
+  rust: 'The generated Rust SDK does not export AKS cert-manager, issuer, Gateway, or TLS configuration APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var certManager = aks.AddCertManager("cert-manager");
@@ -373,7 +408,12 @@ Calling `WithTls` flips the gateway to an HTTPS-first posture:
 
 To tune or disable these defaults, pass an options callback. The `includeSubDomains` and `preload` HSTS flags are off by default because they're hard to reverse once browsers cache them — opt in explicitly when you're ready to commit to the hostname:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS Gateway TLS and HSTS option configuration.',
+  go: 'The generated Go SDK does not export AKS Gateway TLS and HSTS option configuration.',
+  java: 'The generated Java SDK does not export AKS Gateway TLS and HSTS option configuration.',
+  rust: 'The generated Rust SDK does not export AKS Gateway TLS and HSTS option configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 aks.AddGateway("storefront")
@@ -438,7 +478,12 @@ The `*.alb.azure.com` FQDN is fine for testing but real applications need a host
 
 `WithHostname` adds the hostname to the gateway's `HTTPRoute`s and to the HTTPS listener so cert-manager issues the certificate for the right name. Use the parameter overload when the hostname differs across deployment environments.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS Gateway hostname, routing, or TLS configuration.',
+  go: 'The generated Go SDK does not export AKS Gateway hostname, routing, or TLS configuration.',
+  java: 'The generated Java SDK does not export AKS Gateway hostname, routing, or TLS configuration.',
+  rust: 'The generated Rust SDK does not export AKS Gateway hostname, routing, or TLS configuration.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var hostname = builder.AddParameter("hostname"); // e.g. "api.contoso.com"
@@ -529,7 +574,12 @@ After authentication, `aspire deploy` needs a target subscription and location. 
 
 Use `PublishAsKubernetesService` to customize the Kubernetes resources generated for individual services:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export publish_as_kubernetes_service or the generated-workload customization callback.',
+  go: 'The generated Go SDK does not export PublishAsKubernetesService or the generated-workload customization callback.',
+  java: 'The generated Java SDK does not export publishAsKubernetesService or the generated-workload customization callback.',
+  rust: 'The generated Rust SDK does not export publish_as_kubernetes_service or the generated-workload customization callback.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Kubernetes.Resources;

--- a/src/frontend/src/content/docs/deployment/kubernetes/clusters.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/clusters.mdx
@@ -36,7 +36,12 @@ The Aspire CLI adds the [📦 Aspire.Hosting.Kubernetes](https://www.nuget.org/p
 
 Then add the Kubernetes environment in your AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export add_kubernetes_environment, so a Kubernetes deployment environment cannot be modeled from a Python AppHost.',
+  go: 'The generated Go SDK does not export AddKubernetesEnvironment, so a Kubernetes deployment environment cannot be modeled from a Go AppHost.',
+  java: 'The generated Java SDK does not export addKubernetesEnvironment, so a Kubernetes deployment environment cannot be modeled from a Java AppHost.',
+  rust: 'The generated Rust SDK does not export add_kubernetes_environment, so a Kubernetes deployment environment cannot be modeled from a Rust AppHost.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs" {3}
 var builder = DistributedApplication.CreateBuilder(args);
@@ -72,7 +77,12 @@ When a Kubernetes environment is present, all compute resources are automaticall
 
 Unlike managed targets such as AKS, a vanilla Kubernetes cluster doesn't know which container registry to use for your application images. Without a registry, Aspire has no way to make your locally-built images available to cluster nodes. You must provide a container registry that is accessible from both your local machine (to push images) and from the cluster (to pull images):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK exports generic container registries, but not Kubernetes environments or registry attachment to them.',
+  go: 'The generated Go SDK exports AddContainerRegistry, but not AddKubernetesEnvironment or WithContainerRegistry on a Kubernetes environment.',
+  java: 'The generated Java SDK exports addContainerRegistry, but not addKubernetesEnvironment or withContainerRegistry on a Kubernetes environment.',
+  rust: 'The generated Rust SDK exports add_container_registry, but not add_kubernetes_environment or Kubernetes registry attachment.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs" {3-4}
 var builder = DistributedApplication.CreateBuilder(args);
@@ -215,7 +225,12 @@ If you prefer to publish first and deploy separately — for example, in a CI/CD
 
 Use `WithHelm` to configure Helm chart settings such as namespace, release name, and chart version:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes environment or Helm deployment-settings APIs.',
+  go: 'The generated Go SDK does not export Kubernetes environment or Helm deployment-settings APIs.',
+  java: 'The generated Java SDK does not export Kubernetes environment or Helm deployment-settings APIs.',
+  rust: 'The generated Rust SDK does not export Kubernetes environment or Helm deployment-settings APIs.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 builder.AddKubernetesEnvironment("k8s")
@@ -245,7 +260,12 @@ Helm is the default deployment engine. Call `WithHelm` only when you need to cus
 
 Use `AddNodePool` to reference an existing node pool in your cluster, then `WithNodePool` to schedule specific workloads on it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes node-pool resources or workload scheduling to a node pool.',
+  go: 'The generated Go SDK does not export Kubernetes node-pool resources or workload scheduling to a node pool.',
+  java: 'The generated Java SDK does not export Kubernetes node-pool resources or workload scheduling to a node pool.',
+  rust: 'The generated Rust SDK does not export Kubernetes node-pool resources or workload scheduling to a node pool.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 var k8s = builder.AddKubernetesEnvironment("k8s");
@@ -274,7 +294,12 @@ For vanilla Kubernetes, `AddNodePool` creates a named reference to a node pool t
 
 Use `PublishAsKubernetesService` to modify the generated Kubernetes resources for individual services:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export publish_as_kubernetes_service or the generated-workload customization callback.',
+  go: 'The generated Go SDK does not export PublishAsKubernetesService or the generated-workload customization callback.',
+  java: 'The generated Java SDK does not export publishAsKubernetesService or the generated-workload customization callback.',
+  rust: 'The generated Rust SDK does not export publish_as_kubernetes_service or the generated-workload customization callback.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Kubernetes.Resources;

--- a/src/frontend/src/content/docs/deployment/kubernetes/helm-charts.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/helm-charts.mdx
@@ -31,7 +31,12 @@ When you use `aspire deploy`, Aspire deploys your application as a Helm chart an
 
 Add the chart to a Kubernetes or AKS environment resource, passing the chart name (used as both the resource name and the default Helm release name), a chart reference, and a chart version:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes environments or add_helm_chart.',
+  go: 'The generated Go SDK does not export Kubernetes environments or AddHelmChart.',
+  java: 'The generated Java SDK does not export Kubernetes environments or addHelmChart.',
+  rust: 'The generated Rust SDK does not export Kubernetes environments or add_helm_chart.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -84,7 +89,12 @@ Pass the chart version string expected by the chart repository, such as `1.17.0`
 
 Set Helm values to pass `--set key=value` arguments to the Helm install command:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export external Helm chart resources or Helm value configuration.',
+  go: 'The generated Go SDK does not export external Helm chart resources or Helm value configuration.',
+  java: 'The generated Java SDK does not export external Helm chart resources or Helm value configuration.',
+  rust: 'The generated Rust SDK does not export external Helm chart resources or Helm value configuration.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -122,7 +132,12 @@ Value keys support dot-notation (`config.enableGatewayAPI`) and indexed array pa
 
 By default, the chart is installed in a namespace named after the chart resource and uses the chart resource name as the Helm release name. Override these in your AppHost when you need a different namespace or release name:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export external Helm chart namespace or release-name configuration.',
+  go: 'The generated Go SDK does not export external Helm chart namespace or release-name configuration.',
+  java: 'The generated Java SDK does not export external Helm chart namespace or release-name configuration.',
+  rust: 'The generated Rust SDK does not export external Helm chart namespace or release-name configuration.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -163,7 +178,12 @@ By default, external charts are not uninstalled when you run `aspire destroy`. T
 
 To opt in to uninstall-on-destroy, enable destroy-time uninstall in your AppHost:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export external Helm chart destroy-time uninstall configuration.',
+  go: 'The generated Go SDK does not export external Helm chart destroy-time uninstall configuration.',
+  java: 'The generated Java SDK does not export external Helm chart destroy-time uninstall configuration.',
+  rust: 'The generated Rust SDK does not export external Helm chart destroy-time uninstall configuration.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -205,7 +225,12 @@ Enable destroy-time uninstall for charts that are tightly coupled to the specifi
 
 The same `AddHelmChart` API is available on AKS environments through the `Aspire.Hosting.Azure.Kubernetes` package:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export AKS environments or external Helm chart installation on AKS.',
+  go: 'The generated Go SDK does not export AKS environments or external Helm chart installation on AKS.',
+  java: 'The generated Java SDK does not export AKS environments or external Helm chart installation on AKS.',
+  rust: 'The generated Rust SDK does not export AKS environments or external Helm chart installation on AKS.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -254,7 +279,12 @@ The AKS environment delegates external chart installation to its inner Kubernete
 
 The following example installs cert-manager and a custom podinfo chart alongside an Aspire application on Kubernetes:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes environments or external Helm chart configuration used by this complete example.',
+  go: 'The generated Go SDK does not export Kubernetes environments or external Helm chart configuration used by this complete example.',
+  java: 'The generated Java SDK does not export Kubernetes environments or external Helm chart configuration used by this complete example.',
+  rust: 'The generated Rust SDK does not export Kubernetes environments or external Helm chart configuration used by this complete example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/deployment/kubernetes/persistent-volumes.mdx
+++ b/src/frontend/src/content/docs/deployment/kubernetes/persistent-volumes.mdx
@@ -11,7 +11,12 @@ import LearnMore from '@components/LearnMore.astro';
 
 Stateful workloads — databases, message brokers, or any service that writes durable data — need storage that survives pod restarts and rescheduling. Call `AddPersistentVolume` on a Kubernetes environment to describe a durable disk once in your AppHost, configure its storage class, capacity, access modes, and annotations with fluent methods, then bind it to one or more workloads:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes persistent-volume resource or configuration APIs.',
+  go: 'The generated Go SDK does not export Kubernetes persistent-volume resource or configuration APIs.',
+  java: 'The generated Java SDK does not export Kubernetes persistent-volume resource or configuration APIs.',
+  rust: 'The generated Rust SDK does not export Kubernetes persistent-volume resource or configuration APIs.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -54,7 +59,12 @@ The following prerequisites must be in place before you can use persistent volum
 
 The full set of configuration methods lets you pin the storage class, capacity, access modes, and provisioner annotations. A complete AppHost that defines a volume looks like this:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes persistent-volume resource, access-mode, or annotation APIs.',
+  go: 'The generated Go SDK does not export Kubernetes persistent-volume resource, access-mode, or annotation APIs.',
+  java: 'The generated Java SDK does not export Kubernetes persistent-volume resource, access-mode, or annotation APIs.',
+  rust: 'The generated Rust SDK does not export Kubernetes persistent-volume resource, access-mode, or annotation APIs.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -122,7 +132,12 @@ After defining a volume, bind it to the workloads that mount it. There are two o
 
 Use the name-match overload when the workload already declares a volume — for example, through `WithVolume("name", "/path")` or an integration helper such as Postgres' `WithDataVolume()`. The persistent volume's name must match the workload volume's name so the publisher can route the pod's `volumes[]` entry through the generated PVC:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes persistent-volume creation or name-based workload binding.',
+  go: 'The generated Go SDK does not export Kubernetes persistent-volume creation or name-based workload binding.',
+  java: 'The generated Java SDK does not export Kubernetes persistent-volume creation or name-based workload binding.',
+  rust: 'The generated Rust SDK does not export Kubernetes persistent-volume creation or name-based workload binding.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -155,7 +170,12 @@ await pg.withKubernetesPersistentVolume(pgData);
 
 Use the mount-path overload when the workload doesn't already declare a named volume. It creates the mount itself, so it works for projects and any compute resource. Pass the mount path inside the container, and optionally mount read-only:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export Kubernetes persistent-volume creation or mount-path workload binding.',
+  go: 'The generated Go SDK does not export Kubernetes persistent-volume creation or mount-path workload binding.',
+  java: 'The generated Java SDK does not export Kubernetes persistent-volume creation or mount-path workload binding.',
+  rust: 'The generated Rust SDK does not export Kubernetes persistent-volume creation or mount-path workload binding.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -211,7 +231,12 @@ This default only applies to workloads bound through `WithPersistentVolume(...)`
 
 The default security context is applied before any `PublishAsKubernetesService` callback runs, so a workload or cluster that needs a different group can replace it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the Kubernetes publishing callback needed to replace the generated pod security context.',
+  go: 'The generated Go SDK does not export the Kubernetes publishing callback needed to replace the generated pod security context.',
+  java: 'The generated Java SDK does not export the Kubernetes publishing callback needed to replace the generated pod security context.',
+  rust: 'The generated Rust SDK does not export the Kubernetes publishing callback needed to replace the generated pod security context.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -241,7 +266,12 @@ The generated `OnRootMismatch` change policy is retained unless the callback als
 
 To remove the generated pod security context entirely — for example, when ownership is managed by the image, an admission controller, or storage-specific configuration — set it to `null` in the same callback:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The generated Python SDK does not export the Kubernetes publishing callback needed to remove the generated pod security context.',
+  go: 'The generated Go SDK does not export the Kubernetes publishing callback needed to remove the generated pod security context.',
+  java: 'The generated Java SDK does not export the Kubernetes publishing callback needed to remove the generated pod security context.',
+  rust: 'The generated Rust SDK does not export the Kubernetes publishing callback needed to remove the generated pod security context.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/deployment/pipelines.mdx
+++ b/src/frontend/src/content/docs/deployment/pipelines.mdx
@@ -275,7 +275,9 @@ Applications can add custom steps directly through the pipeline API for scenario
 
 **Example: Adding a custom validation step**
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust add_step callback is generated as raw JSON values rather than a typed PipelineStepContext, so this typed validation example is not usable from Rust.',
+}}>
 <Fragment slot="csharp">
 ```csharp title="AppHost.cs"
 using Aspire.Hosting.Pipelines;
@@ -296,7 +298,7 @@ await ValidateDatabaseConnection(context);
 var database = builder.AddPostgres("myapp-db");
 var api = builder.AddProject<Api>("api").WithReference(database);
 
-````
+```
 </Fragment>
 <Fragment slot="typescript">
 ```typescript title="apphost.mts"
@@ -305,7 +307,7 @@ import { createBuilder } from './.aspire/modules/aspire.mjs';
 const builder = await createBuilder();
 
 // Add custom deployment validation
-builder.pipeline.addStep("validate-deployment", async (context) => {
+builder.pipeline().addStep("validate-deployment", async (context) => {
   // Custom validation logic
   await validateApiHealth(context);
   await validateDatabaseConnection(context);
@@ -322,6 +324,107 @@ async function validateApiHealth(_context: unknown) {
 async function validateDatabaseConnection(_context: unknown) {
 }
 ```
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+
+def validate_deployment(_context):
+    # Validate API health and database connectivity.
+    pass
+
+
+with create_builder() as builder:
+    builder.pipeline.add_step(
+        "validate-deployment",
+        validate_deployment,
+        required_by=["deploy"],
+    )
+
+    database = builder.add_container("myapp-db", "postgres:17")
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_reference(database)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	err = builder.Pipeline().AddStep(
+		"validate-deployment",
+		func(_ aspire.PipelineStepContext) {
+			// Validate API health and database connectivity.
+		},
+		&aspire.AddStepOptions{RequiredBy: []string{"deploy"}},
+	)
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	database := builder.AddContainer("myapp-db", "postgres:17")
+	if err := database.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithReference(database)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.pipeline().addStep(
+        "validate-deployment",
+        context -> {
+            // Validate API health and database connectivity.
+        },
+        new AddStepOptions().requiredBy(new String[] {"deploy"})
+    );
+
+    var database = builder.addContainer("myapp-db", "postgres:17");
+    builder.addProject("api", "../Api/Api.csproj")
+        .withReference(database);
+
+    builder.build().run();
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -492,6 +595,14 @@ The pipeline system allows you to add custom steps to handle application-specifi
 
 Use `builder.Pipeline.AddStep` to add custom steps that apply to your entire application:
 
+<AppHostTabs limitations={{
+  python: 'Python emits a typed add_step API, but its callback is synchronous and cannot await the asynchronous validation operations in this example.',
+  go: 'Go emits a typed AddStep API, but its callback has no error or asynchronous return shape for the validation operations in this example.',
+  java: 'Java emits a typed addStep API, but its callback is synchronous and cannot await the asynchronous validation operations in this example.',
+  rust: 'Rust emits add_step with a raw Vec<Value> callback instead of a typed PipelineStepContext, so the typed callback and logger operations in this example are not usable.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="Application-level custom step"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -514,6 +625,40 @@ var api = builder.AddProject<Projects.Api>("api").WithReference(database);
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="Application-level custom step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.pipeline().addStep('validate', async (context) => {
+  await context.logger().logInformation('Running validation checks...');
+
+  await validateApiEndpoints(context);
+  await checkDatabaseConnection(context);
+
+  await context.logger().logInformation('Validation completed successfully');
+}, { requiredBy: ['deploy'] });
+
+const database = await builder.addPostgres('db');
+await builder
+  .addProject('api', '../Api/Api.csproj')
+  .withReference(database);
+
+await builder.build().run();
+
+async function validateApiEndpoints(_context: unknown) {
+}
+
+async function checkDatabaseConnection(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 You can then run this custom step:
 
 ```bash title="Aspire CLI — Run custom step"
@@ -523,6 +668,14 @@ aspire do validate
 ### Resource-level steps
 
 Resources can contribute their own pipeline steps using `WithPipelineStepFactory`:
+
+<AppHostTabs limitations={{
+  python: 'Python emits with_pipeline_step_factory as a step name, typed synchronous callback, and options rather than a factory returning PipelineStep; it cannot await the asynchronous deployment body shown here.',
+  go: 'Go emits WithPipelineStepFactory as a step name, typed callback, and options rather than a factory returning PipelineStep; the callback cannot return an asynchronous operation or error.',
+  java: 'Java emits withPipelineStepFactory as a step name, typed synchronous callback, and options rather than a factory returning PipelineStep; it cannot await the asynchronous deployment body shown here.',
+  rust: 'Rust emits with_pipeline_step_factory with a raw Vec<Value> callback rather than a typed PipelineStepContext, so this typed resource-level deployment callback is not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Resource-level custom step"
 var api = builder.AddProject<Projects.Api>("api")
@@ -546,9 +699,48 @@ var api = builder.AddProject<Projects.Api>("api")
     });
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="Resource-level custom step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder
+  .addProject('api', '../Api/Api.csproj')
+  .withPipelineStepFactory('custom-api-deploy', async (context) => {
+    await context.logger().logInformation(
+      'Custom API deployment starting...'
+    );
+
+    await deployApi(context);
+
+    await context.logger().logInformation(
+      'Custom API deployment completed'
+    );
+  }, { requiredBy: ['deploy'] });
+
+await builder.build().run();
+
+async function deployApi(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ### Step dependencies
 
 Control step execution order using dependencies:
+
+<AppHostTabs limitations={{
+  python: 'Python emits a typed add_step API, but its callback is synchronous and cannot await the asynchronous migration operation in this example.',
+  go: 'Go emits a typed AddStep API, but its callback has no error or asynchronous return shape for the migration operation in this example.',
+  java: 'Java emits a typed addStep API, but its callback is synchronous and cannot await the asynchronous migration operation in this example.',
+  rust: 'Rust emits add_step with a raw Vec<Value> callback instead of a typed PipelineStepContext, so the typed callback and logger operations in this example are not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Step with dependencies"
 // Step that depends on other steps
@@ -560,6 +752,31 @@ builder.Pipeline.AddStep("database-migration", async (context) =>
 dependsOn: ["provision-database"],
 requiredBy: ["deploy-apiservice"]);
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="Step with dependencies — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.pipeline().addStep('database-migration', async (context) => {
+  await context.logger().logInformation('Running database migrations...');
+  await runMigrations(context);
+}, {
+  dependsOn: ['provision-database'],
+  requiredBy: ['deploy-apiservice'],
+});
+
+await builder.build().run();
+
+async function runMigrations(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 You can choose from two dependency types to fix the step order:
 
@@ -581,6 +798,15 @@ To deepen your understanding of pipelines, let's examine scenarios where you mig
 ### Multi-environment deployments
 
 If you're deploying to testing, staging, production, or other environments, you might want to take different deployment actions in each case. You can use the pipeline context to create environment-specific pipeline steps:
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript PipelineStepContext exposes execution mode but not the deployment environment name represented by context.Environment in this C# example.',
+  python: 'The generated Python PipelineStepContext exposes execution mode but not the deployment environment name represented by context.Environment in this C# example; its callback is also synchronous.',
+  go: 'The generated Go PipelineStepContext exposes execution mode but not the deployment environment name represented by context.Environment in this C# example; its callback also has no asynchronous return shape.',
+  java: 'The generated Java PipelineStepContext exposes execution mode but not the deployment environment name represented by context.Environment in this C# example; its callback is also synchronous.',
+  rust: 'The Rust add_step callback is emitted as raw Vec<Value> values, and the generated context does not provide the context.Environment shape used by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Multi-environment deployment"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -606,6 +832,9 @@ dependsOn: [WellKnownPipelineSteps.Deploy]);
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 You can deploy to different environments, and trigger the above environment-specific steps, by using the `--environment` option:
 
 ```bash title="Aspire CLI — Deploy to specific environment"
@@ -619,6 +848,14 @@ aspire do deploy --environment Production
 ### Custom build steps
 
 Add custom build logic that integrates with the pipeline:
+
+<AppHostTabs limitations={{
+  python: 'Python emits a typed add_step API, but its callback is synchronous and cannot await the asynchronous build operations in this example.',
+  go: 'Go emits a typed AddStep API, but its callback has no error or asynchronous return shape for the build operations in this example.',
+  java: 'Java emits a typed addStep API, but its callback is synchronous and cannot await the asynchronous build operations in this example.',
+  rust: 'Rust emits add_step with a raw Vec<Value> callback instead of a typed PipelineStepContext, so the typed callback and logger operations in this example are not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Custom build step"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -642,9 +879,50 @@ requiredBy: [WellKnownPipelineSteps.Push]);
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="Custom build step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.pipeline().addStep('generate-assets', async (context) => {
+  await context.logger().logInformation('Generating static assets...');
+  await generateStaticAssets(context);
+}, { requiredBy: ['build'] });
+
+await builder.pipeline().addStep('optimize-images', async (context) => {
+  await context.logger().logInformation('Optimizing container images...');
+  await optimizeImages(context);
+}, {
+  dependsOn: ['build'],
+  requiredBy: ['push'],
+});
+
+await builder.build().run();
+
+async function generateStaticAssets(_context: unknown) {
+}
+
+async function optimizeImages(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ### Database migrations
 
 If you want to ensure a database is populated as part of your deployment, you can create a step that integrates database migrations into the deployment pipeline:
+
+<AppHostTabs limitations={{
+  python: 'Python emits a typed add_step API, but its callback is synchronous and cannot await connection-string lookup or database migration operations in this example.',
+  go: 'Go emits a typed AddStep API, but its callback has no error or asynchronous return shape for connection-string lookup or database migration operations in this example.',
+  java: 'Java emits a typed addStep API, but its callback is synchronous and cannot await connection-string lookup or database migration operations in this example.',
+  rust: 'Rust emits add_step with a raw Vec<Value> callback instead of a typed PipelineStepContext, so the typed callback, logger, and resource access in this example are not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Database migrations step"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -671,6 +949,50 @@ var api = builder.AddProject<Projects.Api>("api").WithReference(database);
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="Database migrations step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+const database = await builder.addPostgres('db');
+
+await builder.pipeline().addStep('migrate-database', async (context) => {
+  await context.logger().logInformation('Running database migrations...');
+
+  const connectionString = await getConnectionString(context, database);
+  await runDatabaseMigrations(connectionString, await context.logger());
+
+  await context.logger().logInformation('Database migrations completed');
+}, {
+  dependsOn: ['provision-database'],
+  requiredBy: ['deploy-apiservice'],
+});
+
+await builder
+  .addProject('api', '../Api/Api.csproj')
+  .withReference(database);
+
+await builder.build().run();
+
+async function getConnectionString(
+  _context: unknown,
+  _database: unknown
+): Promise<string> {
+  return 'Host=localhost';
+}
+
+async function runDatabaseMigrations(
+  _connectionString: string,
+  _logger: unknown
+) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Migrating from publishing callbacks
 
@@ -712,6 +1034,15 @@ Here are some code examples that show Aspire 9.x code and the Aspire 13.x equiva
 
 **Before (Aspire 9.x):**
 
+<AppHostTabs limitations={{
+  typescript: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current TypeScript AppHost SDK.',
+  python: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Python AppHost SDK.',
+  go: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Go AppHost SDK.',
+  java: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Java AppHost SDK.',
+  rust: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="Old publishing callback"
 var api = builder.AddProject<Projects.Api>("api")
     .WithPublishingCallback(async (context, cancellationToken) =>
@@ -721,7 +1052,18 @@ var api = builder.AddProject<Projects.Api>("api")
     });
 ```
 
+</Fragment>
+</AppHostTabs>
+
 **After (Aspire 13.0):**
+
+<AppHostTabs limitations={{
+  python: 'Python emits with_pipeline_step_factory as a step name, typed synchronous callback, and options rather than a factory returning PipelineStep; it cannot await this asynchronous deployment body.',
+  go: 'Go emits WithPipelineStepFactory as a step name, typed callback, and options rather than a factory returning PipelineStep; the callback cannot return this asynchronous operation or an error.',
+  java: 'Java emits withPipelineStepFactory as a step name, typed synchronous callback, and options rather than a factory returning PipelineStep; it cannot await this asynchronous deployment body.',
+  rust: 'Rust emits with_pipeline_step_factory with a raw Vec<Value> callback rather than a typed PipelineStepContext, so this typed resource-level migration is not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="New pipeline step"
 var api = builder.AddProject<Projects.Api>("api")
@@ -740,9 +1082,41 @@ var api = builder.AddProject<Projects.Api>("api")
     });
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="New pipeline step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder
+  .addProject('api', '../Api/Api.csproj')
+  .withPipelineStepFactory('custom-deploy-api', async (context) => {
+    await customDeploy(context);
+  }, { requiredBy: ['deploy'] });
+
+await builder.build().run();
+
+async function customDeploy(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 #### Application-level callback
 
 **Before (Aspire 9.x):**
+
+<AppHostTabs limitations={{
+  typescript: 'This Aspire 9.x lifecycle-hook publishing pattern depends on C# dependency-injection and lifecycle types and has no generated TypeScript AppHost equivalent.',
+  python: 'This Aspire 9.x lifecycle-hook publishing pattern depends on C# dependency-injection and lifecycle types and has no generated Python AppHost equivalent.',
+  go: 'This Aspire 9.x lifecycle-hook publishing pattern depends on C# dependency-injection and lifecycle types and has no generated Go AppHost equivalent.',
+  java: 'This Aspire 9.x lifecycle-hook publishing pattern depends on C# dependency-injection and lifecycle types and has no generated Java AppHost equivalent.',
+  rust: 'This Aspire 9.x lifecycle-hook publishing pattern depends on C# dependency-injection and lifecycle types and has no generated Rust AppHost equivalent.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Old application-level callback"
 builder.Services.AddLifecycleHook<CustomPublishingHook>();
@@ -759,7 +1133,18 @@ public class CustomPublishingHook : IDistributedApplicationLifecycleHook
 }
 ```
 
+</Fragment>
+</AppHostTabs>
+
 **After (Aspire 13.0):**
+
+<AppHostTabs limitations={{
+  python: 'Python emits a typed add_step API, but its callback is synchronous and cannot await the asynchronous notification operation in this example.',
+  go: 'Go emits a typed AddStep API, but its callback has no error or asynchronous return shape for the notification operation in this example.',
+  java: 'Java emits a typed addStep API, but its callback is synchronous and cannot await the asynchronous notification operation in this example.',
+  rust: 'Rust emits add_step with a raw Vec<Value> callback instead of a typed PipelineStepContext, so this typed asynchronous notification step is not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="New pipeline step"
 builder.Pipeline.AddStep("notify-deployment", async (context) =>
@@ -770,9 +1155,39 @@ builder.Pipeline.AddStep("notify-deployment", async (context) =>
 dependsOn: [WellKnownPipelineSteps.Deploy]);
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="New pipeline step — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.pipeline().addStep('notify-deployment', async (context) => {
+  await sendDeploymentNotification(context);
+}, { dependsOn: ['deploy'] });
+
+await builder.build().run();
+
+async function sendDeploymentNotification(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 #### Complex deployment workflow
 
 **Before (Aspire 9.x):**
+
+<AppHostTabs limitations={{
+  typescript: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current TypeScript AppHost SDK.',
+  python: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Python AppHost SDK.',
+  go: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Go AppHost SDK.',
+  java: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Java AppHost SDK.',
+  rust: 'The removed Aspire 9.x WithPublishingCallback API was C#-specific and is not emitted by the current Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Old complex callback"
 var api = builder.AddProject<Projects.Api>("api")
@@ -787,7 +1202,18 @@ var api = builder.AddProject<Projects.Api>("api")
     });
 ```
 
+</Fragment>
+</AppHostTabs>
+
 **After (Aspire 13.0):**
+
+<AppHostTabs limitations={{
+  python: 'Python emits typed application- and resource-level step callbacks, but both are synchronous and cannot await the asynchronous workflow operations in this example.',
+  go: 'Go emits typed application- and resource-level step callbacks, but they have no error or asynchronous return shape for the workflow operations in this example.',
+  java: 'Java emits typed application- and resource-level step callbacks, but both are synchronous and cannot await the asynchronous workflow operations in this example.',
+  rust: 'Rust emits application- and resource-level callbacks as raw Vec<Value> values rather than typed PipelineStepContext values, so this typed asynchronous workflow is not usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="New pipeline steps with dependencies"
 // Break down into discrete steps with dependencies
@@ -819,6 +1245,53 @@ builder.Pipeline.AddStep("smoke-tests", async (context) =>
     await RunSmokeTests(context);
 }, dependsOn: ["deploy-application"]);
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="New pipeline steps with dependencies — apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.pipeline().addStep('provision-infra', async (context) => {
+  await provisionInfrastructure(context);
+}, { requiredBy: ['build'] });
+
+await builder.pipeline().addStep('migrate-database', async (context) => {
+  await runDatabaseMigrations(context);
+}, {
+  dependsOn: ['provision-infra'],
+  requiredBy: ['deploy-application'],
+});
+
+await builder
+  .addProject('api', '../Api/Api.csproj')
+  .withPipelineStepFactory('deploy-application', async (context) => {
+    await deployApplication(context);
+  }, { dependsOn: ['build', 'push'] });
+
+await builder.pipeline().addStep('smoke-tests', async (context) => {
+  await runSmokeTests(context);
+}, { dependsOn: ['deploy-application'] });
+
+await builder.build().run();
+
+async function provisionInfrastructure(_context: unknown) {
+}
+
+async function runDatabaseMigrations(_context: unknown) {
+}
+
+async function deployApplication(_context: unknown) {
+}
+
+async function runSmokeTests(_context: unknown) {
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ### Benefits of the new system
 

--- a/src/frontend/src/content/docs/diagnostics/aspire001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspire001.mdx
@@ -4,7 +4,7 @@ seoTitle: "ASPIRE001: The code language isn't fully supported by Aspire"
 description: "Learn what causes the Aspire compiler warning ASPIRE001 — the code language isn't fully supported by Aspire — and how to fix it in your AppHost."
 ---
 
-import { Aside, Badge } from '@astrojs/starlight/components';
+import { Badge } from '@astrojs/starlight/components';
 
 <Badge
   text="Version introduced: 8.0.0"
@@ -15,11 +15,11 @@ import { Aside, Badge } from '@astrojs/starlight/components';
 
 > The 'CODELANGUAGE' language isn't fully supported by Aspire - some code generation targets will not run, so will require manual authoring.
 
-This diagnostic warning is reported when using a code language other than C#.
+This MSBuild warning concerns the .NET AppHost SDK's C# code-generation targets when used in a project written in another .NET language. It doesn't mean that TypeScript AppHosts are unsupported: TypeScript AppHosts use a generated SDK rather than these C# project code-generation targets. The same distinction applies to the [experimental Python, Go, Java, and Rust AppHosts](/diagnostics/overview/#experimental-apphost-examples).
 
 ## To correct this warning
 
-In your Aspire project, use C#.
+Use C# for a .NET AppHost project that relies on these code-generation targets. To author your AppHost in TypeScript instead, follow [Build your first Aspire app](/get-started/first-app/?aspire-lang=typescript).
 
 ## Suppress the warning
 
@@ -36,7 +36,7 @@ Suppress the warning with either of the following methods:
 
 - Add the following `PropertyGroup` to your project file:
 
-  ```xml title=C# project file"
+  ```xml title="C# project file"
   <PropertyGroup>
       <NoWarn>$(NoWarn);ASPIRE001</NoWarn>
   </PropertyGroup>

--- a/src/frontend/src/content/docs/diagnostics/aspire006.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspire006.mdx
@@ -5,6 +5,7 @@ description: Learn what causes Aspire compiler error ASPIRE006 — invalid AppHo
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 8.2.2"
@@ -15,19 +16,143 @@ import { Badge } from '@astrojs/starlight/components';
 
 > The resource name 'NAME' is invalid: CONSTRAINT
 
-This diagnostic error is reported when a resource's name is invalid, such as a name with consecutive hyphen (`-`) characters.
+This C# analyzer diagnostic is reported when a resource's name is invalid, such as a name with consecutive hyphen (`-`) characters. The same resource naming constraints apply across AppHost languages. Generated SDKs reject an invalid name at runtime rather than through this C# analyzer.
 
 This error shouldn't be suppressed, as invalid model names throw an exception at runtime.
 
 ## Example
 
-The following code generates `ASPIRE006`:
+The following examples intentionally use an invalid resource name. The C# example generates `ASPIRE006`; the generated SDK examples fail when the AppHost runs. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const bbsContainer = await builder.addContainer('bbs--server', { image: 'coldwall/mystic' });
+await bbsContainer.withEndpoint({ port: 19991, targetPort: 23 });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
 var bbsContainer = builder.AddContainer("bbs--server", "coldwall/mystic")
-                          .WithEndpoint(19991, 23);
+    .WithEndpoint(19991, 23);
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    bbs_container = builder.add_container("bbs--server", "coldwall/mystic")
+    bbs_container.with_endpoint(port=19991, target_port=23)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	bbsContainer := builder.
+		AddContainer("bbs--server", "coldwall/mystic").
+		WithEndpoint(&aspire.WithEndpointOptions{
+			Port:       aspire.Float64Ptr(19991),
+			TargetPort: aspire.Float64Ptr(23),
+		})
+	if err := bbsContainer.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var bbsContainer = builder.addContainer("bbs--server", "coldwall/mystic");
+    bbsContainer.withEndpoint(
+        new WithEndpointOptions().port(19991).targetPort(23));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let bbs_container = builder.add_container(
+        "bbs--server",
+        "coldwall/mystic".into(),
+    )?;
+    bbs_container.with_endpoint(
+        Some(19991.0),
+        Some(23.0),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this error
 
-Use a valid name. For more information, see [Resource naming conventions](/architecture/resource-model/#resource-basics).
+Use a valid name, such as `bbs-server`, in every AppHost language. For more information, see [Resource naming conventions](/architecture/resource-model/#resource-basics).

--- a/src/frontend/src/content/docs/diagnostics/aspireacadomains001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireacadomains001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIREACADOMAINS001 and
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.0"
@@ -29,25 +31,219 @@ When you use one of these methods, the Azure Developer CLI (`azd`) can no longer
 
 ## Example
 
-Before Aspire 13.5, the following code generated `ASPIREACADOMAINS001`:
+Install the Azure Container Apps hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples configure a custom domain across supported AppHost languages. Before Aspire 13.5, the C# call generated `ASPIREACADOMAINS001`; generated AppHost SDKs don't emit this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addAzureContainerAppEnvironment('env');
+const customDomain = await builder.addParameter('customDomain');
+const certificateName = await builder.addParameter('certificateName');
+
+const api = await builder.addProject('api', '../ApiService/ApiService.csproj');
+await api.withExternalHttpEndpoints();
+await api.publishAsAzureContainerApp(async (infra, app) => {
+  await app.configureCustomDomain(customDomain, certificateName);
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("env");
 var customDomain = builder.AddParameter("customDomain");
 var certificateName = builder.AddParameter("certificateName");
 
 builder.AddProject<Projects.AzureContainerApps_ApiService>("api")
-       .WithExternalHttpEndpoints()
-       .PublishAsAzureContainerApp((infra, app) =>
-       {
-           app.ConfigureCustomDomain(customDomain, certificateName);
-       });
+    .WithExternalHttpEndpoints()
+    .PublishAsAzureContainerApp((infra, app) =>
+    {
+        app.ConfigureCustomDomain(customDomain, certificateName);
+    });
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+
+with create_builder() as builder:
+    builder.add_azure_container_app_env("env")
+    custom_domain = builder.add_parameter("customDomain")
+    certificate_name = builder.add_parameter("certificateName")
+
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_external_http_endpoints()
+    api.publish_as_azure_container_app(
+        lambda _infra, app: app.configure_custom_domain(
+            custom_domain,
+            certificate_name,
+        )
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddAzureContainerAppEnvironment("env")
+	customDomain := builder.AddParameter("customDomain")
+	certificateName := builder.AddParameter("certificateName")
+	api := builder.
+		AddProject("api", "../ApiService/ApiService.csproj").
+		WithExternalHttpEndpoints().
+		PublishAsAzureContainerApp(
+			func(_ aspire.AzureResourceInfrastructure, app aspire.ContainerApp) {
+				if err := app.ConfigureCustomDomain(customDomain, certificateName); err != nil {
+					log.Fatal(aspire.FormatError(err))
+				}
+			})
+	for _, err := range []error{
+		env.Err(),
+		customDomain.Err(),
+		certificateName.Err(),
+		api.Err(),
+	} {
+		if err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("env");
+    var customDomain = builder.addParameter("customDomain");
+    var certificateName = builder.addParameter("certificateName");
+
+    var api = builder.addProject(
+        "api",
+        "../ApiService/ApiService.csproj");
+    api.withExternalHttpEndpoints();
+    api.publishAsAzureContainerApp(
+        (_infra, app) -> app.configureCustomDomain(
+            customDomain,
+            certificateName));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust callback receives raw handle values. Reconstruct the public
+`ContainerApp` wrapper before configuring the custom domain:
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_azure_container_app_environment("env")?;
+    let custom_domain = builder.add_parameter(
+        "customDomain",
+        None,
+        None,
+        None,
+    )?;
+    let certificate_name = builder.add_parameter(
+        "certificateName",
+        None,
+        None,
+        None,
+    )?;
+
+    let api = builder.add_project(
+        "api",
+        "../ApiService/ApiService.csproj",
+        None,
+    )?;
+    api.with_external_http_endpoints()?;
+
+    let client = api.client().clone();
+    api.publish_as_azure_container_app(move |args| {
+        let handle = serde_json::from_value(args[1].clone())
+            .expect("Container App callback argument");
+        let app = ContainerApp::new(handle, client.clone());
+        app.configure_custom_domain(&custom_domain, &certificate_name)
+            .expect("configure custom domain");
+        Value::Null
+    })?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this error
 
 If you use Aspire 13.5 or later, you don't need to suppress this diagnostic and can remove any existing `ASPIREACADOMAINS001` suppressions.
 
 If you use an Aspire version earlier than 13.5, suppress the diagnostic with one of the following methods:
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspireacanaming001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireacanaming001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIREACANAMING001 an
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -19,7 +21,30 @@ This diagnostic warning is reported when using the experimental `WithCompactReso
 
 ## Example
 
-The following code generates `ASPIREACANAMING001`:
+Install the Azure Container Apps hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples enable compact resource naming. The C# call generates `ASPIREACANAMING001`; generated AppHost SDKs expose the same experimental hosting operation without emitting this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const env = await builder.addAzureContainerAppEnvironment('env');
+await env.withCompactResourceNaming();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -30,7 +55,97 @@ builder.AddAzureContainerAppEnvironment("env")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    env = builder.add_azure_container_app_env("env")
+    env.with_compact_resource_naming()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.
+		AddAzureContainerAppEnvironment("env").
+		WithCompactResourceNaming()
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("env")
+        .withCompactResourceNaming();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let env = builder.add_azure_container_app_environment("env")?;
+    env.with_compact_resource_naming()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireacanaming002.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireacanaming002.mdx
@@ -1,10 +1,12 @@
 ---
 title: Compiler Error ASPIREACANAMING002
-seoTitle: "ASPIREACANAMING002: WithUniqueResourceNaming is for evaluation"
+seoTitle: 'ASPIREACANAMING002: WithUniqueResourceNaming is for evaluation'
 description: Learn what causes the Aspire compiler error ASPIREACANAMING002 and how to fix it so your AppHost builds cleanly.
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -17,16 +19,131 @@ import { Badge } from '@astrojs/starlight/components';
 
 ## Example
 
-The following code generates `ASPIREACANAMING002`:
+Install the Azure Container Apps hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples enable unique resource naming. The C# call generates `ASPIREACANAMING002`; generated AppHost SDKs expose the same experimental hosting operation without emitting this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const env1 = await builder.addAzureContainerAppEnvironment('cae1');
+await env1.withUniqueResourceNaming();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var env1 = builder.AddAzureContainerAppEnvironment("cae1")
     .WithUniqueResourceNaming();
+
+builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    env = builder.add_azure_container_app_env("cae1")
+    env.with_unique_resource_naming()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.
+		AddAzureContainerAppEnvironment("cae1").
+		WithUniqueResourceNaming()
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("cae1")
+        .withUniqueResourceNaming();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let env = builder.add_azure_container_app_environment("cae1")?;
+    env.with_unique_resource_naming()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireats001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireats001.mdx
@@ -25,7 +25,7 @@ import LearnMore from '@components/LearnMore.astro';
 
 ## If you still see this warning
 
-Upgrade the Aspire CLI, AppHost SDK, and hosting integration packages to Aspire 13.4 or later. After upgrading, remove any `ASPIREATS001` suppressions from _.editorconfig_ files, project files, and `#pragma warning` blocks.
+Upgrade the Aspire CLI, AppHost SDK, and hosting integration packages to Aspire 13.4 or later. After upgrading, remove any `ASPIREATS001` suppressions from _.editorconfig_ files, project files, `#:property NoWarn` directives in C# file-based AppHosts, and `#pragma warning` blocks.
 
 <LearnMore>
   For more information, see [What's new in Aspire 13.4](/whats-new/aspire-13-4/)

--- a/src/frontend/src/content/docs/diagnostics/aspireazure001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireazure001.mdx
@@ -15,17 +15,21 @@ import { Badge } from '@astrojs/starlight/components';
 
 > Publishers are for evaluation purposes only and are subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-The Aspire Azure hosting integration now ships with a publisher. If you're using any of the `Aspire.Hosting.AzurePublisherExtensions.AddAzurePublisher*` APIs, you might see a compiler error/warning indicating that the API is experimental. This behavior is expected, as the API is still in preview and the shape of this API is expected to change in the future.
+Earlier versions of the Aspire Azure hosting integration exposed publisher registration through the `Aspire.Hosting.AzurePublisherExtensions.AddAzurePublisher*` APIs. In versions that expose these experimental APIs, using them can produce this compiler diagnostic.
 
 ## Example
 
-The following code generates `ASPIREAZURE001`:
+`AddAzurePublisher` is a legacy, C#-only publisher-registration API and isn't exported to the generated AppHost SDKs. AppHosts can configure Azure deployment through hosting integrations such as [Azure Container Apps](/integrations/cloud/azure/configure-container-apps/), but the generated SDKs do not expose `addAzurePublisher`.
+
+In versions that expose `AddAzurePublisher`, the following C# code generates `ASPIREAZURE001`:
 
 ```csharp title="AppHost.cs"
 builder.AddAzurePublisher();
 ```
 
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireazure002.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireazure002.mdx
@@ -1,10 +1,12 @@
 ---
 title: Compiler Error ASPIREAZURE002
-seoTitle: "ASPIREAZURE002: Azure Container App Jobs are for evaluation"
+seoTitle: 'ASPIREAZURE002: Azure Container App Jobs are for evaluation'
 description: Learn what causes the Aspire compiler error ASPIREAZURE002 and how to fix it so your AppHost builds cleanly. Resolve or suppress it to keep your Aspire build.
 ---
 
-import { Badge, Aside } from '@astrojs/starlight/components';
+import { Badge, Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.5"
@@ -14,16 +16,310 @@ import { Badge, Aside } from '@astrojs/starlight/components';
 />
 
 <Aside type="note">
-  As of Aspire 13.4, the `PublishAsAzureContainerAppJob` and `PublishAsScheduledAzureContainerAppJob` APIs are no longer experimental and do not trigger `ASPIREAZURE002`. This diagnostic only applies if you are using an earlier version of Aspire.
+  As of Aspire 13.4, the `PublishAsAzureContainerAppJob` and
+  `PublishAsScheduledAzureContainerAppJob` APIs are no longer experimental and
+  do not trigger `ASPIREAZURE002`. This diagnostic only applies if you are using
+  an earlier version of Aspire.
 </Aside>
 
 > Azure Container App Jobs are for evaluation purposes only and are subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-The Aspire Azure hosting integration now ships with support for Azure Container App Jobs. If you're using any of the `PublishAsAzureContainerAppJob` APIs, you might see a compiler error/warning indicating that the API is experimental. This behavior is expected, as the API is still in preview and the shape of this API is expected to change in the future.
+The Aspire Azure hosting integration supports Azure Container App Jobs. In Aspire versions earlier than 13.4, using the `PublishAsAzureContainerAppJob` APIs in C# can produce this experimental API diagnostic. Current AppHosts can use the stable job APIs without suppressing it.
 
 ## Example
 
-The following code generates `ASPIREAZURE002`:
+Install the Azure Container Apps hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples publish a job scheduled to run daily at midnight with the dedicated scheduled-job API:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addAzureContainerAppEnvironment('env');
+const processor = await builder.addProject(
+  'data-processor',
+  '../DataProcessor/DataProcessor.csproj'
+);
+await processor.publishAsScheduledAzureContainerAppJob('0 0 * * *');
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("env");
+builder.AddProject<Projects.DataProcessor>("data-processor")
+    .PublishAsScheduledAzureContainerAppJob("0 0 * * *");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_azure_container_app_env("env")
+    processor = builder.add_project(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj",
+    )
+    processor.publish_as_scheduled_azure_container_app_job("0 0 * * *")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddAzureContainerAppEnvironment("env")
+	processor := builder.
+		AddProject("data-processor", "../DataProcessor/DataProcessor.csproj").
+		PublishAsScheduledAzureContainerAppJob("0 0 * * *")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := processor.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("env");
+    var processor = builder.addProject(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj");
+    processor.publishAsScheduledAzureContainerAppJob("0 0 * * *");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust method requires a callback even when the job doesn't need
+additional configuration, so pass a no-op callback:
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_azure_container_app_environment("env")?;
+    let processor = builder.add_project(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj",
+        None,
+    )?;
+    processor.publish_as_scheduled_azure_container_app_job(
+        "0 0 * * *",
+        |_| Value::Null,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+For a manually triggered job, use the general job API without a schedule:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addAzureContainerAppEnvironment('env');
+const processor = await builder.addProject(
+  'data-processor',
+  '../DataProcessor/DataProcessor.csproj'
+);
+await processor.publishAsAzureContainerAppJob();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("env");
+builder.AddProject<Projects.DataProcessor>("data-processor")
+    .PublishAsAzureContainerAppJob();
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_azure_container_app_env("env")
+    processor = builder.add_project(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj",
+    )
+    processor.publish_as_azure_container_app_job()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddAzureContainerAppEnvironment("env")
+	processor := builder.
+		AddProject("data-processor", "../DataProcessor/DataProcessor.csproj").
+		PublishAsAzureContainerAppJob()
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := processor.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("env");
+    var processor = builder.addProject(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj");
+    processor.publishAsAzureContainerAppJob();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust method requires a callback even when the job doesn't need
+additional configuration, so pass a no-op callback:
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_azure_container_app_environment("env")?;
+    let processor = builder.add_project(
+        "data-processor",
+        "../DataProcessor/DataProcessor.csproj",
+        None,
+    )?;
+    processor.publish_as_azure_container_app_job(|_| Value::Null)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+In earlier Aspire versions, the following C# customization generated `ASPIREAZURE002`. Direct Azure provisioning object mutation in this form is C#-only; use the scheduled-job API shown above for the same scheduling behavior in generated AppHost SDKs.
 
 ```csharp title="AppHost.cs"
 builder.AddProject<Projects.DataProcessor>("data-processor")
@@ -35,6 +331,10 @@ builder.AddProject<Projects.DataProcessor>("data-processor")
 ```
 
 ## To correct this error
+
+On Aspire 13.4 or later, remove existing `ASPIREAZURE002` suppressions. The following suppression options apply only to earlier C# AppHosts.
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireazure003.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireazure003.mdx
@@ -1,10 +1,12 @@
 ---
 title: Compiler Error ASPIREAZURE003
-seoTitle: "ASPIREAZURE003: Azure Virtual Network types and members are"
+seoTitle: 'ASPIREAZURE003: Azure Virtual Network types and members are'
 description: Learn what causes the Aspire compiler error ASPIREAZURE003 and how to fix it so your AppHost builds cleanly. Resolve or suppress it to keep your Aspire build.
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -19,14 +21,148 @@ The Aspire Azure hosting integration now ships with support for Azure Virtual Ne
 
 ## Example
 
-The following code generates `ASPIREAZURE003`:
+Install the Azure Network hosting integration:
 
-```csharp title="AppHost.cs"
-var vnet = builder.AddAzureVirtualNetwork("vnet");
-var subnet = vnet.AddSubnet("pe-subnet", "10.0.1.0/24");
+<InstallPackage packageName="Aspire.Hosting.Azure.Network" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples add a virtual network and subnet. The C# calls generate `ASPIREAZURE003`; generated AppHost SDKs expose the same experimental operations without emitting this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const prefix = await builder.addParameter('subnet-prefix', '10.0.1.0/24');
+const vnet = await builder.addAzureVirtualNetwork('vnet');
+const subnet = await vnet.addSubnet('pe-subnet', prefix);
+
+await builder.build().run();
 ```
 
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var vnet = builder.AddAzureVirtualNetwork("vnet");
+var subnet = vnet.AddSubnet("pe-subnet", "10.0.1.0/24");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    prefix = builder.add_parameter("subnet-prefix", value="10.0.1.0/24")
+    vnet = builder.add_azure_virtual_network("vnet")
+    subnet = vnet.add_subnet("pe-subnet", prefix)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	prefix := builder.AddParameter("subnet-prefix", &aspire.AddParameterOptions{
+		Value: aspire.StringPtr("10.0.1.0/24"),
+	})
+	vnet := builder.AddAzureVirtualNetwork("vnet")
+	subnet := vnet.AddSubnet("pe-subnet", prefix)
+	for _, err := range []error{
+		prefix.Err(),
+		vnet.Err(),
+		subnet.Err(),
+	} {
+		if err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var prefix = builder.addParameter(
+        "subnet-prefix",
+        new AddParameterOptions().value("10.0.1.0/24"));
+    var vnet = builder.addAzureVirtualNetwork("vnet");
+    var subnet = vnet.addSubnet("pe-subnet", prefix, null);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let vnet = builder.add_azure_virtual_network("vnet", None)?;
+    let subnet = vnet.add_subnet(
+        "pe-subnet",
+        "10.0.1.0/24".into(),
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireblazor001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireblazor001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIREBLAZOR001 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.4"
@@ -21,9 +23,35 @@ This diagnostic warning is reported when using experimental Blazor WebAssembly h
 - `BlazorHostedExtensions` — client wiring for a hosted Blazor Web App
 - `BlazorWasmAppResource` — the resource type that represents a Blazor WebAssembly app
 
+The gateway and path-based WebAssembly registration APIs have generated AppHost SDK equivalents, shown below. The `BlazorHostedExtensions` methods `ProxyBlazorService` and `ProxyBlazorTelemetry` are C#-only; they aren't exported to the generated AppHost SDKs.
+
 ## Example
 
-The following code generates `ASPIREBLAZOR001`:
+Install the Blazor hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Blazor" />
+
+The C# example generates `ASPIREBLAZOR001`. The generated SDK examples configure the same resources without a C# compiler diagnostic. The path-based C# `AddBlazorWasmApp` method is exported as `addBlazorWasmProject` in TypeScript; the generic `AddBlazorWasmProject<TProject>` overload is C#-only.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const gateway = await builder.addBlazorGateway("gateway");
+const store = await builder.addBlazorWasmProject("store", "../Store/Store.csproj");
+await gateway.withBlazorClientApp(store);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -37,7 +65,106 @@ gateway.WithBlazorClientApp(store);
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    gateway = builder.add_blazor_gateway("gateway")
+    store = builder.add_blazor_wasm_project("store", "../Store/Store.csproj")
+    gateway.with_blazor_client_app(store)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	gateway := builder.AddBlazorGateway("gateway")
+	store := builder.AddBlazorWasmProject("store", "../Store/Store.csproj")
+	if err := store.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	gateway.WithBlazorClientApp(store)
+	if err := gateway.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var gateway = builder.addBlazorGateway("gateway");
+    var store = builder.addBlazorWasmProject(
+        "store",
+        "../Store/Store.csproj");
+    gateway.withBlazorClientApp(store);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let gateway = builder.add_blazor_gateway("gateway")?;
+    let store =
+        builder.add_blazor_wasm_project("store", "../Store/Store.csproj")?;
+    gateway.with_blazor_client_app(&store, None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirebrowserlogs001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirebrowserlogs001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIREBROWSERLOGS001 an
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.3"
@@ -21,11 +23,35 @@ This diagnostic error is reported when using experimental browser logs APIs in A
 - `BrowserUserDataMode` enum
 - Other types and members that configure the tracked browser session
 
-These APIs let you attach a tracked Chromium browser session to any HTTP/HTTPS resource in your AppHost so that browser console output flows into the resource's console log stream in the Aspire dashboard. For more information, see [Browser logs](/integrations/devtools/browser-logs/).
+These APIs let you attach a tracked Chromium browser session to any HTTP/HTTPS resource in your AppHost. Browser console output flows into a child browser resource's console log stream in the Aspire dashboard. For more information, see [Browser logs](/integrations/devtools/browser-logs/).
 
 ## Example
 
-The following code generates `ASPIREBROWSERLOGS001`:
+Install both the browser logs integration and the JavaScript integration used by the Vite resource:
+
+<InstallPackage packageName="Aspire.Hosting.Browsers" />
+<InstallPackage packageName="Aspire.Hosting.JavaScript" />
+
+The C# example generates `ASPIREBROWSERLOGS001`. Generated AppHost SDKs expose the same browser logging operation without emitting this C# compiler diagnostic.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{ rust: 'The Rust projection contains these APIs, but the daily SDK generated for the browser logs and JavaScript packages used for this documentation does not compile because of invalid generated argument-map code. A verified Rust example is not available in this build.' }}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const web = await builder.addViteApp("web", "../web");
+await web.withBrowserLogs();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -36,9 +62,77 @@ builder.AddViteApp("web", "../web")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_vite_app("web", "../web")
+    web.with_browser_logs()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.AddViteApp("web", "../web")
+	web.WithBrowserLogs()
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var web = builder.addViteApp("web", "../web");
+    web.withBrowserLogs();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this error
 
-Suppress the error with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the error with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecertificates001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecertificates001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRECERTIFICATES001
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -26,29 +28,169 @@ These APIs enable configuring HTTPS/TLS server certificates for resources in you
 
 ## Example
 
-The following code generates `ASPIRECERTIFICATES001`:
+Install Redis for the shared examples and YARP for the C#-only custom-certificate example:
+
+<InstallPackage packageName="Aspire.Hosting.Redis" />
+<InstallPackage packageName="Aspire.Hosting.Yarp" />
+
+The C# examples generate `ASPIRECERTIFICATES001`. The generated AppHost SDKs can configure a developer certificate or disable certificate configuration without emitting this C# compiler diagnostic. These examples use Redis resources, whose integration supports TLS configuration. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const tlsCache = await builder.addRedis("tls-cache");
+await tlsCache.withHttpsDeveloperCertificate();
+
+const cache = await builder.addRedis("cache");
+await cache.withoutHttpsCertificate();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 // Using developer certificate
-builder.AddViteApp("frontend")
+builder.AddRedis("tls-cache")
     .WithHttpsDeveloperCertificate();
+
+// Disabling HTTPS certificate configuration
+builder.AddRedis("cache")
+    .WithoutHttpsCertificate();
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    tls_cache = builder.add_redis("tls-cache")
+    tls_cache.with_https_developer_certificate()
+
+    cache = builder.add_redis("cache")
+    cache.without_https_certificate()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tlsCache := builder.
+		AddRedis("tls-cache").
+		WithHttpsDeveloperCertificate()
+	if err := tlsCache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.
+		AddRedis("cache").
+		WithoutHttpsCertificate()
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRedis("tls-cache")
+        .withHttpsDeveloperCertificate();
+
+    builder.addRedis("cache")
+        .withoutHttpsCertificate();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let tls_cache = builder.add_redis("tls-cache", None, None)?;
+    tls_cache.with_https_developer_certificate(None)?;
+
+    let cache = builder.add_redis("cache", None, None)?;
+    cache.without_https_certificate()?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Custom certificates and .NET services
+
+The `WithHttpsCertificate(X509Certificate2)` overload and `IDeveloperCertificateService` aren't exported to the generated AppHost SDKs. These C#-only operations require .NET certificate objects or access to the .NET service provider:
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
 
 // Using a custom certificate
 var certificate = new X509Certificate2("path/to/certificate.pfx", "password");
 builder.AddYarp("gateway")
     .WithHttpsCertificate(certificate);
 
-// Disabling HTTPS certificate configuration
-builder.AddRedis("cache")
-    .WithoutHttpsCertificate();
-
 // Using IDeveloperCertificateService
 var developerCertService = builder.Services
     .BuildServiceProvider()
     .GetRequiredService<IDeveloperCertificateService>();
 ```
+
+The callback-based `withHttpsCertificateConfiguration` and execution-configuration `withHttpsCertificateConfig` APIs are exported to TypeScript. They configure certificate handling and aren't direct replacements for passing a .NET `X509Certificate2` instance. For their configuration model, see [Certificate configuration](/app-host/certificate-configuration/).
 
 ## Understanding certificate configuration
 
@@ -75,7 +217,9 @@ The `IDeveloperCertificateService` provides information about developer certific
 
 ## To suppress this warning
 
-Suppress the warning with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the warning with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecommand001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecommand001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIRECOMMAND001 and 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -28,22 +29,127 @@ The simpler `WithRequiredCommand(command, helpLink)` overload isn't experimental
 
 ## Example
 
-The following code generates `ASPIRECOMMAND001`:
+The C# example generates `ASPIRECOMMAND001`. The TypeScript, Python, Go, and Java SDKs expose the equivalent required-command validation operation without emitting this C# compiler diagnostic. These APIs belong to the core `Aspire.Hosting` SDK, so no additional integration package is required. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes required-command validation callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments and results to `RequiredCommandValidationContext` and `RequiredCommandValidationResult`. This example requires the typed callback API.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const cache = await builder.addContainer("cache", { image: "redis" });
+await cache.withRequiredCommandValidation("redis-cli", async (context) => {
+  return await context.success();
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddContainer("db", "postgres")
+builder.AddContainer("cache", "redis")
     .WithRequiredCommand(
-        "psql",
+        "redis-cli",
         context => Task.FromResult(context.Success()));
 
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import RequiredCommandValidationContext, create_builder
+
+
+def validate_command(context: RequiredCommandValidationContext):
+    return context.success()
+
+
+with create_builder() as builder:
+    cache = builder.add_container("cache", "redis")
+    cache.with_required_command_validation("redis-cli", validate_command)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddContainer("cache", "redis").
+		WithRequiredCommandValidation(
+			"redis-cli",
+			func(context aspire.RequiredCommandValidationContext) aspire.RequiredCommandValidationResult {
+				result := context.Success()
+				if err := result.Err(); err != nil {
+					log.Fatal(aspire.FormatError(err))
+				}
+				return result
+			},
+		)
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var cache = builder.addContainer("cache", "redis");
+    cache.withRequiredCommandValidation(
+        "redis-cli",
+        RequiredCommandValidationContext::success);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 The diagnostic is triggered because the `WithRequiredCommand` validation-callback overload and the `RequiredCommandValidationContext` type are marked with the `[Experimental("ASPIRECOMMAND001")]` attribute.
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 
@@ -68,7 +174,7 @@ Suppress the warning with one of the following methods:
 
   ```csharp title="Suppressing the warning"
   #pragma warning disable ASPIRECOMMAND001
-  builder.AddContainer("db", "postgres")
-      .WithRequiredCommand("psql", context => Task.FromResult(context.Success()));
+  builder.AddContainer("cache", "redis")
+      .WithRequiredCommand("redis-cli", context => Task.FromResult(context.Success()));
   #pragma warning restore ASPIRECOMMAND001
   ```

--- a/src/frontend/src/content/docs/diagnostics/aspirecompute001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecompute001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIRECOMPUTE001 and ho
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.3"
@@ -17,19 +19,338 @@ import { Badge } from '@astrojs/starlight/components';
 
 ## Example
 
-The following code generates `ASPIRECOMPUTE001`:
+Compute environments can be configured across AppHost languages. `ASPIRECOMPUTE001` is a C# compiler diagnostic for versions that mark the compute APIs as experimental; the generated language SDKs do not emit it. Choose the environment for your deployment target. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+### Docker Compose
+
+<InstallPackage packageName="Aspire.Hosting.Docker" />
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.addDockerComposeEnvironment("env");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddDockerComposeEnvironment("env");
-// or
-builder.AddAzureContainerAppEnvironment("env")
-// or
-builder.AddKubernetesEnvironment("env")
+
+builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_docker_compose_env("env")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddDockerComposeEnvironment("env")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addDockerComposeEnvironment("env");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_docker_compose_environment("env")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Azure Container Apps
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.addAzureContainerAppEnvironment("env");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAzureContainerAppEnvironment("env");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_azure_container_app_env("env")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddAzureContainerAppEnvironment("env")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzureContainerAppEnvironment("env");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_azure_container_app_environment("env")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Kubernetes
+
+<InstallPackage packageName="Aspire.Hosting.Kubernetes" />
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+await builder.addKubernetesEnvironment("env");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddKubernetesEnvironment("env");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_kubernetes_env("env")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddKubernetesEnvironment("env")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addKubernetesEnvironment("env");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_kubernetes_environment("env")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppress only diagnostics emitted by your installed Aspire version.
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecompute002.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecompute002.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRECOMPUTE002 and 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -19,16 +21,168 @@ This diagnostic warning is reported when using the experimental `GetHostAddressE
 
 ## Example
 
-The following code generates `ASPIRECOMPUTE002`:
+The Docker Compose environment exports its host-address expression operation to the generated AppHost SDKs. Pass an endpoint on an application resource, not on the compute environment itself. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
 
-```csharp title="Using GetHostAddressExpression"
+<InstallPackage packageName="Aspire.Hosting.Docker" />
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const computeEnv = await builder.addDockerComposeEnvironment("env");
+const api = await builder.addContainer("api", { image: "nginx" });
+await api.withHttpEndpoint({ targetPort: 80 });
+const endpoint = await api.getEndpoint("http");
+const hostAddress = await computeEnv.getHostAddressExpression(endpoint);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var computeEnv = builder.AddDockerComposeEnvironment("env");
+var api = builder.AddContainer("api", "nginx")
+    .WithHttpEndpoint(targetPort: 80);
+var endpoint = api.GetEndpoint("http");
+var hostAddress = computeEnv.Resource.GetHostAddressExpression(endpoint);
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    compute_env = builder.add_docker_compose_env("env")
+    api = builder.add_container("api", "nginx")
+    api.with_http_endpoint(target_port=80)
+    endpoint = api.get_endpoint("http")
+    host_address = compute_env.get_host_address_expression(endpoint)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	computeEnv := builder.AddDockerComposeEnvironment("env")
+	if err := computeEnv.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	api := builder.AddContainer("api", "nginx").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{TargetPort: aspire.Float64Ptr(80)})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	endpoint := api.GetEndpoint("http")
+	if err := endpoint.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	hostAddress := computeEnv.GetHostAddressExpression(endpoint)
+	if err := computeEnv.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	_ = hostAddress
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var computeEnv = builder.addDockerComposeEnvironment("env");
+    var api = builder.addContainer("api", "nginx");
+    api.withHttpEndpoint(new WithHttpEndpointOptions().targetPort(80));
+    var endpoint = api.getEndpoint("http");
+    var hostAddress = computeEnv.getHostAddressExpression(endpoint);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let compute_env = builder.add_docker_compose_environment("env")?;
+    let api = builder.add_container("api", serde_json::json!("nginx"))?;
+    api.with_http_endpoint(None, Some(80.0), None, None, None)?;
+    let endpoint = api.get_endpoint("http")?;
+    let _host_address = compute_env.get_host_address_expression(&endpoint)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The C# call generates `ASPIRECOMPUTE002`; the operation remains experimental across AppHost languages but the generated language SDKs do not emit this C# compiler diagnostic.
+
+### Azure Container Apps
+
+The Azure Container Apps implementation of `GetHostAddressExpression` is not exported to the TypeScript, Python, Go, Java, or Rust SDKs. This specific implementation requires C#:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.AppContainers" />
+
+```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var computeEnv = builder.AddAzureContainerAppEnvironment("env");
-
-// Accessing GetHostAddressExpression on a compute environment resource
-var endpoint = computeEnv.Resource.GetEndpoint("http");
+var api = builder.AddContainer("api", "nginx")
+    .WithHttpEndpoint(targetPort: 80);
+var endpoint = api.GetEndpoint("http");
 var hostAddress = computeEnv.Resource.GetHostAddressExpression(endpoint);
+
+builder.Build().Run();
 ```
 
 ## Understanding GetHostAddressExpression
@@ -48,6 +202,8 @@ This method is useful when you need to configure resources with just the hostnam
 - Configuring load balancers or ingress controllers
 
 ## To suppress this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the warning with either of the following methods:
 
@@ -74,9 +230,11 @@ Suppress the warning with either of the following methods:
   var builder = DistributedApplication.CreateBuilder(args);
 
   var computeEnv = builder.AddAzureContainerAppEnvironment("env");
+  var api = builder.AddContainer("api", "nginx")
+      .WithHttpEndpoint(targetPort: 80);
 
   #pragma warning disable ASPIRECOMPUTE002
-  var endpoint = computeEnv.Resource.GetEndpoint("http");
+  var endpoint = api.GetEndpoint("http");
   var hostAddress = computeEnv.Resource.GetHostAddressExpression(endpoint);
   #pragma warning restore ASPIRECOMPUTE002
   ```

--- a/src/frontend/src/content/docs/diagnostics/aspirecompute003.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecompute003.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIRECOMPUTE003 and 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.1"
@@ -19,7 +20,26 @@ This diagnostic warning is reported when using the experimental `ContainerRegist
 
 ## Example
 
-The following code generates `ASPIRECOMPUTE003`:
+These APIs are included in the core AppHost SDK; no additional hosting integration is required. The following examples configure a registry with literal values. The C# calls generate `ASPIRECOMPUTE003`; the generated SDKs expose the same experimental operations without emitting this C# compiler diagnostic. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const registry = await builder.addContainerRegistry(
+    "docker-hub", "docker.io", { repository: "myusername" });
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withContainerRegistry(registry);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="Using ContainerRegistryResource"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -29,7 +49,145 @@ var registry = builder.AddContainerRegistry("docker-hub", "docker.io", "myuserna
 
 var api = builder.AddProject<Projects.Api>("api")
     .WithContainerRegistry(registry);
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    registry = builder.add_container_registry(
+        "docker-hub",
+        "docker.io",
+        repository="myusername",
+    )
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_container_registry(registry)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	registry := builder.AddContainerRegistry(
+		"docker-hub",
+		"docker.io",
+		&aspire.AddContainerRegistryOptions{Repository: "myusername"},
+	)
+	if err := registry.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddProject("api", "../Api/Api.csproj").
+		WithContainerRegistry(registry)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var registry = builder.addContainerRegistry(
+        "docker-hub", "docker.io", "myusername");
+    builder.addProject("api", "../Api/Api.csproj")
+        .withContainerRegistry(registry);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let registry = builder.add_container_registry(
+        "docker-hub", json!("docker.io"), Some(json!("myusername")),
+    )?;
+    let registry_resource = IResource::new(
+        registry.handle().clone(), registry.client().clone(),
+    );
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_container_registry(&registry_resource)?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The Rust SDK takes an `IResource` handle for the registry reference. Its public `handle()`, `client()`, and `IResource::new` APIs preserve the existing resource handle without creating another registry.
+
+Alternatively, use parameters for the registry endpoint and repository:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const endpointParameter = await builder.addParameter("registry-endpoint");
+const repositoryParameter = await builder.addParameter("registry-repo");
+const registry = await builder.addContainerRegistry(
+    "my-registry", endpointParameter, { repository: repositoryParameter });
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withContainerRegistry(registry);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="Using ContainerRegistryResource with parameters"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -42,7 +200,136 @@ var registry = builder.AddContainerRegistry("my-registry", endpointParameter, re
 
 var api = builder.AddProject<Projects.Api>("api")
     .WithContainerRegistry(registry);
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    endpoint_parameter = builder.add_parameter("registry-endpoint")
+    repository_parameter = builder.add_parameter("registry-repo")
+    registry = builder.add_container_registry(
+        "my-registry",
+        endpoint_parameter,
+        repository=repository_parameter,
+    )
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_container_registry(registry)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	endpointParameter := builder.AddParameter("registry-endpoint")
+	if err := endpointParameter.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	repositoryParameter := builder.AddParameter("registry-repo")
+	if err := repositoryParameter.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	registry := builder.AddContainerRegistry(
+		"my-registry",
+		endpointParameter,
+		&aspire.AddContainerRegistryOptions{Repository: repositoryParameter},
+	)
+	if err := registry.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddProject("api", "../Api/Api.csproj").
+		WithContainerRegistry(registry)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var endpointParameter = builder.addParameter("registry-endpoint");
+    var repositoryParameter = builder.addParameter("registry-repo");
+    var registry = builder.addContainerRegistry(
+        "my-registry", endpointParameter, repositoryParameter);
+
+    builder.addProject("api", "../Api/Api.csproj")
+        .withContainerRegistry(registry);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let endpoint = builder.add_parameter("registry-endpoint", None, None, None)?;
+    let repository = builder.add_parameter("registry-repo", None, None, None)?;
+    let registry = builder.add_container_registry(
+        "my-registry",
+        endpoint.handle().to_json(),
+        Some(repository.handle().to_json()),
+    )?;
+    let registry_resource = IResource::new(
+        registry.handle().clone(), registry.client().clone(),
+    );
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_container_registry(&registry_resource)?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Understanding container registry resources
 
@@ -74,6 +361,8 @@ The `ContainerRegistryResource` represents a general-purpose container registry 
 - Supports chaining with other resource configuration methods
 
 ## To suppress this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecontainerruntime001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecontainerruntime001.mdx
@@ -28,6 +28,8 @@ This API is experimental because the container runtime abstraction layer is bein
 
 ## Example
 
+`IContainerRuntime` and its runtime detection, image management, and registry methods are .NET service APIs, not generated AppHost SDK exports. This C#-only example resolves that service directly; container resource configuration is a separate hosting API.
+
 The following code generates `ASPIRECONTAINERRUNTIME001`:
 
 ```csharp title="AppHost.cs"
@@ -53,7 +55,9 @@ var runtimeName = containerRuntime.Name;
 
 ## To correct this warning
 
-Suppress the warning with either of the following methods:
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the warning with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecontainershellexecution001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecontainershellexecution001.mdx
@@ -19,18 +19,22 @@ The `ShellExecution` property on `ContainerResource` is an experimental feature 
 
 ## Example
 
+`ShellExecution` is a property of the underlying .NET `ContainerResource`, not its resource builder. The generated AppHost SDKs do not expose this property on the general container resource API. Directly setting it as shown in this C#-only example requires access to the underlying .NET resource.
+
 The following code generates `ASPIRECONTAINERSHELLEXECUTION001`:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var container = builder.AddContainer("mycontainer", "myimage");
-container.ShellExecution = true;
+container.Resource.ShellExecution = true;
 ```
 
 ## To correct this warning
 
-Suppress the warning with either of the following methods:
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the warning with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 
@@ -53,6 +57,6 @@ Suppress the warning with either of the following methods:
 
   ```csharp title="Suppressing the warning"
   #pragma warning disable ASPIRECONTAINERSHELLEXECUTION001
-  container.ShellExecution = true;
+  container.Resource.ShellExecution = true;
   #pragma warning restore ASPIRECONTAINERSHELLEXECUTION001
   ```

--- a/src/frontend/src/content/docs/diagnostics/aspirecosmosdb001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecosmosdb001.mdx
@@ -1,10 +1,12 @@
 ---
 title: Compiler Error ASPIRECOSMOSDB001
-seoTitle: "ASPIRECOSMOSDB001: `RunAsPreviewEmulator` is for evaluation"
+seoTitle: 'ASPIRECOSMOSDB001: `RunAsPreviewEmulator` is for evaluation'
 description: Learn what causes the Aspire compiler error ASPIRECOSMOSDB001 and how to fix it so your AppHost builds cleanly.
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.0"
@@ -25,18 +27,166 @@ Aspire provides a way to use the Cosmos DB Linux-based (preview) emulator and da
 
 ## Example
 
-The following sample generates `ASPIRECOSMOSDB001`:
+Install the Azure Cosmos DB hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.CosmosDB" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples enable the preview emulator and its data explorer. The C# calls generate `ASPIRECOSMOSDB001`; generated AppHost SDKs expose the same experimental operations without emitting this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const cosmos = await builder.addAzureCosmosDB('cosmos');
+await cosmos.runAsPreviewEmulator(async (emulator) => {
+  await emulator.withDataExplorer();
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var cosmos = builder.AddAzureCosmosDB("cosmos")
-                    .RunAsPreviewEmulator(e => e.WithDataExplorer());
+    .RunAsPreviewEmulator(e => e.WithDataExplorer());
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+
+def configure_emulator(emulator) -> None:
+    emulator.with_data_explorer()
+
+
+with create_builder() as builder:
+    cosmos = builder.add_azure_cosmos_db("cosmos")
+    cosmos.run_as_preview_emulator(
+        configure_container=configure_emulator
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cosmos := builder.
+		AddAzureCosmosDB("cosmos").
+		RunAsPreviewEmulator(&aspire.RunAsPreviewEmulatorOptions{
+			ConfigureContainer: func(emulator aspire.AzureCosmosDBEmulatorResource) {
+				emulator.WithDataExplorer()
+				if err := emulator.Err(); err != nil {
+					log.Fatal(aspire.FormatError(err))
+				}
+			},
+		})
+	if err := cosmos.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var cosmos = builder.addAzureCosmosDB("cosmos");
+    cosmos.runAsPreviewEmulator(
+        emulator -> emulator.withDataExplorer());
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust callback receives a raw handle value. Reconstruct the public
+`AzureCosmosDBEmulatorResource` wrapper before enabling the data explorer:
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cosmos = builder.add_azure_cosmos_db("cosmos")?;
+    let client = cosmos.client().clone();
+    cosmos.run_as_preview_emulator(move |args| {
+        let handle = serde_json::from_value(args[0].clone())
+            .expect("Cosmos DB emulator callback argument");
+        let emulator = AzureCosmosDBEmulatorResource::new(
+            handle,
+            client.clone(),
+        );
+        emulator
+            .with_data_explorer(None)
+            .expect("enable data explorer");
+        Value::Null
+    })?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this error
 
-Suppress the Error with either of the following methods:
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
+
+Suppress the error with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspirecsharpapps001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirecsharpapps001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIRECSHARPAPPS001 and
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -19,7 +21,29 @@ Aspire provides a way to add C# app resources to the Aspire AppHost with the `Ad
 
 ## Example
 
-The following code generates `ASPIRECSHARPAPPS001`:
+Install the Redis integration used by the supporting cache resource. The C# app resource API itself is included in core Aspire hosting.
+
+<InstallPackage packageName="Aspire.Hosting.Redis" />
+
+The C# example generates `ASPIRECSHARPAPPS001`. AppHosts written in TypeScript, Python, Go, Java, and Rust can also host a file-based C# app; the hosted app's language doesn't determine the AppHost's language. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const cache = await builder.addRedis("cache");
+const worker = await builder.addCSharpApp("worker", "../worker/Program.cs");
+await worker.withReference(cache);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -32,9 +56,108 @@ builder.AddCSharpApp("worker", "../worker/Program.cs")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_redis("cache")
+    worker = builder.add_c_sharp_app("worker", "../worker/Program.cs")
+    worker.with_reference(cache)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddRedis("cache")
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	worker := builder.
+		AddCSharpApp("worker", "../worker/Program.cs").
+		WithReference(cache)
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var cache = builder.addRedis("cache");
+    builder.addCSharpApp("worker", "../worker/Program.cs")
+        .withReference(cache);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_redis("cache", None, None)?;
+    let worker = builder.add_c_sharp_app("worker", "../worker/Program.cs", None)?;
+    worker.with_reference(cache.handle().to_json(), None, None, None)?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The Rust reference method accepts a JSON-encoded handle. Use the generated `handle().to_json()` helper to pass the existing Redis resource, rather than creating a connection-string literal.
+
 ## To correct this error
 
-Suppress the error with either of the following methods:
+The following suppression options apply to C# AppHosts, not the generated SDK equivalents. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the error with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspiredockerfilebuilder001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiredockerfilebuilder001.mdx
@@ -4,7 +4,8 @@ seoTitle: "ASPIREDOCKERFILEBUILDER001: Dockerfile builder types and"
 description: Learn what causes the Aspire compiler warning ASPIREDOCKERFILEBUILDER001 and how to fix it so your AppHost builds cleanly.
 ---
 
-import { Badge, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -21,50 +22,16 @@ These APIs enable programmatic creation of Dockerfiles at build time, allowing d
 
 ## Example
 
-The following code generates `ASPIREDOCKERFILEBUILDER001` in a C# AppHost:
+The Dockerfile builder APIs are included in core Aspire hosting; no additional hosting integration is required. These examples assume `./service` contains `package.json`, a lockfile, and `index.js`.
 
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
+The C# examples generate `ASPIREDOCKERFILEBUILDER001`. TypeScript, Python, Go, and Java AppHosts can use the same Dockerfile builder callback surface without emitting this C# compiler diagnostic. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
 
-builder.AddDockerfileBuilder("my-service", "./service", context =>
-{
-    var stage = context.Builder.From("node:22-alpine", "runtime");
-    stage.WorkDir("/app")
-        .Copy("package*.json", "./")
-        .Run("npm ci --omit=dev")
-        .Copy(".", ".")
-        .Cmd(["node", "index.js"]);
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes Dockerfile builder callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments to `DockerfileBuilderCallbackContext`. These examples require the typed callback-context API.",
+}}>
+<Fragment slot="typescript">
 
-    return Task.CompletedTask;
-}, stage: "runtime");
-```
-
-## AppHost examples
-
-TypeScript AppHosts can use the same Dockerfile builder callback surface. The warning suppression options below apply to C# compiler diagnostics; TypeScript code doesn't use `#pragma` or `.editorconfig` to suppress `ASPIREDOCKERFILEBUILDER001`.
-
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
-```csharp title="AppHost.cs"
-var builder = DistributedApplication.CreateBuilder(args);
-
-#pragma warning disable ASPIREDOCKERFILEBUILDER001
-builder.AddDockerfileBuilder("my-service", "./service", context =>
-{
-    var stage = context.Builder.From("node:22-alpine", "runtime");
-    stage.WorkDir("/app")
-        .Copy("package*.json", "./")
-        .Run("npm ci --omit=dev")
-        .Copy(".", ".")
-        .Cmd(["node", "index.js"]);
-
-    return Task.CompletedTask;
-}, stage: "runtime");
-#pragma warning restore ASPIREDOCKERFILEBUILDER001
-```
-</TabItem>
-<TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
+```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 import type { DockerfileBuilderCallbackContext } from './.aspire/modules/aspire.mjs';
 
@@ -72,30 +39,195 @@ const builder = await createBuilder();
 
 const configureDockerfile = async (context: DockerfileBuilderCallbackContext) => {
   const dockerfile = await context.builder();
-  await dockerfile
-    .from("node:22-alpine", { stageName: "runtime" })
-    .workDir("/app")
-    .copy("package*.json", "./")
-    .run("npm ci --omit=dev")
-    .copy(".", ".")
-    .cmd(["node", "index.js"]);
+  const stage = await dockerfile.from("node:22-alpine", { stageName: "runtime" });
+  await stage.workDir("/app");
+  await stage.copy("package*.json", "./");
+  await stage.run("npm ci --omit=dev");
+  await stage.copy(".", ".");
+  await stage.cmd(["node", "index.js"]);
 };
 
 await builder.addDockerfileBuilder("my-service", "./service", configureDockerfile, {
   stage: "runtime",
 });
+
+await builder.build().run();
 ```
-</TabItem>
-</Tabs>
 
-The callback can also be applied to an existing container resource with `WithDockerfileBuilder`:
+</Fragment>
+<Fragment slot="csharp">
 
-<Tabs syncKey='aspire-lang'>
-<TabItem id='csharp' label='C#'>
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-#pragma warning disable ASPIREDOCKERFILEBUILDER001
+builder.AddDockerfileBuilder("my-service", "./service", context =>
+{
+    var stage = context.Builder.From("node:22-alpine", "runtime");
+    stage.WorkDir("/app")
+        .Copy("package*.json", "./")
+        .Run("npm ci --omit=dev")
+        .Copy(".", ".")
+        .Cmd(["node", "index.js"]);
+
+    return Task.CompletedTask;
+}, stage: "runtime");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import DockerfileBuilderCallbackContext, create_builder
+
+
+def configure_dockerfile(context: DockerfileBuilderCallbackContext) -> None:
+    stage = context.builder.from_("node:22-alpine", stage_name="runtime")
+    (
+        stage.work_dir("/app")
+        .copy("package*.json", "./")
+        .run("npm ci --omit=dev")
+        .copy(".", ".")
+        .cmd(["node", "index.js"])
+    )
+
+
+with create_builder() as builder:
+    builder.add_dockerfile_builder(
+        "my-service",
+        "./service",
+        configure_dockerfile,
+        stage="runtime",
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.AddDockerfileBuilder(
+		"my-service",
+		"./service",
+		func(context aspire.DockerfileBuilderCallbackContext) {
+			dockerfile := context.Builder()
+			if err := dockerfile.Err(); err != nil {
+				log.Fatal(aspire.FormatError(err))
+			}
+
+			stage := dockerfile.
+				From("node:22-alpine", &aspire.FromOptions{
+					StageName: aspire.StringPtr("runtime"),
+				}).
+				WorkDir("/app").
+				Copy("package*.json", "./").
+				Run("npm ci --omit=dev").
+				Copy(".", ".").
+				Cmd([]string{"node", "index.js"})
+			if err := stage.Err(); err != nil {
+				log.Fatal(aspire.FormatError(err))
+			}
+		},
+		&aspire.AddDockerfileBuilderOptions{
+			Stage: aspire.StringPtr("runtime"),
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addDockerfileBuilder(
+        "my-service",
+        "./service",
+        context -> {
+            var stage = context.builder().from("node:22-alpine", "runtime");
+            stage.workDir("/app")
+                .copy("package*.json", "./")
+                .run("npm ci --omit=dev")
+                .copy(".", ".")
+                .cmd(new String[] { "node", "index.js" });
+        },
+        "runtime");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The callback can also be applied to an existing container resource with `WithDockerfileBuilder`:
+
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes Dockerfile builder callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments to `DockerfileBuilderCallbackContext`. These examples require the typed callback-context API.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+import type { DockerfileBuilderCallbackContext } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const configureDockerfile = async (context: DockerfileBuilderCallbackContext) => {
+  const dockerfile = await context.builder();
+  const stage = await dockerfile.from("node:22-alpine", { stageName: "runtime" });
+  await stage.workDir("/app");
+  await stage.copy("package*.json", "./");
+  await stage.run("npm ci --omit=dev");
+  await stage.copy(".", ".");
+  await stage.cmd(["node", "index.js"]);
+};
+
+const service = await builder.addContainer("my-service", { image: "node", tag: "22-alpine" });
+await service.withDockerfileBuilder("./service", configureDockerfile, {
+  stage: "runtime",
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
 builder.AddContainer("my-service", "node:22-alpine")
     .WithDockerfileBuilder("./service", context =>
     {
@@ -108,35 +240,127 @@ builder.AddContainer("my-service", "node:22-alpine")
 
         return Task.CompletedTask;
     }, stage: "runtime");
-#pragma warning restore ASPIREDOCKERFILEBUILDER001
+
+builder.Build().Run();
 ```
-</TabItem>
-<TabItem id='typescript' label='TypeScript'>
-```typescript title="apphost.mts"
-import { createBuilder } from './.aspire/modules/aspire.mjs';
-import type { DockerfileBuilderCallbackContext } from './.aspire/modules/aspire.mjs';
 
-const builder = await createBuilder();
+</Fragment>
+<Fragment slot="python">
 
-const configureDockerfile = async (context: DockerfileBuilderCallbackContext) => {
-  const dockerfile = await context.builder();
-  await dockerfile
-    .from("node:22-alpine", { stageName: "runtime" })
-    .workDir("/app")
-    .copy("package*.json", "./")
-    .run("npm ci --omit=dev")
-    .copy(".", ".")
-    .cmd(["node", "index.js"]);
-};
+```python title="apphost.py"
+from aspire_app import AddContainerOptions, DockerfileBuilderCallbackContext, create_builder
 
-await builder
-  .addContainer("my-service", "node:22-alpine")
-  .withDockerfileBuilder("./service", configureDockerfile, {
-    stage: "runtime",
-  });
+
+def configure_dockerfile(context: DockerfileBuilderCallbackContext) -> None:
+    stage = context.builder.from_("node:22-alpine", stage_name="runtime")
+    (
+        stage.work_dir("/app")
+        .copy("package*.json", "./")
+        .run("npm ci --omit=dev")
+        .copy(".", ".")
+        .cmd(["node", "index.js"])
+    )
+
+
+with create_builder() as builder:
+    image: AddContainerOptions = {"Image": "node", "Tag": "22-alpine"}
+    service = builder.add_container("my-service", image)
+    service.with_dockerfile_builder(
+        "./service",
+        configure_dockerfile,
+        stage="runtime",
+    )
+
+    builder.run()
 ```
-</TabItem>
-</Tabs>
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.
+		AddContainer("my-service", "node:22-alpine").
+		WithDockerfileBuilder(
+			"./service",
+			func(context aspire.DockerfileBuilderCallbackContext) {
+				dockerfile := context.Builder()
+				if err := dockerfile.Err(); err != nil {
+					log.Fatal(aspire.FormatError(err))
+				}
+
+				stage := dockerfile.
+					From("node:22-alpine", &aspire.FromOptions{
+						StageName: aspire.StringPtr("runtime"),
+					}).
+					WorkDir("/app").
+					Copy("package*.json", "./").
+					Run("npm ci --omit=dev").
+					Copy(".", ".").
+					Cmd([]string{"node", "index.js"})
+				if err := stage.Err(); err != nil {
+					log.Fatal(aspire.FormatError(err))
+				}
+			},
+			&aspire.WithDockerfileBuilderOptions{
+				Stage: aspire.StringPtr("runtime"),
+			},
+		)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var service = builder.addContainer("my-service", "node:22-alpine");
+    service.withDockerfileBuilder(
+        "./service",
+        context -> {
+            var stage = context.builder().from("node:22-alpine", "runtime");
+            stage.workDir("/app")
+                .copy("package*.json", "./")
+                .run("npm ci --omit=dev")
+                .copy(".", ".")
+                .cmd(new String[] { "node", "index.js" });
+        },
+        "runtime");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Understanding Dockerfile builder callbacks
 
@@ -168,11 +392,13 @@ The `DockerfileBuilderCallbackContext` provides context information for Dockerfi
 - Token to observe for cancellation requests
 - Enables cooperative cancellation of long-running operations
 
-In TypeScript AppHosts, callback context values use camelCase names and asynchronous methods. For example, use `await context.builder()` to get the `DockerfileBuilder` instance.
+Callback context and option names follow each SDK's conventions. Python exposes `context.builder` as a property and uses keyword-only options. Go uses option structs and reports fluent-handle errors through `Err`. Java uses typed callback contexts and overloads for optional values.
 
 ## To suppress this warning
 
-Suppress the warning with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the warning with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspiredockerfilebuilder001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiredockerfilebuilder001.mdx
@@ -39,7 +39,7 @@ const builder = await createBuilder();
 
 const configureDockerfile = async (context: DockerfileBuilderCallbackContext) => {
   const dockerfile = await context.builder();
-  const stage = await dockerfile.from("node:22-alpine", { stageName: "runtime" });
+  const stage = await dockerfile.from("node:22-alpine", "runtime");
   await stage.workDir("/app");
   await stage.copy("package*.json", "./");
   await stage.run("npm ci --omit=dev");
@@ -206,7 +206,7 @@ const builder = await createBuilder();
 
 const configureDockerfile = async (context: DockerfileBuilderCallbackContext) => {
   const dockerfile = await context.builder();
-  const stage = await dockerfile.from("node:22-alpine", { stageName: "runtime" });
+  const stage = await dockerfile.from("node:22-alpine", "runtime");
   await stage.workDir("/app");
   await stage.copy("package*.json", "./");
   await stage.run("npm ci --omit=dev");

--- a/src/frontend/src/content/docs/diagnostics/aspiredotnetproject001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiredotnetproject001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIREDOTNETPROJECT00
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -24,7 +26,29 @@ These APIs add a C# project or file-based C# app to the application model as an 
 
 ## Example
 
-The following code generates `ASPIREDOTNETPROJECT001`:
+Install the .NET hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Dotnet" />
+
+The C# example generates `ASPIREDOTNETPROJECT001`. The generated SDK examples host the same file-based C# app without emitting this C# compiler diagnostic.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addDotnetProject("inventoryservice", "../InventoryService.cs");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -34,7 +58,104 @@ builder.AddDotnetProject("inventoryservice", @"..\InventoryService.cs");
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_dotnet_project(
+        "inventoryservice",
+        "../InventoryService.cs",
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	inventory := builder.AddDotnetProject(
+		"inventoryservice",
+		"../InventoryService.cs",
+	)
+	if err := inventory.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addDotnetProject(
+        "inventoryservice",
+        "../InventoryService.cs");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_dotnet_project(
+        "inventoryservice",
+        "../InventoryService.cs",
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspiredotnettool001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiredotnettool001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREDOTNETTOOL001 a
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -27,7 +28,25 @@ Aspire emits this diagnostic as `ASPIREDOTNETTOOL`, without a numeric suffix. Th
 
 ## Example
 
-The following code generates `ASPIREDOTNETTOOL` (documented here as `ASPIREDOTNETTOOL001`):
+The .NET tool resource API is included in core Aspire hosting; no additional hosting integration is required. The tool package is restored when Aspire launches the resource.
+
+The C# example generates `ASPIREDOTNETTOOL` (documented here as `ASPIREDOTNETTOOL001`). The generated SDK examples host the same tool without emitting this C# compiler diagnostic. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const tool = await builder.addDotnetTool("my-tool", "dotnet-tool-package");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -37,7 +56,93 @@ var tool = builder.AddDotnetTool("my-tool", "dotnet-tool-package");
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_dotnet_tool("my-tool", "dotnet-tool-package")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	tool := builder.AddDotnetTool("my-tool", "dotnet-tool-package")
+	if err := tool.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addDotnetTool("my-tool", "dotnet-tool-package");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_dotnet_tool("my-tool", "dotnet-tool-package")?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+Replace `dotnet-tool-package` with the NuGet package ID of the .NET tool you want to run.
+
 ## To correct this warning
+
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspiredurabletask001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiredurabletask001.mdx
@@ -1,10 +1,12 @@
 ---
 title: Compiler Warning ASPIREDURABLETASK001
-seoTitle: "ASPIREDURABLETASK001: Durable Task scheduler and task hub"
+seoTitle: 'ASPIREDURABLETASK001: Durable Task scheduler and task hub'
 description: Learn what causes the Aspire compiler warning ASPIREDURABLETASK001 and how to fix it so your AppHost builds cleanly.
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.3"
@@ -30,7 +32,42 @@ These APIs are brand new and may change shape before the feature becomes general
 
 ## Example
 
-The following code generates `ASPIREDURABLETASK001`:
+Install the Azure Functions and Azure Storage hosting integrations:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.Functions" />
+<InstallPackage packageName="Aspire.Hosting.Azure.Storage" />
+
+For generated AppHost SDK setup, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+The following examples run the scheduler and host storage as emulators and connect a Functions project to a task hub. The C# Durable Task calls generate `ASPIREDURABLETASK001`; generated AppHost SDKs expose the same experimental operations without emitting this C# compiler diagnostic.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const storage = await builder.addAzureStorage('storage');
+await storage.runAsEmulator();
+
+const scheduler = await builder.addDurableTaskScheduler('scheduler');
+await scheduler.runAsEmulator();
+const hub = await scheduler.addTaskHub('hub');
+
+const functions = await builder.addAzureFunctionsProject(
+  'functions',
+  '../MyFunctions/MyFunctions.csproj'
+);
+await functions.withHostStorage(storage);
+await functions.withReference(hub);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -49,7 +86,327 @@ builder.AddAzureFunctionsProject<Projects.MyFunctions>("functions")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    storage = builder.add_azure_storage("storage")
+    storage.run_as_emulator()
+
+    scheduler = builder.add_durable_task_scheduler("scheduler")
+    scheduler.run_as_emulator()
+    hub = scheduler.add_task_hub("hub")
+
+    functions = builder.add_azure_functions_project(
+        "functions",
+        "../MyFunctions/MyFunctions.csproj",
+    )
+    functions.with_host_storage(storage)
+    functions.with_reference(hub)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	storage := builder.AddAzureStorage("storage").RunAsEmulator()
+	scheduler := builder.
+		AddDurableTaskScheduler("scheduler").
+		RunAsEmulator()
+	hub := scheduler.AddTaskHub("hub")
+	functions := builder.
+		AddAzureFunctionsProject(
+			"functions",
+			"../MyFunctions/MyFunctions.csproj").
+		WithHostStorage(storage).
+		WithReference(hub)
+	for _, err := range []error{
+		storage.Err(),
+		scheduler.Err(),
+		hub.Err(),
+		functions.Err(),
+	} {
+		if err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var storage = builder.addAzureStorage("storage");
+    storage.runAsEmulator();
+
+    var scheduler = builder.addDurableTaskScheduler("scheduler");
+    scheduler.runAsEmulator();
+    var hub = scheduler.addTaskHub("hub");
+
+    var functions = builder.addAzureFunctionsProject(
+        "functions",
+        "../MyFunctions/MyFunctions.csproj");
+    functions.withHostStorage(storage);
+    functions.withReference(hub);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+The generated Rust emulator methods require callbacks even when no container
+customization is needed, so pass no-op callbacks:
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let storage = builder.add_azure_storage("storage")?;
+    storage.run_as_emulator(|_| Value::Null)?;
+
+    let scheduler = builder.add_durable_task_scheduler("scheduler")?;
+    scheduler.run_as_emulator(|_| Value::Null)?;
+    let hub = scheduler.add_task_hub("hub")?;
+
+    let functions = builder.add_azure_functions_project(
+        "functions",
+        "../MyFunctions/MyFunctions.csproj",
+    )?;
+    functions.with_host_storage(&storage)?;
+    functions.with_reference(
+        hub.handle().to_json(),
+        None,
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Use an existing scheduler and a custom task hub name
+
+To connect to an existing scheduler during local runs, supply its connection string as a secret parameter. You can also configure the task hub name independently of its Aspire resource name:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const connection = await builder.addParameter('scheduler-connection', {
+  secret: true,
+});
+const hubName = await builder.addParameter('task-hub-name');
+
+const scheduler = await builder.addDurableTaskScheduler('scheduler');
+await scheduler.runAsExisting(connection);
+const hub = await scheduler.addTaskHub('hub');
+await hub.withTaskHubName(hubName);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var connection = builder.AddParameter("scheduler-connection", secret: true);
+var hubName = builder.AddParameter("task-hub-name");
+
+var scheduler = builder.AddDurableTaskScheduler("scheduler")
+    .RunAsExisting(connection);
+var hub = scheduler.AddTaskHub("hub")
+    .WithTaskHubName(hubName);
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    connection = builder.add_parameter(
+        "scheduler-connection",
+        secret=True,
+    )
+    hub_name = builder.add_parameter("task-hub-name")
+
+    scheduler = builder.add_durable_task_scheduler("scheduler")
+    scheduler.run_as_existing(connection)
+    hub = scheduler.add_task_hub("hub")
+    hub.with_task_hub_name(hub_name)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	connection := builder.AddParameter(
+		"scheduler-connection",
+		&aspire.AddParameterOptions{Secret: aspire.BoolPtr(true)})
+	hubName := builder.AddParameter("task-hub-name")
+	scheduler := builder.
+		AddDurableTaskScheduler("scheduler").
+		RunAsExisting(connection)
+	hub := scheduler.
+		AddTaskHub("hub").
+		WithTaskHubName(hubName)
+	for _, err := range []error{
+		connection.Err(),
+		hubName.Err(),
+		scheduler.Err(),
+		hub.Err(),
+	} {
+		if err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var connection = builder.addParameter(
+        "scheduler-connection",
+        new AddParameterOptions().secret(true));
+    var hubName = builder.addParameter("task-hub-name");
+
+    var scheduler = builder.addDurableTaskScheduler("scheduler");
+    scheduler.runAsExisting(connection);
+    var hub = scheduler.addTaskHub("hub");
+    hub.withTaskHubName(hubName);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let connection = builder.add_parameter(
+        "scheduler-connection",
+        None,
+        None,
+        Some(true),
+    )?;
+    let hub_name = builder.add_parameter(
+        "task-hub-name",
+        None,
+        None,
+        None,
+    )?;
+
+    let scheduler = builder.add_durable_task_scheduler("scheduler")?;
+    scheduler.run_as_existing(connection.handle().to_json())?;
+    let hub = scheduler.add_task_hub("hub")?;
+    hub.with_task_hub_name(hub_name.handle().to_json())?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the warning with any of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireexport001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport001.mdx
@@ -19,6 +19,8 @@ This diagnostic error is reported when a method decorated with the `[AspireExpor
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT001`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport002.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport002.mdx
@@ -19,6 +19,8 @@ This diagnostic error is reported when the export ID specified in an `[AspireExp
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT002`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport003.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport003.mdx
@@ -19,6 +19,8 @@ This diagnostic error is reported when a method decorated with `[AspireExport]` 
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT003`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport004.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport004.mdx
@@ -19,6 +19,8 @@ This diagnostic error is reported when a method decorated with `[AspireExport]` 
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT004`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport005.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport005.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when an `[AspireUnion]` attribute is applied
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT005`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport006.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport006.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when one or more types specified in an `[Asp
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT006`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport007.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport007.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when two or more `[AspireExport]` methods in
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT007`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport008.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport008.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when a public static extension method extend
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT008`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport009.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport009.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when an `[AspireExport]` method targets the 
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT009`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport010.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport010.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when an `[AspireExport]` method directly inv
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT010`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport013.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport013.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when two or more Aspire Type System (ATS) ex
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT013`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport015.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport015.mdx
@@ -19,6 +19,8 @@ This diagnostic error is reported when a new `[AspireExport]` attribute sets the
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT015`:
 
 ```csharp title="Integration.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireexport016.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireexport016.mdx
@@ -19,6 +19,8 @@ This diagnostic warning is reported when an `[AspireDto]` type exposes a mutable
 
 ## Example
 
+These are C#-only integration-authoring examples. They define the .NET API surface used to generate AppHost SDKs, rather than configuring resources from a generated SDK.
+
 The following code generates `ASPIREEXPORT016`:
 
 ```csharp title="MyDto.cs"

--- a/src/frontend/src/content/docs/diagnostics/aspireextension001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireextension001.mdx
@@ -25,22 +25,28 @@ This diagnostic warning is reported when using experimental extension debugging 
 
 These APIs are primarily used by integration authors to enable F5 debugging for custom resource types in Visual Studio and other IDEs. 
 
+:::note[Generated AppHost SDK applicability]
+Generic debug launch configuration (`WithDebugSupport`), debug-support inspection, and `WithLaunchToolArgs` aren't exported to the generated AppHost SDKs. These C#-only integration-author APIs use .NET annotations and launch-configuration types; this warning and its suppression apply only to C#.
+:::
+
 `WithLaunchToolArgs` declares the tool-invocation prefix for the tool that hosts a program (for example `run ./cmd/api` for `go` launcher/CLI, or `-m flask` for `python` CLI), separating it from program-specific arguments a caller adds with `WithArgs`. This allows extensions and IDEs to vary host tool arguments as necessary to reach the desired execution mode of the program (e.g. running under debugger vs not, enabling or disabling profiling etc.) without affecting startup arguments the program sees itself.
 
 ## Example
 
-The following code generates `ASPIREEXTENSION001`:
+The following code generates `ASPIREEXTENSION001`. It assumes your integration defines `AddMyResource` and a `MyLaunchConfiguration` derived from `ExecutableLaunchConfiguration`. The callback receives the requested launch mode, not a process ID:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 builder.AddMyResource("resource")
     .WithDebugSupport(
-        processId => new MyLaunchConfiguration { ProcessId = processId },
+        mode => new MyLaunchConfiguration { Mode = mode },
         "myResourceType");
 ```
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirefilesystem001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirefilesystem001.mdx
@@ -24,6 +24,10 @@ This diagnostic warning is reported when using experimental file system service 
 
 These APIs provide a centralized way to manage temporary directories and files used by Aspire, improving testability and consistency across the platform.
 
+:::note[Generated AppHost SDK applicability]
+`IFileSystemService`, `ITempFileSystemService`, and their disposable temporary-file and directory types aren't exported to the generated AppHost SDKs. This C#-only example resolves .NET services and calls `CreateTempSubdirectory` and `CreateTempFile`; it does not configure resource files through the generated SDK. This warning and its suppression apply only to C#.
+:::
+
 ## Example
 
 The following code generates `ASPIREFILESYSTEM001`:
@@ -77,6 +81,8 @@ The `IFileSystemService` provides a standardized interface for managing temporar
 - `Path` property provides the full path to the file
 
 ## To suppress this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirehostingpython001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirehostingpython001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIREHOSTINGPYTHON001 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.0"
@@ -15,22 +17,138 @@ import { Badge } from '@astrojs/starlight/components';
 
 > `AddPythonApp` is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-Aspire provides a way to add Python executables or applications to the Aspire AppHost with the `AddPythonApp` extension. Since the shape of this API is expected to change in the future, it's experimental.
+Aspire provides a way to add Python executables or applications to the Aspire AppHost with the `AddPythonApp` extension. Earlier versions marked this API as experimental. In Aspire 13.5, the three-argument overload shown below is no longer marked experimental, so it doesn't require suppression. This page remains relevant for builds using older package versions.
 
 ## Example
 
-The following code generates `ASPIREHOSTINGPYTHON001`:
+Install the Python hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Python" />
+
+The C# example generates `ASPIREHOSTINGPYTHON001` in versions that mark `AddPythonApp` as experimental. The generated SDK examples host the same Python application and configure its HTTP endpoint and OpenTelemetry exporter without emitting a C# compiler diagnostic.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{ rust: 'The Rust projection contains these APIs, but the daily SDK generated for the Python hosting package used for this documentation does not compile because of invalid generated argument-map code. A verified Rust example is not available in this build.' }}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const pythonApp = await builder.addPythonApp("hello-python", "../hello-python", "main.py");
+await pythonApp.withHttpEndpoint({ env: "PORT" });
+await pythonApp.withExternalHttpEndpoints();
+await pythonApp.withOtlpExporter();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
 var pythonApp = builder.AddPythonApp("hello-python", "../hello-python", "main.py")
-       .WithHttpEndpoint(env: "PORT")
-       .WithExternalHttpEndpoints()
-       .WithOtlpExporter();
+    .WithHttpEndpoint(env: "PORT")
+    .WithExternalHttpEndpoints()
+    .WithOtlpExporter();
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    python_app = builder.add_python_app(
+        "hello-python",
+        "../hello-python",
+        "main.py",
+    )
+    (
+        python_app.with_http_endpoint(env="PORT")
+        .with_external_http_endpoints()
+        .with_otlp_exporter()
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	pythonApp := builder.
+		AddPythonApp("hello-python", "../hello-python", "main.py").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Env: aspire.StringPtr("PORT"),
+		}).
+		WithExternalHttpEndpoints().
+		WithOtlpExporter()
+	if err := pythonApp.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var pythonApp = builder.addPythonApp(
+        "hello-python",
+        "../hello-python",
+        "main.py");
+    pythonApp.withHttpEndpoint(
+        new WithHttpEndpointOptions().env("PORT"));
+    pythonApp.withExternalHttpEndpoints();
+    pythonApp.withOtlpExporter();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this error
 
-Suppress the error with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the error with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspireinteraction001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireinteraction001.mdx
@@ -5,27 +5,216 @@ description: Learn what causes the Aspire compiler warning ASPIREINTERACTION001 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge text="Version introduced: 13.0" variant="note" size="large" class:list={'mb-1'} />
 
 > Interaction service types and members are for evaluation purposes only and are subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-This diagnostic warns when using the experimental `IInteractionService` interface and related interaction APIs. These APIs provide the ability to prompt users for input, request confirmation, and display messages in the Aspire dashboard or CLI during publish and deploy operations.
+This diagnostic warns when using the experimental `IInteractionService` interface and related interaction APIs. These APIs provide the ability to prompt users for input in the Aspire dashboard or CLI during publish and deploy operations. Confirmation, message box, and notification interactions require the dashboard.
 
 ## Example generating diagnostic
+
+The C# example generates `ASPIREINTERACTION001`. The TypeScript, Python, Go, and Java SDKs expose the interaction service through a service-provider handle without emitting this C# compiler diagnostic. The example registers a dashboard resource command so the service is resolved after the application has started. All APIs used here belong to the core `Aspire.Hosting` SDK; no additional integration package is required. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes resource-command callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments to `ExecuteCommandContext`. This example requires that typed context to resolve the interaction service.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+const cache = await builder.addContainer("cache", { image: "redis" });
+
+await cache.withCommand("confirm", "Confirm action", async (context) => {
+  const services = await context.services();
+  const interactionService = await services.getInteractionService();
+
+  if (!await interactionService.isAvailable()) {
+    return { success: false, errorMessage: "Interactive confirmation is unavailable." };
+  }
+
+  const result = await interactionService.promptConfirmation(
+    "Confirmation",
+    "Are you sure you want to proceed?"
+  );
+
+  return { success: !result.canceled && result.value === true };
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-// Using IInteractionService from an IServiceProvider instance
-var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
-if (interactionService.IsAvailable)
-{
-    var result = await interactionService.PromptConfirmationAsync(
-        title: "Confirmation",
-        message: "Are you sure you want to proceed?");
+builder.AddContainer("cache", "redis")
+    .WithCommand("confirm", "Confirm action", async context =>
+    {
+        var interactionService = context.Services
+            .GetRequiredService<IInteractionService>();
+
+        if (!interactionService.IsAvailable)
+        {
+            return new ExecuteCommandResult
+            {
+                Success = false,
+                ErrorMessage = "Interactive confirmation is unavailable."
+            };
+        }
+
+        var result = await interactionService.PromptConfirmationAsync(
+            title: "Confirmation",
+            message: "Are you sure you want to proceed?");
+
+        return new ExecuteCommandResult { Success = !result.Canceled && result.Data };
+    });
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import ExecuteCommandContext, ExecuteCommandResult, create_builder
+
+
+def confirm_action(context: ExecuteCommandContext) -> ExecuteCommandResult:
+    interaction_service = context.services.get_interaction_service()
+    if not interaction_service.is_available():
+        return {
+            "Success": False,
+            "ErrorMessage": "Interactive confirmation is unavailable.",
+        }
+
+    result = interaction_service.prompt_confirmation(
+        "Confirmation",
+        "Are you sure you want to proceed?",
+    )
+    return {
+        "Success": not result["Canceled"] and result.get("Value") is True,
+    }
+
+
+with create_builder() as builder:
+    cache = builder.add_container("cache", "redis")
+    cache.with_command("confirm", "Confirm action", confirm_action)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func commandFailure(message string) *aspire.ExecuteCommandResult {
+	return &aspire.ExecuteCommandResult{
+		Success:      false,
+		ErrorMessage: aspire.StringPtr(message),
+	}
+}
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddContainer("cache", "redis").
+		WithCommand("confirm", "Confirm action", func(context aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			services := context.Services()
+			if err := services.Err(); err != nil {
+				return commandFailure(err.Error())
+			}
+
+			interactionService := services.GetInteractionService()
+			if err := interactionService.Err(); err != nil {
+				return commandFailure(err.Error())
+			}
+
+			available, err := interactionService.IsAvailable()
+			if err != nil {
+				return commandFailure(err.Error())
+			}
+			if !available {
+				return commandFailure("Interactive confirmation is unavailable.")
+			}
+
+			result, err := interactionService.PromptConfirmation(
+				"Confirmation",
+				"Are you sure you want to proceed?",
+			)
+			if err != nil {
+				return commandFailure(err.Error())
+			}
+
+			return &aspire.ExecuteCommandResult{
+				Success: !result.Canceled && result.Value != nil && *result.Value,
+			}
+		})
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
 }
 ```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var cache = builder.addContainer("cache", "redis");
+    cache.withCommand("confirm", "Confirm action", context -> {
+        var interactionService = context.services().getInteractionService();
+        var commandResult = new ExecuteCommandResult();
+
+        if (!interactionService.isAvailable()) {
+            commandResult.setSuccess(false);
+            commandResult.setErrorMessage(
+                "Interactive confirmation is unavailable.");
+            return commandResult;
+        }
+
+        var result = interactionService.promptConfirmation(
+            "Confirmation",
+            "Are you sure you want to proceed?");
+        commandResult.setSuccess(
+            !result.getCanceled() && Boolean.TRUE.equals(result.getValue()));
+        return commandResult;
+    });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 The diagnostic is triggered because `IInteractionService` is marked with the `[Experimental("ASPIREINTERACTION001")]` attribute.
 
@@ -54,7 +243,11 @@ This API is experimental because the interaction patterns and API surface may ev
 - **`PromptInputAsync()`**: Prompts for a single input value
 - **`PromptInputsAsync()`**: Prompts for multiple input values
 
+The TypeScript SDK exports `promptMessageBox`, `promptNotification`, `promptConfirmation`, `promptInput`, and `promptInputs` on the interaction-service handle. For input prompts, use its `createTextInput`, `createSecretInput`, `createChoiceInput`, `createBooleanInput`, or `createNumberInput` methods to create `InteractionInputBuilder` handles, rather than constructing C# `InteractionInput` objects. See [Interaction service](/extensibility/interaction-service/) for these workflows.
+
 ## Suppressing the diagnostic
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 The diagnostic can be suppressed using one of several methods:
 
@@ -77,10 +270,7 @@ dotnet_diagnostic.ASPIREINTERACTION001.severity = none
 
 ```csharp title="Suppressing the warning"
 #pragma warning disable ASPIREINTERACTION001
-var interactionService = serviceProvider.GetRequiredService<IInteractionService>();
-var result = await interactionService.PromptConfirmationAsync(
-    title: "Confirmation",
-    message: "Are you sure?");
+// Register the resource command from the example above.
 #pragma warning restore ASPIREINTERACTION001
 ```
 

--- a/src/frontend/src/content/docs/diagnostics/aspirejavascript001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirejavascript001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIREJAVASCRIPT001 a
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.3"
@@ -27,18 +29,342 @@ These APIs enable you to configure how JavaScript applications (Vite, Node.js, N
 
 ## Example
 
-The following code generates `ASPIREJAVASCRIPT001`:
+Install the JavaScript hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.JavaScript" />
+
+The C# examples generate `ASPIREJAVASCRIPT001`. The generated SDK examples configure the same publishing behavior without emitting this C# compiler diagnostic.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{ rust: 'The Rust projection contains these APIs, but the daily SDK generated for the JavaScript hosting package used for this documentation does not compile because of invalid generated argument-map code. A verified Rust example is not available in this build.' }}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const frontend = await builder.addViteApp("frontend", "../MyViteApp");
+await frontend.publishAsStaticWebsite();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var frontend = builder.AddViteApp("frontend", "../MyViteApp")
     .PublishAsStaticWebsite();
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_vite_app("frontend", "../MyViteApp")
+    frontend.publish_as_static_website()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	frontend := builder.
+		AddViteApp("frontend", "../MyViteApp").
+		PublishAsStaticWebsite()
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addViteApp("frontend", "../MyViteApp")
+        .publishAsStaticWebsite();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Node.js and package script publishing
+
+For server applications, choose either a built Node.js entry point or a package script. These examples assume `../NodeServer` builds `dist/server.js` and `../ScriptServer` defines a `start` script.
+
+<AppHostTabs limitations={{ rust: 'The Rust projection contains these APIs, but the daily SDK generated for the JavaScript hosting package used for this documentation does not compile because of invalid generated argument-map code. A verified Rust example is not available in this build.' }}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const nodeServer = await builder.addJavaScriptApp("node-server", "../NodeServer");
+await nodeServer.publishAsNodeServer("dist/server.js", { outputPath: "dist" });
+
+const scriptServer = await builder.addJavaScriptApp("script-server", "../ScriptServer");
+await scriptServer.publishAsPackageScript({ scriptName: "start" });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddJavaScriptApp("node-server", "../NodeServer")
+    .PublishAsNodeServer("dist/server.js", outputPath: "dist");
+
+builder.AddJavaScriptApp("script-server", "../ScriptServer")
+    .PublishAsPackageScript(scriptName: "start");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    node_server = builder.add_java_script_app(
+        "node-server",
+        "../NodeServer",
+    )
+    node_server.publish_as_node_server(
+        "dist/server.js",
+        output_path="dist",
+    )
+
+    script_server = builder.add_java_script_app(
+        "script-server",
+        "../ScriptServer",
+    )
+    script_server.publish_as_package_script(script_name="start")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	nodeServer := builder.
+		AddJavaScriptApp("node-server", "../NodeServer").
+		PublishAsNodeServer(
+			"dist/server.js",
+			&aspire.PublishAsNodeServerOptions{
+				OutputPath: aspire.StringPtr("dist"),
+			},
+		)
+	if err := nodeServer.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	scriptServer := builder.
+		AddJavaScriptApp("script-server", "../ScriptServer").
+		PublishAsPackageScript(&aspire.PublishAsPackageScriptOptions{
+			ScriptName: aspire.StringPtr("start"),
+		})
+	if err := scriptServer.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addJavaScriptApp("node-server", "../NodeServer")
+        .publishAsNodeServer("dist/server.js", "dist");
+
+    builder.addJavaScriptApp("script-server", "../ScriptServer")
+        .publishAsPackageScript(
+            new PublishAsPackageScriptOptions().scriptName("start"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Next.js build validation
+
+The Next.js integration checks its configuration before publishing, including whether `output: "standalone"` is set. Disable those checks only when the configuration is supplied dynamically or by an external mechanism that static file inspection can't detect:
+
+<AppHostTabs limitations={{ rust: 'The Rust projection contains these APIs, but the daily SDK generated for the JavaScript hosting package used for this documentation does not compile because of invalid generated argument-map code. A verified Rust example is not available in this build.' }}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const web = await builder.addNextJsApp("web", "../NextApp");
+await web.disableBuildValidation();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddNextJsApp("web", "../NextApp")
+    .DisableBuildValidation();
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_next_js_app("web", "../NextApp")
+    web.disable_build_validation()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.
+		AddNextJsApp("web", "../NextApp").
+		DisableBuildValidation()
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addNextJsApp("web", "../NextApp")
+        .disableBuildValidation();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this warning
 
-Suppress the warning with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the warning with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspiremcp001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspiremcp001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREMCP001 and how 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -24,7 +25,26 @@ The following APIs are protected by this diagnostic:
 
 ## Example
 
-The following code generates `ASPIREMCP001`:
+The C# examples generate `ASPIREMCP001`. The generated AppHost SDKs support the same endpoint discovery operation without emitting this C# compiler diagnostic. These APIs and project resources belong to the core `Aspire.Hosting` SDK; no additional integration package is required. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+The referenced API project must expose an HTTP or HTTPS endpoint and implement an MCP server at `/mcp`. Adding the annotation doesn't implement the server.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../MyApi/MyApi.csproj");
+await api.withMcpServer();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -35,9 +55,113 @@ var api = builder.AddProject<Projects.MyApi>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../MyApi/MyApi.csproj")
+    api.with_mcp_server()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../MyApi/MyApi.csproj").
+		WithMcpServer()
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addProject("api", "../MyApi/MyApi.csproj");
+    api.withMcpServer();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../MyApi/MyApi.csproj", None)?;
+    api.with_mcp_server(None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 —or—
 
-The following code uses a custom path and endpoint name:
+The following code uses a custom path and endpoint name. The API project must expose an endpoint named `https` and serve MCP at `/sse`:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../MyApi/MyApi.csproj");
+await api.withMcpServer({ path: "/sse", endpointName: "https" });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -48,7 +172,101 @@ var api = builder.AddProject<Projects.MyApi>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../MyApi/MyApi.csproj")
+    api.with_mcp_server(path="/sse", endpoint_name="https")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../MyApi/MyApi.csproj").
+		WithMcpServer(&aspire.WithMcpServerOptions{
+			Path:         aspire.StringPtr("/sse"),
+			EndpointName: aspire.StringPtr("https"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addProject("api", "../MyApi/MyApi.csproj");
+    api.withMcpServer(new WithMcpServerOptions()
+        .path("/sse")
+        .endpointName("https"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../MyApi/MyApi.csproj", None)?;
+    api.with_mcp_server(Some("/sse"), Some("https"))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepersistence001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepersistence001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler error ASPIREPERSISTENCE001 an
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.4"
@@ -28,7 +29,28 @@ The following APIs and types are protected by this diagnostic:
 
 ## Example
 
-The following code generates `ASPIREPERSISTENCE001`:
+These APIs are included in core Aspire hosting; no additional hosting integration is required.
+
+The C# example generates `ASPIREPERSISTENCE001`. The TypeScript, Python, Go, and Java examples configure the same executable lifetime without emitting this C# compiler diagnostic. The `../worker` directory must contain `server.js` and `helper.js`. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{
+  rust: "The current experimental Rust SDK has a runtime serialization issue with executable argument arrays. These examples require `add_executable` with script arguments, so a Rust variant isn't provided.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const worker = await builder.addExecutable("worker", "node", "../worker", ["server.js"]);
+await worker.withPersistentLifetime();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -39,9 +61,214 @@ var worker = builder.AddExecutable("worker", "node", "../worker", "server.js")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    worker = builder.add_executable("worker", "node", "../worker", ["server.js"])
+    worker.with_persistent_lifetime()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	worker := builder.
+		AddExecutable("worker", "node", "../worker", []string{"server.js"}).
+		WithPersistentLifetime()
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addExecutable("worker", "node", "../worker", new String[] { "server.js" })
+        .withPersistentLifetime();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The same shared lifetime APIs also support session, parent-process, and resource-scoped lifetimes. Choose the lifetime appropriate to each resource. Replace `12345` with the ID of the process that should own the parent-process resource.
+
+<AppHostTabs limitations={{
+  rust: "The current experimental Rust SDK has a runtime serialization issue with executable argument arrays. These examples require `add_executable` with script arguments, so a Rust variant isn't provided.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const sessionWorker = await builder.addExecutable("session-worker", "node", "../worker", ["server.js"]);
+await sessionWorker.withSessionLifetime();
+
+const parentWorker = await builder.addExecutable("parent-worker", "node", "../worker", ["server.js"]);
+await parentWorker.withParentProcessLifetime(12345);
+
+const helper = await builder.addExecutable("helper", "node", "../worker", ["helper.js"]);
+await helper.withLifetimeOf(sessionWorker);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var sessionWorker = builder.AddExecutable("session-worker", "node", "../worker", "server.js")
+    .WithSessionLifetime();
+
+var parentWorker = builder.AddExecutable("parent-worker", "node", "../worker", "server.js")
+    .WithParentProcessLifetime(12345);
+
+var helper = builder.AddExecutable("helper", "node", "../worker", "helper.js")
+    .WithLifetimeOf(sessionWorker);
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    session_worker = builder.add_executable("session-worker", "node", "../worker", ["server.js"])
+    session_worker.with_session_lifetime()
+
+    parent_worker = builder.add_executable("parent-worker", "node", "../worker", ["server.js"])
+    parent_worker.with_parent_process_lifetime(12345)
+
+    helper = builder.add_executable("helper", "node", "../worker", ["helper.js"])
+    helper.with_lifetime_of(session_worker)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	sessionWorker := builder.
+		AddExecutable("session-worker", "node", "../worker", []string{"server.js"}).
+		WithSessionLifetime()
+	if err := sessionWorker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	parentWorker := builder.
+		AddExecutable("parent-worker", "node", "../worker", []string{"server.js"}).
+		WithParentProcessLifetime(12345)
+	if err := parentWorker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	helper := builder.
+		AddExecutable("helper", "node", "../worker", []string{"helper.js"}).
+		WithLifetimeOf(sessionWorker)
+	if err := helper.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var sessionWorker = builder.addExecutable(
+        "session-worker", "node", "../worker", new String[] { "server.js" });
+    sessionWorker.withSessionLifetime();
+
+    builder.addExecutable("parent-worker", "node", "../worker", new String[] { "server.js" })
+        .withParentProcessLifetime(12345);
+
+    builder.addExecutable("helper", "node", "../worker", new String[] { "helper.js" })
+        .withLifetimeOf(sessionWorker);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this error
 
 Suppress the diagnostic when you intentionally opt in to the experimental shared lifetime APIs. For container resources, you can instead use the supported container-specific `WithLifetime(ContainerLifetime.Persistent)` and `WithLifetime(ContainerLifetime.Session)` APIs.
+
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the error with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepipelines001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepipelines001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler error ASPIREPIPELINES001 and 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -34,7 +35,146 @@ This diagnostic applies to the following pipeline infrastructure APIs:
 In Aspire 13.5, only the `CompletionState` enumeration graduated from experimental and no longer triggers this diagnostic. The other APIs listed above remain experimental and continue to require suppressing `ASPIREPIPELINES001`.
 :::
 
+## Report progress from a pipeline step
+
+The TypeScript, Python, Go, and Java SDKs export pipeline step registration and reporting-task operations. The following examples create and complete a reporting task. The C# reporting APIs generate `ASPIREPIPELINES001`; these generated SDKs expose the experimental operations without emitting this C# compiler diagnostic. No additional hosting package is required. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes pipeline-step callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments to `PipelineStepContext`. This example requires that typed context to obtain the reporting-step and reporting-task handles.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const pipeline = await builder.pipeline();
+await pipeline.addStep("report-status", async context => {
+    const step = await context.reportingStep();
+    const task = await step.createTask("Checking deployment prerequisites");
+    await task.completeTask("Prerequisites checked");
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.Pipeline.AddStep("report-status", async context =>
+{
+    await using var task = await context.ReportingStep.CreateTaskAsync(
+        "Checking deployment prerequisites");
+    await task.CompleteAsync("Prerequisites checked");
+});
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import PipelineStepContext, create_builder
+
+
+def report_status(context: PipelineStepContext) -> None:
+    task = context.reporting_step.create_task(
+        "Checking deployment prerequisites"
+    )
+    task.complete_task(completion_message="Prerequisites checked")
+
+
+with create_builder() as builder:
+    builder.pipeline.add_step("report-status", report_status)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	pipeline := builder.Pipeline()
+	if err := pipeline.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	err = pipeline.AddStep("report-status", func(context aspire.PipelineStepContext) {
+		step := context.ReportingStep()
+		if err := step.Err(); err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+
+		task := step.CreateTask("Checking deployment prerequisites")
+		if err := task.Err(); err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+		if err := task.CompleteTask(&aspire.CompleteTaskOptions{
+			CompletionMessage: aspire.StringPtr("Prerequisites checked"),
+		}); err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	})
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.pipeline().addStep("report-status", context -> {
+        var task = context.reportingStep().createTask(
+            "Checking deployment prerequisites");
+        task.completeTask(new CompleteTaskOptions()
+            .completionMessage("Prerequisites checked"));
+    });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+Run the registered step with `aspire do report-status`. Implementing .NET interfaces such as `IPipelineActivityReporter`, or constructing `PublishingContext` and `PublishingCallbackAnnotation` directly, remains a C#-only extensibility operation; the generated SDKs do not expose those construction APIs.
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the error with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepipelines002.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepipelines002.mdx
@@ -32,7 +32,11 @@ This diagnostic applies to the following deployment state manager APIs:
 - Azure provisioning context providers
 - Related extension methods and implementations
 
+The deployment-state service, `PublishingOptions` properties, and callback annotations listed here are C#-only .NET infrastructure APIs, not exported AppHost operations. AppHosts using generated SDKs can participate in deployment pipelines, but do not directly resolve `IDeploymentStateManager` or construct these annotations, and do not emit this C# compiler diagnostic.
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the error with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepipelines003.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepipelines003.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler error ASPIREPIPELINES003 and 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.0"
@@ -31,7 +32,141 @@ This diagnostic applies to the following container image build APIs:
 - Docker and Podman container runtime implementations
 - Related extension methods and implementations
 
+## Configure a container build
+
+The core AppHost SDK exports container build configuration to TypeScript, Python, Go, and Java. The following examples select the Linux AMD64 target platform and OCI image format for a resource built from a Dockerfile. No additional hosting package is required; the `../Api` directory must contain the application's Dockerfile and build context. Python, Go, and Java examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs limitations={{
+  rust: "The generated Rust SDK exposes container build callbacks as raw `Fn(Vec<Value>) -> Value` callbacks, without converting their arguments to `ContainerBuildOptionsCallbackContext`. These examples require the typed callback-context API.",
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import {
+    ContainerImageFormat,
+    ContainerTargetPlatform,
+    createBuilder,
+} from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addDockerfile("api", "../Api");
+await api.withContainerBuildOptions(async context => {
+    await context.setTargetPlatform(ContainerTargetPlatform.LinuxAmd64);
+    await context.setImageFormat(ContainerImageFormat.Oci);
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+using Aspire.Hosting.Publishing;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddDockerfile("api", "../Api")
+    .WithContainerBuildOptions(context =>
+    {
+        context.TargetPlatform = ContainerTargetPlatform.LinuxAmd64;
+        context.ImageFormat = ContainerImageFormat.Oci;
+        return Task.CompletedTask;
+    });
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import ContainerBuildOptionsCallbackContext, create_builder
+
+
+def configure_build(context: ContainerBuildOptionsCallbackContext) -> None:
+    context.target_platform = "LinuxAmd64"
+    context.image_format = "Oci"
+
+
+with create_builder() as builder:
+    api = builder.add_dockerfile("api", "../Api")
+    api.with_container_build_options(configure_build)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddDockerfile("api", "../Api").
+		WithContainerBuildOptions(func(context aspire.ContainerBuildOptionsCallbackContext) {
+			platform := aspire.ContainerTargetPlatformLinuxAmd64
+			format := aspire.ContainerImageFormatOci
+			context.
+				SetTargetPlatform(&platform).
+				SetImageFormat(&format)
+			if err := context.Err(); err != nil {
+				log.Fatal(aspire.FormatError(err))
+			}
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addDockerfile("api", "../Api");
+    api.withContainerBuildOptions(context -> {
+        context.setTargetPlatform(ContainerTargetPlatform.LINUX_AMD64);
+        context.setImageFormat(ContainerImageFormat.OCI);
+    });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The C# build configuration APIs generate `ASPIREPIPELINES003`; the TypeScript, Python, Go, and Java SDKs expose the same experimental AppHost configuration without emitting this C# compiler diagnostic. Implementing `IResourceContainerImageBuilder` or a container runtime remains .NET extensibility work, not an AppHost operation in these SDKs.
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the error with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepipelines004.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepipelines004.mdx
@@ -27,6 +27,8 @@ This API is experimental because the pipeline infrastructure is under active dev
 
 ## Example
 
+`IPipelineOutputService`, its implementation, and its directory methods are .NET infrastructure APIs and are not exported to the generated AppHost SDKs. Resolving this service from the dependency-injection container is therefore a C#-only operation.
+
 The following code generates `ASPIREPIPELINES004`:
 
 ```csharp title="AppHost.cs"
@@ -48,6 +50,8 @@ var tempDir = outputService.GetTempDirectory();
 - **`GetTempDirectory(IResource)`**: Gets a resource-specific temporary subdirectory
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepostgres001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepostgres001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIREPOSTGRES001 —
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.2"
@@ -24,7 +26,31 @@ The following APIs are protected by this diagnostic:
 
 ## Example
 
-The following code generates `ASPIREPOSTGRES001` when using a PostgreSQL database resource:
+Install the PostgreSQL hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.PostgreSQL" />
+
+The following examples add an MCP server to a PostgreSQL database. Both `Aspire.Hosting.PostgreSQL` and `Aspire.Hosting.Azure.PostgreSQL` export the MCP operation to generated AppHost SDKs, even though only the C# compiler reports `ASPIREPOSTGRES001`.
+
+For the daily CLI, matching packages, and feature flags required by Python, Go, Java, and Rust, see [Experimental AppHost examples](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres("postgres");
+const db = await postgres.addDatabase("mydb");
+await db.withPostgresMcp();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs (PostgreSQL)"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -36,9 +62,125 @@ var db = builder.AddPostgres("postgres")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_postgres("postgres")
+    db = postgres.add_database("mydb")
+    db.with_postgres_mcp()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	db := builder.
+		AddPostgres("postgres").
+		AddDatabase("mydb").
+		WithPostgresMcp()
+	if err := db.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addPostgres("postgres")
+        .addDatabase("mydb")
+        .withPostgresMcp();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let postgres = builder.add_postgres("postgres", None, None, None)?;
+    let db = postgres.add_database("mydb", None)?;
+    db.with_postgres_mcp(|_| Value::Null, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 —or—
 
-The following code generates `ASPIREPOSTGRES001` when using an Azure PostgreSQL Flexible Server database resource:
+Install the Azure PostgreSQL hosting integration to use an Azure PostgreSQL Flexible Server database:
+
+<InstallPackage packageName="Aspire.Hosting.Azure.PostgreSQL" />
+
+Run the server as a local container before enabling its MCP server. The C# `WithPostgresMcp` call also generates `ASPIREPOSTGRES001` in this example. The generated SDKs expose the same operation on `AzurePostgresFlexibleServerDatabaseResource`.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const postgres = await builder.addAzurePostgresFlexibleServer("postgres");
+await postgres.runAsContainer();
+const db = await postgres.addDatabase("mydb");
+await db.withPostgresMcp();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs (Azure PostgreSQL)"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -51,7 +193,106 @@ var db = builder.AddAzurePostgresFlexibleServer("postgres")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    postgres = builder.add_azure_postgres_flexible_server("postgres")
+    postgres.run_as_container()
+    db = postgres.add_database("mydb")
+    db.with_postgres_mcp()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	db := builder.
+		AddAzurePostgresFlexibleServer("postgres").
+		RunAsContainer().
+		AddDatabase("mydb").
+		WithPostgresMcp()
+	if err := db.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addAzurePostgresFlexibleServer("postgres")
+        .runAsContainer()
+        .addDatabase("mydb")
+        .withPostgresMcp();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::Value;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let postgres = builder.add_azure_postgres_flexible_server("postgres")?;
+    postgres.run_as_container(|_| Value::Null)?;
+    let db = postgres.add_database("mydb", None)?;
+    db.with_postgres_mcp(|_| Value::Null, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#; generated AppHost SDKs use the same API without the compiler warning.
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireprobes001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireprobes001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREPROBES001 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 9.5"
@@ -27,7 +28,46 @@ These APIs enable configuring HTTP health probes for resources to monitor startu
 
 ## Example
 
-The following code generates `ASPIREPROBES001`:
+The C# example generates `ASPIREPROBES001`. The generated AppHost SDKs support HTTP probes and probe types without emitting this C# compiler diagnostic. Probe configuration and project resources belong to the core `Aspire.Hosting` SDK; no additional integration package is required for this example. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+Each referenced project must expose an HTTP or HTTPS endpoint and implement the health paths shown.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder, ProbeType } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withHttpProbe(ProbeType.Readiness, { path: "/health/ready" });
+
+const worker = await builder.addProject("worker", "../Worker/Worker.csproj");
+await worker.withHttpProbe(ProbeType.Liveness, { path: "/health/live" });
+
+const service = await builder.addProject("service", "../Service/Service.csproj");
+await service.withHttpProbe(ProbeType.Startup, {
+  path: "/health/startup",
+  initialDelaySeconds: 15,
+  failureThreshold: 10,
+});
+await service.withHttpProbe(ProbeType.Readiness, {
+  path: "/health/ready",
+  periodSeconds: 5,
+  timeoutSeconds: 3,
+});
+await service.withHttpProbe(ProbeType.Liveness, {
+  path: "/health/live",
+  periodSeconds: 30,
+  failureThreshold: 3,
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="Using HTTP probes"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -52,9 +92,216 @@ var service = builder.AddProject<Projects.Service>("service")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_http_probe("Readiness", path="/health/ready")
+
+    worker = builder.add_project("worker", "../Worker/Worker.csproj")
+    worker.with_http_probe("Liveness", path="/health/live")
+
+    service = builder.add_project("service", "../Service/Service.csproj")
+    (
+        service.with_http_probe(
+            "Startup",
+            path="/health/startup",
+            initial_delay_seconds=15,
+            failure_threshold=10,
+        )
+        .with_http_probe(
+            "Readiness",
+            path="/health/ready",
+            period_seconds=5,
+            timeout_seconds=3,
+        )
+        .with_http_probe(
+            "Liveness",
+            path="/health/live",
+            period_seconds=30,
+            failure_threshold=3,
+        )
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithHttpProbe(aspire.ProbeTypeReadiness, &aspire.WithHttpProbeOptions{
+			Path: aspire.StringPtr("/health/ready"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	worker := builder.AddProject("worker", "../Worker/Worker.csproj").
+		WithHttpProbe(aspire.ProbeTypeLiveness, &aspire.WithHttpProbeOptions{
+			Path: aspire.StringPtr("/health/live"),
+		})
+	if err := worker.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.AddProject("service", "../Service/Service.csproj").
+		WithHttpProbe(aspire.ProbeTypeStartup, &aspire.WithHttpProbeOptions{
+			Path:                aspire.StringPtr("/health/startup"),
+			InitialDelaySeconds: aspire.Float64Ptr(15),
+			FailureThreshold:    aspire.Float64Ptr(10),
+		}).
+		WithHttpProbe(aspire.ProbeTypeReadiness, &aspire.WithHttpProbeOptions{
+			Path:           aspire.StringPtr("/health/ready"),
+			PeriodSeconds:  aspire.Float64Ptr(5),
+			TimeoutSeconds: aspire.Float64Ptr(3),
+		}).
+		WithHttpProbe(aspire.ProbeTypeLiveness, &aspire.WithHttpProbeOptions{
+			Path:             aspire.StringPtr("/health/live"),
+			PeriodSeconds:    aspire.Float64Ptr(30),
+			FailureThreshold: aspire.Float64Ptr(3),
+		})
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withHttpProbe(
+        ProbeType.READINESS,
+        new WithHttpProbeOptions().path("/health/ready"));
+
+    var worker = builder.addProject("worker", "../Worker/Worker.csproj");
+    worker.withHttpProbe(
+        ProbeType.LIVENESS,
+        new WithHttpProbeOptions().path("/health/live"));
+
+    var service = builder.addProject(
+        "service",
+        "../Service/Service.csproj");
+    service.withHttpProbe(
+        ProbeType.STARTUP,
+        new WithHttpProbeOptions()
+            .path("/health/startup")
+            .initialDelaySeconds(15)
+            .failureThreshold(10));
+    service.withHttpProbe(
+        ProbeType.READINESS,
+        new WithHttpProbeOptions()
+            .path("/health/ready")
+            .periodSeconds(5)
+            .timeoutSeconds(3));
+    service.withHttpProbe(
+        ProbeType.LIVENESS,
+        new WithHttpProbeOptions()
+            .path("/health/live")
+            .periodSeconds(30)
+            .failureThreshold(3));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_http_probe(
+        ProbeType::Readiness,
+        Some("/health/ready"),
+        None, None, None, None, None, None,
+    )?;
+
+    let worker = builder.add_project(
+        "worker",
+        "../Worker/Worker.csproj",
+        None,
+    )?;
+    worker.with_http_probe(
+        ProbeType::Liveness,
+        Some("/health/live"),
+        None, None, None, None, None, None,
+    )?;
+
+    let service = builder.add_project(
+        "service",
+        "../Service/Service.csproj",
+        None,
+    )?;
+    service.with_http_probe(
+        ProbeType::Startup,
+        Some("/health/startup"),
+        Some(15.0), None, None, Some(10.0), None, None,
+    )?;
+    service.with_http_probe(
+        ProbeType::Readiness,
+        Some("/health/ready"),
+        None, Some(5.0), Some(3.0), None, None, None,
+    )?;
+    service.with_http_probe(
+        ProbeType::Liveness,
+        Some("/health/live"),
+        None, Some(30.0), None, Some(3.0), None, None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## Understanding health probes
 
-Health probes allow you to configure monitoring for your resources' health state. Aspire supports three types of probes that align with Kubernetes health check concepts:
+Health probes allow you to configure monitoring for your resources' health state. `WithHttpProbe`/`withHttpProbe` adds both a deployment probe annotation and an HTTP health check used during local runs. Aspire supports three probe types that align with Kubernetes health check concepts. Startup ordering, traffic routing, and automatic restarts described below are deployment-platform behaviors, not promises that the local AppHost will restart or stop routing to an unhealthy resource:
 
 ### Probe types
 
@@ -97,6 +344,29 @@ Health probes allow you to configure monitoring for your resources' health state
 
 ### Custom endpoint targeting
 
+Select an endpoint by name in any supported AppHost language:
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder, ProbeType } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withHttpEndpoint({ port: 8080, name: "management" });
+await api.withHttpProbe(ProbeType.Readiness, {
+  path: "/actuator/health",
+  endpointName: "management",
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
 ```csharp title="Probe specific endpoint"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -106,39 +376,301 @@ var api = builder.AddProject<Projects.Api>("api")
     .WithHttpProbe(ProbeType.Readiness, "/actuator/health",
         endpointName: "management");
 
-// Probe with endpoint selector function
-var service = builder.AddProject<Projects.Service>("service")
-    .WithHttpProbe(ProbeType.Liveness, "/status",
-        endpointSelector: () => service.GetEndpoint("https"));
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_http_endpoint(port=8080, name="management")
+    api.with_http_probe(
+        "Readiness",
+        path="/actuator/health",
+        endpoint_name="management",
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Port: aspire.Float64Ptr(8080),
+			Name: aspire.StringPtr("management"),
+		}).
+		WithHttpProbe(aspire.ProbeTypeReadiness, &aspire.WithHttpProbeOptions{
+			Path:         aspire.StringPtr("/actuator/health"),
+			EndpointName: aspire.StringPtr("management"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withHttpEndpoint(new WithHttpEndpointOptions()
+        .port(8080)
+        .name("management"));
+    api.withHttpProbe(
+        ProbeType.READINESS,
+        new WithHttpProbeOptions()
+            .path("/actuator/health")
+            .endpointName("management"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_http_endpoint(
+        Some(8080.0),
+        None,
+        Some("management"),
+        None,
+        None,
+    )?;
+    api.with_http_probe(
+        ProbeType::Readiness,
+        Some("/actuator/health"),
+        None, None, None, None, None,
+        Some("management"),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The overload accepting an endpoint-selector callback is C#-only; the generated SDKs use the endpoint-name option instead. When using a C# callback, create the resource before capturing it:
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var service = builder.AddProject<Projects.Service>("service");
+service.WithHttpProbe(
+    ProbeType.Liveness,
+    endpointSelector: () => service.GetEndpoint("https"),
+    path: "/status");
 
 builder.Build().Run();
 ```
 
 ### Integration with resource dependencies
 
-Probes work seamlessly with resource wait dependencies:
+The HTTP health checks registered by probes participate in local resource wait dependencies. In this example, the frontend waits until the API's readiness probe succeeds.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder, ProbeType } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const api = await builder.addProject("api", "../Api/Api.csproj");
+await api.withHttpProbe(ProbeType.Readiness, { path: "/health/ready" });
+
+const frontend = await builder.addProject("frontend", "../Frontend/Frontend.csproj");
+await frontend.waitFor(api);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="Probes with dependencies"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var database = builder.AddPostgres("postgres");
-var cache = builder.AddRedis("redis");
-
-// API with probes that check dependencies
 var api = builder.AddProject<Projects.Api>("api")
-    .WithHttpProbe(ProbeType.Readiness, "/health/ready")
-    .WaitFor(database)
-    .WaitFor(cache)
-    .WithReference(database)
-    .WithReference(cache);
+    .WithHttpProbe(ProbeType.Readiness, "/health/ready");
 
-// Frontend waits for API to be ready (not just started)
 var frontend = builder.AddProject<Projects.Frontend>("frontend")
-    .WaitFor(api)  // Waits for API readiness probe to pass
-    .WithReference(api);
+    .WaitFor(api);
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_http_probe("Readiness", path="/health/ready")
+
+    frontend = builder.add_project(
+        "frontend",
+        "../Frontend/Frontend.csproj",
+    )
+    frontend.wait_for(api)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj").
+		WithHttpProbe(aspire.ProbeTypeReadiness, &aspire.WithHttpProbeOptions{
+			Path: aspire.StringPtr("/health/ready"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	frontend := builder.AddProject(
+		"frontend",
+		"../Frontend/Frontend.csproj",
+	).WaitFor(api)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withHttpProbe(
+        ProbeType.READINESS,
+        new WithHttpProbeOptions().path("/health/ready"));
+
+    var frontend = builder.addProject(
+        "frontend",
+        "../Frontend/Frontend.csproj");
+    frontend.waitFor(api);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_http_probe(
+        ProbeType::Readiness,
+        Some("/health/ready"),
+        None, None, None, None, None, None,
+    )?;
+
+    let frontend = builder.add_project(
+        "frontend",
+        "../Frontend/Frontend.csproj",
+        None,
+    )?;
+    let api_resource = IResource::new(
+        api.handle().clone(),
+        api.client().clone(),
+    );
+    frontend.wait_for(&api_resource, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Deployment integration
 
@@ -149,6 +681,8 @@ Probes are automatically configured when deploying to supported compute environm
 - **Docker Compose** — Health checks are configured based on probe settings
 
 ## To suppress this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireprocesscommand001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireprocesscommand001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREPROCESSCOMMAND0
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.4"
@@ -25,12 +26,32 @@ The following APIs are protected by this diagnostic:
 
 ## Example
 
-The following code generates `ASPIREPROCESSCOMMAND001`:
+The C# example generates `ASPIREPROCESSCOMMAND001`. The generated AppHost SDKs support the same operation, but don't emit this C# compiler diagnostic. The command API and container resource belong to the core `Aspire.Hosting` SDK, so no additional integration package is required. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const cache = await builder.addContainer("cache", { image: "redis" });
+await cache.withProcessCommand("dotnet-version", "Show .NET version", {
+  executablePath: "dotnet",
+  arguments: ["--version"],
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddRedis("cache")
+builder.AddContainer("cache", "redis")
     .WithProcessCommand(
         commandName: "dotnet-version",
         displayName: "Show .NET version",
@@ -40,9 +61,126 @@ builder.AddRedis("cache")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import ProcessCommandExportOptions, create_builder
+
+with create_builder() as builder:
+    cache = builder.add_container("cache", "redis")
+    options: ProcessCommandExportOptions = {
+        "ExecutablePath": "dotnet",
+        "Arguments": ["--version"],
+    }
+    cache.with_process_command("dotnet-version", "Show .NET version", options)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddContainer("cache", "redis").
+		WithProcessCommand(
+			"dotnet-version",
+			"Show .NET version",
+			&aspire.ProcessCommandExportOptions{
+				ExecutablePath: aspire.StringPtr("dotnet"),
+				Arguments:      []string{"--version"},
+			},
+		)
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var options = new ProcessCommandExportOptions();
+    options.setExecutablePath("dotnet");
+    options.setArguments(new String[] { "--version" });
+
+    var cache = builder.addContainer("cache", "redis");
+    cache.withProcessCommand(
+        "dotnet-version",
+        "Show .NET version",
+        options);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_container("cache", serde_json::json!("redis"))?;
+    cache.with_process_command(
+        "dotnet-version",
+        "Show .NET version",
+        ProcessCommandExportOptions {
+            executable_path: Some("dotnet".to_string()),
+            arguments: vec!["--version".to_string()],
+            ..Default::default()
+        },
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+TypeScript passes process settings in `ProcessCommandExportOptions`, rather than the positional C# overload. Its `createProcessSpec` option supports dynamically created process specifications; the older `withProcessCommandFactory` export is obsolete.
+
 The diagnostic is triggered because `WithProcessCommand`, `ProcessCommandSpec`, and `ProcessCommandOptions` are all marked with the `[Experimental("ASPIREPROCESSCOMMAND001")]` attribute.
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 
@@ -67,7 +205,7 @@ Suppress the warning with one of the following methods:
 
   ```csharp title="Suppressing the warning"
   #pragma warning disable ASPIREPROCESSCOMMAND001
-  builder.AddRedis("cache")
+  builder.AddContainer("cache", "redis")
       .WithProcessCommand("dotnet-version", "Show .NET version", "dotnet", ["--version"]);
   #pragma warning restore ASPIREPROCESSCOMMAND001
   ```

--- a/src/frontend/src/content/docs/diagnostics/aspireprojects001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireprojects001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREPROJECTS001 and
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -25,7 +26,115 @@ These APIs let a resource opt into the same launch-profile, Kestrel endpoint, an
 
 ## Example
 
-The following code generates `ASPIREPROJECTS001`:
+All AppHost languages can add a project resource. This operation already applies the launch-profile, Kestrel endpoint, and `ASPNETCORE_URLS` wiring. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const web = await builder.addProject("web", "../Web/Web.csproj");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+var web = builder.AddProject<Projects.Web>("web");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_project("web", "../Web/Web.csproj")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.AddProject("web", "../Web/Web.csproj")
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addProject("web", "../Web/Web.csproj");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_project("web", "../Web/Web.csproj", None)?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+`WithProjectDefaults` and its annotations aren't exported to the generated AppHost SDKs. They are C#-only APIs for custom .NET integration authors implementing resources that carry `IProjectMetadata`. The following operation generates `ASPIREPROJECTS001` and isn't equivalent to adding a normal project resource:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -36,6 +145,8 @@ builder.AddResource(new MyDotnetResource("resource"))
 ```
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireproxyendpoints001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireproxyendpoints001.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler error ASPIREPROXYENDPOINTS001
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 9.1"
@@ -25,18 +27,132 @@ Container resources use proxied endpoints by default. Adjusting this setting is 
 
 ## Example
 
-The following code generates `ASPIREPROXYENDPOINTS001`:
+Install the Redis integration used by these examples:
+
+<InstallPackage packageName="Aspire.Hosting.Redis" />
+
+The C# example generates `ASPIREPROXYENDPOINTS001`. The generated SDK examples configure the same Redis endpoint proxy behavior without emitting this C# compiler diagnostic. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const redis = await builder.addRedis("example-redis", { port: 1234 });
+await redis.withEndpointProxySupport(false);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var redis = builder.AddRedis($"example-redis", 1234)
-                   .WithEndpointProxySupport(false);
+var redis = builder.AddRedis("example-redis", 1234)
+    .WithEndpointProxySupport(false);
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_redis("example-redis", port=1234)
+    redis.with_endpoint_proxy_support(False)
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.
+		AddRedis("example-redis", &aspire.AddRedisOptions{
+			Port: aspire.Float64Ptr(1234),
+		}).
+		WithEndpointProxySupport(false)
+	if err := redis.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRedis("example-redis", new AddRedisOptions().port(1234))
+        .withEndpointProxySupport(false);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let redis = builder.add_redis("example-redis", Some(1234.0), None)?;
+    redis.with_endpoint_proxy_support(false)?;
+
+    builder.build()?.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## To correct this error
 
-Suppress the error with either of the following methods:
+The following suppression options apply to C# AppHosts. For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
+
+Suppress the error with one of the following methods:
 
 - Set the severity of the rule in the _.editorconfig_ file.
 

--- a/src/frontend/src/content/docs/diagnostics/aspirepublishers001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirepublishers001.mdx
@@ -15,11 +15,15 @@ import { Badge } from '@astrojs/starlight/components';
 
 > Publishers are for evaluation purposes only and are subject to change or removal in future updates. Suppress this diagnostic to proceed.
 
-Aspire introduced the concept of _Publishers_ starting in version 9.2. Publishers play a pivotal role in the deployment process, enabling the transformation of your distributed app into deployable assets. This alleviates the intermediate step of producing the publishing [manifest](/architecture/resource-publishing/) for tools to act on, instead empowering the developer to express their intent directly in C#.
+Aspire introduced the concept of _Publishers_ starting in version 9.2. Publishers transform your distributed app into deployable assets. This avoids the intermediate step of producing a publishing [manifest](/architecture/resource-publishing/) for tools to act on, letting you express deployment intent in your AppHost.
 
 Publishers are considered experimental and are expected to change in the future.
 
+This diagnostic concerns C#-only publisher infrastructure and registration APIs. Implementing a custom .NET publisher is not an exported AppHost operation. AppHosts across languages can configure supported deployment targets through [compute environment integrations](/diagnostics/aspirecompute001/); generated language SDKs do not emit or suppress this C# compiler diagnostic.
+
 ## To correct this error
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the error with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireradius003.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireradius003.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRERADIUS003 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -23,7 +25,121 @@ These APIs configure the Azure and AWS cloud providers that the Radius publisher
 
 ## Example
 
-The following code generates `ASPIRERADIUS003`:
+Install the Radius hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Radius" />
+
+Creating a Radius environment is supported across AppHost languages. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples). The cloud-provider callbacks are a separate, C#-only operation shown after these setup examples.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+await builder.addRadiusEnvironment("radius");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddRadiusEnvironment("radius");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_radius_env("radius")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddRadiusEnvironment("radius")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRadiusEnvironment("radius");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_radius_environment("radius")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Configure cloud providers in C#
+
+`WithAzureProvider`, `WithAwsProvider`, and their credential-builder callbacks are not exported to the TypeScript SDK catalog for `Aspire.Hosting.Radius` or to the daily Python, Go, Java, and Rust SDKs used for this documentation. Configuring providers through these APIs requires a C# AppHost:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -43,6 +159,8 @@ builder.Build().Run();
 ```
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). The warning is only emitted by C#; the generated language SDKs do not export the provider callbacks that trigger it.
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireradius004.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireradius004.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRERADIUS004 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -24,7 +26,121 @@ This callback lets you customize the generated Radius infrastructure (its constr
 
 ## Example
 
-The following code generates `ASPIRERADIUS004`:
+Install the Radius hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Radius" />
+
+Creating a Radius environment is supported across AppHost languages. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples). Infrastructure customization is a separate, C#-only operation shown after these setup examples.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+await builder.addRadiusEnvironment("radius");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddRadiusEnvironment("radius");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_radius_env("radius")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddRadiusEnvironment("radius")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRadiusEnvironment("radius");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_radius_environment("radius")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Customize infrastructure in C#
+
+The `ConfigureRadiusInfrastructure` callback and its construct types are not exported to the TypeScript SDK catalog for `Aspire.Hosting.Radius` or to the daily Python, Go, Java, and Rust SDKs used for this documentation. This customization requires a C# AppHost:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -39,6 +155,8 @@ builder.Build().Run();
 ```
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). The warning is only emitted by C#; the generated language SDKs do not export the callback or its construct types.
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireradius006.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireradius006.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRERADIUS006 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.6"
@@ -25,7 +27,121 @@ These APIs declare a Radius secret store and populate it from Aspire secret para
 
 ## Example
 
-The following code generates `ASPIRERADIUS006`:
+Install a version of the Radius hosting integration that includes the 13.6 secret-store APIs:
+
+<InstallPackage packageName="Aspire.Hosting.Radius" />
+
+Creating a Radius environment is supported across AppHost languages. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples). Secret-store configuration is a separate, C#-only operation shown after these setup examples.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+await builder.addRadiusEnvironment("radius");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddRadiusEnvironment("radius");
+
+builder.Build().Run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_radius_env("radius")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddRadiusEnvironment("radius")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRadiusEnvironment("radius");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_radius_environment("radius")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+### Configure secret stores in C#
+
+`AddRadiusSecretStore`, `WithSecretStore`, their callbacks, and `RadiusSecretStoreType` are not exported to the TypeScript SDK catalog for `Aspire.Hosting.Radius` or to the daily Python, Go, Java, and Rust SDKs used for this documentation. Secret-store configuration requires the C# APIs in the daily build:
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -44,6 +160,8 @@ builder.Build().Run();
 ```
 
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). The warning is only emitted by C#; the generated language SDKs do not export the secret-store APIs.
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireradius057.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireradius057.mdx
@@ -5,6 +5,8 @@ description: Learn what causes the Aspire compiler warning ASPIRERADIUS057 and h
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
+import InstallPackage from '@components/InstallPackage.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -19,7 +21,29 @@ This diagnostic warning is reported when using the experimental `WithContainerIm
 
 ## Example
 
-The following code generates `ASPIRERADIUS057`:
+Install the Radius hosting integration:
+
+<InstallPackage packageName="Aspire.Hosting.Radius" />
+
+The following examples associate a pre-built image with a project. The C# call generates `ASPIRERADIUS057`; the generated language SDKs expose the same experimental operation without emitting this C# compiler diagnostic. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+await builder.addRadiusEnvironment("radius");
+const api = await builder.addProject("apiservice", "../ApiService/ApiService.csproj");
+await api.withContainerImage("localhost:5001/apiservice:latest");
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -32,7 +56,102 @@ builder.AddProject<Projects.ApiService>("apiservice")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_radius_env("radius")
+    api = builder.add_project("apiservice", "../ApiService/ApiService.csproj")
+    api.with_container_image("localhost:5001/apiservice:latest")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"apphost/modules/aspire"
+	"log"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	env := builder.AddRadiusEnvironment("radius")
+	if err := env.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	api := builder.AddProject("apiservice", "../ApiService/ApiService.csproj").
+		WithContainerImage("localhost:5001/apiservice:latest")
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addRadiusEnvironment("radius");
+    var api = builder.addProject("apiservice", "../ApiService/ApiService.csproj");
+    api.withContainerImage("localhost:5001/apiservice:latest");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_radius_environment("radius")?;
+    let api = builder.add_project("apiservice", "../ApiService/ApiService.csproj", None)?;
+    api.with_container_image("localhost:5001/apiservice:latest")?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost). Suppression is only needed for C#.
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireterminal001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireterminal001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIRETERMINAL001 and
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -24,7 +25,24 @@ This diagnostic warning is reported when using experimental terminal configurati
 
 ## Example
 
-The following code generates `ASPIRETERMINAL001`:
+The C# example generates `ASPIRETERMINAL001`. The generated AppHost SDKs support the parameterless terminal method but don't emit this C# compiler diagnostic. This method and the container resource belong to the core `Aspire.Hosting` SDK; no additional integration package is required. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const cache = await builder.addContainer("cache", { image: "redis" });
+await cache.withTerminal();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -35,7 +53,97 @@ builder.AddContainer("cache", "redis")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    cache = builder.add_container("cache", "redis")
+    cache.with_terminal()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	cache := builder.AddContainer("cache", "redis").WithTerminal()
+	if err := cache.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addContainer("cache", "redis").withTerminal();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let cache = builder.add_container("cache", json!("redis"))?;
+    cache.with_terminal()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+The `TerminalOptions` configuration callback isn't exported to the polyglot SDKs; their parameterless terminal method uses the default terminal options.
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with one of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/aspireusersecrets001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspireusersecrets001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREUSERSECRETS001 
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.1"
@@ -28,16 +29,192 @@ This API is experimental because the user secrets management strategy is being r
 
 ## Example
 
-The following code generates `ASPIREUSERSECRETS001`:
+The C# example generates `ASPIREUSERSECRETS001`. The generated AppHost SDKs also expose the user secrets manager without emitting this C# compiler diagnostic. These APIs belong to the core `Aspire.Hosting` SDK; no additional integration package is required. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+Use a value supplied outside source control, such as an environment variable. User secrets are stored in a local JSON file, not encrypted; use them for development, not as a production secret store.
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+
+const configuration = await builder.getConfiguration();
+const secretValue = await configuration.getConfigValue("MY_SECRET");
+if (!secretValue) {
+  throw new Error("Set MY_SECRET before running the AppHost.");
+}
+
+const userSecretsManager = await builder.userSecretsManager();
+const filePath = await userSecretsManager.filePath();
+const success = await userSecretsManager.trySetSecret("MySecret", secretValue);
+if (!success) {
+  throw new Error("Could not save the development secret.");
+}
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-// Using IUserSecretsManager
+var secretValue = builder.Configuration["MY_SECRET"];
+if (string.IsNullOrEmpty(secretValue))
+{
+    throw new InvalidOperationException("Set MY_SECRET before running the AppHost.");
+}
+
 var userSecretsManager = builder.UserSecretsManager;
 var filePath = userSecretsManager.FilePath;
-bool success = userSecretsManager.TrySetSecret("MySecret", "SecretValue");
+bool success = userSecretsManager.TrySetSecret("MySecret", secretValue);
+if (!success)
+{
+    throw new InvalidOperationException("Could not save the development secret.");
+}
+
+builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+import os
+
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    secret_value = os.environ.get("MY_SECRET")
+    if not secret_value:
+        raise RuntimeError("Set MY_SECRET before running the AppHost.")
+
+    user_secrets_manager = builder.user_secrets_manager
+    file_path = user_secrets_manager.file_path
+    success = user_secrets_manager.try_set_secret("MySecret", secret_value)
+    if not success:
+        raise RuntimeError("Could not save the development secret.")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+	"os"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secretValue := os.Getenv("MY_SECRET")
+	if secretValue == "" {
+		log.Fatal("Set MY_SECRET before running the AppHost.")
+	}
+
+	userSecretsManager := builder.UserSecretsManager()
+	if err := userSecretsManager.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	filePath, err := userSecretsManager.FilePath()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	_ = filePath
+
+	success, err := userSecretsManager.TrySetSecret("MySecret", secretValue)
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if !success {
+		log.Fatal("Could not save the development secret.")
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var secretValue = System.getenv("MY_SECRET");
+    if (secretValue == null || secretValue.isEmpty()) {
+        throw new IllegalStateException(
+            "Set MY_SECRET before running the AppHost.");
+    }
+
+    var userSecretsManager = builder.userSecretsManager();
+    var filePath = userSecretsManager.filePath();
+    var success = userSecretsManager.trySetSecret(
+        "MySecret",
+        secretValue);
+    if (!success) {
+        throw new IllegalStateException(
+            "Could not save the development secret.");
+    }
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let secret_value = std::env::var("MY_SECRET")
+        .map_err(|_| "Set MY_SECRET before running the AppHost.")?;
+    if secret_value.is_empty() {
+        return Err("Set MY_SECRET before running the AppHost.".into());
+    }
+
+    let user_secrets_manager = builder.user_secrets_manager()?;
+    let _file_path = user_secrets_manager.file_path()?;
+    if !user_secrets_manager.try_set_secret("MySecret", &secret_value)? {
+        return Err("Could not save the development secret.".into());
+    }
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 ### Related types
 
@@ -49,7 +226,11 @@ bool success = userSecretsManager.TrySetSecret("MySecret", "SecretValue");
 - **`GetOrSetSecret()`**: Gets a secret from configuration or generates and saves a new value
 - **`SaveStateAsync()`**: Saves deployment state to user secrets asynchronously
 
+The generated SDKs expose the manager through the builder instead of as a public constructor. Python uses `user_secrets_manager` and `file_path` properties. TypeScript uses asynchronous `userSecretsManager()` and `filePath()` accessors. Go and Rust return explicit errors from manager operations. Java methods throw when the underlying capability call fails.
+
 ## To correct this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 
@@ -75,6 +256,6 @@ Suppress the warning with either of the following methods:
   ```csharp title="Suppressing the warning"
   #pragma warning disable ASPIREUSERSECRETS001
   var userSecretsManager = builder.UserSecretsManager;
-  bool success = userSecretsManager.TrySetSecret("MySecret", "SecretValue");
+  bool success = userSecretsManager.TrySetSecret("MySecret", secretValue);
   #pragma warning restore ASPIREUSERSECRETS001
   ```

--- a/src/frontend/src/content/docs/diagnostics/aspirewatch001.mdx
+++ b/src/frontend/src/content/docs/diagnostics/aspirewatch001.mdx
@@ -5,6 +5,7 @@ description: Learn what causes the Aspire compiler warning ASPIREWATCH001 and ho
 ---
 
 import { Badge } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 <Badge
   text="Version introduced: 13.5"
@@ -25,7 +26,30 @@ These APIs let integrations vary how their resources are launched based on the k
 
 ## Example
 
-The following code generates `ASPIREWATCH001`:
+The C# example generates `ASPIREWATCH001`. The generated AppHost SDKs can also read the execution context and its run configuration but don't emit this C# compiler diagnostic. These APIs belong to the core `Aspire.Hosting` SDK; no additional integration package is required. Python, Go, Java, and Rust examples require the [experimental AppHost setup](/diagnostics/overview/#experimental-apphost-examples).
+
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from "./.aspire/modules/aspire.mjs";
+
+const builder = await createBuilder();
+const executionContext = await builder.executionContext();
+
+if (await executionContext.isRunMode()) {
+  const runConfiguration = await executionContext.runConfiguration();
+
+  if (runConfiguration.watchEnabled) {
+    // Launch resources so source changes are hot-reloaded.
+  }
+}
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
 
 ```csharp title="Reading run mode configuration"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -43,6 +67,127 @@ if (builder.ExecutionContext.IsRunMode)
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    execution_context = builder.execution_context
+
+    if execution_context.is_run_mode:
+        run_configuration = execution_context.run_config
+
+        if run_configuration.get("WatchEnabled", False):
+            # Launch resources so source changes are hot-reloaded.
+            pass
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	executionContext := builder.ExecutionContext()
+	if err := executionContext.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	isRunMode, err := executionContext.IsRunMode()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if isRunMode {
+		runConfiguration, err := executionContext.RunConfiguration()
+		if err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+
+		if runConfiguration.WatchEnabled != nil && *runConfiguration.WatchEnabled {
+			// Launch resources so source changes are hot-reloaded.
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+    var executionContext = builder.executionContext();
+
+    if (executionContext.isRunMode()) {
+        var runConfiguration = executionContext.runConfiguration();
+
+        if (Boolean.TRUE.equals(runConfiguration.getWatchEnabled())) {
+            // Launch resources so source changes are hot-reloaded.
+        }
+    }
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+    let execution_context = builder.execution_context()?;
+
+    if execution_context.is_run_mode()? {
+        let run_configuration = execution_context.run_configuration()?;
+
+        if run_configuration.watch_enabled.unwrap_or(false) {
+            // Launch resources so source changes are hot-reloaded.
+        }
+    }
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
+Execution-context access follows each SDK's conventions. Python returns a `RunConfiguration` dictionary with wire-format field names, Go uses explicit errors and pointer-valued optional DTO fields, Java exposes bean accessors, and Rust returns `Result` values with optional DTO fields.
+
 ## Understanding run mode configuration
 
 `RunConfiguration` holds settings that only apply when the AppHost is running in [run mode](/app-host/resource-lifetimes/) (as opposed to publish mode). Integrations use it to vary how their resources are launched without changing the core hosting behavior.
@@ -52,6 +197,8 @@ builder.Build().Run();
 Indicates that resources should start in watch mode if able. Integrations that support watch can launch their resources so that source changes are hot-reloaded. This is a hint: integrations that cannot watch their resources should start them in the normal fashion.
 
 ## To suppress this warning
+
+For a C# file-based AppHost, see [Suppress in a file-based AppHost](/diagnostics/overview/#suppress-in-a-file-based-apphost).
 
 Suppress the warning with either of the following methods:
 

--- a/src/frontend/src/content/docs/diagnostics/overview.mdx
+++ b/src/frontend/src/content/docs/diagnostics/overview.mdx
@@ -4,7 +4,11 @@ seoTitle: 'Aspire diagnostics overview: ASPIRE compiler diagnostics'
 description: Learn about the diagnostics tools and features available in Aspire — analyzers, compiler errors, the dashboard, structured telemetry, and troubleshooting workflows.
 ---
 
-The following table lists the possible MSBuild and analyzer warnings and errors you might encounter with Aspire:
+The following table lists the possible MSBuild and analyzer warnings and errors you might encounter with Aspire.
+
+These diagnostic IDs describe checks performed by the .NET build tools and C# analyzers. AppHosts written in TypeScript, Python, Go, Java, and Rust can use many of the same hosting APIs without emitting the corresponding C# compiler diagnostic. Diagnostic pages include a language variant only where its generated SDK supports the operation. The examples share your `aspire-lang` selection and default to TypeScript when you haven't selected a language.
+
+MSBuild configuration, C# integration-authoring examples, and C# diagnostic suppressions remain language-specific. An API's experimental status still applies across AppHost languages, even when no compiler suppression is required. Python, Go, Java, and Rust AppHost authoring is also experimental; see [Experimental AppHost examples](#experimental-apphost-examples).
 
 | Diagnostic ID                                                                      | Type                   | Description                                                                                                                                                                                    |
 | ---------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -74,22 +78,37 @@ The following table lists the possible MSBuild and analyzer warnings and errors 
 | [ASPIREUSERSECRETS001](/diagnostics/aspireusersecrets001/)                         | (Experimental) Warning | Type is for evaluation purposes only and is subject to change or removal in future updates.                                                                                                    |
 | [ASPIREWATCH001](/diagnostics/aspirewatch001/)                                     | (Experimental) Warning | Run mode configuration types and members are for evaluation purposes only and are subject to change or removal in future updates.                                                              |
 
+## Experimental AppHost examples
+
+The Python, Go, Java, and Rust examples target the dev-channel Aspire CLI and matching prerelease hosting packages, not the Aspire 13.5.3 release. Their signatures match the daily generated SDK used for this documentation. Use the [Aspire CLI installer](/get-started/install-cli/) with the dev channel and regenerate your AppHost SDK after adding the integration packages named on the diagnostic page.
+
+Enable the feature flag for your AppHost language:
+
+```bash title="Enable an experimental AppHost language"
+aspire config set features:experimentalPolyglot:python true --global
+```
+
+Replace `python` with `go`, `java`, or `rust` for those AppHosts. Experimental language availability is separate from an individual API's experimental status: neither flag removes C# compiler diagnostics or makes unexported C# callbacks available in a generated SDK. When an operation isn't available, the example explains the limitation instead of showing a substitute implementation.
+
 ## Suppress diagnostic
 
-You can suppress any diagnostic in this document using one of the following methods:
+For a suppressible C# diagnostic, use a method supported by that diagnostic:
 
 - Add the `System.Diagnostics.CodeAnalysis.SuppressMessageAttribute` at the assembly, class, method, line, etc.
 - Include the diagnostic ID in the `NoWarn` property of your project file.
+- For a C# file-based AppHost, set `NoWarn` with a `#:property` directive.
 - Use preprocessor directives in your code.
 - Configure diagnostic severity in an _.editorconfig_ file.
 
-There are some common patterns for suppressing diagnostics in .NET projects. The best method depends on your context and the specific diagnostic. Here's a quick guide to help you choose:
+These methods apply to C# code and .NET builds, not to `apphost.mts`. Read the diagnostic's guidance before suppressing it: configuration errors and invalid resource names should be corrected, and not every diagnostic supports every suppression method.
 
 :::note[Important]
 The following sections provide examples for suppressing the `ASPIREE000` diagnostic, which is a placeholder for any diagnostic ID you might encounter. Replace `ASPIREE000` with the actual diagnostic ID you want to suppress.
 :::
 
 ### Suppress with the suppress message attribute
+
+This attribute is for analyzer diagnostics that support it. It doesn't suppress C# compiler diagnostics, including diagnostics emitted by `[Experimental]`; use `NoWarn` or `#pragma warning disable` for those instead.
 
 The `System.Diagnostics.CodeAnalysis.SuppressMessageAttribute` is ideal when you need targeted, documented suppression tied directly to a specific code element like a class or method. It shines when you're making a deliberate exception to a rule that is valid in most other places. This attribute keeps the suppression close to the code it affects, which helps reviewers and future maintainers understand the rationale. While it's a clean solution for isolated cases, it can clutter the code if overused, and it's not the best choice for widespread or bulk suppressions.
 
@@ -123,6 +142,20 @@ Adding the diagnostic ID to the `NoWarn` property in your _.csproj_ file is a st
     <NoWarn>$(NoWarn);ASPIREE000</NoWarn>
 </PropertyGroup>
 ```
+
+### Suppress in a file-based AppHost
+
+A C# [file-based AppHost](/get-started/aspire-sdk/) doesn't have a _.csproj_ file to edit. Add a `#:property` directive at the top of _AppHost.cs_, alongside its existing `#:sdk` and `#:package` directives:
+
+```csharp title="AppHost.cs"
+#:property NoWarn=$(NoWarn);ASPIREE000
+```
+
+This sets the `NoWarn` MSBuild property on the project generated for the file-based app. Keep `$(NoWarn)` to preserve existing suppressions, and separate additional diagnostic IDs with semicolons. Replace `ASPIREE000` with the actual suppressible diagnostic ID.
+
+The directive applies to the whole file-based app. To suppress a diagnostic only around a particular API call, use the [preprocessor directives](#suppress-with-preprocessor-directives) below instead; they work in both file-based and project-based C# AppHosts. You don't need to create a project file or convert the app.
+
+For more information, see [File-based app directives](https://learn.microsoft.com/dotnet/core/sdk/file-based-apps#supported-directives).
 
 ### Suppress with preprocessor directives
 

--- a/src/frontend/src/content/docs/extensibility/custom-resources.mdx
+++ b/src/frontend/src/content/docs/extensibility/custom-resources.mdx
@@ -4,6 +4,7 @@ description: "Learn how to create custom resource types for the Aspire AppHost t
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 
 Creating custom resources allows you to extend Aspire to model components that aren't covered by built-in integrations. This guide covers the patterns and APIs for building your own resource types.
@@ -162,6 +163,15 @@ public static IResourceBuilder<MailDevResource> AddMailDev(
 
 For simpler cases, you can subscribe to events directly on the resource builder:
 
+<AppHostTabs limitations={{
+  typescript: 'Inline event subscriptions that define a custom resource extension run in the C# integration implementation and are not authored from generated AppHost SDKs.',
+  python: 'Inline event subscriptions that define a custom resource extension run in the C# integration implementation and are not authored from generated AppHost SDKs.',
+  go: 'Inline event subscriptions that define a custom resource extension run in the C# integration implementation and are not authored from generated AppHost SDKs.',
+  java: 'Inline event subscriptions that define a custom resource extension run in the C# integration implementation and are not authored from generated AppHost SDKs.',
+  rust: 'Inline event subscriptions that define a custom resource extension run in the C# integration implementation and are not authored from generated AppHost SDKs.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 public static IResourceBuilder<MailDevResource> AddMailDev(
     this IDistributedApplicationBuilder builder,
@@ -177,6 +187,9 @@ public static IResourceBuilder<MailDevResource> AddMailDev(
     return builder.AddResource(resource);
 }
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Resource state management
 
@@ -248,15 +261,94 @@ Use relationships to organize how resources appear in the dashboard:
 
 Create custom relationships between resources for visual organization:
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var api = builder.AddProject<Projects.Api>("api");
 var worker = builder.AddProject<Projects.Worker>("worker")
     .WithRelationship(api.Resource, "publishes-to");
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('api', '../Api/Api.csproj');
+const worker = await builder.addProject('worker', '../Worker/Worker.csproj');
+await worker.withRelationship(api, 'publishes-to');
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    worker = builder.add_project("worker", "../Worker/Worker.csproj")
+    worker.with_relationship(api, "publishes-to")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+api := builder.AddProject("api", "../Api/Api.csproj")
+worker := builder.AddProject("worker", "../Worker/Worker.csproj").
+	WithRelationship(api, "publishes-to")
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var api = builder.addProject("api", "../Api/Api.csproj");
+var worker = builder.addProject("worker", "../Worker/Worker.csproj");
+worker.withRelationship(api, "publishes-to");
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+let worker = builder.add_project(
+    "worker",
+    "../Worker/Worker.csproj",
+    None,
+)?;
+let api_resource = IResource::new(
+    api.handle().clone(),
+    api.client().clone(),
+);
+worker.with_relationship(&api_resource, "publishes-to")?;
+```
+
+</Fragment>
+</AppHostTabs>
+
 ### WithChildRelationship
 
 Group related resources under a parent in the dashboard:
+
+<AppHostTabs limitations={{
+  typescript: 'This example depends on the C#-defined AddMailDev extension and PostgreSQL integration APIs, which are not exported by the generated TypeScript SDK used for this guide.',
+  python: 'This example depends on the C#-defined AddMailDev extension and PostgreSQL integration APIs, which are not exported by the generated Python SDK used for this guide.',
+  go: 'This example depends on the C#-defined AddMailDev extension and PostgreSQL integration APIs, which are not exported by the generated Go SDK used for this guide.',
+  java: 'This example depends on the C#-defined AddMailDev extension and PostgreSQL integration APIs, which are not exported by the generated Java SDK used for this guide.',
+  rust: 'This example depends on the C#-defined AddMailDev extension and PostgreSQL integration APIs, which are not exported by the generated Rust SDK used for this guide.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var postgres = builder.AddPostgres("postgres");
@@ -266,6 +358,9 @@ var catalogDb = postgres.AddDatabase("catalog");
 var mailDev = builder.AddMailDev("mail")
     .WithChildRelationship(catalogDb);
 ```
+
+</Fragment>
+</AppHostTabs>
 
 <LearnMore>
 For more on how the Aspire Dashboard displays resources, see [Dashboard overview](/dashboard/overview/).

--- a/src/frontend/src/content/docs/extensibility/interaction-service.mdx
+++ b/src/frontend/src/content/docs/extensibility/interaction-service.mdx
@@ -31,7 +31,7 @@ Commands can also display a [progress dialog](/fundamentals/custom-resource-comm
 
 ## The interaction service API
 
-The `IInteractionService` interface provides methods for prompting users. In C#, it's retrieved from the dependency injection container. In TypeScript, it's resolved from the command context's service provider. Always check if the service is available before use — if you attempt to call a method when it's not available, an exception is thrown. For example, the interaction service isn't available when a command is triggered from the CLI.
+The interaction service provides methods for prompting users. In C#, retrieve `IInteractionService` from the dependency injection container. In TypeScript, Python, Go, Java, and Rust AppHosts, resolve the generated interaction-service wrapper from a callback context's service provider. Always check if the service is available before use — if you attempt to call a method when it isn't available, the SDK reports an error or throws an exception. For example, the interaction service isn't available when a command is triggered from the CLI.
 
 <AppHostTabs>
 <Fragment slot="csharp">
@@ -66,6 +66,81 @@ if (await interactionService.isAvailable()) {
   if (!result.canceled) {
     // Run your resource/command logic.
   }
+}
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+
+if interaction_service.is_available():
+    result = interaction_service.prompt_confirmation(
+        "Delete confirmation",
+        "Are you sure you want to delete the data?",
+    )
+    if not result.get("Canceled", False) and result.get("Value", False):
+        # Run your resource or command logic.
+        pass
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+interactionService := context.Services().GetInteractionService()
+available, err := interactionService.IsAvailable()
+if err != nil {
+	return err
+}
+if available {
+	result, err := interactionService.PromptConfirmation(
+		"Delete confirmation",
+		"Are you sure you want to delete the data?",
+	)
+	if err != nil {
+		return err
+	}
+	if !result.Canceled && result.Value != nil && *result.Value {
+		// Run your resource or command logic.
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var interactionService = context.services().getInteractionService();
+
+if (interactionService.isAvailable()) {
+    var result = interactionService.promptConfirmation(
+        "Delete confirmation",
+        "Are you sure you want to delete the data?"
+    );
+    if (!result.getCanceled() && Boolean.TRUE.equals(result.getValue())) {
+        // Run your resource or command logic.
+    }
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let interaction_service = context.services()?.get_interaction_service()?;
+
+if interaction_service.is_available()? {
+    let result = interaction_service.prompt_confirmation(
+        "Delete confirmation",
+        "Are you sure you want to delete the data?",
+        None,
+        None,
+    )?;
+    if !result.canceled && result.value.unwrap_or(false) {
+        // Run your resource or command logic.
+    }
 }
 ```
 
@@ -113,6 +188,17 @@ These approaches help you create interactive, user-friendly experiences for loca
 <Aside type="tip">
 For example, the following code subscribes to the `ResourceStoppedEvent` on a resource and displays a notification if the resource exits with a non-zero exit code:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript ResourceStoppedEvent exposes the resource and services, but not the resource snapshot or exit code required by this notification scenario.',
+    python: 'The generated Python ResourceStoppedEvent exposes the resource and services, but not the resource snapshot or exit code required by this notification scenario.',
+    go: 'The generated Go ResourceStoppedEvent exposes the resource and services, but not the resource snapshot or exit code required by this notification scenario.',
+    java: 'The generated Java ResourceStoppedEvent exposes the resource and services, but not the resource snapshot or exit code required by this notification scenario.',
+    rust: 'The generated Rust resource-stopped callback is untyped and does not provide the typed resource snapshot and exit code required by this notification scenario.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -143,6 +229,9 @@ builder
         }
     });
 ```
+
+</Fragment>
+</AppHostTabs>
 
 For CLI specific contexts, the interaction service is retrieved from either the `PublishingContext` or `PipelineStepContext` depending on the operation being performed.
 
@@ -223,6 +312,96 @@ const result = await interactionService.promptMessageBox(
 if (!result.canceled) {
   // User clicked "Apply"
   // Run migrations.
+}
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+result = interaction_service.prompt_message_box(
+    "Apply migrations",
+    "The database schema is out of date.\nWould you like to apply pending migrations now?",
+    options={
+        "EnableMessageMarkdown": True,
+        "PrimaryButtonText": "Apply",
+        "SecondaryButtonText": "Skip",
+        "ShowSecondaryButton": True,
+    },
+)
+
+if not result.get("Canceled", False) and result.get("Value", False):
+    # Run migrations.
+    pass
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+primary, secondary, showSecondary, markdown := "Apply", "Skip", true, true
+result, err := context.Services().GetInteractionService().PromptMessageBox(
+	"Apply migrations",
+	"The database schema is out of date.\nWould you like to apply pending migrations now?",
+	&aspire.PromptMessageBoxOptions{
+		Options: &aspire.InteractionMessageBoxOptions{
+			PrimaryButtonText:    &primary,
+			SecondaryButtonText:  &secondary,
+			ShowSecondaryButton:  &showSecondary,
+			EnableMessageMarkdown: &markdown,
+		},
+	},
+)
+if err != nil {
+	return err
+}
+if !result.Canceled && result.Value != nil && *result.Value {
+	// Run migrations.
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var options = new InteractionMessageBoxOptions();
+options.setEnableMessageMarkdown(true);
+options.setPrimaryButtonText("Apply");
+options.setSecondaryButtonText("Skip");
+options.setShowSecondaryButton(true);
+
+var result = context.services().getInteractionService().promptMessageBox(
+    "Apply migrations",
+    "The database schema is out of date.\nWould you like to apply pending migrations now?",
+    new PromptMessageBoxOptions().options(options)
+);
+
+if (!result.getCanceled() && Boolean.TRUE.equals(result.getValue())) {
+    // Run migrations.
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let options = InteractionMessageBoxOptions {
+    enable_message_markdown: Some(true),
+    primary_button_text: Some("Apply".into()),
+    secondary_button_text: Some("Skip".into()),
+    show_secondary_button: Some(true),
+    ..Default::default()
+};
+let result = context.services()?.get_interaction_service()?.prompt_message_box(
+    "Apply migrations",
+    "The database schema is out of date.\nWould you like to apply pending migrations now?",
+    Some(options),
+    None,
+)?;
+
+if !result.canceled && result.value.unwrap_or(false) {
+    // Run migrations.
 }
 ```
 
@@ -309,6 +488,111 @@ await interactionService.promptNotification(
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+
+interaction_service.prompt_notification(
+    "Success",
+    "Your operation completed successfully.",
+    options={
+        "Intent": "Success",
+        "LinkText": "View Details",
+        "LinkUrl": "/",
+    },
+)
+interaction_service.prompt_notification(
+    "Warning",
+    "Your SSL certificate will expire soon.",
+    options={
+        "Intent": "Warning",
+        "LinkText": "Renew Certificate",
+        "LinkUrl": "https://portal.azure.com/certificates",
+    },
+)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+success, warning := aspire.MessageIntentSuccess, aspire.MessageIntentWarning
+view, root := "View Details", "/"
+renew, portal := "Renew Certificate", "https://portal.azure.com/certificates"
+interactionService := context.Services().GetInteractionService()
+
+if _, err := interactionService.PromptNotification("Success", "Your operation completed successfully.",
+	&aspire.PromptNotificationOptions{Options: &aspire.InteractionNotificationOptions{
+		Intent: &success, LinkText: &view, LinkUrl: &root,
+	}}); err != nil {
+	return err
+}
+if _, err := interactionService.PromptNotification("Warning", "Your SSL certificate will expire soon.",
+	&aspire.PromptNotificationOptions{Options: &aspire.InteractionNotificationOptions{
+		Intent: &warning, LinkText: &renew, LinkUrl: &portal,
+	}}); err != nil {
+	return err
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var success = new InteractionNotificationOptions();
+success.setIntent(MessageIntent.SUCCESS);
+success.setLinkText("View Details");
+success.setLinkUrl("/");
+
+var warning = new InteractionNotificationOptions();
+warning.setIntent(MessageIntent.WARNING);
+warning.setLinkText("Renew Certificate");
+warning.setLinkUrl("https://portal.azure.com/certificates");
+
+var interactionService = context.services().getInteractionService();
+interactionService.promptNotification(
+    "Success",
+    "Your operation completed successfully.",
+    new PromptNotificationOptions().options(success)
+);
+interactionService.promptNotification(
+    "Warning",
+    "Your SSL certificate will expire soon.",
+    new PromptNotificationOptions().options(warning)
+);
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let interaction_service = context.services()?.get_interaction_service()?;
+interaction_service.prompt_notification(
+    "Success",
+    "Your operation completed successfully.",
+    Some(InteractionNotificationOptions {
+        intent: Some(MessageIntent::Success),
+        link_text: Some("View Details".into()),
+        link_url: Some("/".into()),
+        ..Default::default()
+    }),
+    None,
+)?;
+interaction_service.prompt_notification(
+    "Warning",
+    "Your SSL certificate will expire soon.",
+    Some(InteractionNotificationOptions {
+        intent: Some(MessageIntent::Warning),
+        link_text: Some("Renew Certificate".into()),
+        link_url: Some("https://portal.azure.com/certificates".into()),
+        ..Default::default()
+    }),
+    None,
+)?;
+```
+
+</Fragment>
 </AppHostTabs>
 
 The previous example demonstrates how to use the notification API with different intents and optional action links.
@@ -376,6 +660,97 @@ const resetConfirmation = await interactionService.promptConfirmation(
 
 if (!resetConfirmation.canceled) {
   // Perform the reset operation...
+}
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+reset_confirmation = interaction_service.prompt_confirmation(
+    "Confirm Reset",
+    "Are you sure you want to reset the database? This action cannot be undone.",
+    options={
+        "Intent": "Confirmation",
+        "PrimaryButtonText": "Reset",
+        "SecondaryButtonText": "Cancel",
+        "ShowSecondaryButton": True,
+        "EnableMessageMarkdown": True,
+    },
+)
+
+if not reset_confirmation.get("Canceled", False) and reset_confirmation.get("Value", False):
+    # Perform the reset operation.
+    pass
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+intent := aspire.MessageIntentConfirmation
+primary, secondary := "Reset", "Cancel"
+showSecondary, markdown := true, true
+result, err := context.Services().GetInteractionService().PromptConfirmation(
+	"Confirm Reset",
+	"Are you sure you want to reset the database? This action cannot be undone.",
+	&aspire.PromptConfirmationOptions{Options: &aspire.InteractionMessageBoxOptions{
+		Intent: &intent, PrimaryButtonText: &primary, SecondaryButtonText: &secondary,
+		ShowSecondaryButton: &showSecondary, EnableMessageMarkdown: &markdown,
+	}},
+)
+if err != nil {
+	return err
+}
+if !result.Canceled && result.Value != nil && *result.Value {
+	// Perform the reset operation.
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var options = new InteractionMessageBoxOptions();
+options.setIntent(MessageIntent.CONFIRMATION);
+options.setPrimaryButtonText("Reset");
+options.setSecondaryButtonText("Cancel");
+options.setShowSecondaryButton(true);
+options.setEnableMessageMarkdown(true);
+
+var result = context.services().getInteractionService().promptConfirmation(
+    "Confirm Reset",
+    "Are you sure you want to reset the database? This action cannot be undone.",
+    new PromptConfirmationOptions().options(options)
+);
+
+if (!result.getCanceled() && Boolean.TRUE.equals(result.getValue())) {
+    // Perform the reset operation.
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let options = InteractionMessageBoxOptions {
+    intent: Some(MessageIntent::Confirmation),
+    primary_button_text: Some("Reset".into()),
+    secondary_button_text: Some("Cancel".into()),
+    show_secondary_button: Some(true),
+    enable_message_markdown: Some(true),
+    ..Default::default()
+};
+let result = context.services()?.get_interaction_service()?.prompt_confirmation(
+    "Confirm Reset",
+    "Are you sure you want to reset the database? This action cannot be undone.",
+    Some(options),
+    None,
+)?;
+
+if !result.canceled && result.value.unwrap_or(false) {
+    // Perform the reset operation.
 }
 ```
 
@@ -549,7 +924,191 @@ if (!(await result.canceled())) {
 ```
 
 </Fragment>
-</AppHostTabs>
+  <Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+app_name = interaction_service.create_text_input(
+    "AppName",
+    options={"Label": "Application Name", "Required": True, "Placeholder": "my-app"},
+)
+environment = interaction_service.create_choice_input(
+    "Environment",
+    choices=[
+        {"Value": "dev", "Label": "Development"},
+        {"Value": "staging", "Label": "Staging"},
+        {"Value": "test", "Label": "Testing"},
+    ],
+    options={"Required": True},
+)
+instance_count = interaction_service.create_number_input(
+    "InstanceCount",
+    options={"Label": "Instance Count", "Required": True, "Placeholder": "1"},
+)
+enable_monitoring = interaction_service.create_boolean_input(
+    "EnableMonitoring",
+    options={"Label": "Enable Monitoring"},
+)
+
+result = interaction_service.prompt_inputs(
+    "Application Configuration",
+    "Configure your application deployment settings:",
+    [app_name, environment, instance_count, enable_monitoring],
+)
+if not result.canceled:
+    name = result.inputs.value("AppName")
+    environment_name = result.inputs.value("Environment")
+    count = result.inputs.value("InstanceCount")
+    monitoring = result.inputs.value("EnableMonitoring")
+```
+
+  </Fragment>
+  <Fragment slot="go">
+
+```go title="apphost.go"
+label, placeholder, required := "Application Name", "my-app", true
+interactionService := context.Services().GetInteractionService()
+appName := interactionService.CreateTextInput("AppName", &aspire.CreateInteractionInputOptions{
+    Label: &label, Required: &required, Placeholder: &placeholder,
+})
+environment := interactionService.CreateChoiceInput("Environment", &aspire.CreateChoiceInputOptions{
+    Choices: []*aspire.InteractionChoiceOption{
+        {Value: "dev", Label: "Development"},
+        {Value: "staging", Label: "Staging"},
+        {Value: "test", Label: "Testing"},
+    },
+    Options: &aspire.CreateInteractionInputOptions{Required: &required},
+})
+instanceLabel, one := "Instance Count", "1"
+instanceCount := interactionService.CreateNumberInput("InstanceCount",
+    &aspire.CreateInteractionInputOptions{Label: &instanceLabel, Required: &required, Placeholder: &one})
+monitoringLabel := "Enable Monitoring"
+enableMonitoring := interactionService.CreateBooleanInput("EnableMonitoring",
+    &aspire.CreateInteractionInputOptions{Label: &monitoringLabel})
+
+result := interactionService.PromptInputs(
+    "Application Configuration",
+    "Configure your application deployment settings:",
+    []aspire.InteractionInputBuilder{appName, environment, instanceCount, enableMonitoring},
+)
+canceled, err := result.Canceled()
+if err != nil {
+    return err
+}
+if !canceled {
+    name, err := result.Inputs().Value("AppName")
+    if err != nil {
+        return err
+    }
+    _ = name // Use the collected values as needed.
+}
+```
+
+  </Fragment>
+  <Fragment slot="java">
+
+```java title="AppHost.java"
+var interactionService = context.services().getInteractionService();
+
+var appNameOptions = new CreateInteractionInputOptions();
+appNameOptions.setLabel("Application Name");
+appNameOptions.setRequired(true);
+appNameOptions.setPlaceholder("my-app");
+var appName = interactionService.createTextInput("AppName", appNameOptions);
+
+var development = new InteractionChoiceOption();
+development.setValue("dev");
+development.setLabel("Development");
+var staging = new InteractionChoiceOption();
+staging.setValue("staging");
+staging.setLabel("Staging");
+var testing = new InteractionChoiceOption();
+testing.setValue("test");
+testing.setLabel("Testing");
+var choices = new InteractionChoiceOption[] { development, staging, testing };
+var requiredOptions = new CreateInteractionInputOptions();
+requiredOptions.setRequired(true);
+var environment = interactionService.createChoiceInput(
+    "Environment",
+    new CreateChoiceInputOptions().choices(choices).options(requiredOptions)
+);
+
+var instanceOptions = new CreateInteractionInputOptions();
+instanceOptions.setLabel("Instance Count");
+instanceOptions.setRequired(true);
+instanceOptions.setPlaceholder("1");
+var instanceCount = interactionService.createNumberInput("InstanceCount", instanceOptions);
+
+var monitoringOptions = new CreateInteractionInputOptions();
+monitoringOptions.setLabel("Enable Monitoring");
+var enableMonitoring = interactionService.createBooleanInput("EnableMonitoring", monitoringOptions);
+
+var result = interactionService.promptInputs(
+    "Application Configuration",
+    "Configure your application deployment settings:",
+    new InteractionInputBuilder[] { appName, environment, instanceCount, enableMonitoring }
+);
+if (!result.canceled()) {
+    var name = result.inputs().value("AppName");
+    // Use the collected values as needed.
+}
+```
+
+  </Fragment>
+  <Fragment slot="rust">
+
+```rust title="apphost.rs"
+let interaction_service = context.services()?.get_interaction_service()?;
+let app_name = interaction_service.create_text_input(
+    "AppName",
+    Some(CreateInteractionInputOptions {
+        label: Some("Application Name".into()),
+        required: Some(true),
+        placeholder: Some("my-app".into()),
+        ..Default::default()
+    }),
+)?;
+let environment = interaction_service.create_choice_input(
+    "Environment",
+    Some(vec![
+        InteractionChoiceOption { value: "dev".into(), label: "Development".into() },
+        InteractionChoiceOption { value: "staging".into(), label: "Staging".into() },
+        InteractionChoiceOption { value: "test".into(), label: "Testing".into() },
+    ]),
+    Some(CreateInteractionInputOptions { required: Some(true), ..Default::default() }),
+)?;
+let instance_count = interaction_service.create_number_input(
+    "InstanceCount",
+    Some(CreateInteractionInputOptions {
+        label: Some("Instance Count".into()),
+        required: Some(true),
+        placeholder: Some("1".into()),
+        ..Default::default()
+    }),
+)?;
+let enable_monitoring = interaction_service.create_boolean_input(
+    "EnableMonitoring",
+    Some(CreateInteractionInputOptions {
+        label: Some("Enable Monitoring".into()),
+        ..Default::default()
+    }),
+)?;
+
+let result = interaction_service.prompt_inputs(
+    "Application Configuration",
+    "Configure your application deployment settings:",
+    vec![app_name, environment, instance_count, enable_monitoring],
+    None,
+    None,
+)?;
+if !result.canceled()? {
+    let inputs = result.inputs()?.to_array()?;
+    // Process the collected inputs in declaration order.
+}
+```
+
+  </Fragment>
+  </AppHostTabs>
 
 **Dashboard view:**
 
@@ -615,7 +1174,9 @@ Environment:
 
 The interaction service supports dynamic inputs so you can populate options based on earlier responses. This enables cascading dropdowns and other dependent prompts in both the dashboard and CLI experiences.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK exposes with_dynamic_loading only through an untyped Vec<Value> callback marker, so it cannot express the typed InteractionInputLoadContext workflow shown here.',
+}}>
 <Fragment slot="csharp">
 
 To configure a dynamic input, set the `InteractionInput.DynamicLoading` property to an instance of `InputLoadOptions`. `InputLoadOptions` has a range of properties:
@@ -716,6 +1277,151 @@ if (!(await result.canceled())) {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+Use `with_dynamic_loading` with an `InteractionInputLoadContext` callback:
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+db_type = interaction_service.create_choice_input(
+    "DatabaseType",
+    choices=[
+        {"Value": "postgres", "Label": "PostgreSQL"},
+        {"Value": "mysql", "Label": "MySQL"},
+        {"Value": "sqlserver", "Label": "SQL Server"},
+    ],
+    options={"Label": "Database Type", "Required": True},
+)
+db_version = interaction_service.create_choice_input(
+    "DatabaseVersion",
+    options={"Label": "Database Version", "Required": True},
+)
+
+def load_versions(load_context):
+    versions = {
+        "postgres": [{"Value": "17", "Label": "PostgreSQL 17"}],
+        "mysql": [{"Value": "9", "Label": "MySQL 9"}],
+        "sqlserver": [{"Value": "2025", "Label": "SQL Server 2025"}],
+    }
+    selected = load_context.inputs.value("DatabaseType")
+    load_context.input().set_choice_options(versions.get(selected, []))
+
+db_version.with_dynamic_loading(
+    load_versions,
+    options={"DependsOnInputs": ["DatabaseType"]},
+)
+result = interaction_service.prompt_inputs(
+    "Database configuration",
+    "Select a database type and version",
+    [db_type, db_version],
+)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+Use `WithDynamicLoading` with a typed `InteractionInputLoadContext` callback:
+
+```go title="apphost.go"
+interactionService := context.Services().GetInteractionService()
+required := true
+dbType := interactionService.CreateChoiceInput("DatabaseType", &aspire.CreateChoiceInputOptions{
+	Choices: []*aspire.InteractionChoiceOption{
+		{Value: "postgres", Label: "PostgreSQL"},
+		{Value: "mysql", Label: "MySQL"},
+		{Value: "sqlserver", Label: "SQL Server"},
+	},
+	Options: &aspire.CreateInteractionInputOptions{Required: &required},
+})
+dbVersion := interactionService.CreateChoiceInput("DatabaseVersion",
+	&aspire.CreateChoiceInputOptions{Options: &aspire.CreateInteractionInputOptions{Required: &required}})
+
+dbVersion.WithDynamicLoading(func(loadContext aspire.InteractionInputLoadContext) {
+	selected, err := loadContext.Inputs().Value("DatabaseType")
+	if err != nil {
+		log.Printf("load database type: %v", err)
+		return
+	}
+	choices := map[string][]*aspire.InteractionChoiceOption{
+		"postgres": {&aspire.InteractionChoiceOption{Value: "17", Label: "PostgreSQL 17"}},
+		"mysql": {&aspire.InteractionChoiceOption{Value: "9", Label: "MySQL 9"}},
+		"sqlserver": {&aspire.InteractionChoiceOption{Value: "2025", Label: "SQL Server 2025"}},
+	}
+	if err := loadContext.Input().SetChoiceOptions(choices[selected]); err != nil {
+		log.Printf("set database versions: %v", err)
+	}
+}, &aspire.DynamicLoadingOptions{DependsOnInputs: []string{"DatabaseType"}})
+if err := dbVersion.Err(); err != nil {
+	return err
+}
+
+result := interactionService.PromptInputs(
+	"Database configuration",
+	"Select a database type and version",
+	[]aspire.InteractionInputBuilder{dbType, dbVersion},
+)
+if err := result.Err(); err != nil {
+	return err
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+Use `withDynamicLoading` with a typed `InteractionInputLoadContext` callback:
+
+```java title="AppHost.java"
+var interactionService = context.services().getInteractionService();
+var required = new CreateInteractionInputOptions();
+required.setRequired(true);
+
+var postgres = new InteractionChoiceOption();
+postgres.setValue("postgres");
+postgres.setLabel("PostgreSQL");
+var mysql = new InteractionChoiceOption();
+mysql.setValue("mysql");
+mysql.setLabel("MySQL");
+var sqlserver = new InteractionChoiceOption();
+sqlserver.setValue("sqlserver");
+sqlserver.setLabel("SQL Server");
+
+var dbType = interactionService.createChoiceInput(
+    "DatabaseType",
+    new CreateChoiceInputOptions()
+        .choices(new InteractionChoiceOption[] { postgres, mysql, sqlserver })
+        .options(required)
+);
+var dbVersion = interactionService.createChoiceInput(
+    "DatabaseVersion",
+    new CreateChoiceInputOptions().options(required)
+);
+
+var dynamicOptions = new DynamicLoadingOptions();
+dynamicOptions.setDependsOnInputs(new String[] { "DatabaseType" });
+dbVersion.withDynamicLoading(loadContext -> {
+    var selected = loadContext.inputs().value("DatabaseType");
+    var version = new InteractionChoiceOption();
+    version.setValue(switch (selected) {
+        case "postgres" -> "17";
+        case "mysql" -> "9";
+        default -> "2025";
+    });
+    version.setLabel(switch (selected) {
+        case "postgres" -> "PostgreSQL 17";
+        case "mysql" -> "MySQL 9";
+        default -> "SQL Server 2025";
+    });
+    loadContext.input().setChoiceOptions(new InteractionChoiceOption[] { version });
+}, dynamicOptions);
+
+var result = interactionService.promptInputs(
+    "Database configuration",
+    "Select a database type and version",
+    new InteractionInputBuilder[] { dbType, dbVersion }
+);
+```
+
+</Fragment>
 </AppHostTabs>
 
 In the preceding example, the database version input is dynamically populated based on the selected database type.
@@ -724,7 +1430,9 @@ In the preceding example, the database version input is dynamically populated ba
 
 Basic input validation is available by configuring inputs with `Required` and `MaxLength` properties. For complex scenarios, you can provide a custom validation callback that runs server-side when the user submits the dialog.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK represents InteractionInputsDialogOptions.validation_callback as an untyped serde_json::Value marker, so it cannot register the typed validation callback used here.',
+}}>
 <Fragment slot="csharp">
 
 Use the `InputsDialogInteractionOptions.ValidationCallback` property:
@@ -856,6 +1564,121 @@ if (!(await result.canceled())) {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+password = interaction_service.create_secret_input(
+    "password",
+    options={"Label": "Password", "Required": True, "Placeholder": "Enter a strong password"},
+)
+confirm_password = interaction_service.create_secret_input(
+    "confirmPassword",
+    options={"Label": "Confirm password", "Required": True, "Placeholder": "Confirm your password"},
+)
+
+def validate(validation_context):
+    password_value = validation_context.inputs.value("password")
+    confirmation = validation_context.inputs.value("confirmPassword")
+    if password_value and len(password_value) < 8:
+        validation_context.add_validation_error(
+            "password",
+            "Password must be at least 8 characters long",
+        )
+    if password_value != confirmation:
+        validation_context.add_validation_error(
+            "confirmPassword",
+            "Passwords do not match",
+        )
+
+result = interaction_service.prompt_inputs(
+    "Database configuration",
+    "Configure your PostgreSQL database connection:",
+    [password, confirm_password],
+    options={"ValidationCallback": validate},
+)
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+interactionService := context.Services().GetInteractionService()
+label, confirmLabel := "Password", "Confirm password"
+required := true
+password := interactionService.CreateSecretInput("password",
+	&aspire.CreateInteractionInputOptions{Label: &label, Required: &required})
+confirmPassword := interactionService.CreateSecretInput("confirmPassword",
+	&aspire.CreateInteractionInputOptions{Label: &confirmLabel, Required: &required})
+
+dialogOptions := &aspire.InteractionInputsDialogOptions{
+	ValidationCallback: func(validationContext aspire.InputsDialogValidationContext) {
+		passwordValue, err := validationContext.Inputs().Value("password")
+		if err != nil {
+			log.Printf("read password input: %v", err)
+			return
+		}
+		confirmation, err := validationContext.Inputs().Value("confirmPassword")
+		if err != nil {
+			log.Printf("read confirmation input: %v", err)
+			return
+		}
+		if len(passwordValue) < 8 {
+			_ = validationContext.AddValidationError(
+				"password",
+				"Password must be at least 8 characters long",
+			)
+		}
+		if passwordValue != confirmation {
+			_ = validationContext.AddValidationError("confirmPassword", "Passwords do not match")
+		}
+	},
+}
+result := interactionService.PromptInputs(
+	"Database configuration",
+	"Configure your PostgreSQL database connection:",
+	[]aspire.InteractionInputBuilder{password, confirmPassword},
+	&aspire.PromptInputsOptions{Options: dialogOptions},
+)
+if err := result.Err(); err != nil {
+	return err
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var interactionService = context.services().getInteractionService();
+var required = new CreateInteractionInputOptions();
+required.setRequired(true);
+var password = interactionService.createSecretInput("password", required);
+var confirmPassword = interactionService.createSecretInput("confirmPassword", required);
+
+var dialogOptions = new InteractionInputsDialogOptions();
+dialogOptions.setValidationCallback(validationContext -> {
+    var passwordValue = validationContext.inputs().value("password");
+    var confirmation = validationContext.inputs().value("confirmPassword");
+    if (!passwordValue.isEmpty() && passwordValue.length() < 8) {
+        validationContext.addValidationError(
+            "password",
+            "Password must be at least 8 characters long"
+        );
+    }
+    if (!passwordValue.equals(confirmation)) {
+        validationContext.addValidationError("confirmPassword", "Passwords do not match");
+    }
+});
+
+var result = interactionService.promptInputs(
+    "Database configuration",
+    "Configure your PostgreSQL database connection:",
+    new InteractionInputBuilder[] { password, confirmPassword },
+    new PromptInputsOptions().options(dialogOptions)
+);
+```
+
+</Fragment>
 </AppHostTabs>
 
 Prompting the user for a password and confirming they match is referred to as "dual independent verification" input. This approach is common in scenarios where you want to ensure the user enters the same password twice to avoid typos or mismatches.
@@ -875,7 +1698,12 @@ File upload functionality is a common source of exploitable vulnerabilities. Use
 
 :::
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The Python SDK exports file-input creation and prompting, but its generated InteractionInput result does not expose uploaded file metadata or paths, so the file-processing workflow cannot be completed.',
+  go: 'The Go SDK exports file-input creation and prompting, but its generated InteractionInput result does not expose uploaded file metadata or paths, so the file-processing workflow cannot be completed.',
+  java: 'The Java SDK exports file-input creation and prompting, but its generated InteractionInput result does not expose uploaded file metadata or paths, so the file-processing workflow cannot be completed.',
+  rust: 'The Rust SDK exports file-input creation and prompting, but its generated InteractionInput result does not expose uploaded file metadata or paths, so the file-processing workflow cannot be completed.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -990,7 +1818,9 @@ The `PromptProgressAsync` method is only available in dashboard contexts. It thr
 
 The simplest approach is to provide a `Work` callback via `ProgressInteractionOptions`. The progress dialog opens when `PromptProgressAsync` is called and closes automatically when the callback completes:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK represents InteractionProgressOptions.work as an untyped serde_json::Value marker, so it cannot register the typed progress work callback used here.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1041,6 +1871,78 @@ if (result.canceled) {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+interaction_service = context.services.get_interaction_service()
+
+def download_resources(progress_context):
+    run_download()
+
+result = interaction_service.prompt_progress(
+    "Please wait while resources are being downloaded...",
+    options={
+        "Title": "Downloading resources",
+        "PrimaryButtonText": "Cancel",
+        "Work": download_resources,
+    },
+)
+
+if result.get("Canceled", False):
+    # The user clicked the cancel button.
+    pass
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+title, cancel := "Downloading resources", "Cancel"
+result, err := context.Services().GetInteractionService().PromptProgress(
+	"Please wait while resources are being downloaded...",
+	&aspire.PromptProgressOptions{Options: &aspire.InteractionProgressOptions{
+		Title: &title,
+		PrimaryButtonText: &cancel,
+		Work: func(progressContext aspire.ProgressContext) {
+			token, err := progressContext.CancellationToken()
+			if err != nil {
+				log.Printf("get progress cancellation token: %v", err)
+				return
+			}
+			runDownload(token)
+		},
+	}},
+)
+if err != nil {
+	return err
+}
+if result.Canceled {
+	// The user clicked the cancel button.
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var progressOptions = new InteractionProgressOptions();
+progressOptions.setTitle("Downloading resources");
+progressOptions.setPrimaryButtonText("Cancel");
+progressOptions.setWork(progressContext ->
+    runDownload(progressContext.cancellationToken())
+);
+
+var result = context.services().getInteractionService().promptProgress(
+    "Please wait while resources are being downloaded...",
+    new PromptProgressOptions().options(progressOptions)
+);
+
+if (result.getCanceled()) {
+    // The user clicked the cancel button.
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 When a `Work` callback is provided:
@@ -1052,6 +1954,16 @@ When a `Work` callback is provided:
 ### Display progress without a work callback
 
 If you don't provide a `Work` callback, the progress dialog stays open until the `cancellationToken` passed to `PromptProgressAsync` is canceled, or the user clicks the cancel button (if `PrimaryButtonText` is set). This pattern is useful when you manage the work yourself and want to close the dialog at a specific point:
+
+<AppHostTabs
+  limitations={{
+    python: 'The generated Python prompt_progress API exposes a timeout, but it does not accept a cancellation token that this no-work callback pattern can cancel.',
+    go: 'The generated Go PromptProgress API is synchronous, so it does not return a progress task that the same execution flow can cancel after completing separate work.',
+    java: 'The generated Java promptProgress API is synchronous, so it does not return a progress task that the same execution flow can cancel after completing separate work.',
+    rust: 'The generated Rust prompt_progress API is synchronous, so it does not return a progress task that the same execution flow can cancel after completing separate work.',
+  }}
+>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREINTERACTION001
@@ -1070,6 +1982,29 @@ cts.Cancel();
 
 await progressTask;
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+const interactionService = await context.services().getInteractionService();
+const controller = new AbortController();
+
+const progressTask = interactionService.promptProgress(
+  'Processing data...',
+  { title: 'Processing' },
+  controller.signal
+);
+
+// Do work, then close the dialog by canceling the signal.
+await doWork();
+controller.abort();
+
+await progressTask;
+```
+
+</Fragment>
+</AppHostTabs>
 
 Because no `PrimaryButtonText` is set, the dialog has no cancel button and the user cannot dismiss it.
 

--- a/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
+++ b/src/frontend/src/content/docs/extensibility/multi-language-integration-authoring.mdx
@@ -570,6 +570,15 @@ Use the analyzer and a test AppHost for every guest language your integration cl
 
 The TypeScript example below demonstrates its asynchronous generated shape:
 
+<AppHostTabs limitations={{
+  csharp: 'This example demonstrates the asynchronous generated TypeScript SDK shape; C# AppHosts call the integration API directly.',
+  python: 'This example demonstrates the asynchronous generated TypeScript SDK shape; Python uses snake_case methods and synchronous exception-based calls.',
+  go: 'This example demonstrates the asynchronous generated TypeScript SDK shape; Go uses PascalCase methods and fluent Err checks.',
+  java: 'This example demonstrates the asynchronous generated TypeScript SDK shape; Java uses lowerCamelCase methods and synchronous exceptions.',
+  rust: 'This example demonstrates the asynchronous generated TypeScript SDK shape; Rust uses snake_case methods that return Result values.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="Await generated AppHost APIs"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -582,6 +591,9 @@ await worker.withConfiguration(async (config) => {
 
 await builder.build().run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Export resource types
 
@@ -933,12 +945,24 @@ public sealed class MyAccessRule
 
 The TypeScript SDK exposes collection values using ordinary TypeScript collection shapes:
 
+<AppHostTabs limitations={{
+  csharp: 'This example intentionally shows the generated TypeScript DTO shape; the C# integration defines and consumes the source DTO type directly.',
+  python: 'This example intentionally shows the generated TypeScript DTO shape; Python receives an equivalent generated DTO using Python collection conventions.',
+  go: 'This example intentionally shows the generated TypeScript DTO shape; Go receives an equivalent generated DTO using Go collection conventions.',
+  java: 'This example intentionally shows the generated TypeScript DTO shape; Java receives an equivalent generated DTO using Java collection conventions.',
+  rust: 'This example intentionally shows the generated TypeScript DTO shape; Rust receives an equivalent generated DTO using Rust collection conventions.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 const rule: MyAccessRule = {
   addressPrefixes: ['203.0.113.0/24', '198.51.100.0/24'],
   fullyQualifiedDomainNames: ['example.com'],
 };
 ```
+
+</Fragment>
+</AppHostTabs>
 
 :::note
 This behavior applies to DTOs only. Mutable collection properties on **exported resource types** (classes annotated with `[AspireExport]`) continue to use handle-backed wrappers such as `AspireList<T>` so that guest code can add or remove values imperatively. DTOs use value-shaped types because they are consumed as JSON input objects, not as live handles.
@@ -990,6 +1014,15 @@ The scanner snaps the values at scan time by serializing each field or property 
 
 After generating the SDK (for example, with `aspire run`), the catalog is available as a nested object in the TypeScript SDK. The nesting mirrors the static class hierarchy of the C# source:
 
+<AppHostTabs limitations={{
+  csharp: 'This example intentionally shows the generated TypeScript value catalog; C# integration consumers reference the source static members directly.',
+  python: 'This example intentionally shows the generated TypeScript value catalog; Python receives an equivalent generated catalog using Python naming conventions.',
+  go: 'This example intentionally shows the generated TypeScript value catalog; Go receives an equivalent generated catalog using Go naming conventions.',
+  java: 'This example intentionally shows the generated TypeScript value catalog; Java receives an equivalent generated catalog using Java naming conventions.',
+  rust: 'This example intentionally shows the generated TypeScript value catalog; Rust receives an equivalent generated catalog using Rust naming conventions.',
+}}>
+<Fragment slot="typescript">
+
 ```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 import { MyModels } from './.aspire/modules/my-integration.mjs';
@@ -1001,6 +1034,9 @@ await builder.addMyService('svc', { model: MyModels.FastModels.Lite });
 
 await builder.build().run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ### Override the exported name
 

--- a/src/frontend/src/content/docs/fundamentals/annotations-overview.mdx
+++ b/src/frontend/src/content/docs/fundamentals/annotations-overview.mdx
@@ -6,6 +6,7 @@ description: Learn how Aspire annotations work, how the AppHost composes built-i
 
 import { Aside } from '@astrojs/starlight/components';
 import LearnMore from '@components/LearnMore.astro';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 Annotations are a key extensibility mechanism in Aspire that allow you to attach metadata and behavior to resources. They provide a way to customize how resources are configured, deployed, and managed throughout the application lifecycle. This article explains how annotations work and how to use them effectively in your Aspire applications.
 
@@ -26,16 +27,28 @@ When you add a resource to your app model, you can attach annotations using vari
 
 Here's a simple example of how annotations are used:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var redis = builder.AddRedis("cache")
     .WithCommand("clear-cache", "Clear Cache",
         async context => new ExecuteCommandResult { Success = true })
-    .WithUrl("admin", "http://localhost:8080/admin");
+    .WithUrl("http://localhost:8080/admin", "Admin");
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 In this example:
 
@@ -45,6 +58,15 @@ In this example:
 ## Adding and managing annotations
 
 The `WithAnnotation` extension method is the primary way to add annotations to resources. It supports different behaviors when an annotation of the same type already exists:
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 // Add only if no annotation of this type exists (default)
@@ -56,9 +78,21 @@ builder.AddContainer("mycontainer", "myimage")
     .WithAnnotation(new MyAnnotation(), ResourceAnnotationMutationBehavior.Replace);
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### Reading annotations
 
 To read annotations from a resource, use the `Annotations` collection or helper methods:
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="Reading annotations"
 // Get all annotations of a type
@@ -74,6 +108,9 @@ if (resource.TryGetLastAnnotation<EndpointAnnotation>(out var endpoint))
 bool hasEndpoints = resource.Annotations.OfType<EndpointAnnotation>().Any();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ## Built-in annotation types
 
 Aspire includes many built-in annotation types for common scenarios. This section covers _some_ of the more commonly used annotations, but there are many more available for specific use cases.
@@ -81,6 +118,15 @@ Aspire includes many built-in annotation types for common scenarios. This sectio
 ### `EndpointAnnotation`
 
 The `EndpointAnnotation` defines network endpoints for resources. It contains information about ports, protocols, and endpoint configuration.
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var api = builder.AddProject<Projects.Api>("api")
@@ -93,18 +139,42 @@ var api = builder.AddProject<Projects.Api>("api")
     });
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### `ResourceUrlAnnotation`
 
 The `ResourceUrlAnnotation` defines custom URLs that appear in the dashboard, often pointing to management interfaces or documentation.
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var database = builder.AddPostgres("postgres")
     .WithUrl("admin", "https://localhost:5050");
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### `EnvironmentCallbackAnnotation`
 
 The `EnvironmentCallbackAnnotation` allows you to modify environment variables at runtime based on the state of other resources.
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 // This is typically used internally by WithReference
@@ -112,23 +182,50 @@ var app = builder.AddProject<Projects.MyApp>("app")
     .WithReference(database);
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### `ContainerMountAnnotation`
 
 The `ContainerMountAnnotation` defines volume mounts for containerized resources.
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var postgres = builder.AddPostgres("postgres")
     .WithDataVolume(); // Adds a ContainerMountAnnotation
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### `HealthCheckAnnotation`
 
 The `HealthCheckAnnotation` associates health checks with a resource, used by `WaitFor()` to determine when a resource is ready:
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var api = builder.AddProject<Projects.Api>("api")
     .WithHttpHealthCheck("/health");  // Adds HealthCheckAnnotation
 ```
+
+</Fragment>
+</AppHostTabs>
 
 <LearnMore>
 Learn more about how Aspire uses health checks for orchestration in the [Health checks guide](/fundamentals/health-checks/).
@@ -138,6 +235,15 @@ Learn more about how Aspire uses health checks for orchestration in the [Health 
 
 The `WaitAnnotation` declares a dependency on another resource and controls startup order. The `WaitFor`, `WaitForStart`, and `WaitForCompletion` methods add this annotation:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var cache = builder.AddRedis("cache");
 
@@ -145,6 +251,9 @@ var cache = builder.AddRedis("cache");
 var web = builder.AddProject<Projects.Web>("web")
     .WaitFor(cache);  // Adds WaitAnnotation with WaitType.WaitForHealthy
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The `WaitType` enum specifies what condition to wait for:
 
@@ -158,19 +267,43 @@ The `WaitType` enum specifies what condition to wait for:
 
 The `ReplicaAnnotation` specifies how many instances of a resource should run:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var api = builder.AddProject<Projects.Api>("api")
     .WithReplicas(3);  // Adds ReplicaAnnotation
 ```
 
+</Fragment>
+</AppHostTabs>
+
 ### `PersistenceAnnotation`
 
 The `PersistenceAnnotation` controls whether a supported resource uses the default session lifetime, persists across AppHost runs, matches another resource's lifetime, or is scoped to a parent process:
+
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var postgres = builder.AddPostgres("postgres")
     .WithPersistentLifetime();  // Resource survives AppHost restarts
 ```
+
+</Fragment>
+</AppHostTabs>
 
 <LearnMore>
 For details on supported lifetime modes and their use cases, see [Resource lifetimes](/app-host/resource-lifetimes/).
@@ -180,10 +313,22 @@ For details on supported lifetime modes and their use cases, see [Resource lifet
 
 The `ExplicitStartupAnnotation` prevents a resource from starting automatically. Users must manually start it from the dashboard:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var worker = builder.AddProject<Projects.BatchJob>("batch")
     .WithExplicitStart();  // Adds ExplicitStartupAnnotation
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Creating custom annotations
 
@@ -255,12 +400,24 @@ The extension methods serve as the primary API surface for your annotation. They
 
 Once defined, annotations integrate seamlessly into the AppHost model:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
 var api = builder.AddProject<Projects.Api>("api")
     .WithMetrics("/api/metrics", 9090, "environment:production", "service:api");
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ## Testing with annotations
 
@@ -314,11 +471,23 @@ public sealed class DbAnnotation : IResourceAnnotation
 
 Create fluent extension methods that follow Aspire's builder pattern:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  python: 'The generated Python SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  go: 'The generated Go SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  java: 'The generated Java SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+  rust: 'The generated Rust SDK exposes high-level resource APIs, but not the generic IResourceAnnotation mutation and Annotations collection APIs needed to inspect or extend the annotation represented by this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var resource = builder.AddMyResource("name")
     .WithCustomBehavior()
     .WithAnotherFeature();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ### Document your annotations
 

--- a/src/frontend/src/content/docs/fundamentals/container-networking.mdx
+++ b/src/frontend/src/content/docs/fundamentals/container-networking.mdx
@@ -77,6 +77,99 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_executable("api", "node", "./api", ["index.js"])
+    container = builder.add_container("mycontainer", "myimage")
+    container.with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddExecutable("api", "node", "./api", []string{"index.js"})
+	container := builder.AddContainer("mycontainer", "myimage").WithReference(api)
+	if err := container.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addExecutable(
+        "api", "node", "./api", new String[] { "index.js" });
+    var container = builder.addContainer("mycontainer", "myimage");
+    container.withReference(api);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_executable(
+        "api",
+        "node",
+        "./api",
+        vec!["index.js".to_string()],
+    )?;
+    let container = builder.add_container("mycontainer", json!("myimage"))?;
+    container.with_reference(serialize_handle(&api), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Network identifiers
@@ -90,6 +183,15 @@ The `KnownNetworkIdentifiers` class provides predefined identifiers for common s
 - `KnownNetworkIdentifiers.PublicInternet` — resolves the endpoint as reachable from external networks.
 
 You can use these identifiers when you need to obtain an endpoint for a specific network context:
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK exposes getEndpoint(name), but it does not emit the overload that accepts an explicit network identifier.',
+  python: 'The Python SDK exposes get_endpoint(name), but it does not emit the overload that accepts an explicit network identifier.',
+  go: 'The Go SDK exposes GetEndpoint(name), but it does not emit the overload that accepts an explicit network identifier.',
+  java: 'The Java SDK exposes getEndpoint(name), but it does not emit the overload that accepts an explicit network identifier.',
+  rust: 'The Rust SDK exposes get_endpoint(name), but it does not emit the overload that accepts an explicit network identifier.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -107,10 +209,8 @@ var containerEndpoint = api.GetEndpoint(
 builder.Build().Run();
 ```
 
-<Aside type="note">
-  TypeScript AppHost support for resolving endpoints with explicit network
-  identifiers isn't yet available.
-</Aside>
+</Fragment>
+</AppHostTabs>
 
 <Aside type="note">
   In most cases you don't need to use network identifiers directly. When you

--- a/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
+++ b/src/frontend/src/content/docs/fundamentals/custom-resource-commands.mdx
@@ -23,7 +23,12 @@ Each resource in the Aspire app model is represented as an `IResource` and when 
 
 Start with an Aspire AppHost project. The walkthrough below registers a `clear-cache` command on a Redis resource. The C# version uses an extension method that wraps the registration; the TypeScript version registers the command inline against a Node service that exposes an admin endpoint. Both flows produce the same dashboard/CLI experience.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python generates a synchronous with_command callback, so the awaitable HTTP implementation in this walkthrough is not directly supported.',
+  go: 'Go generates a synchronous WithCommand callback, so the awaitable HTTP implementation in this walkthrough is not directly supported.',
+  java: 'Java generates a synchronous withCommand callback, so the awaitable HTTP implementation in this walkthrough is not directly supported.',
+  rust: 'Rust generates the callback as Fn(Vec<Value>) -> Value rather than typed command context and result values.',
+}}>
 <Fragment slot="csharp">
 
 Add a new class named _RedisResourceBuilderExtensions.cs_ to the AppHost project and replace its contents with the following code:
@@ -165,7 +170,12 @@ The `WithCommand` API adds the appropriate annotations to the resource, which ar
 
 The `executeCommand` callback is where the command logic is implemented. The `ExecuteCommandContext` it receives gives you access to command-specific data such as the resource being acted on, cancellation, and logging.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python exposes a synchronous ExecuteCommandContext callback rather than the awaitable callback used by this HTTP example.',
+  go: 'Go exposes a synchronous ExecuteCommandContext callback rather than the awaitable callback used by this HTTP example.',
+  java: 'Java exposes a synchronous ExecuteCommandContext callback rather than the awaitable callback used by this HTTP example.',
+  rust: 'Rust emits this callback as Fn(Vec<Value>) -> Value, so the typed context accessors are not available in the callback signature.',
+}}>
 <Fragment slot="csharp">
 
 In C# the parameter is typed as `Func<ExecuteCommandContext, Task<ExecuteCommandResult>>`. `ExecuteCommandContext` exposes:
@@ -251,7 +261,9 @@ The preceding code:
 
 The `updateState` callback decides whether a command is enabled in the dashboard. The dashboard invokes it whenever the resource's state changes — typical use cases are gating destructive commands behind a healthy resource, or only enabling a command after a startup probe has succeeded.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits CommandOptions.update_state as an untyped Value callback instead of a typed UpdateCommandStateContext callback.',
+}}>
 <Fragment slot="csharp">
 
 In C# the parameter is typed as `Func<UpdateCommandStateContext, ResourceCommandState>`. `UpdateCommandStateContext` exposes:
@@ -322,13 +334,64 @@ The preceding code:
 The `HealthStatus` and `ResourceCommandState` enums are exported from the generated SDK (`aspire.ts`) and are available to import directly.
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def update_state(context):
+    snapshot = context.resource_snapshot
+    return (
+        "Enabled"
+        if snapshot.get("HealthStatus") == "Healthy"
+        else "Disabled"
+    )
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+func updateState(context aspire.UpdateCommandStateContext) aspire.ResourceCommandState {
+	snapshot, err := context.ResourceSnapshot()
+	if err == nil &&
+		snapshot.HealthStatus != nil &&
+		*snapshot.HealthStatus == aspire.HealthStatusHealthy {
+		return aspire.ResourceCommandStateEnabled
+	}
+	return aspire.ResourceCommandStateDisabled
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+ResourceCommandState updateState(UpdateCommandStateContext context) {
+    var snapshot = context.resourceSnapshot();
+    return snapshot.getHealthStatus() == HealthStatus.HEALTHY
+        ? ResourceCommandState.ENABLED
+        : ResourceCommandState.DISABLED;
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ## Test the custom command
 
 To test the custom command, update your AppHost to wire up the resource and the command:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Redis integration method used by this complete walkthrough, and its command callback is synchronous.',
+  go: 'The verified Go SDK does not include the Redis integration method used by this complete walkthrough, and its command callback is synchronous.',
+  java: 'The verified Java SDK does not include the Redis integration method used by this complete walkthrough, and its command callback is synchronous.',
+  rust: 'The verified Rust SDK does not include the Redis integration method, and its command callback is untyped.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs" {4}
@@ -438,7 +501,12 @@ The most common scenario is to call commands from within other custom command im
 
 The following example shows how to create a custom command that executes other commands. In this case, a "reset-all" command clears the cache and restarts a database:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Redis and PostgreSQL integration methods used by this orchestration example.',
+  go: 'The verified Go SDK does not include the Redis and PostgreSQL integration methods used by this orchestration example.',
+  java: 'The verified Java SDK does not include the Redis and PostgreSQL integration methods used by this orchestration example.',
+  rust: 'The verified Rust SDK does not include the Redis and PostgreSQL integration methods used by this orchestration example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -596,6 +664,97 @@ else {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def execute_clear_cache(command_service):
+    result = command_service.execute_command("cache", "clear-cache")
+    if result.get("Success"):
+        print("Command executed successfully")
+    elif result.get("Canceled"):
+        print("Command was canceled")
+    else:
+        print(f"Command failed: {result.get('Message')}")
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"fmt"
+
+	"apphost/modules/aspire"
+)
+
+func executeClearCache(commandService aspire.ResourceCommandService) error {
+	result, err := commandService.ExecuteCommandAsync("cache", "clear-cache")
+	if err != nil {
+		return err
+	}
+	if result.Success {
+		fmt.Println("Command executed successfully")
+	} else if result.Canceled != nil && *result.Canceled {
+		fmt.Println("Command was canceled")
+	} else {
+		fmt.Printf("Command failed: %s\n", *result.Message)
+	}
+	return nil
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void executeClearCache(ResourceCommandService commandService) {
+    var result = commandService.executeCommandAsync(
+        "cache", "clear-cache");
+    if (result.getSuccess()) {
+        System.out.println("Command executed successfully");
+    } else if (Boolean.TRUE.equals(result.getCanceled())) {
+        System.out.println("Command was canceled");
+    } else {
+        System.out.printf("Command failed: %s%n", result.getMessage());
+    }
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn execute_clear_cache(
+    command_service: &ResourceCommandService,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let result = command_service.execute_command_async(
+        json!("cache"),
+        "clear-cache",
+        None,
+        None,
+    )?;
+    if result.success {
+        println!("Command executed successfully");
+    } else if result.canceled == Some(true) {
+        println!("Command was canceled");
+    } else {
+        println!("Command failed: {}", result.message.unwrap_or_default());
+    }
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The resource identifier argument (`resourceId` in C#, or the first argument in TypeScript when passing a string) can be either:
@@ -607,6 +766,15 @@ The resource identifier argument (`resourceId` in C#, or the first argument in T
 
 When executing a command on a resource with multiple replicas using the C# `IResource` overload, the command runs in parallel on all instances:
 
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript command service uses a resource identifier string rather than the C# IResource overload.',
+  python: 'The Python command service uses a resource identifier string rather than the C# IResource overload.',
+  go: 'The Go command service uses a resource identifier string rather than the C# IResource overload.',
+  java: 'The Java command service uses a resource identifier string rather than the C# IResource overload.',
+  rust: 'The Rust command service uses a resource identifier string rather than the C# IResource overload.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 // For a resource with replicas, the command executes on all instances
 var result = await commandService.ExecuteCommandAsync(
@@ -614,6 +782,9 @@ var result = await commandService.ExecuteCommandAsync(
     commandName: "clear-cache",
     cancellationToken: cancellationToken);
 ```
+
+</Fragment>
+</AppHostTabs>
 
 In TypeScript, use the resource identifier overload shown earlier: pass a specific replica ID to target one instance, or pass a unique resource name when there are no duplicate names.
 
@@ -676,6 +847,62 @@ return { success: false, message: err instanceof Error ? err.message : String(er
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def command_result():
+    return {"Success": True, "Message": "Command completed."}
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+func commandResult() *aspire.ExecuteCommandResult {
+	return &aspire.ExecuteCommandResult{
+		Success: true,
+		Message: aspire.StringPtr("Command completed."),
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+ExecuteCommandResult commandResult() {
+    var result = new ExecuteCommandResult();
+    result.setSuccess(true);
+    result.setMessage("Command completed.");
+    return result;
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn command_result() -> ExecuteCommandResult {
+    ExecuteCommandResult {
+        success: true,
+        message: Some("Command completed.".to_string()),
+        ..Default::default()
+    }
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <span id="return-structured-output-from-a-command"></span>
@@ -699,7 +926,9 @@ A common scenario is issuing an **access token** from a custom command — devel
 
 Use the `CommandResults.Success(message, result, resultFormat)` overload to attach a payload to a successful result. The `message` is the notification center/CLI status; `result` is the payload string; `resultFormat` controls how the dashboard visualizer interprets it.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits WithCommand callbacks as Fn(Vec<Value>) -> Value, so typed structured results cannot be returned through this callback shape.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -828,13 +1057,128 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+import json
+import secrets
+
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_project(
+        "myservice", "../MyService/MyService.csproj"
+    )
+
+    def issue_token(_context):
+        payload = json.dumps(
+            {"token": secrets.token_urlsafe(24), "scopes": ["read", "write"]}
+        )
+        return {
+            "Success": True,
+            "Message": "Access token issued.",
+            "Data": {"Value": payload, "Format": "Json"},
+        }
+
+    service.with_command(
+        "issue-access-token", "Issue Access Token", issue_token
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"encoding/json"
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.AddProject("myservice", "../MyService/MyService.csproj")
+	service.WithCommand(
+		"issue-access-token",
+		"Issue Access Token",
+		func(_ aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			payload, _ := json.Marshal(map[string]any{
+				"token": "generated-token",
+				"scopes": []string{"read", "write"},
+			})
+			format := aspire.CommandResultFormatJson
+			return &aspire.ExecuteCommandResult{
+				Success: true,
+				Message: aspire.StringPtr("Access token issued."),
+				Data: &aspire.CommandResultData{
+					Value: string(payload), Format: &format,
+				},
+			}
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var service = builder.addProject(
+        "myservice", "../MyService/MyService.csproj");
+
+    service.withCommand(
+        "issue-access-token",
+        "Issue Access Token",
+        context -> {
+            var data = new CommandResultData();
+            data.setValue(
+                "{\"token\":\"generated-token\",\"scopes\":[\"read\",\"write\"]}");
+            data.setFormat(CommandResultFormat.JSON);
+
+            var result = new ExecuteCommandResult();
+            result.setSuccess(true);
+            result.setMessage("Access token issued.");
+            result.setData(data);
+            return result;
+        });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Return Markdown
 
 When a command needs rich output (for example headings, tables, and lists), use the `CommandResults.Success(string, CommandResultData)` overload to return a `CommandResultData` with `Format = CommandResultFormat.Markdown`. This alternative to the three-parameter string overload gives you full control over the result payload:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits WithCommand callbacks as Fn(Vec<Value>) -> Value, so typed Markdown results cannot be returned through this callback shape.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="C# — AppHost.cs"
@@ -927,6 +1271,109 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_project(
+        "myservice", "../MyService/MyService.csproj"
+    )
+
+    def migrate(_context):
+        return {
+            "Success": True,
+            "Message": "Database migrated.",
+            "Data": {
+                "Value": "# Database migration\n\nAll tables migrated.",
+                "Format": "Markdown",
+            },
+        }
+
+    service.with_command("migrate-database", "Migrate Database", migrate)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.AddProject("myservice", "../MyService/MyService.csproj")
+	service.WithCommand(
+		"migrate-database",
+		"Migrate Database",
+		func(_ aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			format := aspire.CommandResultFormatMarkdown
+			return &aspire.ExecuteCommandResult{
+				Success: true,
+				Message: aspire.StringPtr("Database migrated."),
+				Data: &aspire.CommandResultData{
+					Value: "# Database migration\n\nAll tables migrated.",
+					Format: &format,
+				},
+			}
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var service = builder.addProject(
+        "myservice", "../MyService/MyService.csproj");
+
+    service.withCommand(
+        "migrate-database",
+        "Migrate Database",
+        context -> {
+            var data = new CommandResultData();
+            data.setValue("# Database migration\n\nAll tables migrated.");
+            data.setFormat(CommandResultFormat.MARKDOWN);
+
+            var result = new ExecuteCommandResult();
+            result.setSuccess(true);
+            result.setMessage("Database migrated.");
+            result.setData(data);
+            return result;
+        });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Choose a result format
@@ -970,6 +1417,78 @@ return {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def failed_result(error_json):
+    return {
+        "Success": False,
+        "Message": "Migration failed.",
+        "Data": {"Value": error_json, "Format": "Json"},
+    }
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+func failedResult(errorJSON string) *aspire.ExecuteCommandResult {
+	format := aspire.CommandResultFormatJson
+	return &aspire.ExecuteCommandResult{
+		Success: false,
+		Message: aspire.StringPtr("Migration failed."),
+		Data: &aspire.CommandResultData{Value: errorJSON, Format: &format},
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+ExecuteCommandResult failedResult(String errorJson) {
+    var data = new CommandResultData();
+    data.setValue(errorJson);
+    data.setFormat(CommandResultFormat.JSON);
+
+    var result = new ExecuteCommandResult();
+    result.setSuccess(false);
+    result.setMessage("Migration failed.");
+    result.setData(data);
+    return result;
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn failed_result(error_json: String) -> ExecuteCommandResult {
+    ExecuteCommandResult {
+        success: false,
+        message: Some("Migration failed.".to_string()),
+        data: Some(CommandResultData {
+            value: error_json,
+            format: Some(CommandResultFormat::Json),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Auto-open the result dialog in the dashboard
@@ -1000,6 +1519,86 @@ return {
         displayImmediately: true,
     },
 };
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def token_result(json_value):
+    return {
+        "Success": True,
+        "Message": "Access token issued.",
+        "Data": {
+            "Value": json_value,
+            "Format": "Json",
+            "DisplayImmediately": True,
+        },
+    }
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+func tokenResult(jsonValue string) *aspire.ExecuteCommandResult {
+	format := aspire.CommandResultFormatJson
+	return &aspire.ExecuteCommandResult{
+		Success: true,
+		Message: aspire.StringPtr("Access token issued."),
+		Data: &aspire.CommandResultData{
+			Value: jsonValue, Format: &format,
+			DisplayImmediately: aspire.BoolPtr(true),
+		},
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+ExecuteCommandResult tokenResult(String jsonValue) {
+    var data = new CommandResultData();
+    data.setValue(jsonValue);
+    data.setFormat(CommandResultFormat.JSON);
+    data.setDisplayImmediately(true);
+
+    var result = new ExecuteCommandResult();
+    result.setSuccess(true);
+    result.setMessage("Access token issued.");
+    result.setData(data);
+    return result;
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn token_result(json_value: String) -> ExecuteCommandResult {
+    ExecuteCommandResult {
+        success: true,
+        message: Some("Access token issued.".to_string()),
+        data: Some(CommandResultData {
+            value: json_value,
+            format: Some(CommandResultFormat::Json),
+            display_immediately: Some(true),
+        }),
+        ..Default::default()
+    }
+}
 ```
 
 </Fragment>
@@ -1045,7 +1644,9 @@ fi
 
 Commands can declare input arguments that the dashboard renders as a prompt dialog before execution and that the CLI accepts as named `--<name>` options. Arguments are defined by setting `CommandOptions.Arguments` to an array of `InteractionInput` objects.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits the command callback as Fn(Vec<Value>) -> Value, so typed command arguments are not usable in this callback shape.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1119,6 +1720,166 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_project(
+        "myservice", "../MyService/MyService.csproj"
+    )
+
+    def send_message(context):
+        arguments = context.arguments
+        text = arguments.required_value("text")
+        repeat = int(arguments.value("repeat") or "1")
+        return {
+            "Success": True,
+            "Message": f"Sent '{text}' {repeat} time(s).",
+        }
+
+    service.with_command(
+        "send-message",
+        "Send Message",
+        send_message,
+        command_options={
+            "Arguments": [
+                {
+                    "Name": "text",
+                    "Label": "Message",
+                    "InputType": "Text",
+                    "Required": True,
+                    "MaxLength": 200,
+                },
+                {
+                    "Name": "repeat",
+                    "Label": "Repeat",
+                    "InputType": "Number",
+                    "Value": "1",
+                },
+            ]
+        },
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	textType := aspire.InputTypeText
+	numberType := aspire.InputTypeNumber
+	service := builder.AddProject("myservice", "../MyService/MyService.csproj")
+	service.WithCommand(
+		"send-message",
+		"Send Message",
+		func(context aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			arguments := context.Arguments()
+			text, _ := arguments.RequiredValue("text")
+			repeatText, _ := arguments.Value("repeat")
+			repeat, _ := strconv.Atoi(repeatText)
+			return &aspire.ExecuteCommandResult{
+				Success: true,
+				Message: aspire.StringPtr(
+					fmt.Sprintf("Sent %q %d time(s).", text, repeat),
+				),
+			}
+		},
+		&aspire.WithCommandOptions{
+			CommandOptions: &aspire.CommandOptions{
+				Arguments: []*aspire.InteractionInput{
+					{
+						Name: "text", Label: aspire.StringPtr("Message"),
+						InputType: textType, Required: aspire.BoolPtr(true),
+						MaxLength: aspire.Float64Ptr(200),
+					},
+					{
+						Name: "repeat", Label: aspire.StringPtr("Repeat"),
+						InputType: numberType, Value: aspire.StringPtr("1"),
+					},
+				},
+			},
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var service = builder.addProject(
+        "myservice", "../MyService/MyService.csproj");
+
+    var text = new InteractionInput();
+    text.setName("text");
+    text.setLabel("Message");
+    text.setInputType(InputType.TEXT);
+    text.setRequired(true);
+    text.setMaxLength(200);
+
+    var repeat = new InteractionInput();
+    repeat.setName("repeat");
+    repeat.setLabel("Repeat");
+    repeat.setInputType(InputType.NUMBER);
+    repeat.setValue("1");
+
+    var options = new CommandOptions();
+    options.setArguments(new InteractionInput[] { text, repeat });
+
+    service.withCommand(
+        "send-message",
+        "Send Message",
+        context -> {
+            var arguments = context.arguments();
+            var message = arguments.requiredValue("text");
+            var count = Integer.parseInt(arguments.value("repeat"));
+
+            var result = new ExecuteCommandResult();
+            result.setSuccess(true);
+            result.setMessage(
+                "Sent '%s' %d time(s).".formatted(message, count));
+            return result;
+        },
+        options);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### InteractionInput properties
@@ -1180,6 +1941,65 @@ const must   = await args.requiredValue("text");     // string (throws if absent
 Use `requiredValue` for arguments declared with `required: true` to get a non-nullable string directly. Use `value` when the argument is optional and you want to handle the absent case yourself.
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+def read_arguments(context):
+    arguments = context.arguments
+    return {
+        "all": list(arguments.to_array()),
+        "text": arguments.required_value("text"),
+        "optional": arguments.value("optional"),
+    }
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+func readArguments(context aspire.ExecuteCommandContext) (string, error) {
+	arguments := context.Arguments()
+	return arguments.RequiredValue("text")
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+String readArguments(ExecuteCommandContext context) {
+    var arguments = context.arguments();
+    return arguments.requiredValue("text");
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn read_argument(
+    context: &ExecuteCommandContext,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let arguments = context.arguments()?.to_array()?;
+    Ok(arguments
+        .into_iter()
+        .find(|input| input.name == "text")
+        .and_then(|input| input.value))
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Pass arguments from the CLI
@@ -1208,7 +2028,9 @@ The CLI parses and validates values before forwarding them to the AppHost as str
 
 Commands can run server-side validation before the callback executes. Declare a `ValidateArguments` callback on `CommandOptions` to add custom rules on top of the built-in required, max-length, and type checks.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits validate_arguments as an untyped Value callback, so the typed validation context is not available.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1291,6 +2113,152 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_project(
+        "myservice", "../MyService/MyService.csproj"
+    )
+
+    def validate(context):
+        target = context.inputs.value("target")
+        if target.lower() == "prod":
+            context.add_validation_error(
+                "target", "Target must not be 'prod'."
+            )
+
+    service.with_command(
+        "deploy",
+        "Deploy",
+        lambda context: {
+            "Success": True,
+            "Message": (
+                f"Deployed to {context.arguments.required_value('target')}."
+            ),
+        },
+        command_options={
+            "Arguments": [
+                {
+                    "Name": "target",
+                    "Label": "Target",
+                    "InputType": "Text",
+                    "Required": True,
+                }
+            ],
+            "ValidateArguments": validate,
+        },
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+	"strings"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	inputType := aspire.InputTypeText
+	service := builder.AddProject("myservice", "../MyService/MyService.csproj")
+	service.WithCommand(
+		"deploy",
+		"Deploy",
+		func(context aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			target, _ := context.Arguments().RequiredValue("target")
+			return &aspire.ExecuteCommandResult{
+				Success: true,
+				Message: aspire.StringPtr("Deployed to " + target + "."),
+			}
+		},
+		&aspire.WithCommandOptions{
+			CommandOptions: &aspire.CommandOptions{
+				Arguments: []*aspire.InteractionInput{{
+					Name: "target", InputType: inputType,
+					Required: aspire.BoolPtr(true),
+				}},
+				ValidateArguments: func(context aspire.InputsDialogValidationContext) {
+					target, _ := context.Inputs().Value("target")
+					if strings.EqualFold(target, "prod") {
+						_ = context.AddValidationError(
+							"target", "Target must not be 'prod'.",
+						)
+					}
+				},
+			},
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var service = builder.addProject(
+        "myservice", "../MyService/MyService.csproj");
+
+    var target = new InteractionInput();
+    target.setName("target");
+    target.setInputType(InputType.TEXT);
+    target.setRequired(true);
+
+    var options = new CommandOptions();
+    options.setArguments(new InteractionInput[] { target });
+    options.setValidateArguments(context -> {
+        var value = context.inputs().value("target");
+        if ("prod".equalsIgnoreCase(value)) {
+            context.addValidationError(
+                "target", "Target must not be 'prod'.");
+        }
+    });
+
+    service.withCommand(
+        "deploy",
+        "Deploy",
+        context -> {
+            var value = context.arguments().requiredValue("target");
+            var result = new ExecuteCommandResult();
+            result.setSuccess(true);
+            result.setMessage("Deployed to " + value + ".");
+            return result;
+        },
+        options);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 Built-in validation runs first (required fields, max length, choice membership, and type coercion). If built-in validation passes, the `ValidateArguments` callback runs next. Either kind of validation failure prevents the command callback from executing and returns structured field errors to the caller:
@@ -1311,7 +2279,9 @@ By default, commands registered with `WithCommand` are visible to both the Aspir
 | `ResourceCommandVisibility.UI \| ResourceCommandVisibility.Api` | Both UI and API/MCP (default) |
 | `ResourceCommandVisibility.None` | Hidden from all clients |
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust emits the command callback as Fn(Vec<Value>) -> Value, so the typed result callback in this sample is not usable.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1374,6 +2344,113 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_project(
+        "myservice", "../MyService/MyService.csproj"
+    )
+    service.with_command(
+        "get-metrics",
+        "Get Metrics",
+        lambda _context: {
+            "Success": True,
+            "Message": "Metrics collected.",
+            "Data": {"Value": "{}", "Format": "Json"},
+        },
+        command_options={"Visibility": "Api"},
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	format := aspire.CommandResultFormatJson
+	service := builder.AddProject("myservice", "../MyService/MyService.csproj")
+	service.WithCommand(
+		"get-metrics",
+		"Get Metrics",
+		func(_ aspire.ExecuteCommandContext) *aspire.ExecuteCommandResult {
+			return &aspire.ExecuteCommandResult{
+				Success: true,
+				Message: aspire.StringPtr("Metrics collected."),
+				Data: &aspire.CommandResultData{Value: "{}", Format: &format},
+			}
+		},
+		&aspire.WithCommandOptions{
+			CommandOptions: &aspire.CommandOptions{
+				Visibility: aspire.ResourceCommandVisibilityApi,
+			},
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+    var service = builder.addProject(
+        "myservice", "../MyService/MyService.csproj");
+
+    var options = new CommandOptions();
+    options.setVisibility(ResourceCommandVisibility.API);
+
+    service.withCommand(
+        "get-metrics",
+        "Get Metrics",
+        context -> {
+            var data = new CommandResultData();
+            data.setValue("{}");
+            data.setFormat(CommandResultFormat.JSON);
+
+            var result = new ExecuteCommandResult();
+            result.setSuccess(true);
+            result.setMessage("Metrics collected.");
+            result.setData(data);
+            return result;
+        },
+        options);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="tip">
@@ -1384,7 +2461,12 @@ Use `ResourceCommandVisibility.Api` for automation-only commands (diagnostics, s
 
 Commands can display a progress dialog in the dashboard while they execute. The progress dialog shows an indeterminate progress indicator with an optional title, message, and cancel button. Set `CommandOptions.Progress` to a `CommandProgressOptions` value with a `Message` to enable this behavior — the dialog only appears when `Message` is set.
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Python supports progress options, but its generated command callback is synchronous and cannot directly reproduce the awaited seed operation.',
+  go: 'Go supports progress options, but its generated command callback is synchronous and cannot directly reproduce the awaited seed operation.',
+  java: 'Java supports progress options, but its generated command callback is synchronous and cannot directly reproduce the awaited seed operation.',
+  rust: 'Rust emits the command callback as Fn(Vec<Value>) -> Value, so the typed progress-command callback is not usable.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1467,6 +2549,72 @@ var commandOptions = new CommandOptions
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+command_options = {
+    "Progress": {
+        "Message": "Finalizing...",
+        "HideCancelButton": True,
+    }
+}
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import "apphost/modules/aspire"
+
+var commandOptions = aspire.CommandOptions{
+	Progress: &aspire.CommandProgressOptions{
+		Message:          aspire.StringPtr("Finalizing..."),
+		HideCancelButton: true,
+	},
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+CommandOptions commandOptions() {
+    var progress = new CommandProgressOptions();
+    progress.setMessage("Finalizing...");
+    progress.setHideCancelButton(true);
+
+    var options = new CommandOptions();
+    options.setProgress(progress);
+    return options;
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn command_options() -> CommandOptions {
+    CommandOptions {
+        progress: CommandProgressOptions {
+            message: Some("Finalizing...".to_string()),
+            hide_cancel_button: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 For more control over progress behavior, including custom work callbacks and programmatic dismissal, use `IInteractionService.PromptProgressAsync` directly. For more information, see [Display progress](/extensibility/interaction-service/#display-progress).
@@ -1493,7 +2641,12 @@ The `WithProcessCommand` API provides a reusable helper for the common pattern o
 
 The simplest form takes the executable and an argument array directly:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Redis integration method used as this process command target.',
+  go: 'The verified Go SDK does not include the Redis integration method used as this process command target.',
+  java: 'The verified Java SDK does not include the Redis integration method used as this process command target.',
+  rust: 'The verified Rust SDK does not include the Redis integration method used as this process command target.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1541,7 +2694,12 @@ When the command runs in the dashboard or CLI, `dotnet --version` (C#) or `node 
 
 When the command arguments depend on runtime context — for example, a dataset name supplied by the user through the dashboard's argument dialog — build the process specification from the command execution context:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Redis integration method used as this process command target.',
+  go: 'The verified Go SDK does not include the Redis integration method used as this process command target.',
+  java: 'The verified Java SDK does not include the Redis integration method used as this process command target.',
+  rust: 'The verified Rust SDK does not include the Redis integration method, and its process-spec callback is emitted without a typed context.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/fundamentals/custom-resource-urls.mdx
+++ b/src/frontend/src/content/docs/fundamentals/custom-resource-urls.mdx
@@ -5,6 +5,7 @@ description: Create custom resource URLs in Aspire so the dashboard, MCP server,
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 In Aspire, resources that expose endpoints only configure host and port, which aren't known until run time. If you need to access a specific path on one of these endpoints—especially from the [dashboard](/dashboard/overview/)—you can define custom resource URLs. You can also add custom URLs that aren't tied to any endpoint. All custom URLs are only available in "run" mode, since they're meant for dashboard use. This article demonstrates how to define custom URLs.
 
@@ -31,6 +32,9 @@ Custom resource URLs are supported for the following resource types:
 
 Use the appropriate `WithUrl` overload, `WithUrls`, or `WithUrlForEndpoint` APIs on any supported resource builder to define custom URLs for a resource. The following example demonstrates how to set a custom URL for a project resource:
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -41,19 +45,135 @@ api.WithUrl("/admin", "Admin Portal");
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('api', '../AspireApp.Api/AspireApp.Api.csproj');
+await api.withUrl('/admin', { displayText: 'Admin Portal' });
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project(
+        "api", "../AspireApp.Api/AspireApp.Api.csproj"
+    )
+    api.with_url("/admin", display_text="Admin Portal")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddProject("api", "../AspireApp.Api/AspireApp.Api.csproj").
+		WithUrl("/admin", &aspire.WithUrlOptions{
+			DisplayText: aspire.StringPtr("Admin Portal"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject(
+        "api", "../AspireApp.Api/AspireApp.Api.csproj");
+    api.withUrl("/admin", "Admin Portal");
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project(
+        "api",
+        "../AspireApp.Api/AspireApp.Api.csproj",
+        None,
+    )?;
+    api.with_url(json!("/admin"), Some("Admin Portal"))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 <Aside type="tip">
   There's an overload that accepts a `string` allowing you to pass any URL. This
   is useful for defining custom URLs that aren't directly related to the
   resource's endpoint.
 </Aside>
 
-The preceding code assigns a project reference to the `api` variable, which is then used to create a custom URL for the `Admin Portal` route. The `WithUrl` method takes a `ReferenceExpression` and a display name as parameters. The resulting URL is available in the dashboard.
+The preceding code assigns a project reference to the `api` variable, which is then used to create a custom URL for the `Admin Portal` route. The custom URL API accepts either a string or reference expression plus an optional display name. The resulting URL is available in the dashboard.
 
 ### Customize endpoint URL
 
 Both [Scalar](https://scalar.com/) and [Swagger](https://swagger.io/tools/swagger-ui/) are common API services that enhance the usability of endpoints. These services are accessed via URLs tied to declared endpoints.
 
 To customize the URL for the first associated resource endpoint, use the `WithUrlForEndpoint` method. If you want to add a separate URL (even for the same endpoint) you need to call the `WithUrl` overload that takes a `ReferenceExpression` or interpolated string, or call `WithUrls` and add the URL to the `Urls` list on the context.
+
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK emits with_url_for_endpoint only with an untyped transport callback, so typed ResourceUrlAnnotation mutation is not currently usable.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -68,15 +188,121 @@ builder.AddProject<Projects.AspireApp_Api>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('api', '../AspireApp.Api/AspireApp.Api.csproj');
+await api.withUrlForEndpoint('https', async (url) => {
+  url.displayText = 'Scalar (HTTPS)';
+  url.url = '/scalar';
+});
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import ResourceUrlAnnotation, create_builder
+
+
+def customize_scalar_url(url: ResourceUrlAnnotation) -> None:
+    url["DisplayText"] = "Scalar (HTTPS)"
+    url["Url"] = "/scalar"
+
+
+with create_builder() as builder:
+    api = builder.add_project(
+        "api", "../AspireApp.Api/AspireApp.Api.csproj"
+    )
+    api.with_url_for_endpoint("https", customize_scalar_url)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../AspireApp.Api/AspireApp.Api.csproj")
+	api.WithUrlForEndpoint("https", func(url *aspire.ResourceUrlAnnotation) {
+		url.DisplayText = aspire.StringPtr("Scalar (HTTPS)")
+		url.Url = "/scalar"
+	})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject(
+        "api", "../AspireApp.Api/AspireApp.Api.csproj");
+    api.withUrlForEndpoint("https", url -> {
+        url.setDisplayText("Scalar (HTTPS)");
+        url.setUrl("/scalar");
+    });
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+</AppHostTabs>
+
 The preceding example assumes that the `api` project resource has an `https` endpoint configured. The `WithUrlForEndpoint` method updates the `ResourceUrlAnnotation` associated with the endpoint. In this case, it assigns the display text to `Scalar (HTTPS)` and assigns the relative `/scalar` path to the URL.
 
 When the resource is started, the URL is available in the dashboard.
 
-Alternatively, you could use the overload that accepts a `Func<EndpointReference, ResourceUrlAnnotation>` as a callback. This allows you to specify deep-links on target `EndpointReference` instances.
+In C#, you can alternatively use the overload that accepts a `Func<EndpointReference, ResourceUrlAnnotation>` callback. This allows you to specify deep-links on target `EndpointReference` instances.
 
 ### Customize multiple resource URLs
 
 To customize multiple URLs for a resource, use the `WithUrls` method. This method allows you to specify multiple URLs for a resource, each with its own display text. The following example demonstrates how to set multiple URLs for a project resource:
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript ResourceUrlsEditor can add URLs, but it does not expose iteration over existing URLs for this relabel-all operation.',
+  python: 'The Python ResourceUrlsEditor can add URLs, but it does not expose iteration over existing URLs for this relabel-all operation.',
+  go: 'The Go ResourceUrlsEditor can add URLs, but it does not expose iteration over existing URLs for this relabel-all operation.',
+  java: 'The Java ResourceUrlsEditor can add URLs, but it does not expose iteration over existing URLs for this relabel-all operation.',
+  rust: 'The Rust ResourceUrlsEditor can add URLs, but with_urls uses an untyped transport callback and does not expose iteration over existing URLs for this relabel-all operation.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -95,6 +321,9 @@ builder.AddProject<Projects.AspireApp_Api>("api")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding code iterates through the URLs defined for the `api` project resource and assigns a display text with scheme.
 

--- a/src/frontend/src/content/docs/fundamentals/environment-variables.mdx
+++ b/src/frontend/src/content/docs/fundamentals/environment-variables.mdx
@@ -5,6 +5,7 @@ description: Learn how Aspire generates environment variable names for connectio
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 
 When you use `WithReference` to connect resources in the AppHost, Aspire automatically injects environment variables into the consuming resource. This process is called _configuration injection_.
 
@@ -24,6 +25,15 @@ ConnectionStrings__{resource-name}
 
 The resource name is used **as-is** (preserving the original casing and hyphens). For example:
 
+<AppHostTabs limitations={{
+  typescript: 'This example uses Redis and PostgreSQL hosting integration APIs that are not emitted in the TypeScript AppHost SDK.',
+  python: 'This example uses Redis and PostgreSQL hosting integration APIs that are not emitted in the Python AppHost SDK.',
+  go: 'This example uses Redis and PostgreSQL hosting integration APIs that are not emitted in the Go AppHost SDK.',
+  java: 'This example uses Redis and PostgreSQL hosting integration APIs that are not emitted in the Java AppHost SDK.',
+  rust: 'This example uses Redis and PostgreSQL hosting integration APIs that are not emitted in the Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -37,6 +47,9 @@ var api = builder.AddProject<Projects.Api>("api")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The `api` resource receives the following environment variables:
 
@@ -61,6 +74,9 @@ When you reference a resource that exposes endpoints (such as a project or conta
 
 For example:
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -72,6 +88,125 @@ var frontend = builder.AddJavaScriptApp("frontend", "./app")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts"
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('my-api', '../Api/Api.csproj');
+const frontend = await builder.addExecutable(
+  'frontend',
+  'node',
+  './app',
+  ['index.js'],
+);
+await frontend.withReference(api);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("my-api", "../Api/Api.csproj")
+    frontend = builder.add_executable(
+        "frontend", "node", "./app", ["index.js"]
+    )
+    frontend.with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("my-api", "../Api/Api.csproj")
+	frontend := builder.
+		AddExecutable("frontend", "node", "./app", []string{"index.js"}).
+		WithReference(api)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("my-api", "../Api/Api.csproj");
+    var frontend = builder.addExecutable(
+        "frontend", "node", "./app", new String[] { "index.js" });
+    frontend.withReference(api);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("my-api", "../Api/Api.csproj", None)?;
+    let frontend = builder.add_executable(
+        "frontend",
+        "node",
+        "./app",
+        vec!["index.js".to_string()],
+    )?;
+    frontend.with_reference(serialize_handle(&api), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 The `frontend` resource receives:
 
@@ -187,6 +322,15 @@ In JavaScript, `process.env` is an object. Property names containing hyphens req
 
 If you need different variable names, use `WithEnvironment` to set custom environment variables:
 
+<AppHostTabs limitations={{
+  typescript: 'This example depends on PostgreSQL and Python hosting integration APIs that are not emitted in the TypeScript AppHost SDK.',
+  python: 'This example depends on PostgreSQL and Python hosting integration APIs that are not emitted in the Python AppHost SDK.',
+  go: 'This example depends on PostgreSQL and Python hosting integration APIs that are not emitted in the Go AppHost SDK.',
+  java: 'This example depends on PostgreSQL and Python hosting integration APIs that are not emitted in the Java AppHost SDK.',
+  rust: 'This example depends on PostgreSQL and Python hosting integration APIs that are not emitted in the Rust AppHost SDK.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="C# — AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -200,6 +344,9 @@ var api = builder.AddPythonApp("api", "../api", "main.py")
 // After adding all resources, run the app...
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 This approach lets you define explicit, predictable variable names without relying on the automatic naming conventions.
 

--- a/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
@@ -1198,6 +1198,7 @@ void main() throws Exception {
 <Fragment slot="rust">
 
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;
@@ -1390,6 +1391,7 @@ void main() throws Exception {
 <Fragment slot="rust">
 
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;

--- a/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
@@ -1088,9 +1088,7 @@ If you're connecting to a local database, and want to use Integrated Security or
 
 Consider the following example AppHost _AppHost.cs_ file:
 
-<AppHostTabs limitations={{
-  rust: 'The Rust SDK wait_for signature requires an IResource marker that the generated connection-string handle does not implement, so this dependency-gated form is not currently usable.',
-}}>
+<AppHostTabs>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1197,6 +1195,36 @@ void main() throws Exception {
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let redis = builder.add_connection_string("redis", None)?;
+    let api = builder.add_project(
+        "api",
+        "../WebApplication/WebApplication.csproj",
+        None,
+    )?;
+    api.with_reference(serialize_handle(&redis), None, None, None)?;
+    let redis_resource = IResource::new(
+        redis.handle().clone(),
+        redis.client().clone(),
+    );
+    api.wait_for(&redis_resource, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="note">
@@ -1222,9 +1250,7 @@ If you want to construct a connection string from parameters and ensure that it'
 
 For example, if you have a secret parameter that stores a small part of a connection string, use this code to insert it:
 
-<AppHostTabs limitations={{
-  rust: 'Rust can construct the reference expression, but the generated wait_for signature requires an IResource marker that the connection-string handle does not implement.',
-}}>
+<AppHostTabs>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -1357,6 +1383,55 @@ void main() throws Exception {
     api.waitFor(connection);
 
     builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let secret_key = builder.add_parameter(
+        "secretkey",
+        None,
+        None,
+        Some(true),
+    )?;
+    let expression = ref_expr(
+        "Endpoint=https://api.contoso.com/v1;Key={0}",
+        vec![serialize_handle(&secret_key)],
+    );
+    let connection = builder.add_connection_string(
+        "composedconnectionstring",
+        Some(serde_json::to_value(expression)?),
+    )?;
+
+    let api = builder.add_project(
+        "catalogapi",
+        "../CatalogApi/CatalogApi.csproj",
+        None,
+    )?;
+    api.with_reference(
+        serialize_handle(&connection),
+        None,
+        None,
+        None,
+    )?;
+    let connection_resource = IResource::new(
+        connection.handle().clone(),
+        connection.client().clone(),
+    );
+    api.wait_for(&connection_resource, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
 }
 ```
 

--- a/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
+++ b/src/frontend/src/content/docs/fundamentals/external-parameters.mdx
@@ -48,6 +48,106 @@ await api.withEnvironment('ENVIRONMENT_VARIABLE_NAME', parameter);
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    parameter = builder.add_parameter("example-parameter-name")
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_env("ENVIRONMENT_VARIABLE_NAME", parameter)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	parameter := builder.AddParameter("example-parameter-name")
+	api := builder.
+		AddProject("api", "../ApiService/ApiService.csproj").
+		WithEnvironment("ENVIRONMENT_VARIABLE_NAME", parameter)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var parameter = builder.addParameter("example-parameter-name");
+    var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+    api.withEnvironment("ENVIRONMENT_VARIABLE_NAME", parameter);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let parameter = builder.add_parameter(
+        "example-parameter-name",
+        None,
+        None,
+        None,
+    )?;
+    let api = builder.add_project(
+        "api",
+        "../ApiService/ApiService.csproj",
+        None,
+    )?;
+    api.with_environment(
+        "ENVIRONMENT_VARIABLE_NAME",
+        serialize_handle(&parameter),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding code adds a parameter named `example-parameter-name` to the AppHost. The parameter is then passed to the `Projects.ApiService` project as an environment variable named `ENVIRONMENT_VARIABLE_NAME`.
@@ -88,6 +188,91 @@ const builder = await createBuilder();
 
 const key = 'Parameters:example-parameter-name';
 const value = builder.getConfiguration().getConfigValue(key); // value = "local-value"
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    key = "Parameters:example-parameter-name"
+    value = builder.get_config().get_config_value(key)  # value = "local-value"
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	value, err := builder.GetConfiguration().
+		GetConfigValue("Parameters:example-parameter-name")
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	log.Print(value)
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var key = "Parameters:example-parameter-name";
+    var value = builder.getConfiguration().getConfigValue(key);
+    System.out.println(value);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let key = "Parameters:example-parameter-name";
+    let value = builder.get_configuration()?.get_config_value(key)?;
+    println!("{value}");
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -147,6 +332,108 @@ const repository = await builder.addParameter('registry-repository');
 await builder.addContainerRegistry('container-registry', endpoint, repository);
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    endpoint = builder.add_parameter("registry-endpoint")
+    repository = builder.add_parameter("registry-repository")
+    builder.add_container_registry(
+        "container-registry", endpoint, repository=repository
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	endpoint := builder.AddParameter("registry-endpoint")
+	repository := builder.AddParameter("registry-repository")
+	registry := builder.AddContainerRegistry(
+		"container-registry",
+		endpoint,
+		&aspire.AddContainerRegistryOptions{Repository: repository},
+	)
+	if err := registry.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var endpoint = builder.addParameter("registry-endpoint");
+    var repository = builder.addParameter("registry-repository");
+    builder.addContainerRegistry(
+        "container-registry", endpoint, repository);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let endpoint = builder.add_parameter(
+        "registry-endpoint", None, None, None
+    )?;
+    let repository = builder.add_parameter(
+        "registry-repository", None, None, None
+    )?;
+    builder.add_container_registry(
+        "container-registry",
+        serialize_handle(&endpoint),
+        Some(serialize_handle(&repository)),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -258,6 +545,137 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service_url = builder.add_parameter("external-service-url")
+    service_url.with_description(
+        "The URL of the external service. See [example.com](https://example.com) for details.",
+        enable_markdown=True,
+    )
+    service_url.with_custom_input(
+        {
+            "InputType": "Text",
+            "Label": "External service URL",
+            "Placeholder": "Enter value for external-service-url",
+        }
+    )
+    builder.add_external_service("external-service", service_url)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	inputType := aspire.InputTypeText
+	serviceURL := builder.
+		AddParameter("external-service-url").
+		WithDescription(
+			"The URL of the external service. See [example.com](https://example.com) for details.",
+			&aspire.WithDescriptionOptions{EnableMarkdown: aspire.BoolPtr(true)},
+		).
+		WithCustomInput(&aspire.ParameterCustomInputOptions{
+			InputType:   &inputType,
+			Label:       aspire.StringPtr("External service URL"),
+			Placeholder: aspire.StringPtr("Enter value for external-service-url"),
+		})
+	builder.AddExternalService("external-service", serviceURL)
+	if err := serviceURL.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var input = new ParameterCustomInputOptions();
+    input.setInputType(InputType.TEXT);
+    input.setLabel("External service URL");
+    input.setPlaceholder("Enter value for external-service-url");
+
+    var serviceUrl = builder.addParameter("external-service-url");
+    serviceUrl.withDescription(
+        "The URL of the external service. See [example.com](https://example.com) for details.",
+        true);
+    serviceUrl.withCustomInput(input);
+    builder.addExternalService("external-service", serviceUrl);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let service_url = builder.add_parameter(
+        "external-service-url", None, None, None
+    )?;
+    service_url.with_description(
+        "The URL of the external service. See [example.com](https://example.com) for details.",
+        Some(true),
+    )?;
+    service_url.with_custom_input(ParameterCustomInputOptions {
+        input_type: Some(InputType::Text),
+        label: Some("External service URL".to_string()),
+        placeholder: Some(
+            "Enter value for external-service-url".to_string()
+        ),
+        ..Default::default()
+    })?;
+    builder.add_external_service(
+        "external-service",
+        serialize_handle(&service_url),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The code renders this control in the dashboard:
@@ -333,6 +751,104 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    secret = builder.add_parameter("secret", secret=True)
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_env("SECRET", secret)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secret := builder.AddParameter(
+		"secret",
+		&aspire.AddParameterOptions{Secret: aspire.BoolPtr(true)},
+	)
+	api := builder.
+		AddProject("api", "../ApiService/ApiService.csproj").
+		WithEnvironment("SECRET", secret)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var secret = builder.addParameter(
+        "secret", new AddParameterOptions().secret(true));
+    var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+    api.withEnvironment("SECRET", secret);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let secret = builder.add_parameter(
+        "secret", None, None, Some(true)
+    )?;
+    let api = builder.add_project(
+        "api",
+        "../ApiService/ApiService.csproj",
+        None,
+    )?;
+    api.with_environment("SECRET", serialize_handle(&secret))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 Now consider the following AppHost configuration file _appsettings.json_:
@@ -368,9 +884,8 @@ The manifest representation is as follows:
 
 In some scenarios, you might want to read parameter values directly from a specific configuration key rather than following the standard `Parameters:*` pattern. The `AddParameterFromConfiguration` method allows you to specify a custom configuration key for a parameter.
 
-<Aside type="note">
-The `addParameterFromConfiguration` API is not yet available in the TypeScript AppHost SDK.
-</Aside>
+The generated AppHost SDKs expose this capability using each language's naming
+and options conventions.
 
 ### API signature
 
@@ -433,6 +948,113 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    password = builder.add_parameter_from_config(
+        "db-password",
+        "CustomConfig:Database:Password",
+        secret=True,
+    )
+    api = builder.add_project("api", "../ApiService/ApiService.csproj")
+    api.with_env("DB_PASSWORD", password)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	password := builder.AddParameterFromConfiguration(
+		"db-password",
+		"CustomConfig:Database:Password",
+		&aspire.AddParameterFromConfigurationOptions{
+			Secret: aspire.BoolPtr(true),
+		},
+	)
+	api := builder.
+		AddProject("api", "../ApiService/ApiService.csproj").
+		WithEnvironment("DB_PASSWORD", password)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var password = builder.addParameterFromConfiguration(
+        "db-password", "CustomConfig:Database:Password", true);
+    var api = builder.addProject("api", "../ApiService/ApiService.csproj");
+    api.withEnvironment("DB_PASSWORD", password);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let password = builder.add_parameter_from_configuration(
+        "db-password",
+        "CustomConfig:Database:Password",
+        Some(true),
+    )?;
+    let api = builder.add_project(
+        "api",
+        "../ApiService/ApiService.csproj",
+        None,
+    )?;
+    api.with_environment("DB_PASSWORD", serialize_handle(&password))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The corresponding configuration file would look like:
@@ -466,7 +1088,9 @@ If you're connecting to a local database, and want to use Integrated Security or
 
 Consider the following example AppHost _AppHost.cs_ file:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK wait_for signature requires an IResource marker that the generated connection-string handle does not implement, so this dependency-gated form is not currently usable.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -501,6 +1125,78 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    redis = builder.add_connection_string("redis")
+    api = builder.add_project(
+        "api", "../WebApplication/WebApplication.csproj"
+    )
+    api.with_reference(redis)
+    api.wait_for(redis)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	redis := builder.AddConnectionString("redis")
+	api := builder.
+		AddProject("api", "../WebApplication/WebApplication.csproj").
+		WithReference(redis).
+		WaitFor(redis)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var redis = builder.addConnectionString("redis");
+    var api = builder.addProject(
+        "api", "../WebApplication/WebApplication.csproj");
+    api.withReference(redis);
+    api.waitFor(redis);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 <Aside type="note">
@@ -526,7 +1222,9 @@ If you want to construct a connection string from parameters and ensure that it'
 
 For example, if you have a secret parameter that stores a small part of a connection string, use this code to insert it:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'Rust can construct the reference expression, but the generated wait_for signature requires an IResource marker that the connection-string handle does not implement.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -566,11 +1264,113 @@ await catalogApi.withReference(connectionString).waitFor(connectionString);
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder, string_expr
+
+with create_builder() as builder:
+    secret_key = builder.add_parameter("secretkey", secret=True)
+    expression = string_expr(
+        "Endpoint=https://api.contoso.com/v1;Key={key}",
+        key=secret_key,
+    )
+    connection = builder.add_connection_string(
+        "composedconnectionstring",
+        env_var_name_or_expression=expression,
+    )
+    api = builder.add_project("catalogapi", "../CatalogApi/CatalogApi.csproj")
+    api.with_reference(connection)
+    api.wait_for(connection)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	secretKey := builder.AddParameter(
+		"secretkey",
+		&aspire.AddParameterOptions{Secret: aspire.BoolPtr(true)},
+	)
+	expression := aspire.RefExpr(
+		"Endpoint=https://api.contoso.com/v1;Key={0}",
+		secretKey,
+	)
+	connection := builder.AddConnectionString(
+		"composedconnectionstring",
+		&aspire.AddConnectionStringOptions{
+			EnvironmentVariableNameOrExpression: expression,
+		},
+	)
+	api := builder.
+		AddProject("catalogapi", "../CatalogApi/CatalogApi.csproj").
+		WithReference(connection).
+		WaitFor(connection)
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var secretKey = builder.addParameter(
+        "secretkey", new AddParameterOptions().secret(true));
+    var expression = ReferenceExpression.refExpr(
+        "Endpoint=https://api.contoso.com/v1;Key={0}", secretKey);
+    var connection = builder.addConnectionString(
+        "composedconnectionstring", expression);
+
+    var api = builder.addProject(
+        "catalogapi", "../CatalogApi/CatalogApi.csproj");
+    api.withReference(connection);
+    api.waitFor(connection);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 You can also use reference expressions to append text to connection strings created by Aspire resources. For example, when you add a PostgreSQL resource to your Aspire solution, the database server runs in a container and a connection string is formulated for it. In the following code, the extra property `Include Error Details` is appended to that connection string before it's passed to consuming projects:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the PostgreSQL integration methods used to create the database resource in this example.',
+  go: 'The verified Go SDK does not include the PostgreSQL integration methods used to create the database resource in this example.',
+  java: 'The verified Java SDK does not include the PostgreSQL integration methods used to create the database resource in this example.',
+  rust: 'The verified Rust SDK does not include the PostgreSQL integration methods used to create the database resource in this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -615,7 +1415,12 @@ await customerApi.withReference(pgConnectionString).waitFor(pgConnectionString);
 
 To express a parameter, consider the following example code:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The execution-context and parameter APIs are available, but the verified Python SDK does not include the SQL Server integration methods used by the run-mode branch.',
+  go: 'The execution-context and parameter APIs are available, but the verified Go SDK does not include the SQL Server integration methods used by the run-mode branch.',
+  java: 'The execution-context and parameter APIs are available, but the verified Java SDK does not include the SQL Server integration methods used by the run-mode branch.',
+  rust: 'The execution-context and parameter APIs are available, but the verified Rust SDK does not include the SQL Server integration methods used by the run-mode branch.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/fundamentals/health-checks.mdx
+++ b/src/frontend/src/content/docs/fundamentals/health-checks.mdx
@@ -561,6 +561,7 @@ void main() throws Exception {
 <Fragment slot="rust">
 
 ```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
 mod aspire;
 
 use aspire::*;

--- a/src/frontend/src/content/docs/fundamentals/health-checks.mdx
+++ b/src/frontend/src/content/docs/fundamentals/health-checks.mdx
@@ -431,9 +431,7 @@ When a resource has health checks configured, the AppHost uses them to determine
 
 For resources that expose HTTP endpoints, you can add health checks that poll specific paths:
 
-<AppHostTabs limitations={{
-  rust: 'The Rust SDK exposes wait_for through an IResource marker type that a concrete generated resource cannot currently satisfy, so this dependency-gated sample is not usable as written.',
-}}>
+<AppHostTabs>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -560,13 +558,57 @@ void main() throws Exception {
 ```
 
 </Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let catalog_api = builder.add_container("catalog-api", json!("catalog-api"))?;
+    catalog_api.with_http_endpoint(
+        None,
+        Some(8080.0),
+        None,
+        None,
+        None,
+    )?;
+    catalog_api.with_http_health_check(Some("/health"), None, None)?;
+
+    let webapp = builder.add_executable(
+        "webapp",
+        "node",
+        "./webapp",
+        vec!["index.js".to_string()],
+    )?;
+    webapp.with_reference(
+        serialize_handle(&catalog_api),
+        None,
+        None,
+        None,
+    )?;
+    let catalog_resource = IResource::new(
+        catalog_api.handle().clone(),
+        catalog_api.client().clone(),
+    );
+    webapp.wait_for(&catalog_resource, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The `WithHttpHealthCheck` method can also be applied to project resources:
 
-<AppHostTabs limitations={{
-  rust: 'The Rust SDK exposes wait_for through an IResource marker type that a concrete generated project resource cannot currently satisfy, so this dependency-gated sample is not usable as written.',
-}}>
+<AppHostTabs>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -671,6 +713,30 @@ void main() throws Exception {
 
     builder.build().run();
 }
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let backend = builder.add_project(
+    "backend",
+    "../Backend/Backend.csproj",
+    None,
+)?;
+backend.with_http_health_check(Some("/health"), None, None)?;
+
+let frontend = builder.add_project(
+    "frontend",
+    "../Frontend/Frontend.csproj",
+    None,
+)?;
+frontend.with_reference(serialize_handle(&backend), None, None, None)?;
+let backend_resource = IResource::new(
+    backend.handle().clone(),
+    backend.client().clone(),
+);
+frontend.wait_for(&backend_resource, None)?;
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/fundamentals/health-checks.mdx
+++ b/src/frontend/src/content/docs/fundamentals/health-checks.mdx
@@ -431,7 +431,9 @@ When a resource has health checks configured, the AppHost uses them to determine
 
 For resources that expose HTTP endpoints, you can add health checks that poll specific paths:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK exposes wait_for through an IResource marker type that a concrete generated resource cannot currently satisfy, so this dependency-gated sample is not usable as written.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -467,11 +469,104 @@ await webapp.waitFor(catalogApi); // Waits for /health to return HTTP 200
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    catalog_api = builder.add_container("catalog-api", "catalog-api")
+    catalog_api.with_http_endpoint(target_port=8080)
+    catalog_api.with_http_health_check(path="/health")
+
+    webapp = builder.add_executable(
+        "webapp", "node", "./webapp", ["index.js"]
+    )
+    webapp.with_reference(catalog_api)
+    webapp.wait_for(catalog_api)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	catalogAPI := builder.
+		AddContainer("catalog-api", "catalog-api").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			TargetPort: aspire.Float64Ptr(8080),
+		}).
+		WithHttpHealthCheck(&aspire.WithHttpHealthCheckOptions{
+			Path: aspire.StringPtr("/health"),
+		})
+	if err := catalogAPI.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	webapp := builder.
+		AddExecutable("webapp", "node", "./webapp", []string{"index.js"}).
+		WithReference(catalogAPI).
+		WaitFor(catalogAPI)
+	if err := webapp.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var catalogApi = builder.addContainer("catalog-api", "catalog-api");
+    catalogApi.withHttpEndpoint(
+        new WithHttpEndpointOptions().targetPort(8080));
+    catalogApi.withHttpHealthCheck(
+        new WithHttpHealthCheckOptions().path("/health"));
+
+    var webapp = builder.addExecutable(
+        "webapp", "node", "./webapp", new String[] { "index.js" });
+    webapp.withReference(catalogApi);
+    webapp.waitFor(catalogApi);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The `WithHttpHealthCheck` method can also be applied to project resources:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK exposes wait_for through an IResource marker type that a concrete generated project resource cannot currently satisfy, so this dependency-gated sample is not usable as written.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -500,6 +595,85 @@ await frontend.waitFor(backend);
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    backend = builder.add_project("backend", "../Backend/Backend.csproj")
+    backend.with_http_health_check(path="/health")
+
+    frontend = builder.add_project("frontend", "../Frontend/Frontend.csproj")
+    frontend.with_reference(backend)
+    frontend.wait_for(backend)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	backend := builder.
+		AddProject("backend", "../Backend/Backend.csproj").
+		WithHttpHealthCheck(&aspire.WithHttpHealthCheckOptions{
+			Path: aspire.StringPtr("/health"),
+		})
+	frontend := builder.
+		AddProject("frontend", "../Frontend/Frontend.csproj").
+		WithReference(backend).
+		WaitFor(backend)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var backend = builder.addProject("backend", "../Backend/Backend.csproj");
+    backend.withHttpHealthCheck(
+        new WithHttpHealthCheckOptions().path("/health"));
+
+    var frontend = builder.addProject(
+        "frontend", "../Frontend/Frontend.csproj");
+    frontend.withReference(backend);
+    frontend.waitFor(backend);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Custom resource health checks
@@ -508,6 +682,10 @@ You can create custom health checks for more complex readiness scenarios. Start 
 
 <AppHostTabs limitations={{
   typescript: 'The generated TypeScript SDK does not expose the AppHost service-collection API required to register this custom health check.',
+  python: 'The generated Python SDK does not expose the AppHost service-collection API required to register this custom health check.',
+  go: 'The generated Go SDK does not expose the AppHost service-collection API required to register this custom health check.',
+  java: 'The generated Java SDK does not expose the AppHost service-collection API required to register this custom health check.',
+  rust: 'The generated Rust SDK does not expose the AppHost service-collection API required to register this custom health check.',
 }}>
 <Fragment slot="csharp">
 
@@ -536,8 +714,9 @@ builder.AddProject<Projects.MyApp>("myapp")
 </AppHostTabs>
 
 <Aside type="note">
-  TypeScript AppHost support for registering custom health checks with
-  `builder.Services.AddHealthChecks()` is not yet available.
+  Generated TypeScript, Python, Go, Java, and Rust AppHost SDKs don't expose the
+  service-collection API required to register custom health checks with
+  `builder.Services.AddHealthChecks()`.
 </Aside>
 
 The `AddCheck` method registers the health check, and `WithHealthCheck` associates it with specific resources. For more details about creating and registering custom health checks, see [Create health checks](https://learn.microsoft.com/aspnet/core/host-and-deploy/health-checks#create-health-checks).

--- a/src/frontend/src/content/docs/fundamentals/http-commands.mdx
+++ b/src/frontend/src/content/docs/fundamentals/http-commands.mdx
@@ -48,6 +48,15 @@ HTTP commands are user-cancelable from the dashboard, so by default the request 
 
 If you want a command to time out after a specific duration, specify `HttpCommandOptions.HttpClientName` with the name of an `HttpClient` you configure with `IHttpClientFactory`, and set its `Timeout` accordingly:
 
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript AppHost SDK does not expose the AppHost service collection used to register a named .NET HttpClient.',
+  python: 'The Python AppHost SDK does not expose the AppHost service collection used to register a named .NET HttpClient.',
+  go: 'The Go AppHost SDK does not expose the AppHost service collection used to register a named .NET HttpClient.',
+  java: 'The Java AppHost SDK does not expose the AppHost service collection used to register a named .NET HttpClient.',
+  rust: 'The Rust AppHost SDK does not expose the AppHost service collection used to register a named .NET HttpClient.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -68,11 +77,23 @@ builder.AddProject<Projects.Api>("api")
 builder.Build().Run();
 ```
 
+</Fragment>
+</AppHostTabs>
+
 When `HttpCommandOptions.HttpClientName` is specified, the named `HttpClient` is used as configured, including its `Timeout`.
 
 ## Add a custom HTTP command
 
 In your _AppHost.cs_ file, you add a custom HTTP command using the `WithHttpCommand` API on an `IResourceBuilder<T>` where `T` is an `IResourceWithEndpoints`. Here's an example of how to do this:
+
+<AppHostTabs limitations={{
+  typescript: 'The TypeScript SDK emits withHttpCommand export options, but this complete example also uses a Redis hosting integration and the mutable .NET HttpCommandOptions callback shape, which are not emitted by this SDK.',
+  python: 'The Python SDK emits with_http_command export options, but this complete example also uses a Redis hosting integration and the mutable .NET HttpCommandOptions callback shape, which are not emitted by this SDK.',
+  go: 'The Go SDK emits WithHttpCommand export options, but this complete example also uses a Redis hosting integration and the mutable .NET HttpCommandOptions callback shape, which are not emitted by this SDK.',
+  java: 'The Java SDK emits withHttpCommand export options, but this complete example also uses a Redis hosting integration and the mutable .NET HttpCommandOptions callback shape, which are not emitted by this SDK.',
+  rust: 'The Rust SDK emits with_http_command export options, but this complete example also uses a Redis hosting integration and the mutable .NET HttpCommandOptions callback shape, which are not emitted by this SDK.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
@@ -105,6 +126,9 @@ var api = builder.AddProject<Projects.AspireApp_Api>("api")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 The preceding code:
 
@@ -206,6 +230,109 @@ await builder
   });
 
 await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_http_command(
+        "/admin/sync",
+        "Sync now",
+        options={"MethodName": "POST", "ResultMode": "Auto"},
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddProject("api", "../Api/Api.csproj").
+		WithHttpCommand("/admin/sync", "Sync now", &aspire.HttpCommandExportOptions{
+			MethodName: aspire.StringPtr("POST"),
+			ResultMode: aspire.HttpCommandResultModeAuto,
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var options = new HttpCommandExportOptions();
+    options.setMethodName("POST");
+    options.setResultMode(HttpCommandResultMode.AUTO);
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withHttpCommand("/admin/sync", "Sync now", options);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_http_command(
+        "/admin/sync",
+        "Sync now",
+        Some(HttpCommandExportOptions {
+            method_name: Some("POST".to_string()),
+            result_mode: HttpCommandResultMode::Auto,
+            ..Default::default()
+        }),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
+++ b/src/frontend/src/content/docs/fundamentals/networking-overview.mdx
@@ -108,7 +108,12 @@ By default, containers are accessible on the container network using their **res
 
 Sometimes you need additional aliases—for example, when a third-party tool expects a specific hostname, or when migrating from an existing Docker Compose setup. Use `WithContainerNetworkAlias` to add custom DNS names:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the Redis integration method used by this example.',
+  go: 'The verified Go SDK does not include the Redis integration method used by this example.',
+  java: 'The verified Java SDK does not include the Redis integration method used by this example.',
+  rust: 'The verified Rust SDK does not include the Redis integration method used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -179,7 +184,12 @@ The preceding diagram depicts the following:
 
 For a JavaScript app that reads its listener port from an environment variable, expose a stable host port like this:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the JavaScript hosting integration method used by this example.',
+  go: 'The verified Go SDK does not include the JavaScript hosting integration method used by this example.',
+  java: 'The verified Java SDK does not include the JavaScript hosting integration method used by this example.',
+  rust: 'The verified Rust SDK does not include the JavaScript hosting integration method used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -260,6 +270,95 @@ await web.withHttpEndpoint({ targetPort: 80, isProxied: false });
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    web = builder.add_container("web", "nginx")
+    web.with_http_endpoint(target_port=80, is_proxied=False)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	web := builder.
+		AddContainer("web", "nginx").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			TargetPort: aspire.Float64Ptr(80),
+			IsProxied: aspire.BoolPtr(false),
+		})
+	if err := web.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var web = builder.addContainer("web", "nginx");
+    web.withHttpEndpoint(
+        new WithHttpEndpointOptions().targetPort(80).isProxied(false));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let web = builder.add_container("web", json!("nginx"))?;
+    web.with_http_endpoint(None, Some(80.0), None, None, Some(false))?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Allocate ports for dynamic proxyless endpoints
@@ -298,6 +397,125 @@ await database.withEnvironment('PUBLIC_PORT', database.getEndpoint('tcp').proper
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    database = builder.add_container("database", "image")
+    database.with_endpoint(
+        name="tcp", target_port=5432, is_proxied=False
+    )
+    public_port = database.get_endpoint("tcp").property("Port")
+    database.with_env("PUBLIC_PORT", public_port)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	database := builder.
+		AddContainer("database", "image").
+		WithEndpoint(&aspire.WithEndpointOptions{
+			Name:       aspire.StringPtr("tcp"),
+			TargetPort: aspire.Float64Ptr(5432),
+			IsProxied:  aspire.BoolPtr(false),
+		})
+	database.WithEnvironment(
+		"PUBLIC_PORT",
+		database.GetEndpoint("tcp").Property(aspire.EndpointPropertyPort),
+	)
+	if err := database.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var database = builder.addContainer("database", "image");
+    database.withEndpoint(new WithEndpointOptions()
+        .name("tcp")
+        .targetPort(5432)
+        .isProxied(false));
+    database.withEnvironment(
+        "PUBLIC_PORT",
+        database.getEndpoint("tcp").property(EndpointProperty.PORT));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let database = builder.add_container("database", json!("image"))?;
+    database.with_endpoint(
+        None,
+        Some(5432.0),
+        None,
+        Some("tcp"),
+        None,
+        Some(false),
+        None,
+        None,
+    )?;
+    let public_port = database
+        .get_endpoint("tcp")?
+        .property(EndpointProperty::Port)?;
+    database.with_environment(
+        "PUBLIC_PORT",
+        serialize_handle(&public_port),
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 In this example, `PUBLIC_PORT` is set to the endpoint's allocated public host port before the container is created. Because the endpoint is proxyless and doesn't specify `port`, Aspire allocates a port from the proxyless endpoint port range.
@@ -310,7 +528,12 @@ For persistent resources, Aspire stores allocated proxyless endpoint ports in us
 
 For proxied endpoints, when you omit the host port, Aspire generates a random port for both host and service port. This is useful when you want to avoid port conflicts and don't care about the host or service port. Consider the following code:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the JavaScript hosting integration method used by this example.',
+  go: 'The verified Go SDK does not include the JavaScript hosting integration method used by this example.',
+  java: 'The verified Java SDK does not include the JavaScript hosting integration method used by this example.',
+  rust: 'The verified Rust SDK does not include the JavaScript hosting integration method used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -375,6 +598,107 @@ await frontend.withHttpEndpoint({ port: 8000, targetPort: 8080 });
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    frontend = builder.add_container(
+        "frontend", "mcr.microsoft.com/dotnet/samples:aspnetapp"
+    )
+    frontend.with_http_endpoint(port=8000, target_port=8080)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	frontend := builder.
+		AddContainer("frontend", "mcr.microsoft.com/dotnet/samples:aspnetapp").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Port:       aspire.Float64Ptr(8000),
+			TargetPort: aspire.Float64Ptr(8080),
+		})
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var frontend = builder.addContainer(
+        "frontend", "mcr.microsoft.com/dotnet/samples:aspnetapp");
+    frontend.withHttpEndpoint(
+        new WithHttpEndpointOptions().port(8000).targetPort(8080));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let frontend = builder.add_container(
+        "frontend",
+        json!("mcr.microsoft.com/dotnet/samples:aspnetapp"),
+    )?;
+    frontend.with_http_endpoint(
+        Some(8000.0),
+        Some(8080.0),
+        None,
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding code:
@@ -395,7 +719,9 @@ Any resource that implements the `IResourceWithEndpoints` interface can use the 
 
 There's also an overload that allows you to specify a delegate to configure the endpoint. This is useful when you need to configure the endpoint based on the environment or other factors. Consider the following code:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK currently emits the endpoint callback as Fn(Vec<Value>) -> Value instead of a typed EndpointUpdateContext callback, so this shape is not usable as canonical Rust code.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -432,6 +758,91 @@ await apiService.withEndpointCallback(
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api_service = builder.add_container("apiService", "nginx")
+
+    def configure_admin(endpoint):
+        endpoint.port = 17003
+        endpoint.uri_scheme = "http"
+        endpoint.transport = "http"
+
+    api_service.with_endpoint_callback(
+        "admin", configure_admin, create_if_not_exists=True
+    )
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	apiService := builder.AddContainer("apiService", "nginx")
+	apiService.WithEndpointCallback(
+		"admin",
+		func(endpoint aspire.EndpointUpdateContext) {
+			endpoint.
+				SetPort(aspire.Float64Ptr(17003)).
+				SetUriScheme("http").
+				SetTransport("http")
+		},
+		&aspire.WithEndpointCallbackOptions{CreateIfNotExists: aspire.BoolPtr(true)},
+	)
+	if err := apiService.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var apiService = builder.addContainer("apiService", "nginx");
+    apiService.withEndpointCallback(
+        "admin",
+        endpoint -> endpoint
+            .setPort(17003)
+            .setUriScheme("http")
+            .setTransport("http"),
+        true);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The preceding code provides a callback delegate to configure the endpoint. The endpoint is named `admin` and configured to use the `http` scheme and transport, as well as the 17003 host port. Consumers can reference this endpoint by name with a URI such as `http://_admin.apiservice`. The `_` sentinel indicates that the `admin` segment is the endpoint name belonging to the `apiservice` service. For more information, see [Service discovery](/fundamentals/service-discovery/).
@@ -463,7 +874,9 @@ For project-resource-specific endpoint filtering, see [Project resources](/integ
 
 By default, every endpoint on a resource is included when another resource references it via `WithReference(resource)`. Some resources expose auxiliary endpoints—such as admin dashboards or health-check ports—that consumer services should not discover automatically. Use the `ExcludeReferenceEndpoint` property on `EndpointAnnotation` to opt an endpoint out of the default reference set:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK currently emits the endpoint callback as Fn(Vec<Value>) -> Value instead of a typed EndpointUpdateContext callback, so this shape is not usable as canonical Rust code.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -491,11 +904,94 @@ await myService.withEndpointCallback('management', async (endpoint) => {
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_container("myservice", "myimage")
+    service.with_http_endpoint(name="management", port=8080)
+
+    def exclude_management(endpoint):
+        endpoint.exclude_reference_endpoint = True
+
+    service.with_endpoint_callback("management", exclude_management)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.
+		AddContainer("myservice", "myimage").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Name: aspire.StringPtr("management"),
+			Port: aspire.Float64Ptr(8080),
+		})
+	service.WithEndpointCallback(
+		"management",
+		func(endpoint aspire.EndpointUpdateContext) {
+			endpoint.SetExcludeReferenceEndpoint(true)
+		},
+	)
+	if err := service.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var service = builder.addContainer("myservice", "myimage");
+    service.withHttpEndpoint(
+        new WithHttpEndpointOptions().name("management").port(8080));
+    service.withEndpointCallback(
+        "management",
+        endpoint -> endpoint.setExcludeReferenceEndpoint(true));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 When `ExcludeReferenceEndpoint` is `true`, the endpoint is **not** injected into dependent services by a plain `WithReference(resource)` call. It can still be referenced explicitly by name:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  rust: 'The Rust SDK currently emits the endpoint callback as Fn(Vec<Value>) -> Value instead of a typed EndpointUpdateContext callback, so this endpoint-exclusion sample is not usable as canonical Rust code.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -536,6 +1032,114 @@ await api.withReference(myService);
 
 const adminApp = await builder.addProject('admin', '../Admin/Admin.csproj');
 await adminApp.withReference(myService.getEndpoint('management'));
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    service = builder.add_container("myservice", "myimage")
+    service.with_http_endpoint(name="api", port=5000)
+    service.with_http_endpoint(name="management", port=8080)
+
+    def exclude_management(endpoint):
+        endpoint.exclude_reference_endpoint = True
+
+    service.with_endpoint_callback("management", exclude_management)
+
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_reference(service)
+
+    admin = builder.add_project("admin", "../Admin/Admin.csproj")
+    admin.with_reference(service.get_endpoint("management"))
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	service := builder.
+		AddContainer("myservice", "myimage").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Name: aspire.StringPtr("api"),
+			Port: aspire.Float64Ptr(5000),
+		}).
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Name: aspire.StringPtr("management"),
+			Port: aspire.Float64Ptr(8080),
+		})
+	service.WithEndpointCallback(
+		"management",
+		func(endpoint aspire.EndpointUpdateContext) {
+			endpoint.SetExcludeReferenceEndpoint(true)
+		},
+	)
+
+	api := builder.AddProject("api", "../Api/Api.csproj").WithReference(service)
+	admin := builder.
+		AddProject("admin", "../Admin/Admin.csproj").
+		WithReference(service.GetEndpoint("management"))
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := admin.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var service = builder.addContainer("myservice", "myimage");
+    service.withHttpEndpoint(
+        new WithHttpEndpointOptions().name("api").port(5000));
+    service.withHttpEndpoint(
+        new WithHttpEndpointOptions().name("management").port(8080));
+    service.withEndpointCallback(
+        "management",
+        endpoint -> endpoint.setExcludeReferenceEndpoint(true));
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withReference(service);
+
+    var admin = builder.addProject("admin", "../Admin/Admin.csproj");
+    admin.withReference(service.getEndpoint("management"));
+
+    builder.build().run();
+}
 ```
 
 </Fragment>
@@ -587,7 +1191,12 @@ The following built-in Aspire integrations already apply this pattern to their a
 2. Add `.WithHttpHealthCheck()` or `.WithHealthCheck()` to the container resource
 3. Ensure host services use the **exposed port** (not the container's internal port):
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the JavaScript and PostgreSQL integration methods used by this example.',
+  go: 'The verified Go SDK does not include the JavaScript and PostgreSQL integration methods used by this example.',
+  java: 'The verified Java SDK does not include the JavaScript and PostgreSQL integration methods used by this example.',
+  rust: 'The verified Rust SDK does not include the JavaScript and PostgreSQL integration methods used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp

--- a/src/frontend/src/content/docs/fundamentals/persist-data-volumes.mdx
+++ b/src/frontend/src/content/docs/fundamentals/persist-data-volumes.mdx
@@ -74,11 +74,92 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    # Configure resources and persistent storage here.
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	// Configure resources and persistent storage here.
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    // Configure resources and persistent storage here.
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    // Configure resources and persistent storage here.
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 The first code snippet to consider uses the `WithVolume` API to configure a volume for a SQL Server resource. The following code demonstrates how to configure a volume for a SQL Server resource in an Aspire AppHost project:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the SQL Server integration methods used by this example.',
+  go: 'The verified Go SDK does not include the SQL Server integration methods used by this example.',
+  java: 'The verified Java SDK does not include the SQL Server integration methods used by this example.',
+  rust: 'The verified Rust SDK does not include the SQL Server integration methods used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -103,7 +184,12 @@ In this example `/var/opt/mssql` sets the path to the database files in the cont
 
 All Aspire container resources can utilize volumes, and some provide convenient APIs for adding named volumes derived from resources. Using the `WithDataVolume` method as an example, the following code is functionally equivalent to the previous example but more succinct:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the SQL Server integration-specific with_data_volume method.',
+  go: 'The verified Go SDK does not include the SQL Server integration-specific WithDataVolume method.',
+  java: 'The verified Java SDK does not include the SQL Server integration-specific withDataVolume method.',
+  rust: 'The verified Rust SDK does not include the SQL Server integration-specific with_data_volume method.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -138,7 +224,12 @@ Bind mounts enable access to the data from both within the container and from pr
 
 Consider this code snippet, which uses the `WithBindMount` API to configure a bind mount for a SQL Server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the SQL Server integration methods used by this example.',
+  go: 'The verified Go SDK does not include the SQL Server integration methods used by this example.',
+  java: 'The verified Java SDK does not include the SQL Server integration methods used by this example.',
+  rust: 'The verified Rust SDK does not include the SQL Server integration methods used by this example.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -166,7 +257,12 @@ In this example:
 
 As for volumes, some Aspire container resources provide convenient APIs for adding bind mounts. Using the `WithDataBindMount` method as an example, the following code is functionally equivalent to the previous example but more succinct:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the SQL Server integration-specific with_data_bind_mount method.',
+  go: 'The verified Go SDK does not include the SQL Server integration-specific WithDataBindMount method.',
+  java: 'The verified Java SDK does not include the SQL Server integration-specific withDataBindMount method.',
+  rust: 'The verified Rust SDK does not include the SQL Server integration-specific with_data_bind_mount method.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -191,7 +287,12 @@ const sqldb = await sql.addDatabase("sqldb");
 
 Named volumes require a consistent password between app launches. Aspire conveniently provides random password generation functionality. Consider the previous example once more, where a password is generated automatically:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the SQL Server integration-specific with_data_volume method.',
+  go: 'The verified Go SDK does not include the SQL Server integration-specific WithDataVolume method.',
+  java: 'The verified Java SDK does not include the SQL Server integration-specific withDataVolume method.',
+  rust: 'The verified Rust SDK does not include the SQL Server integration-specific with_data_volume method.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
@@ -241,7 +342,12 @@ The same pattern applies to the other server-based resource types, such as those
 
 By overriding the generated password, you can ensure that the password remains consistent between app launches. An alternative approach is to use the `AddParameter` method to create a parameter that can be used as a password. The following code demonstrates how to create a persistent password for a SQL Server resource:
 
-<AppHostTabs>
+<AppHostTabs limitations={{
+  python: 'Parameter resources are supported, but the verified Python SDK does not include the SQL Server integration methods used here.',
+  go: 'Parameter resources are supported, but the verified Go SDK does not include the SQL Server integration methods used here.',
+  java: 'Parameter resources are supported, but the verified Java SDK does not include the SQL Server integration methods used here.',
+  rust: 'Parameter resources are supported, but the verified Rust SDK does not include the SQL Server integration methods used here.',
+}}>
 <Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"

--- a/src/frontend/src/content/docs/fundamentals/service-discovery.mdx
+++ b/src/frontend/src/content/docs/fundamentals/service-discovery.mdx
@@ -74,6 +74,123 @@ await builder.build().run();
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    catalog = builder.add_project(
+        "catalog", "../CatalogService/CatalogService.csproj"
+    )
+    basket = builder.add_project(
+        "basket", "../BasketService/BasketService.csproj"
+    )
+    frontend = builder.add_project(
+        "frontend", "../MyFrontend/MyFrontend.csproj"
+    )
+    frontend.with_reference(basket)
+    frontend.with_reference(catalog)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	catalog := builder.AddProject("catalog", "../CatalogService/CatalogService.csproj")
+	basket := builder.AddProject("basket", "../BasketService/BasketService.csproj")
+	frontend := builder.
+		AddProject("frontend", "../MyFrontend/MyFrontend.csproj").
+		WithReference(basket).
+		WithReference(catalog)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var catalog = builder.addProject(
+        "catalog", "../CatalogService/CatalogService.csproj");
+    var basket = builder.addProject(
+        "basket", "../BasketService/BasketService.csproj");
+    var frontend = builder.addProject(
+        "frontend", "../MyFrontend/MyFrontend.csproj");
+    frontend.withReference(basket);
+    frontend.withReference(catalog);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let catalog = builder.add_project(
+        "catalog",
+        "../CatalogService/CatalogService.csproj",
+        None,
+    )?;
+    let basket = builder.add_project(
+        "basket",
+        "../BasketService/BasketService.csproj",
+        None,
+    )?;
+    let frontend = builder.add_project(
+        "frontend",
+        "../MyFrontend/MyFrontend.csproj",
+        None,
+    )?;
+    frontend.with_reference(serialize_handle(&basket), None, None, None)?;
+    frontend.with_reference(serialize_handle(&catalog), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 In the preceding example, the _frontend_ project references the _catalog_ project and the _basket_ project. The two `WithReference` calls instruct Aspire to:
@@ -212,6 +329,107 @@ const basket = await builder.addProject(
   '../BasketService/BasketService.csproj'
 );
 await basket.withHttpsEndpoint({ port: 9999, name: 'dashboard' });
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    basket = builder.add_project(
+        "basket", "../BasketService/BasketService.csproj"
+    )
+    basket.with_https_endpoint(port=9999, name="dashboard")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	basket := builder.
+		AddProject("basket", "../BasketService/BasketService.csproj").
+		WithHttpsEndpoint(&aspire.WithHttpsEndpointOptions{
+			Port: aspire.Float64Ptr(9999),
+			Name: aspire.StringPtr("dashboard"),
+		})
+	if err := basket.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var basket = builder.addProject(
+        "basket", "../BasketService/BasketService.csproj");
+    basket.withHttpsEndpoint(
+        new WithHttpsEndpointOptions().port(9999).name("dashboard"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let basket = builder.add_project(
+        "basket",
+        "../BasketService/BasketService.csproj",
+        None,
+    )?;
+    basket.with_https_endpoint(
+        Some(9999.0),
+        None,
+        Some("dashboard"),
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>
@@ -394,6 +612,99 @@ await frontend.withReference(api); // This is required!
 ```
 
 </Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    frontend = builder.add_project("frontend", "../Frontend/Frontend.csproj")
+    frontend.with_reference(api)
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.AddProject("api", "../Api/Api.csproj")
+	frontend := builder.
+		AddProject("frontend", "../Frontend/Frontend.csproj").
+		WithReference(api)
+	if err := frontend.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    var frontend = builder.addProject(
+        "frontend", "../Frontend/Frontend.csproj");
+    frontend.withReference(api);
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    let frontend = builder.add_project(
+        "frontend",
+        "../Frontend/Frontend.csproj",
+        None,
+    )?;
+    frontend.with_reference(serialize_handle(&api), None, None, None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
 </AppHostTabs>
 
 ### Named endpoint doesn't resolve
@@ -416,6 +727,100 @@ var api = builder.AddProject<Projects.Api>("api")
 ```typescript title="apphost.mts"
 const api = await builder.addProject('api', '../Api/Api.csproj');
 await api.withHttpEndpoint({ port: 9999, name: 'dashboard' }); // Name must match
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    api = builder.add_project("api", "../Api/Api.csproj")
+    api.with_http_endpoint(port=9999, name="dashboard")
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	api := builder.
+		AddProject("api", "../Api/Api.csproj").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			Port: aspire.Float64Ptr(9999),
+			Name: aspire.StringPtr("dashboard"),
+		})
+	if err := api.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main() throws Exception {
+    var builder = DistributedApplication.CreateBuilder();
+
+    var api = builder.addProject("api", "../Api/Api.csproj");
+    api.withHttpEndpoint(
+        new WithHttpEndpointOptions().port(9999).name("dashboard"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let api = builder.add_project("api", "../Api/Api.csproj", None)?;
+    api.with_http_endpoint(
+        Some(9999.0),
+        None,
+        Some("dashboard"),
+        None,
+        None,
+    )?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
 ```
 
 </Fragment>

--- a/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
+++ b/src/frontend/src/content/docs/get-started/add-aspire-existing-app.mdx
@@ -6,7 +6,7 @@ next: false
 
 import AppHostTabs from '@components/AppHostTabs.astro';
 
-import { Steps, TabItem, Tabs } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 import FileTree from 'starlight-plugin-icons/components/FileTree.astro';
 import { Kbd } from 'starlight-kbd/components';
 import LearnMore from '@components/LearnMore.astro';
@@ -592,10 +592,10 @@ Use this approach when Aspire already has a first-class resource type for the wo
 Common examples include Node.js apps, Vite frontends, Python workers, and Uvicorn-based APIs.
 
 <AppHostTabs limitations={{
-  python: 'This multi-workload sample has not yet been validated against the Python generated SDK. Add integrations one at a time and inspect apphost.py plus .aspire/modules after aspire restore.',
-  go: 'This multi-workload sample has not yet been validated against the Go generated SDK. Add integrations one at a time and check Err() after each fluent resource chain.',
-  java: 'This multi-workload sample has not yet been validated against the Java generated SDK. Add integrations one at a time and compile the generated surface with aspire run.',
-  rust: 'This multi-workload sample is not supported as canonical Rust guidance while Rust SDK validation has known non-blocking failures.',
+  python: 'The verified generated Python SDK does not emit add_redis, add_uvicorn_app, add_python_app, or add_vite_app, which this multi-workload sample requires.',
+  go: 'The verified generated Go SDK does not emit AddRedis, AddUvicornApp, AddPythonApp, or AddViteApp, which this multi-workload sample requires.',
+  java: 'The verified generated Java SDK does not emit addRedis, addUvicornApp, addPythonApp, or addViteApp, which this multi-workload sample requires.',
+  rust: 'The verified generated Rust SDK does not emit add_redis, add_uvicorn_app, add_python_app, or add_vite_app, which this multi-workload sample requires.',
 }}>
 <Fragment slot="csharp">
 
@@ -680,10 +680,10 @@ aspire add redis
 ```
 
 <AppHostTabs limitations={{
-  python: 'This container-topology sample has not yet been validated against the Python generated SDK.',
-  go: 'This container-topology sample has not yet been validated against the Go generated SDK.',
-  java: 'This container-topology sample has not yet been validated against the Java generated SDK.',
-  rust: 'This container-topology sample is not supported as canonical Rust guidance while Rust SDK validation has known non-blocking failures.',
+  python: 'The verified generated Python SDK does not emit add_postgres, add_database, or add_redis, which this container-topology sample requires.',
+  go: 'The verified generated Go SDK does not emit AddPostgres, AddDatabase, or AddRedis, which this container-topology sample requires.',
+  java: 'The verified generated Java SDK does not emit addPostgres, addDatabase, or addRedis, which this container-topology sample requires.',
+  rust: 'The verified generated Rust SDK does not emit add_postgres, add_database, or add_redis, which this container-topology sample requires.',
 }}>
 <Fragment slot="csharp">
 
@@ -746,8 +746,7 @@ Use this scenario when Docker Compose already captures the shape of your system.
 
 The goal is not a line-by-line translation of every field, but a clearer resource model of the same relationships.
 
-<Tabs>
-<TabItem label='Docker Compose'>
+#### Docker Compose source
 
 ```yaml title="docker-compose.yml" showLineNumbers
 services:
@@ -774,8 +773,15 @@ services:
       - api
 ```
 
-</TabItem>
-<TabItem label='C#'>
+#### AppHost model
+
+<AppHostTabs limitations={{
+  python: 'The verified generated Python SDK emits add_dockerfile, with_reference, and with_http_endpoint, but not the add_postgres or add_database integration methods this conversion requires.',
+  go: 'The verified generated Go SDK emits AddDockerfile, WithReference, and WithHttpEndpoint, but not the AddPostgres or AddDatabase integration methods this conversion requires.',
+  java: 'The verified generated Java SDK emits addDockerfile, withReference, and withHttpEndpoint, but not the addPostgres or addDatabase integration methods this conversion requires.',
+  rust: 'The verified generated Rust SDK emits add_dockerfile and with_http_endpoint, but not add_postgres or add_database; its with_reference parameter is also emitted as untyped JSON.',
+}}>
+<Fragment slot="csharp">
 
 ```csharp title="apphost.cs" showLineNumbers
 #:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
@@ -797,8 +803,8 @@ var web = builder.AddDockerfile("web", "./web")
 builder.Build().Run();
 ```
 
-</TabItem>
-<TabItem label='TypeScript'>
+</Fragment>
+<Fragment slot="typescript">
 
 ```typescript title="apphost.mts" showLineNumbers twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
@@ -820,8 +826,8 @@ await builder
 await builder.build().run();
 ```
 
-</TabItem>
-</Tabs>
+</Fragment>
+</AppHostTabs>
 
 These scenarios are starting points, not mutually exclusive modes. Most real apps mix workload-specific resources, containers, shared infrastructure, project-path references, and occasional custom commands in a single application model. The key is that dependencies, endpoints, configuration, and startup behavior become explicit.
 

--- a/src/frontend/src/content/docs/get-started/aspire-mcp-server.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-mcp-server.mdx
@@ -19,7 +19,8 @@ For most AI coding-agent workflows, install [Aspire skills](/get-started/aspire-
 :::
 
 <LearnMore>
-  To set up your project for AI coding agents, see [Use AI coding agents](/get-started/ai-coding-agents/).
+  To set up your project for AI coding agents, see [Use AI coding
+  agents](/get-started/ai-coding-agents/).
 </LearnMore>
 
 ## Configuration
@@ -44,6 +45,7 @@ When you select **Install Aspire MCP server**, the `aspire agent init` command c
       }
     }
     ```
+
   </TabItem>
   <TabItem label="Claude Code" id="claude">
     Creates or updates `.mcp.json`:
@@ -61,6 +63,7 @@ When you select **Install Aspire MCP server**, the `aspire agent init` command c
       }
     }
     ```
+
   </TabItem>
   <TabItem label="Copilot CLI" id="copilot-cli">
     Creates or updates `~/.copilot/mcp-config.json`:
@@ -79,6 +82,7 @@ When you select **Install Aspire MCP server**, the `aspire agent init` command c
       }
     }
     ```
+
   </TabItem>
   <TabItem label="OpenCode" id="opencode">
     Creates or updates `opencode.jsonc`:
@@ -98,6 +102,7 @@ When you select **Install Aspire MCP server**, the `aspire agent init` command c
       }
     }
     ```
+
   </TabItem>
 </Tabs>
 
@@ -105,23 +110,23 @@ When you select **Install Aspire MCP server**, the `aspire agent init` command c
 
 The Aspire MCP server provides the following tools to AI agents:
 
-| Tool | Description |
-|------|-------------|
-| `list_resources` | Lists all resources, including state, health status, source, endpoints, and commands |
-| `list_console_logs` | Lists console logs for a resource |
-| `list_structured_logs` | Lists structured logs, optionally filtered by resource name |
-| `list_traces` | Lists distributed traces, optionally filtered by resource name |
-| `list_trace_structured_logs` | Lists structured logs for a specific trace |
-| `execute_resource_command` | Executes a resource command (start, stop, restart) |
-| `list_apphosts` | Lists detected AppHost connections and their scope |
-| `select_apphost` | Selects which AppHost to use when multiple are running |
-| `list_integrations` | Lists available Aspire hosting integration packages |
-| `get_integration_docs` | Gets documentation for a specific integration package |
-| `list_docs` | Lists all available documentation pages from aspire.dev |
-| `search_docs` | Searches aspire.dev documentation using keyword-based search |
-| `get_doc` | Retrieves the full content of a documentation page by slug |
-| `doctor` | Diagnoses Aspire environment issues and verifies setup |
-| `refresh_tools` | Requests the server to re-emit its tool list for clients to re-fetch |
+| Tool                         | Description                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------ |
+| `list_resources`             | Lists all resources, including state, health status, source, endpoints, and commands |
+| `list_console_logs`          | Lists console logs for a resource                                                    |
+| `list_structured_logs`       | Lists structured logs, optionally filtered by resource name                          |
+| `list_traces`                | Lists distributed traces, optionally filtered by resource name                       |
+| `list_trace_structured_logs` | Lists structured logs for a specific trace                                           |
+| `execute_resource_command`   | Executes a resource command (start, stop, restart)                                   |
+| `list_apphosts`              | Lists detected AppHost connections and their scope                                   |
+| `select_apphost`             | Selects which AppHost to use when multiple are running                               |
+| `list_integrations`          | Lists available Aspire hosting integration packages                                  |
+| `get_integration_docs`       | Gets documentation for a specific integration package                                |
+| `list_docs`                  | Lists all available documentation pages from aspire.dev                              |
+| `search_docs`                | Searches aspire.dev documentation using keyword-based search                         |
+| `get_doc`                    | Retrieves the full content of a documentation page by slug                           |
+| `doctor`                     | Diagnoses Aspire environment issues and verifies setup                               |
+| `refresh_tools`              | Requests the server to re-emit its tool list for clients to re-fetch                 |
 
 ### Exclude resources from MCP
 
@@ -129,36 +134,122 @@ By default, all resources, console logs, and telemetry are accessible through th
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
-var apiservice = builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
+builder.AddProject<Projects.AspireApp_ApiService>("apiservice")
     .ExcludeFromMcp();
-
-builder.AddProject<Projects.AspireApp_Web>("webfrontend")
-    .WithExternalHttpEndpoints()
-    .WithReference(apiservice);
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const apiservice = await builder
-  .addProject("apiservice", "./api/ApiService.csproj")
-  .excludeFromMcp();
-
 await builder
-  .addProject("webfrontend", "./web/Web.csproj")
-  .withExternalHttpEndpoints()
-  .withReference(apiservice);
+  .addProject('apiservice', './api/ApiService.csproj')
+  .excludeFromMcp();
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_project(
+        "apiservice", "./api/ApiService.csproj"
+    ).exclude_from_mcp()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	apiservice := builder.
+		AddProject("apiservice", "./api/ApiService.csproj").
+		ExcludeFromMcp()
+	if err := apiservice.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder
+        .addProject("apiservice", "./api/ApiService.csproj")
+        .excludeFromMcp();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let apiservice = builder.add_project(
+        "apiservice",
+        "./api/ApiService.csproj",
+        None,
+    )?;
+    apiservice.exclude_from_mcp()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -176,7 +267,9 @@ The MCP server uses the **STDIO transport protocol** when started via `aspire ag
 - Only the parent process (your AI assistant) can communicate with the MCP server.
 
 <Aside type="tip">
-Because STDIO transport uses pipes rather than network sockets, there is no network attack surface. The MCP server is only accessible to the AI assistant process that started it.
+  Because STDIO transport uses pipes rather than network sockets, there is no
+  network attack surface. The MCP server is only accessible to the AI assistant
+  process that started it.
 </Aside>
 
 ### What data is accessible
@@ -188,7 +281,7 @@ The MCP server provides access to:
 - **Structured logs** — log entries via OpenTelemetry
 - **Distributed traces** — request flow across resources
 - **Integration catalog** — available hosting integration packages
-- **Product documentation** — Official LLMS.txt-based `aspire.dev` content 
+- **Product documentation** — Official LLMS.txt-based `aspire.dev` content
 
 The MCP server does **not** expose:
 
@@ -220,10 +313,9 @@ If your AppHost includes dev-only resources, use `ExecutionContext.IsRunMode` to
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
-
-var api = builder.AddProject<Projects.Api>("api");
 
 if (builder.ExecutionContext.IsRunMode)
 {
@@ -233,23 +325,124 @@ if (builder.ExecutionContext.IsRunMode)
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
-```typescript title="apphost.mts" twoslash
+
+```typescript title="apphost.mts"
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const api = await builder
-  .addProject("api", "./api/Api.csproj");
-
-if (await builder.executionContext.isRunMode()) {
-    // Only available during local development
-    await builder.addContainer("dev-tool", { image: "some-dev-image", tag: "latest" });
+if (await builder.executionContext().isRunMode()) {
+  // Only available during local development
+  await builder.addContainer('dev-tool', {
+    image: 'some-dev-image',
+    tag: 'latest',
+  });
 }
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    if builder.execution_context.is_run_mode:
+        # Only available during local development
+        builder.add_container("dev-tool", "some-dev-image:latest")
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	isRunMode, err := builder.ExecutionContext().IsRunMode()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if isRunMode {
+		// Only available during local development
+		devTool := builder.AddContainer("dev-tool", "some-dev-image:latest")
+		if err := devTool.Err(); err != nil {
+			log.Fatal(aspire.FormatError(err))
+		}
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    if (builder.executionContext().isRunMode()) {
+        // Only available during local development
+        builder.addContainer("dev-tool", "some-dev-image:latest");
+    }
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    if builder.execution_context()?.is_run_mode()? {
+        // Only available during local development
+        builder.add_container(
+            "dev-tool",
+            serde_json::json!("some-dev-image:latest"),
+        )?;
+    }
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
@@ -273,7 +466,9 @@ The MCP server automatically detects running AppHosts within the working directo
 - Use `select_apphost` to switch between multiple running AppHosts
 
 <Aside type="note">
-If your AI assistant doesn't detect your AppHost, verify it's running with `aspire start` and that the assistant was started from the same workspace directory.
+  If your AI assistant doesn't detect your AppHost, verify it's running with
+  `aspire start` and that the assistant was started from the same workspace
+  directory.
 </Aside>
 
 ### If your agent can't connect

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -4,9 +4,10 @@ description: Learn how the Aspire SDK simplifies orchestrating Aspire applicatio
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 
-The Aspire SDK is intended for [AppHost projects](/get-started/app-host/), which serve as the orchestrator for Aspire applications. These projects are designated by their usage of the `Aspire.AppHost.Sdk` in the project file. The SDK provides features that simplify the development of Aspire apps.
+The `Aspire.AppHost.Sdk` is the SDK for C# [AppHost projects](/get-started/app-host/), which serve as the orchestrator for Aspire applications. C# AppHosts are designated by their usage of the SDK in a project file or file-based app directive. TypeScript, Python, Go, Java, and Rust AppHosts instead use generated SDKs managed by the Aspire CLI.
 
 The [📦 Aspire.AppHost.Sdk](https://www.nuget.org/packages/Aspire.AppHost.Sdk) is used for building Aspire apps.
 
@@ -34,6 +35,17 @@ The `Aspire.AppHost.Sdk` is defined in the top-level `Project` node's `Sdk` attr
 
 The `Aspire.AppHost.Sdk` is defined in a file-based app's source file using the `#:sdk` directive:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'TypeScript AppHosts use the generated SDK in .aspire/modules and do not support the C# #:sdk directive.',
+    python: 'Python AppHosts use the generated SDK in .aspire/modules and do not support the C# #:sdk directive.',
+    go: 'Go AppHosts use the generated SDK in .aspire/modules and do not support the C# #:sdk directive.',
+    java: 'Java AppHosts use the generated SDK in .aspire/modules and do not support the C# #:sdk directive.',
+    rust: 'Rust AppHosts use the generated SDK in .aspire/modules and do not support the C# #:sdk directive.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title='file-based app' {1}
 #:sdk Aspire.AppHost.Sdk@%ASPIRE_VERSION%
 
@@ -41,6 +53,9 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Omitted for brevity
 ```
+
+</Fragment>
+</AppHostTabs>
 
 </TabItem>
 
@@ -67,7 +82,8 @@ Otherwise, by default, the `ProjectReference` is treated as Aspire project resou
 :::
 
 <LearnMore>
-For the end-to-end `AddProject` workflow, see [Project resources](/integrations/dotnet/project-resources/).
+  For the end-to-end `AddProject` workflow, see [Project
+  resources](/integrations/dotnet/project-resources/).
 </LearnMore>
 
 #### Customizing generated project names
@@ -87,10 +103,24 @@ For example, if you have two microservices with the same project name (like `Pre
 
 This generates `Projects.MicroService1` and `Projects.MicroService2` classes, allowing you to reference each project distinctly in your AppHost:
 
+<AppHostTabs
+  limitations={{
+    typescript: 'The generated TypeScript AppHost SDK uses project paths with addProject and does not emit C# Projects metadata types.',
+    python: 'The generated Python AppHost SDK uses project paths with add_project and does not emit C# Projects metadata types.',
+    go: 'The generated Go AppHost SDK uses project paths with AddProject and does not emit C# Projects metadata types.',
+    java: 'The generated Java AppHost SDK uses project paths with addProject and does not emit C# Projects metadata types.',
+    rust: 'The generated Rust AppHost SDK uses project paths with add_project and does not emit C# Projects metadata types.',
+  }}
+>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var microservice1 = builder.AddProject<Projects.MicroService1>("micro1");
 var microservice2 = builder.AddProject<Projects.MicroService2>("micro2");
 ```
+
+</Fragment>
+</AppHostTabs>
 
 ### Orchestrator dependencies
 
@@ -147,6 +177,7 @@ Most apps don't need to set either path. `AspireCliPath` selects an explicit `as
   <!-- <AspireCliBundlePath>/path/to/aspire/bundle</AspireCliBundlePath> -->
 </PropertyGroup>
 ```
+
 :::
 
 #### Running with aspire run or aspire start

--- a/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
+++ b/src/frontend/src/content/docs/get-started/aspire-sdk.mdx
@@ -161,9 +161,21 @@ Set `AspireUseCliBundle` in your AppHost `.csproj`:
 
 For an existing single-file AppHost, set the equivalent `#:property` directive:
 
+<AppHostTabs limitations={{
+  typescript: 'AspireUseCliBundle is an MSBuild property for C# AppHosts; generated TypeScript AppHosts use the Aspire CLI bundle directly.',
+  python: 'AspireUseCliBundle is an MSBuild property for C# AppHosts; generated Python AppHosts use the Aspire CLI bundle directly.',
+  go: 'AspireUseCliBundle is an MSBuild property for C# AppHosts; generated Go AppHosts use the Aspire CLI bundle directly.',
+  java: 'AspireUseCliBundle is an MSBuild property for C# AppHosts; generated Java AppHosts use the Aspire CLI bundle directly.',
+  rust: 'AspireUseCliBundle is an MSBuild property for C# AppHosts; generated Rust AppHosts use the Aspire CLI bundle directly.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="apphost.cs"
 #:property AspireUseCliBundle=true
 ```
+
+</Fragment>
+</AppHostTabs>
 
 :::note[Advanced scenario: Override the bundle path]
 Most apps don't need to set either path. `AspireCliPath` selects an explicit `aspire` executable for invocation and bundle discovery. `AspireCliBundlePath` supplies an explicit unpacked bundle layout for DCP and Dashboard resolution, but it doesn't select the executable used to launch the AppHost:

--- a/src/frontend/src/content/docs/get-started/resource-mcp-servers.mdx
+++ b/src/frontend/src/content/docs/get-started/resource-mcp-servers.mdx
@@ -6,9 +6,8 @@ description: Expose MCP tools from Aspire resources and interact with them using
 
 import AppHostTabs from '@components/AppHostTabs.astro';
 
-import { Aside, Code, Steps } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
 import ContainerImages from '@components/ContainerImages.astro';
-import LearnMore from '@components/LearnMore.astro';
 
 Aspire resources can expose their own <abbr title="Model Context Protocol" data-tooltip-placement="top">MCP</abbr> (Model Context Protocol) servers, enabling AI coding agents to interact directly with databases, APIs, and other services. For example, a PostgreSQL resource can expose SQL query tools, allowing an agent to run queries without leaving the conversation.
 
@@ -23,10 +22,19 @@ When a resource is annotated with `WithMcpServer()` in the AppHost, Aspire disco
 
 Use the `WithMcpServer()` extension method to declare that a resource hosts an MCP server:
 
-<AppHostTabs>
+<AppHostTabs
+  limitations={{
+    python: 'The verified generated Python SDK does not emit the PostgreSQL integration methods used by this example: add_postgres, add_database, and with_postgres_mcp.',
+    go: 'The verified generated Go SDK does not emit the PostgreSQL integration methods used by this example: AddPostgres, AddDatabase, and WithPostgresMcp.',
+    java: 'The verified generated Java SDK does not emit the PostgreSQL integration methods used by this example: addPostgres, addDatabase, and withPostgresMcp.',
+    rust: 'The verified generated Rust SDK does not emit the PostgreSQL integration methods used by this example: add_postgres, add_database, and with_postgres_mcp.',
+  }}
+>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREMCP001
+#pragma warning disable ASPIREPOSTGRES001
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -38,27 +46,29 @@ db.WithPostgresMcp();
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
 const builder = await createBuilder();
 
-const db = await builder
-  .addPostgres("db")
-  .addDatabase("appdata");
+const db = await builder.addPostgres('db').addDatabase('appdata');
 
 // Expose PostgreSQL MCP tools (SQL queries, schema inspection, etc.)
 await db.withPostgresMcp();
 
 await builder.build().run();
 ```
+
 </Fragment>
 </AppHostTabs>
 
 <Aside type="note">
-`WithMcpServer()` and `WithPostgresMcp()` are experimental APIs. Suppress the `ASPIREMCP001` or `ASPIREPOSTGRES001` diagnostic to use them.
+  `WithMcpServer()` and `WithPostgresMcp()` are experimental APIs. Suppress the
+  `ASPIREMCP001` or `ASPIREPOSTGRES001` diagnostic to use them.
 </Aside>
 
 <ContainerImages package="Aspire.Hosting.PostgreSQL" only="Postgres MCP" />
@@ -97,6 +107,7 @@ You can add any container that implements the MCP protocol as an MCP-enabled res
 
 <AppHostTabs>
 <Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 #pragma warning disable ASPIREMCP001
 
@@ -109,8 +120,10 @@ var myMcpServer = builder.AddContainer("my-mcp", "myregistry/my-mcp-server")
 
 builder.Build().Run();
 ```
+
 </Fragment>
 <Fragment slot="typescript">
+
 ```typescript title="apphost.mts" twoslash
 import { createBuilder } from './.aspire/modules/aspire.mjs';
 
@@ -118,20 +131,127 @@ const builder = await createBuilder();
 
 // Add a custom MCP server container
 const myMcpServer = await builder
-  .addContainer("my-mcp", { image: "myregistry/my-mcp-server", tag: "latest" })
+  .addContainer('my-mcp', { image: 'myregistry/my-mcp-server', tag: 'latest' })
   .withHttpEndpoint({ targetPort: 8080 })
-  .withMcpServer("/mcp");
+  .withMcpServer({ path: '/mcp' });
 
 await builder.build().run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    my_mcp_server = (
+        builder.add_container("my-mcp", "myregistry/my-mcp-server:latest")
+        .with_http_endpoint(target_port=8080)
+        .with_mcp_server(path="/mcp")
+    )
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	myMcpServer := builder.
+		AddContainer("my-mcp", "myregistry/my-mcp-server:latest").
+		WithHttpEndpoint(&aspire.WithHttpEndpointOptions{
+			TargetPort: aspire.Float64Ptr(8080),
+		}).
+		WithMcpServer(&aspire.WithMcpServerOptions{
+			Path: aspire.StringPtr("/mcp"),
+		})
+	if err := myMcpServer.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    var myMcpServer = builder
+        .addContainer("my-mcp", "myregistry/my-mcp-server:latest");
+    myMcpServer
+        .withHttpEndpoint(new WithHttpEndpointOptions().targetPort(8080))
+        .withMcpServer(new WithMcpServerOptions().path("/mcp"));
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    let my_mcp_server = builder.add_container(
+        "my-mcp",
+        serde_json::json!("myregistry/my-mcp-server:latest"),
+    )?;
+    let my_mcp_server = my_mcp_server.with_http_endpoint(
+        None,
+        Some(8080.0),
+        None,
+        None,
+        None,
+    )?;
+    my_mcp_server.with_mcp_server(Some("/mcp"), None)?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
 </Fragment>
 </AppHostTabs>
 
-The `WithMcpServer()` method accepts an optional path and endpoint name:
+The MCP server annotation accepts an optional path and endpoint name:
 
-- `WithMcpServer()` — uses the default HTTP endpoint at the root path
-- `WithMcpServer("/mcp")` — uses the default HTTP endpoint at `/mcp`
-- `WithMcpServer("/sse", endpointName: "https")` — uses a named endpoint at `/sse`
+- Omit both options to use the default HTTP endpoint and path.
+- Set the path to `/mcp` to expose that route on the default HTTP endpoint.
+- Set the path to `/sse` and the endpoint name to `https` to expose that route on the named HTTPS endpoint.
 
 ## See also
 
@@ -139,4 +259,3 @@ The `WithMcpServer()` method accepts an optional path and endpoint name:
 - [Aspire MCP server](/get-started/aspire-mcp-server/) — the built-in MCP server tools
 - [ASPIREMCP001 diagnostic](/diagnostics/aspiremcp001/) — experimental MCP server API warning
 - [ASPIREPOSTGRES001 diagnostic](/diagnostics/aspirepostgres001/) — experimental PostgreSQL MCP warning
-

--- a/src/frontend/src/content/docs/get-started/troubleshooting.mdx
+++ b/src/frontend/src/content/docs/get-started/troubleshooting.mdx
@@ -5,6 +5,7 @@ description: Solutions to common problems when getting started with Aspire — D
 
 import { Aside, Code, Steps } from '@astrojs/starlight/components';
 import { Kbd } from 'starlight-kbd/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 import OsAwareTabs from '@components/OsAwareTabs.astro';
 
@@ -72,13 +73,93 @@ Having issues getting started with Aspire? This page covers solutions to the mos
 
 **Symptoms**: Your frontend can't connect to the API, showing connection refused errors.
 
-**Solution**: Make sure you're using `WaitFor()` in your AppHost:
+**Solution**: Make sure you're using the generated wait-for API in your AppHost:
+
+<AppHostTabs>
+<Fragment slot="csharp">
 
 ```csharp title="AppHost.cs"
 builder.AddProject<Projects.WebFrontend>("frontend")
     .WithReference(apiService)
     .WaitFor(apiService);  // Add this line!
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+const apiService = await builder.addProject(
+  'api',
+  '../Api/Api.csproj'
+);
+const frontend = await builder.addProject(
+  'frontend',
+  '../WebFrontend/WebFrontend.csproj'
+);
+await frontend.withReference(apiService);
+await frontend.waitFor(apiService); // Add this line!
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+frontend = builder.add_project(
+    "frontend", "../WebFrontend/WebFrontend.csproj"
+)
+frontend.with_reference(api_service)
+frontend.wait_for(api_service)  # Add this line!
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+frontend := builder.
+	AddProject("frontend", "../WebFrontend/WebFrontend.csproj").
+	WithReference(apiService).
+	WaitFor(apiService) // Add this call!
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var frontend = builder.addProject(
+    "frontend", "../WebFrontend/WebFrontend.csproj");
+frontend.withReference(apiService);
+frontend.waitFor(apiService); // Add this call!
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let frontend = builder.add_project(
+    "frontend",
+    "../WebFrontend/WebFrontend.csproj",
+    None,
+)?;
+frontend.with_reference(
+    serialize_handle(&api_service),
+    None,
+    None,
+    None,
+)?;
+let api_resource = IResource::new(
+    api_service.handle().clone(),
+    api_service.client().clone(),
+);
+frontend.wait_for(&api_resource, None)?; // Add this call!
+```
+
+</Fragment>
+</AppHostTabs>
 
 ## Environment variables not available
 
@@ -90,11 +171,23 @@ builder.AddProject<Projects.WebFrontend>("frontend")
 
 In your AppHost:
 
+<AppHostTabs limitations={{
+  typescript: 'The generated TypeScript SDK used for this core guide does not include the PostgreSQL integration methods in this example.',
+  python: 'The generated Python SDK used for this core guide does not include the PostgreSQL integration methods in this example.',
+  go: 'The generated Go SDK used for this core guide does not include the PostgreSQL integration methods in this example.',
+  java: 'The generated Java SDK used for this core guide does not include the PostgreSQL integration methods in this example.',
+  rust: 'The generated Rust SDK used for this core guide does not include the PostgreSQL integration methods in this example.',
+}}>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var db = builder.AddPostgres("db");
 var api = builder.AddProject<Projects.Api>("api")
     .WithReference(db);  // This injects the connection string
 ```
+
+</Fragment>
+</AppHostTabs>
 
 In your service code, access the connection string via configuration:
 
@@ -147,10 +240,63 @@ docker pull redis:latest
 
 ### Example: Correct service discovery setup
 
+<AppHostTabs>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 // In AppHost
 var api = builder.AddProject<Projects.Api>("apiservice");  // Name is "apiservice"
 ```
+
+</Fragment>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+const api = await builder.addProject(
+  'apiservice',
+  '../Api/Api.csproj'
+);
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+api = builder.add_project("apiservice", "../Api/Api.csproj")
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+api := builder.AddProject("apiservice", "../Api/Api.csproj")
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+var api = builder.addProject("apiservice", "../Api/Api.csproj");
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+let api = builder.add_project(
+    "apiservice",
+    "../Api/Api.csproj",
+    None,
+)?;
+```
+
+</Fragment>
+</AppHostTabs>
 
 ```csharp title="Program.cs"
 // In your consuming service, use exactly this name

--- a/src/frontend/src/content/docs/testing/advanced-scenarios.mdx
+++ b/src/frontend/src/content/docs/testing/advanced-scenarios.mdx
@@ -5,6 +5,7 @@ description: Advanced patterns for DistributedApplicationTestingBuilder — sele
 ---
 
 import { Aside } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import LearnMore from '@components/LearnMore.astro';
 
 This article covers advanced patterns for testing Aspire applications, including selectively disabling resources during tests, overriding environment variables, and customizing the AppHost for specific test scenarios.
@@ -19,6 +20,27 @@ The recommended way to make a resource optional is to use `WithExplicitStart` in
 
 In your AppHost, mark the resource as explicitly started:
 
+<AppHostTabs>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+await builder.addProject('api', '../Api/Api.csproj');
+
+// This resource is optional and won't start automatically
+await builder
+  .addContainer('monitoring', { image: 'grafana/grafana' })
+  .withExplicitStart();
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -30,6 +52,107 @@ builder.AddContainer("monitoring", "grafana/grafana")
 
 builder.Build().Run();
 ```
+
+</Fragment>
+<Fragment slot="python">
+
+```python title="apphost.py"
+from aspire_app import create_builder
+
+with create_builder() as builder:
+    builder.add_project("api", "../Api/Api.csproj")
+
+    # This resource is optional and won't start automatically
+    monitoring = builder.add_container("monitoring", "grafana/grafana")
+    monitoring.with_explicit_start()
+
+    builder.run()
+```
+
+</Fragment>
+<Fragment slot="go">
+
+```go title="apphost.go"
+package main
+
+import (
+	"log"
+
+	"apphost/modules/aspire"
+)
+
+func main() {
+	builder, err := aspire.CreateBuilder()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	builder.AddProject("api", "../Api/Api.csproj")
+
+	// This resource is optional and won't start automatically
+	monitoring := builder.
+		AddContainer("monitoring", "grafana/grafana").
+		WithExplicitStart()
+	if err := monitoring.Err(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+
+	app, err := builder.Build()
+	if err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+	if err := app.Run(); err != nil {
+		log.Fatal(aspire.FormatError(err))
+	}
+}
+```
+
+</Fragment>
+<Fragment slot="java">
+
+```java title="AppHost.java"
+import aspire.*;
+
+void main(String[] args) throws Exception {
+    var builder = DistributedApplication.CreateBuilder(args);
+
+    builder.addProject("api", "../Api/Api.csproj");
+
+    // This resource is optional and won't start automatically
+    var monitoring = builder.addContainer("monitoring", "grafana/grafana");
+    monitoring.withExplicitStart();
+
+    builder.build().run();
+}
+```
+
+</Fragment>
+<Fragment slot="rust">
+
+```rust title="apphost.rs"
+#[path = ".aspire/modules/mod.rs"]
+mod aspire;
+
+use aspire::*;
+use serde_json::json;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let builder = create_builder(None)?;
+
+    builder.add_project("api", "../Api/Api.csproj", None)?;
+
+    // This resource is optional and won't start automatically
+    let monitoring = builder.add_container("monitoring", json!("grafana/grafana"))?;
+    monitoring.with_explicit_start()?;
+
+    let app = builder.build()?;
+    app.run(None)?;
+    Ok(())
+}
+```
+
+</Fragment>
+</AppHostTabs>
 
 In your test, you can start the resource manually if needed, or leave it stopped:
 
@@ -57,6 +180,36 @@ public async Task ApiWorksWithoutMonitoring()
 
 Another approach is to use configuration in your AppHost to conditionally add resources. This gives tests control over which resources are included:
 
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the PostgreSQL integration APIs used in this example.',
+  go: 'The verified Go SDK does not include the PostgreSQL integration APIs used in this example.',
+  java: 'The verified Java SDK does not include the PostgreSQL integration APIs used in this example.',
+  rust: 'The verified Rust SDK does not include the PostgreSQL integration APIs used in this example.',
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const api = await builder.addProject('api', '../Api/Api.csproj');
+
+// Only add the database resource if not explicitly disabled
+const addDatabase =
+  (await builder.getConfiguration().getConfigValue('AddDatabase')) !== 'false';
+if (addDatabase) {
+  const postgres = await builder.addPostgres('postgres');
+  const db = await postgres.addDatabase('mydb');
+  await api.withReference(db);
+}
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
 ```csharp title="AppHost.cs"
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -71,6 +224,9 @@ if (builder.Configuration.GetValue("AddDatabase", true))
 
 builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 In tests, pass the configuration argument to skip the database:
 

--- a/src/frontend/src/content/docs/testing/manage-app-host.mdx
+++ b/src/frontend/src/content/docs/testing/manage-app-host.mdx
@@ -5,6 +5,7 @@ description: Manage the Aspire AppHost lifecycle in your tests — start, dispos
 ---
 
 import { Aside, Steps } from '@astrojs/starlight/components';
+import AppHostTabs from '@components/AppHostTabs.astro';
 import PivotSelector from '@components/PivotSelector.astro';
 import Pivot from '@components/Pivot.astro';
 
@@ -141,13 +142,46 @@ Other arguments can be passed to your AppHost `Program` and made available in yo
 
 In the AppHost `Program`, you use configuration to support enabling or disabling volumes:
 
-```csharp
+<AppHostTabs limitations={{
+  python: 'The verified Python SDK does not include the PostgreSQL integration APIs used in this example.',
+  go: 'The verified Go SDK does not include the PostgreSQL integration APIs used in this example.',
+  java: 'The verified Java SDK does not include the PostgreSQL integration APIs used in this example.',
+  rust: 'The verified Rust SDK does not include the PostgreSQL integration APIs used in this example.',
+}}>
+<Fragment slot="typescript">
+
+```typescript title="apphost.mts" twoslash
+import { createBuilder } from './.aspire/modules/aspire.mjs';
+
+const builder = await createBuilder();
+
+const postgres = await builder.addPostgres('postgres1');
+const useVolumes =
+  (await builder.getConfiguration().getConfigValue('UseVolumes')) !== 'false';
+if (useVolumes) {
+  await postgres.withDataVolume();
+}
+
+await builder.build().run();
+```
+
+</Fragment>
+<Fragment slot="csharp">
+
+```csharp title="AppHost.cs"
+var builder = DistributedApplication.CreateBuilder(args);
+
 var postgres = builder.AddPostgres("postgres1");
 if (builder.Configuration.GetValue("UseVolumes", true))
 {
     postgres.WithDataVolume();
 }
+
+builder.Build().Run();
 ```
+
+</Fragment>
+</AppHostTabs>
 
 In test code, you pass `"UseVolumes=false"` in the `args` to the AppHost:
 

--- a/src/frontend/src/content/docs/testing/write-your-first-test.mdx
+++ b/src/frontend/src/content/docs/testing/write-your-first-test.mdx
@@ -105,7 +105,7 @@ Finally, you can uncomment out the `IntegrationTest1.cs` file in the test projec
 
 ## Explore the test project
 
-The following example test project was created as part of the **Blazor & Minimal API starter** template. If you're unfamiliar with it, see [Build your first app—C#](/get-started/first-app/?lang=csharp). The Aspire test project takes a project reference dependency on the target AppHost. Consider the template project:
+The following example test project was created as part of the **Blazor & Minimal API starter** template. If you're unfamiliar with it, see [Build your first app—C#](/get-started/first-app/?aspire-lang=csharp). The Aspire test project takes a project reference dependency on the target AppHost. Consider the template project:
 
 <Pivot id="xunit">
 

--- a/src/frontend/tests/e2e/diagnostics-language.spec.ts
+++ b/src/frontend/tests/e2e/diagnostics-language.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test, type Page } from '@playwright/test';
+import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
+import languageConfig from '../../src/data/apphost-languages.json' with { type: 'json' };
+
+const enabledLanguages = languageConfig.languages.filter(({ enabled }) => enabled);
+type Language = (typeof enabledLanguages)[number];
+
+function languageAccessibleName(language: Language) {
+  const label = language.label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${label}${language.experimental ? '(?:\\s*Experimental)?' : ''}$`, 'i');
+}
+
+async function expectDiagnosticsLanguage(page: Page, language: Language) {
+  const groups = page.locator('[data-apphost-tabs]');
+  await expect(groups.first()).toBeVisible();
+  for (const group of await groups.all()) {
+    const supportedIds = await group.evaluate((element) =>
+      element
+        .getAttributeNames()
+        .filter((name) => name.startsWith('data-supports-'))
+        .map((name) => name.slice('data-supports-'.length))
+    );
+    const supported = enabledLanguages.filter(({ id }) => supportedIds.includes(id));
+    await expect(group.getByRole('tab', { includeHidden: true })).toHaveText(
+      supported.map(({ label }) => label)
+    );
+    if (!supportedIds.includes(language.id)) {
+      await expect(group.locator('.apphost-tabs__tabs')).toBeHidden();
+      await expect(group.locator(`[data-apphost-limitation="${language.id}"]`)).toBeVisible();
+      await expect(group.getByRole('tabpanel')).toHaveCount(0);
+      continue;
+    }
+    for (const candidate of supported) {
+      await expect(
+        group.getByRole('tab', { name: languageAccessibleName(candidate) })
+      ).toHaveAttribute('aria-selected', String(candidate.id === language.id));
+    }
+    await expect(group.getByRole('tabpanel')).toHaveCount(1);
+    await expect(
+      group.getByRole('tabpanel', { name: languageAccessibleName(language) })
+    ).toBeVisible();
+  }
+}
+
+const typescript = enabledLanguages.find(({ id }) => id === 'typescript')!;
+const csharp = enabledLanguages.find(({ id }) => id === 'csharp')!;
+
+test('diagnostics render typed AppHost examples and file-based suppression guidance', async ({
+  page,
+}) => {
+  await page.goto('/diagnostics/aspire006/?aspire-lang=typescript');
+  await dismissCookieConsentIfVisible(page);
+  await expectDiagnosticsLanguage(page, typescript);
+  const panel = page
+    .locator('starlight-tabs[data-sync-key="aspire-lang"]')
+    .getByRole('tabpanel', { name: typescript.label, exact: true });
+  const hover = panel.locator('.twoslash-hover').first();
+  await hover.hover();
+  await expect(panel.getByRole('tooltip')).toBeVisible();
+  await expect(panel.getByRole('tooltip')).toContainText('createBuilder');
+
+  await page.goto('/diagnostics/overview/#suppress-in-a-file-based-apphost');
+  await expect(
+    page.getByRole('heading', { name: 'Suppress in a file-based AppHost', exact: true })
+  ).toBeVisible();
+  await expect(
+    page.locator('pre').filter({ hasText: '#:property NoWarn=$(NoWarn);ASPIREE000' })
+  ).toBeVisible();
+});
+
+test('diagnostics ignore an invalid aspire-lang query and restore the saved language', async ({
+  page,
+}) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('aspire-lang', 'csharp');
+    localStorage.setItem('starlight-synced-tabs__aspire-lang', 'C#');
+  });
+  await page.goto('/diagnostics/aspireprobes001/?aspire-lang=unknown');
+  await dismissCookieConsentIfVisible(page);
+  await expectDiagnosticsLanguage(page, csharp);
+});
+
+test('diagnostics AppHost tabs default to TypeScript and synchronize keyboard selection', async ({
+  page,
+}) => {
+  await page.goto('/diagnostics/aspireprobes001/');
+  await dismissCookieConsentIfVisible(page);
+  const groups = page.locator('starlight-tabs[data-sync-key="aspire-lang"]');
+  expect(await groups.count()).toBeGreaterThan(1);
+  await expectDiagnosticsLanguage(page, typescript);
+
+  await groups.first().getByRole('tab', { name: typescript.label, exact: true }).focus();
+  await page.keyboard.press('ArrowRight');
+  await expectDiagnosticsLanguage(page, csharp);
+  await expect(page).toHaveURL(/aspire-lang=csharp/);
+});
+
+for (const language of languageConfig.languages.filter(({ enabled }) => !enabled)) {
+  test(`diagnostics do not expose disabled ${language.label} examples`, async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('aspire-lang', 'csharp');
+      localStorage.setItem('starlight-synced-tabs__aspire-lang', 'C#');
+    });
+    await page.goto(`/diagnostics/aspireprobes001/?aspire-lang=${language.id}`);
+    await dismissCookieConsentIfVisible(page);
+    await expectDiagnosticsLanguage(page, typescript);
+    await expect(page).toHaveURL(/aspire-lang=typescript/);
+    await expect(page.getByRole('tab', { name: language.label, exact: true })).toHaveCount(0);
+  });
+}
+
+for (const language of enabledLanguages) {
+  const { id: value, label } = language;
+  const opposite = enabledLanguages.find(({ id }) => id !== value)!;
+  test(`diagnostics URL selects ${label} over the saved preference`, async ({ page }) => {
+    await page.addInitScript(({ id, label }) => {
+      localStorage.setItem('aspire-lang', id);
+      localStorage.setItem('starlight-synced-tabs__aspire-lang', label);
+    }, opposite);
+
+    await page.goto(`/diagnostics/aspireprobes001/?aspire-lang=${value}`);
+    await dismissCookieConsentIfVisible(page);
+    await expectDiagnosticsLanguage(page, language);
+    await expect.poll(() => page.evaluate(() => localStorage.getItem('aspire-lang'))).toBe(value);
+    await page.reload();
+    await expectDiagnosticsLanguage(page, language);
+  });
+
+  test(`diagnostics persist ${label} across pages and reloads`, async ({ page }) => {
+    await page.goto(`/diagnostics/aspirepostgres001/?aspire-lang=${opposite.id}`);
+    await dismissCookieConsentIfVisible(page);
+    const tab = page
+      .locator('starlight-tabs[data-sync-key="aspire-lang"]')
+      .first()
+      .getByRole('tab', { name: languageAccessibleName(language) });
+    if (await tab.count()) {
+      await tab.click();
+    } else {
+      await page.goto(`/diagnostics/aspirepostgres001/?aspire-lang=${value}`);
+    }
+    await expectDiagnosticsLanguage(page, language);
+    await expect(page).toHaveURL(new RegExp(`aspire-lang=${value}`));
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('starlight-synced-tabs__aspire-lang')))
+      .toBe(label);
+
+    await page
+      .locator('a[href="/diagnostics/overview/#suppress-in-a-file-based-apphost"]')
+      .first()
+      .click();
+    await expect(
+      page.getByRole('heading', { name: 'Suppress in a file-based AppHost', exact: true })
+    ).toBeVisible();
+    // Navigate without a query to exercise persistence independently of link rewriting.
+    await page.goto('/diagnostics/aspireprobes001/');
+    await expect(page).toHaveURL(/\/diagnostics\/aspireprobes001\//);
+    await expectDiagnosticsLanguage(page, language);
+    await page.reload();
+    await expectDiagnosticsLanguage(page, language);
+  });
+}

--- a/src/frontend/tests/unit/apphost-language-coverage.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-language-coverage.vitest.test.ts
@@ -1,0 +1,262 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createProcessor } from '@mdx-js/mdx';
+import { expect, test } from 'vitest';
+
+import {
+  appHostLanguageConfig,
+  getEnabledAppHostLanguages,
+} from '../../src/utils/apphost-languages';
+
+interface MdxNode {
+  type?: string;
+  name?: string;
+  value?: string;
+  lang?: string;
+  meta?: string;
+  attributes?: MdxAttribute[];
+  children?: MdxNode[];
+  position?: {
+    start?: {
+      line?: number;
+    };
+  };
+}
+
+interface MdxAttribute {
+  type?: string;
+  name?: string;
+  value?: string | {
+    data?: {
+      estree?: {
+        body?: Array<{
+          expression?: {
+            type?: string;
+            properties?: Array<{
+              type?: string;
+              key?: { type?: string; name?: string; value?: unknown };
+            }>;
+          };
+        }>;
+      };
+    };
+  };
+}
+
+const testDirectory = path.dirname(fileURLToPath(import.meta.url));
+const docsDirectory = path.resolve(testDirectory, '..', '..', 'src', 'content', 'docs');
+const parser = createProcessor();
+const excludedTopLevel = new Set([
+  'da',
+  'de',
+  'es',
+  'fr',
+  'hi',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'pt-br',
+  'ru',
+  'tr',
+  'uk',
+  'whats-new',
+  'zh-cn',
+]);
+const specializedParityTopLevel = new Set(['diagnostics', 'integrations']);
+const standaloneAppHostExamplePages = new Set([
+  'app-host/go-apphost.mdx',
+  'app-host/java-apphost.mdx',
+  'app-host/python-apphost.mdx',
+  'app-host/rust-apphost.mdx',
+  'app-host/typescript-apphost.mdx',
+  'community/contributor-guide.mdx',
+]);
+const appHostBuilderPattern =
+  /\b(?:DistributedApplication\.(?:CreateBuilder|createBuilder)|aspire\.CreateBuilder|createBuilder|create_builder)\s*\(/;
+const appHostEntryPointPattern = /\bapphost\.(?:cs|go|java|mts|py|rs|ts)\b/i;
+
+function getStringAttribute(node: MdxNode, name: string): string | undefined {
+  const attribute = node.attributes?.find(
+    (candidate) => candidate.type === 'mdxJsxAttribute' && candidate.name === name
+  );
+  return typeof attribute?.value === 'string' ? attribute.value : undefined;
+}
+
+function getLimitationIds(node: MdxNode): Set<string> {
+  const attribute = node.attributes?.find(
+    (candidate) =>
+      candidate.type === 'mdxJsxAttribute' && candidate.name === 'limitations'
+  );
+  if (!attribute || typeof attribute.value === 'string') {
+    return new Set();
+  }
+
+  const expression = attribute.value?.data?.estree?.body?.[0]?.expression;
+  if (expression?.type !== 'ObjectExpression') {
+    return new Set();
+  }
+
+  return new Set(
+    (expression.properties ?? [])
+      .filter((property) => property.type === 'Property')
+      .map((property) =>
+        property.key?.type === 'Identifier'
+          ? property.key.name
+          : property.key?.type === 'Literal'
+            ? property.key.value
+            : undefined
+      )
+      .filter((value): value is string => typeof value === 'string')
+  );
+}
+
+function getActiveEnglishDocs(): string[] {
+  const files: string[] = [];
+
+  function visit(directory: string): void {
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      if (
+        entry.isDirectory() &&
+        directory === docsDirectory &&
+        excludedTopLevel.has(entry.name.toLowerCase())
+      ) {
+        continue;
+      }
+
+      const resolved = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(resolved);
+      } else if (entry.isFile() && entry.name.endsWith('.mdx')) {
+        files.push(resolved);
+      }
+    }
+  }
+
+  visit(docsDirectory);
+  return files;
+}
+
+function inspectNode(
+  node: MdxNode,
+  requiredLanguages: readonly string[],
+  relativePath: string,
+  violations: string[],
+  state: { selector: boolean; pivots: Set<string> },
+  insideLanguageComponent = false
+): void {
+  const isLanguageComponent =
+    node.type === 'mdxJsxFlowElement' &&
+    (node.name === 'AppHostTabs' || node.name === 'AppHostLanguagePivot');
+  const languageComponentAncestor = insideLanguageComponent || isLanguageComponent;
+
+  if (node.type === 'mdxJsxFlowElement' && node.name === 'AppHostTabs') {
+    const slots = new Set(
+      (node.children ?? [])
+        .filter(
+          (child) =>
+            child.type === 'mdxJsxFlowElement' &&
+            child.name === 'Fragment'
+        )
+        .map((child) => getStringAttribute(child, 'slot'))
+        .filter((value): value is string => Boolean(value))
+    );
+    const limitations = getLimitationIds(node);
+
+    for (const language of requiredLanguages) {
+      if (!slots.has(language) && !limitations.has(language)) {
+        violations.push(
+          `${relativePath}: AppHostTabs omits ${language} without a limitation`
+        );
+      }
+    }
+  }
+
+  if (node.type === 'mdxJsxFlowElement' && node.name === 'AppHostLanguageSelector') {
+    state.selector = true;
+  }
+
+  if (node.type === 'mdxJsxFlowElement' && node.name === 'AppHostLanguagePivot') {
+    const id = getStringAttribute(node, 'id');
+    if (id) {
+      state.pivots.add(id);
+    }
+  }
+
+  if (
+    node.type === 'code' &&
+    !languageComponentAncestor &&
+    !standaloneAppHostExamplePages.has(relativePath) &&
+    (appHostBuilderPattern.test(node.value ?? '') ||
+      (appHostEntryPointPattern.test(node.meta ?? '') &&
+        !/^\s*#:package\b/.test(node.value ?? '')))
+  ) {
+    violations.push(
+      `${relativePath}:${node.position?.start?.line ?? '?'} has an AppHost builder example outside AppHostTabs or AppHostLanguagePivot`
+    );
+  }
+
+  for (const child of node.children ?? []) {
+    inspectNode(
+      child,
+      requiredLanguages,
+      relativePath,
+      violations,
+      state,
+      languageComponentAncestor
+    );
+  }
+}
+
+test('AppHost language examples account for every required language', () => {
+  const requiredLanguages =
+    process.env.APPHOST_LANGUAGE_AUDIT_ALL === '1'
+      ? appHostLanguageConfig.languages.map((language) => language.id)
+      : getEnabledAppHostLanguages().map((language) => language.id);
+  const violations: string[] = [];
+
+  for (const file of getActiveEnglishDocs()) {
+    const relativePath = path.relative(docsDirectory, file).replaceAll('\\', '/');
+    const source = fs.readFileSync(file, 'utf8');
+    const staleQuery = source.match(
+      /[?&](?:lang|language)=(?:typescript|csharp|python|go|java|rust)\b/i
+    );
+    if (staleQuery) {
+      violations.push(
+        `${relativePath} uses obsolete AppHost selector query "${staleQuery[0]}"`
+      );
+    }
+
+    let tree: MdxNode;
+    try {
+      tree = parser.parse(source) as MdxNode;
+    } catch (error) {
+      violations.push(
+        `${relativePath}: MDX parse failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      continue;
+    }
+
+    if (specializedParityTopLevel.has(relativePath.split('/')[0])) {
+      continue;
+    }
+
+    const state = { selector: false, pivots: new Set<string>() };
+    inspectNode(tree, requiredLanguages, relativePath, violations, state);
+
+    if (state.selector) {
+      for (const language of requiredLanguages) {
+        if (!state.pivots.has(language)) {
+          violations.push(
+            `${relativePath}: AppHostLanguageSelector has no ${language} pivot`
+          );
+        }
+      }
+    }
+  }
+
+  expect(violations).toEqual([]);
+});

--- a/src/frontend/tests/unit/diagnostics-language.vitest.test.ts
+++ b/src/frontend/tests/unit/diagnostics-language.vitest.test.ts
@@ -1,0 +1,256 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { createProcessor } from '@mdx-js/mdx';
+import ts from 'typescript';
+import { describe, expect, test } from 'vitest';
+import { getAppHostLanguages, getEnabledAppHostLanguages } from '../../src/utils/apphost-languages';
+import { renderAppHostTabsInMarkdown } from '../../config/apphost-language-markdown.mjs';
+
+const diagnosticsRoot = new URL('../../src/content/docs/diagnostics/', import.meta.url);
+const parser = createProcessor();
+const languages = getAppHostLanguages();
+const enabledLanguages = getEnabledAppHostLanguages();
+const pages = readdirSync(diagnosticsRoot)
+  .filter((name) => name.endsWith('.mdx'))
+  .map((name) => ({
+    name,
+    source: readFileSync(new URL(name, diagnosticsRoot), 'utf8'),
+  }));
+const modulesRoot = new URL('../../src/data/ts-modules/', import.meta.url);
+const apiPackages = new Map<string, Set<string>>();
+for (const file of readdirSync(modulesRoot).filter((file) => file.endsWith('.json'))) {
+  const module: { package: { name: string }; functions: Array<{ name: string }> } = JSON.parse(
+    readFileSync(new URL(file, modulesRoot), 'utf8')
+  );
+  for (const api of module.functions) {
+    const packages = apiPackages.get(api.name) ?? new Set<string>();
+    packages.add(module.package.name);
+    apiPackages.set(api.name, packages);
+  }
+}
+
+describe('diagnostics AppHost language examples', () => {
+  test.each(pages)(
+    '$name uses canonical, TypeScript-first language tabs and twoslash',
+    ({ source }) => {
+      expect(() => parser.parse(source.replace(/^---\r?\n[\s\S]*?\r?\n---/, ''))).not.toThrow();
+      expect(source).not.toMatch(/<Tabs\b[^>]*syncKey=['"]aspire-lang['"]/);
+      const documentedPackages = new Set(
+        [
+          'Aspire.Hosting',
+          ...source.matchAll(
+            /\b(?:CommunityToolkit\.)?Aspire\.Hosting(?:\.[A-Za-z][A-Za-z0-9]*)+/g
+          ),
+        ].map((match) => (typeof match === 'string' ? match : match[0]))
+      );
+      const languageGroups = [
+        ...source.matchAll(
+          /<AppHostTabs\b(?:[^>"'`]|"[^"]*"|'[^']*'|`[^`]*`)*>([\s\S]*?)<\/AppHostTabs>/g
+        ),
+      ];
+
+      if (languageGroups.length > 0) {
+        expect(source).toContain('/diagnostics/overview/#experimental-apphost-examples');
+      }
+
+      for (const [wrapper, group] of languageGroups) {
+        expect(source).toContain("import AppHostTabs from '@components/AppHostTabs.astro';");
+        const slots = [
+          ...group.matchAll(/<Fragment\s+slot=['"]([^'"]+)['"]>([\s\S]*?)<\/Fragment>/g),
+        ];
+        const ids = slots.map(([, id]) => id);
+        expect(ids).toEqual(languages.filter(({ id }) => ids.includes(id)).map(({ id }) => id));
+        expect(new Set(ids).size).toBe(ids.length);
+        const allLanguageMarkdown = renderAppHostTabsInMarkdown(
+          wrapper,
+          languages.map((language) => ({ ...language, enabled: true }))
+        );
+        for (const language of languages) {
+          expect(
+            allLanguageMarkdown,
+            `Provide a ${language.id} example or a specific SDK limitation before activation.`
+          ).toContain(`### ${language.label}`);
+        }
+        const markdown = renderAppHostTabsInMarkdown(wrapper, languages);
+        for (const language of enabledLanguages) {
+          // A missing slot must have an explicit, readable limitation, just as in the renderer.
+          expect(markdown).toContain(`### ${language.label}`);
+        }
+        for (const language of languages.filter(({ enabled }) => !enabled)) {
+          expect(markdown).not.toContain(`### ${language.label}`);
+        }
+        for (const [, id, content] of slots) {
+          const language = languages.find((language) => language.id === id)!;
+          expect(content).toContain(`\`\`\`${language.codeFence}`);
+          if (language.experimental) {
+            expect(content).toContain(`title="${language.appHostFile}"`);
+            expect(content).not.toMatch(/```[^\n]*\btwoslash\b/);
+            expect(content).not.toMatch(/\bTODO\b|not yet (?:implemented|validated)/i);
+          }
+        }
+      }
+
+      for (const block of source.matchAll(/```([\w+-]+)\b[^\n]*\n([\s\S]*?)```/g)) {
+        const title = block[0]
+          .slice(0, block[0].indexOf('\n'))
+          .match(/\btitle\s*=\s*["']([^"']+)["']/)?.[1];
+        const appHostFileTitle = /\bapphost\.(?:cs|mts|py|go|java|rs)\b/i.test(title ?? '');
+        if (
+          !appHostFileTitle &&
+          !/\b(?:createBuilder|CreateBuilder|create_builder)\s*\(|\bbuilder\s*\.\s*(?:[Aa]dd|[Bb]uild|[Ww]ith)/.test(
+            block[2]
+          )
+        ) {
+          continue;
+        }
+        if (
+          block[1] === 'csharp' &&
+          block[2]
+            .trim()
+            .split(/\r?\n/)
+            .every((line) => !line.trim() || line.trim().startsWith('#:package '))
+        ) {
+          continue;
+        }
+        if (
+          languageGroups.some(
+            (group) =>
+              block.index >= group.index &&
+              block.index + block[0].length <= group.index + group[0].length
+          )
+        ) {
+          continue;
+        }
+
+        expect(block[1], 'AppHost builder examples belong in AppHostTabs.').toBe('csharp');
+        if (
+          /\bthis\s+(?:IResourceBuilder<|IDistributedApplicationBuilder\b)/.test(block[2]) &&
+          !/\bCreateBuilder\s*\(/.test(block[2])
+        ) {
+          expect(source).toContain('C#-only integration-authoring examples');
+          continue;
+        }
+        const precedingProse = source
+          .slice(0, block.index)
+          .replace(/```[\s\S]*?```/g, '')
+          .slice(-1800);
+        if (
+          /#pragma warning disable\b|#:property\s+NoWarn\b|\bSuppressMessage\s*\(/.test(block[2])
+        ) {
+          expect(precedingProse).toMatch(/suppress(?:ion|ing| the| in)/i);
+          continue;
+        }
+        expect(
+          precedingProse,
+          'A standalone C# AppHost example needs a nearby, specific C#-only explanation.'
+        ).toMatch(/C#-only|requires? (?:a )?C#|apply only to C#/);
+      }
+
+      for (const block of source.matchAll(/```(?:typescript|ts|tsx)\b([^\n]*)\n([\s\S]*?)```/g)) {
+        expect(block[1]).toMatch(/\btwoslash\b/);
+        expect(block[1]).toMatch(/title=['"]apphost\.mts['"]/);
+        expect(block[2]).not.toMatch(/@ts-(?:ignore|expect-error)|\/\/\s*@errors:|\bas any\b/);
+        expect(
+          languageGroups.some(([, group]) =>
+            [...group.matchAll(/<Fragment\s+slot=['"]typescript['"]>([\s\S]*?)<\/Fragment>/g)].some(
+              ([, content]) => content.includes(block[0])
+            )
+          )
+        ).toBe(true);
+        const syntax = ts.createSourceFile('apphost.mts', block[2], ts.ScriptTarget.Latest, true);
+        function checkAwaitedCalls(node: ts.Node): void {
+          if (ts.isCallExpression(node)) {
+            const expression = node.expression;
+            const name = ts.isIdentifier(expression)
+              ? expression.text
+              : ts.isPropertyAccessExpression(expression)
+                ? expression.name.text
+                : '';
+            if (name === 'createBuilder' || name === 'run' || apiPackages.has(name)) {
+              let call = node;
+              // SDK thenable wrappers also support awaiting the complete fluent chain.
+              while (
+                ts.isPropertyAccessExpression(call.parent) &&
+                ts.isCallExpression(call.parent.parent) &&
+                call.parent.parent.expression === call.parent
+              ) {
+                call = call.parent.parent;
+              }
+              expect(
+                ts.isAwaitExpression(call.parent),
+                `Await SDK call: ${node.getText(syntax)}`
+              ).toBe(true);
+            }
+          }
+          ts.forEachChild(node, checkAwaitedCalls);
+        }
+        checkAwaitedCalls(syntax);
+        for (const [, method] of block[2].matchAll(/\.(\w+)\s*\(/g)) {
+          const packages = apiPackages.get(method);
+          if (packages) {
+            expect(
+              [...packages].some((name) => documentedPackages.has(name)),
+              `Document the package for ${method}: ${[...packages].join(', ')}`
+            ).toBe(true);
+          }
+        }
+      }
+    }
+  );
+
+  test('shared APIs retain language examples even on compiler diagnostic pages', () => {
+    for (const name of [
+      'aspire006.mdx',
+      'aspireacadomains001.mdx',
+      'aspireacanaming001.mdx',
+      'aspireacanaming002.mdx',
+      'aspireazure002.mdx',
+      'aspireazure003.mdx',
+      'aspireblazor001.mdx',
+      'aspirebrowserlogs001.mdx',
+      'aspirecertificates001.mdx',
+      'aspirecommand001.mdx',
+      'aspirecompute001.mdx',
+      'aspirecompute002.mdx',
+      'aspirecompute003.mdx',
+      'aspirecosmosdb001.mdx',
+      'aspirecsharpapps001.mdx',
+      'aspiredockerfilebuilder001.mdx',
+      'aspiredotnetproject001.mdx',
+      'aspiredotnettool001.mdx',
+      'aspiredurabletask001.mdx',
+      'aspirehostingpython001.mdx',
+      'aspireinteraction001.mdx',
+      'aspirejavascript001.mdx',
+      'aspiremcp001.mdx',
+      'aspirepersistence001.mdx',
+      'aspirepipelines001.mdx',
+      'aspirepipelines003.mdx',
+      'aspirepostgres001.mdx',
+      'aspireprobes001.mdx',
+      'aspireprocesscommand001.mdx',
+      'aspireprojects001.mdx',
+      'aspireproxyendpoints001.mdx',
+      'aspireradius003.mdx',
+      'aspireradius004.mdx',
+      'aspireradius006.mdx',
+      'aspireradius057.mdx',
+      'aspireterminal001.mdx',
+      'aspireusersecrets001.mdx',
+      'aspirewatch001.mdx',
+    ]) {
+      const source = readFileSync(new URL(name, diagnosticsRoot), 'utf8');
+      expect(source, name).toContain('<AppHostTabs');
+    }
+  });
+
+  test('overview distinguishes file-based C# suppression from TypeScript AppHosts', () => {
+    const overview = readFileSync(new URL('overview.mdx', diagnosticsRoot), 'utf8');
+    expect(overview).toContain('### Suppress in a file-based AppHost');
+    expect(overview).toContain('#:property NoWarn=$(NoWarn);ASPIREE000');
+    expect(overview).toContain('#pragma warning restore ASPIREE000');
+    expect(overview).toContain('not to `apphost.mts`');
+    expect(overview).toContain('## Experimental AppHost examples');
+    expect(overview).toContain('features:experimentalPolyglot:python');
+    expect(overview).toContain('daily generated SDK');
+  });
+});


### PR DESCRIPTION
Stack 3/5. Depends on #1635.

## Summary

- Audits 70 diagnostics pages with 51 shared groups.
- Adds broad core AppHost, deployment, fundamentals, testing, and extensibility coverage.
- Provides all six language variants or explicit limitations.
- Strengthens the global AST/MDX activation gate.
- Corrects Rust module paths.
- Preserves the real runtime evidence from stack 1.

Python, Go, Java, and Rust remain disabled until stack 5.

## Validation

- `git diff --check origin/ievangelist-add-integration-docs...HEAD`
- `pnpm --dir src/frontend exec vitest run tests/unit/apphost-language-coverage.vitest.test.ts tests/unit/diagnostics-language.vitest.test.ts tests/unit/apphost-languages.vitest.test.ts --reporter=dot` (3 files, 84 tests passed)
- No local production build was run.