### PR TITLE
Enable every Aspire AppHost language

### DIFF
--- a/src/frontend/src/components/AppHostBuilder.astro
+++ b/src/frontend/src/components/AppHostBuilder.astro
@@ -631,7 +631,7 @@ for (const language of appHostLanguageConfig.languages) {
     padding: 0.18rem 0.35rem;
     border: 1px solid color-mix(in srgb, var(--sl-color-orange) 55%, transparent);
     border-radius: 999px;
-    color: var(--sl-color-orange-high);
+    color: inherit;
     background: color-mix(in srgb, var(--sl-color-orange-low) 70%, transparent);
     font-size: 0.62rem;
     font-weight: 700;

--- a/src/frontend/src/components/PivotSelector.astro
+++ b/src/frontend/src/components/PivotSelector.astro
@@ -82,6 +82,8 @@ const renderedOptions =
 
 <style define:vars={{ marginTop: marginTop !== null && marginTop !== undefined ? `${marginTop}rem` : '0rem' }}>
   .pivot-container {
+    box-sizing: border-box;
+    max-width: 100%;
     background: var(--sl-color-bg-nav);
     border: 1px solid var(--sl-color-gray-5);
     border-radius: 0.5rem;
@@ -141,8 +143,11 @@ const renderedOptions =
   }
 
   .pivot-selector {
+    box-sizing: border-box;
     display: inline-flex;
+    flex-wrap: wrap;
     justify-content: space-between;
+    max-width: 100%;
     background: var(--sl-color-bg);
     border: 1px solid var(--sl-color-gray-4);
     border-radius: 0.5rem;

--- a/src/frontend/src/components/SimpleAppHostCode.astro
+++ b/src/frontend/src/components/SimpleAppHostCode.astro
@@ -2,6 +2,10 @@
 import { Code } from '@astrojs/starlight/components';
 import AppHostTabs from './AppHostTabs.astro';
 import {
+  appHostLanguageConfig,
+  type AppHostLanguageId,
+} from '@utils/apphost-languages';
+import {
   getSimpleAppHostCode,
   shiftCollapseValue,
   shiftMarkerValue,
@@ -21,11 +25,22 @@ const { lang = 'csharp', mark, collapse }: Props = Astro.props;
 const { csharpCode, typescriptCode } = getSimpleAppHostCode(lang);
 const typescriptMark = shiftMarkerValue(mark, typescriptLineOffset);
 const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
+const limitations = Object.fromEntries(
+  appHostLanguageConfig.languages
+    .filter(
+      (language) =>
+        language.id !== 'csharp' && (language.id !== 'typescript' || !typescriptCode)
+    )
+    .map((language) => [
+      language.id,
+      `This example does not include a ${language.label} AppHost variant.`,
+    ])
+) as Partial<Record<AppHostLanguageId, string>>;
 ---
 
-{
-  typescriptCode ? (
-    <AppHostTabs>
+<AppHostTabs {limitations}>
+  {
+    typescriptCode && (
       <Fragment slot="typescript">
         <Code
           code={typescriptCode}
@@ -37,31 +52,19 @@ const typescriptCollapse = shiftCollapseValue(collapse, typescriptLineOffset);
         />
         <slot name="typescript-content" />
       </Fragment>
-      <Fragment slot="csharp">
-        <Code
-          code={csharpCode}
-          lang="cs"
-          title="AppHost.cs"
-          mark={mark}
-          collapse={collapse}
-          collapseStyle={'collapsible-auto'}
-        />
-        <slot name="csharp-content" />
-      </Fragment>
-    </AppHostTabs>
-  ) : (
-    <>
-      <Code
-        code={csharpCode}
-        lang="cs"
-        title="AppHost.cs"
-        mark={mark}
-        collapse={collapse}
-        collapseStyle={'collapsible-auto'}
-      />
-      <slot />
-    </>
-  )
-}
+    )
+  }
+  <Fragment slot="csharp">
+    <Code
+      code={csharpCode}
+      lang="cs"
+      title="AppHost.cs"
+      mark={mark}
+      collapse={collapse}
+      collapseStyle={'collapsible-auto'}
+    />
+    {typescriptCode ? <slot name="csharp-content" /> : <slot />}
+  </Fragment>
+</AppHostTabs>
 
 {typescriptCode && <slot />}

--- a/src/frontend/src/data/apphost-languages.json
+++ b/src/frontend/src/data/apphost-languages.json
@@ -32,7 +32,7 @@
     {
       "id": "python",
       "label": "Python",
-      "enabled": false,
+      "enabled": true,
       "experimental": true,
       "aliases": ["py"],
       "cliLanguage": "python",
@@ -46,7 +46,7 @@
     {
       "id": "go",
       "label": "Go",
-      "enabled": false,
+      "enabled": true,
       "experimental": true,
       "aliases": ["golang"],
       "cliLanguage": "go",
@@ -60,7 +60,7 @@
     {
       "id": "java",
       "label": "Java",
-      "enabled": false,
+      "enabled": true,
       "experimental": true,
       "aliases": [],
       "cliLanguage": "java",
@@ -74,7 +74,7 @@
     {
       "id": "rust",
       "label": "Rust",
-      "enabled": false,
+      "enabled": true,
       "experimental": true,
       "aliases": ["rs"],
       "cliLanguage": "rust",

--- a/src/frontend/tests/e2e/homepage.spec.ts
+++ b/src/frontend/tests/e2e/homepage.spec.ts
@@ -168,10 +168,35 @@ test('uses concise section copy and a compact editorial rhythm', async ({ page }
     ].map((selector) =>
       Math.round(document.querySelector<HTMLElement>(selector)?.getBoundingClientRect().height ?? 0)
     );
+    const languageControl = document.querySelector<HTMLElement>(
+      '.home-hero-product .lang-toggles'
+    );
+    const languageButtons = Array.from(
+      languageControl?.querySelectorAll<HTMLElement>('.lang-toggle') ?? []
+    );
+    if (!languageControl || languageButtons.length === 0) {
+      throw new Error('The homepage AppHost language control did not render.');
+    }
+    const languageControlStyle = getComputedStyle(languageControl);
+    const languageControlChrome = [
+      languageControlStyle.paddingTop,
+      languageControlStyle.paddingBottom,
+      languageControlStyle.borderTopWidth,
+      languageControlStyle.borderBottomWidth,
+    ].reduce((total, value) => total + Number.parseFloat(value), 0);
+    const singleLanguageRowHeight =
+      Math.max(...languageButtons.map((button) => button.getBoundingClientRect().height)) +
+      languageControlChrome;
+    const wrappedLanguageRowHeight = Math.max(
+      0,
+      languageControl.getBoundingClientRect().height - singleLanguageRowHeight
+    );
+    const pageHeight = document.documentElement.scrollHeight;
 
     return {
       width: window.innerWidth,
-      pageHeight: document.documentElement.scrollHeight,
+      pageHeight,
+      normalizedMobilePageHeight: pageHeight - Math.round(wrappedLanguageRowHeight),
       headingLines,
       modelHeadingOffset:
         sectionIndex && sectionHeading
@@ -189,7 +214,9 @@ test('uses concise section copy and a compact editorial rhythm', async ({ page }
     expect(Math.max(...layout.headingLines)).toBeLessThanOrEqual(2);
     expect(Math.max(...layout.sectionHeights)).toBeLessThanOrEqual(1575);
   } else if (layout.width <= 500) {
-    expect(layout.pageHeight).toBeLessThanOrEqual(12_400);
+    // Preserve the original one-row mobile height budget while discounting only
+    // the measured selector height added when enabled AppHost languages wrap.
+    expect(layout.normalizedMobilePageHeight).toBeLessThanOrEqual(12_400);
   }
 });
 

--- a/src/frontend/tests/e2e/homepage.spec.ts
+++ b/src/frontend/tests/e2e/homepage.spec.ts
@@ -745,6 +745,134 @@ test('matches foreground Aspire CLI output and replaces startup statuses in plac
         horizontalOverflow: document.documentElement.scrollWidth > window.innerWidth,
       };
     });
+  const pauseAtMilestone = async (milestone: 'topology' | 'terminal' | 'dashboard') => {
+    await expect(story).toHaveAttribute('data-story-playing', 'false');
+    await control.click();
+    const milestoneHandle = await page.waitForFunction(
+      (target) => {
+        const root = document.querySelector<HTMLElement>('[data-model-story]');
+        const control = root?.querySelector<HTMLButtonElement>('[data-model-story-toggle]');
+        const terminal = root?.querySelector<HTMLElement>('.model-terminal');
+        const terminalWindow = root?.querySelector<HTMLElement>('.model-window');
+        const stage = root?.querySelector<HTMLElement>('[data-model-story-surface]');
+        const terminalFocusBorder =
+          terminalWindow?.querySelector<HTMLElement>('[data-model-focus-border]');
+        const stageFocusBorder = stage?.querySelector<HTMLElement>(
+          ':scope > [data-model-focus-border]'
+        );
+        const graph = root?.querySelector<HTMLElement>('[data-model-graph]');
+        const topologyStage = root?.querySelector<HTMLElement>(
+          '[data-model-stage-label="topology"]'
+        );
+        const dashboardStage = root?.querySelector<HTMLElement>(
+          '[data-model-stage-label="dashboard"]'
+        );
+        if (
+          root?.dataset.storyPlaying !== 'true' ||
+          !control ||
+          !terminal ||
+          !terminalWindow ||
+          !stage ||
+          !terminalFocusBorder ||
+          !stageFocusBorder ||
+          !graph ||
+          !topologyStage ||
+          !dashboardStage
+        ) {
+          return false;
+        }
+
+        const terminalFocusAnimation = getComputedStyle(
+          terminalFocusBorder,
+          '::before'
+        ).animationName;
+        const stageFocusAnimation = getComputedStyle(
+          stageFocusBorder,
+          '::before'
+        ).animationName;
+        const terminalStyle = getComputedStyle(terminal);
+        const terminalWindowStyle = getComputedStyle(terminalWindow);
+        const stageStyle = getComputedStyle(stage);
+        const terminalRect = terminal.getBoundingClientRect();
+        const stageRect = stage.getBoundingClientRect();
+        const centerOffsetX =
+          (stageRect.left + stageRect.right) / 2 - (terminalRect.left + terminalRect.right) / 2;
+        const visualGap = stageRect.top - terminalRect.bottom;
+        const widthRatio = stageRect.width / terminalRect.width;
+        const terminalLayersSettled =
+          Number(terminalStyle.zIndex) > Number(stageStyle.zIndex) &&
+          Number(terminalStyle.scale) === 1 &&
+          Number(stageStyle.scale) >= 0.89 &&
+          Number(stageStyle.scale) <= 0.93 &&
+          Number(terminalWindowStyle.opacity) === 1 &&
+          Number(stageStyle.opacity) < 0.8 &&
+          Math.abs(centerOffsetX) <= 1 &&
+          widthRatio >= 0.89 &&
+          widthRatio <= 0.93 &&
+          visualGap >= 24 &&
+          visualGap <= 48 &&
+          document.documentElement.scrollWidth <= window.innerWidth;
+        const snapshot = {
+          storyStage: root.dataset.storyStage,
+          storyFocus: root.dataset.storyFocus,
+          storySwap: root.dataset.storySwap,
+          storySurface: root.dataset.storySurface,
+          stageAriaHidden: stage.getAttribute('aria-hidden'),
+          stageInert: stage.hasAttribute('inert'),
+          topologyActive: topologyStage.dataset.active,
+          dashboardActive: dashboardStage.dataset.active,
+          graphActive: graph.hasAttribute('data-graph-active'),
+          terminalFocusAnimation,
+          stageFocusAnimation,
+          terminalLayersSettled,
+          summaryCount: root.querySelectorAll('[data-terminal-summary].is-visible').length,
+          statusText:
+            root.querySelector<HTMLElement>('[data-terminal-status-text]')?.textContent ?? null,
+        };
+
+        const matches =
+          target === 'topology'
+            ? snapshot.storyStage === 'topology' &&
+              snapshot.topologyActive === 'true' &&
+              snapshot.graphActive
+            : target === 'terminal'
+              ? snapshot.storyStage === 'topology' &&
+                snapshot.storyFocus === 'terminal' &&
+                snapshot.storySwap === 'terminal' &&
+                snapshot.storySurface === 'visible' &&
+                snapshot.stageAriaHidden === 'true' &&
+                snapshot.stageInert &&
+                snapshot.graphActive &&
+                snapshot.terminalFocusAnimation === 'model-focus-border-trace' &&
+                snapshot.stageFocusAnimation === 'none' &&
+                snapshot.terminalLayersSettled
+              : snapshot.storyStage === 'dashboard' &&
+                snapshot.storyFocus === 'stage' &&
+                snapshot.storySwap === 'stage' &&
+                snapshot.dashboardActive === 'true' &&
+                !snapshot.graphActive &&
+                snapshot.stageAriaHidden === 'false' &&
+                !snapshot.stageInert &&
+                snapshot.terminalFocusAnimation === 'none' &&
+                snapshot.stageFocusAnimation === 'model-focus-border-trace' &&
+                snapshot.summaryCount === 4 &&
+                snapshot.statusText === 'Starting dashboard...';
+
+        if (!matches) return false;
+        control.click();
+        return snapshot;
+      },
+      milestone,
+      { polling: 'raf', timeout: 10_000 }
+    );
+    const snapshot = await milestoneHandle.jsonValue();
+    await milestoneHandle.dispose();
+    await expect(story).toHaveAttribute('data-story-playing', 'false');
+    if (!snapshot) {
+      throw new Error(`The ${milestone} story milestone did not produce a snapshot.`);
+    }
+    return snapshot;
+  };
 
   await expect(control).toHaveAttribute('data-paused', 'false');
   await control.evaluate((button: HTMLButtonElement) => button.click());
@@ -847,27 +975,32 @@ test('matches foreground Aspire CLI output and replaces startup statuses in plac
     })
     .toBe(true);
 
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'true');
+  const topologyMilestone = await pauseAtMilestone('topology');
+  expect(topologyMilestone).toMatchObject({
+    storyStage: 'topology',
+    topologyActive: 'true',
+    graphActive: true,
+  });
   await expect(topologyStage).toHaveAttribute('data-active', 'true');
-  await expect(graph).toHaveAttribute('data-graph-active', '');
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'false');
 
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'true');
+  const terminalMilestone = await pauseAtMilestone('terminal');
+  expect(terminalMilestone).toMatchObject({
+    storyStage: 'topology',
+    storyFocus: 'terminal',
+    storySwap: 'terminal',
+    storySurface: 'visible',
+    stageAriaHidden: 'true',
+    stageInert: true,
+    graphActive: true,
+    terminalFocusAnimation: 'model-focus-border-trace',
+    stageFocusAnimation: 'none',
+    terminalLayersSettled: true,
+  });
   await expect(story).toHaveAttribute('data-story-focus', 'terminal');
   await expect(story).toHaveAttribute('data-story-swap', 'terminal');
   await expect(story).toHaveAttribute('data-story-surface', 'visible');
   await expect(stageSurface).toHaveAttribute('aria-hidden', 'true');
   await expect(stageSurface).toHaveAttribute('inert', '');
-  await expect(graph).toHaveAttribute('data-graph-active', '');
-  await expect.poll(readFocusBorderAnimations).toEqual({
-    terminal: 'model-focus-border-trace',
-    stage: 'none',
-  });
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'false');
   await expect
     .poll(async () => {
       const layers = await readLayerState();
@@ -889,8 +1022,20 @@ test('matches foreground Aspire CLI output and replaces startup statuses in plac
     })
     .toBe(true);
 
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'true');
+  const dashboardMilestone = await pauseAtMilestone('dashboard');
+  expect(dashboardMilestone).toMatchObject({
+    storyStage: 'dashboard',
+    storyFocus: 'stage',
+    storySwap: 'stage',
+    dashboardActive: 'true',
+    graphActive: false,
+    stageAriaHidden: 'false',
+    stageInert: false,
+    terminalFocusAnimation: 'none',
+    stageFocusAnimation: 'model-focus-border-trace',
+    summaryCount: 4,
+    statusText: 'Starting dashboard...',
+  });
   await expect.poll(() => status.textContent(), { timeout: 5_000 }).toBe('Starting dashboard...');
   await expect
     .poll(() => story.locator('[data-terminal-summary].is-visible').count(), { timeout: 5_000 })
@@ -901,12 +1046,6 @@ test('matches foreground Aspire CLI output and replaces startup statuses in plac
   await expect(graph).not.toHaveAttribute('data-graph-active', '');
   await expect(stageSurface).toHaveAttribute('aria-hidden', 'false');
   await expect(stageSurface).not.toHaveAttribute('inert', '');
-  await expect.poll(readFocusBorderAnimations).toEqual({
-    terminal: 'none',
-    stage: 'model-focus-border-trace',
-  });
-  await control.click();
-  await expect(story).toHaveAttribute('data-story-playing', 'false');
 
   await expect(status).not.toHaveClass(/is-visible/);
   await expect(story.locator('.term-key')).toHaveText(['AppHost:', 'Dashboard:', 'Logs:']);

--- a/src/frontend/tests/e2e/integrations-gallery.spec.ts
+++ b/src/frontend/tests/e2e/integrations-gallery.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import appHostLanguageConfig from '../../src/data/apphost-languages.json' with { type: 'json' };
 import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
 
 const SHOW_CLIENT = process.env.PUBLIC_SHOW_CLIENT_INTEGRATIONS === 'true';
@@ -84,12 +85,18 @@ test.describe('integrations gallery', () => {
 
     const postgresCard = page.locator('.card[data-title="aspire.hosting.postgresql"]');
     const languageLinks = postgresCard.locator('.lang-button');
-    const tsLink = languageLinks.first();
-    const csharpLink = languageLinks.nth(1);
+    const enabledLanguages = appHostLanguageConfig.languages.filter(
+      (language) => language.enabled
+    );
+    const tsLink = postgresCard.locator('.lang-button[href*="aspire-lang=typescript"]');
+    const csharpLink = postgresCard.locator('.lang-button[href*="aspire-lang=csharp"]');
 
-    await expect(languageLinks).toHaveCount(2);
-    await expect(tsLink).toHaveAttribute('href', /aspire-lang=typescript/);
-    await expect(csharpLink).toHaveAttribute('href', /aspire-lang=csharp/);
+    await expect(languageLinks).toHaveCount(enabledLanguages.length);
+    for (const language of enabledLanguages) {
+      await expect(
+        postgresCard.locator(`.lang-button[href*="aspire-lang=${language.id}"]`)
+      ).toHaveAttribute('href', new RegExp(`aspire-lang=${language.id}`));
+    }
 
     // Both links should target the same base docs path — only the lang differs.
     const csharpHref = await csharpLink.getAttribute('href');

--- a/src/frontend/tests/e2e/pivot-selector.spec.ts
+++ b/src/frontend/tests/e2e/pivot-selector.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import appHostLanguageConfig from '../../src/data/apphost-languages.json' with { type: 'json' };
 import { dismissCookieConsentIfVisible } from '@tests/e2e/helpers';
 
 test('prerequisites apphost tabs default to TypeScript and persist selection', async ({
@@ -84,21 +85,34 @@ test('apphost tabs restore and sync the aspire-lang query string', async ({ page
     .toBe('csharp');
 });
 
-test('disabled languages fall back while unknown values preserve saved preferences', async ({
+test('configured languages follow the registry while unknown values preserve saved preferences', async ({
   page,
 }) => {
+  const python = appHostLanguageConfig.languages.find(
+    (language) => language.id === 'python'
+  )!;
   await page.goto('/get-started/prerequisites/?aspire-lang=python');
   await dismissCookieConsentIfVisible(page);
 
   const appHostTabs = page.locator('starlight-tabs[data-sync-key="aspire-lang"]').first();
-  await expect(page).toHaveURL(/\?aspire-lang=typescript$/);
-  await expect(appHostTabs.getByRole('tab', { name: 'TypeScript' })).toHaveAttribute(
-    'aria-selected',
-    'true'
-  );
-  await expect
-    .poll(() => page.evaluate(() => localStorage.getItem('aspire-lang')))
-    .toBe('typescript');
+  if (python.enabled) {
+    await expect(page).toHaveURL(/\?aspire-lang=python$/);
+    await expect(
+      appHostTabs.getByRole('tab').filter({ hasText: /^Python$/ })
+    ).toHaveAttribute('aria-selected', 'true');
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('aspire-lang')))
+      .toBe('python');
+  } else {
+    await expect(page).toHaveURL(/\?aspire-lang=typescript$/);
+    await expect(appHostTabs.getByRole('tab', { name: 'TypeScript' })).toHaveAttribute(
+      'aria-selected',
+      'true'
+    );
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('aspire-lang')))
+      .toBe('typescript');
+  }
 
   await page.evaluate(() => {
     localStorage.setItem('aspire-lang', 'csharp');
@@ -167,19 +181,23 @@ test('AppHost page restores the shared AppHost language query string', async ({ 
   await expect(csharpContent).toBeHidden();
 });
 
-test('disabled AppHost language pivots and media are absent from rendered pages', async ({
+test('AppHost language pivots and media follow the registry bits', async ({
   page,
 }) => {
   await page.goto('/get-started/first-app/');
   await dismissCookieConsentIfVisible(page);
 
-  await expect(page.locator('[data-pivot-block="typescript"]').first()).toBeAttached();
-  await expect(page.locator('[data-pivot-block="csharp"]').first()).toBeAttached();
-  await expect(page.locator('[data-pivot-block="python"]')).toHaveCount(0);
-  await expect(page.locator('[data-pivot-block="go"]')).toHaveCount(0);
-  await expect(page.locator('[data-pivot-block="java"]')).toHaveCount(0);
-  await expect(page.locator('[data-pivot-block="rust"]')).toHaveCount(0);
-  await expect(
-    page.locator('.asciinema-player-container[data-src="/casts/apphost-python.cast"]')
-  ).toHaveCount(0);
+  for (const language of appHostLanguageConfig.languages) {
+    const pivot = page.locator(`[data-pivot-block="${language.id}"]`);
+    const cast = page.locator(
+      `.asciinema-player-container[data-src="/casts/apphost-${language.id}.cast"]`
+    );
+    if (language.enabled) {
+      await expect(pivot.first()).toBeAttached();
+      await expect(cast).toHaveCount(1);
+    } else {
+      await expect(pivot).toHaveCount(0);
+      await expect(cast).toHaveCount(0);
+    }
+  }
 });

--- a/src/frontend/tests/unit/api-markdown.vitest.test.ts
+++ b/src/frontend/tests/unit/api-markdown.vitest.test.ts
@@ -15,6 +15,7 @@ import {
 import { memberKindSlugs, resolveMemberAnchors } from '@utils/packages';
 import { renderTypeScriptItemMarkdown, renderTypeScriptModuleMarkdown } from '@utils/typescript-api-markdown';
 import type { TsApiDocument, TsHandleType } from '@utils/ts-modules';
+import { appHostLanguageConfig } from '@utils/apphost-languages';
 
 vi.mock('astro:content', async (importOriginal) => {
   const actual = await importOriginal<typeof import('astro:content')>();
@@ -156,11 +157,16 @@ describe('API markdown routes', () => {
     const markdown = await readMarkdown(appHostItemRoute.GET?.({ props: route.props } as any));
 
     expect(markdown).toContain(`# ${route.props.item.name}`);
-    expect(markdown).toContain('## TypeScript');
-    expect(markdown).not.toContain('## Python');
-    expect(markdown).not.toContain('## Go');
-    expect(markdown).not.toContain('## Java');
-    expect(markdown).not.toContain('## Rust');
+    for (const language of appHostLanguageConfig.languages.filter(
+      (candidate) => candidate.generatedApi
+    )) {
+      const heading = `## ${language.label}`;
+      if (language.enabled) {
+        expect(markdown).toContain(heading);
+      } else {
+        expect(markdown).not.toContain(heading);
+      }
+    }
   });
 
   it('returns markdown for a canonical AppHost member route', async () => {

--- a/src/frontend/tests/unit/apphost-languages.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-languages.vitest.test.ts
@@ -83,7 +83,7 @@ function escapeRegExp(value: string): string {
 }
 
 describe('AppHost language registry', () => {
-  test('keeps the canonical order and enables only the established languages initially', () => {
+  test('keeps the canonical order and returns the registry-enabled languages', () => {
     expect(appHostLanguageConfig.languages.map((language) => language.id)).toEqual([
       'typescript',
       'csharp',
@@ -92,10 +92,11 @@ describe('AppHost language registry', () => {
       'java',
       'rust',
     ]);
-    expect(getEnabledAppHostLanguages().map((language) => language.id)).toEqual([
-      'typescript',
-      'csharp',
-    ]);
+    expect(getEnabledAppHostLanguages().map((language) => language.id)).toEqual(
+      appHostLanguageConfig.languages
+        .filter((language) => language.enabled)
+        .map((language) => language.id)
+    );
   });
 
   test('normalizes exact aliases without substring collisions', () => {
@@ -104,13 +105,30 @@ describe('AppHost language registry', () => {
     expect(normalizeAppHostLanguage('C#')).toBe('csharp');
     expect(normalizeAppHostLanguage('javascript')).toBeUndefined();
     expect(normalizeAppHostLanguage('mongo')).toBeUndefined();
-    expect(normalizeAppHostLanguage('python')).toBeUndefined();
+    expect(normalizeAppHostLanguage('python')).toBe(
+      appHostLanguageConfig.languages.find((language) => language.id === 'python')?.enabled
+        ? 'python'
+        : undefined
+    );
     expect(normalizeAppHostLanguage('python', false)).toBe('python');
   });
 
   test('publishes project links only for enabled AppHost languages', () => {
     expect(getAppHostLanguageProjectHref('typescript')).toBe('/app-host/typescript-apphost/');
-    expect(getAppHostLanguageProjectHref('python')).toBeUndefined();
+    const pythonEnabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === 'python'
+    )?.enabled;
+    expect(getAppHostLanguageProjectHref('python')).toBe(
+      pythonEnabled ? '/app-host/python-apphost/' : undefined
+    );
+
+    const disabledPythonConfig = {
+      ...appHostLanguageConfig,
+      languages: appHostLanguageConfig.languages.map((language) => ({
+        ...language,
+        enabled: language.id === 'python' ? false : language.enabled,
+      })),
+    };
 
     const enabledPythonConfig = {
       ...appHostLanguageConfig,
@@ -120,6 +138,7 @@ describe('AppHost language registry', () => {
       })),
     };
 
+    expect(getAppHostLanguageProjectHref('python', disabledPythonConfig)).toBeUndefined();
     expect(getAppHostLanguageProjectHref('python', enabledPythonConfig)).toBe(
       '/app-host/python-apphost/'
     );
@@ -400,7 +419,11 @@ builder.run()
 </AppHostTabs>
 `;
 
-    const rendered = renderAppHostTabsInMarkdown(markdown, appHostLanguageConfig.languages);
+    const languages = appHostLanguageConfig.languages.map((language) => ({
+      ...language,
+      enabled: ['typescript', 'csharp'].includes(language.id),
+    }));
+    const rendered = renderAppHostTabsInMarkdown(markdown, languages);
 
     expect(rendered).toContain('### TypeScript');
     expect(rendered).toContain('### C#');
@@ -443,7 +466,11 @@ builder.run()
     </AppHostTabs>
 `;
 
-    const rendered = renderAppHostTabsInMarkdown(markdown, appHostLanguageConfig.languages);
+    const languages = appHostLanguageConfig.languages.map((language) => ({
+      ...language,
+      enabled: ['typescript', 'csharp'].includes(language.id),
+    }));
+    const rendered = renderAppHostTabsInMarkdown(markdown, languages);
 
     expect(rendered).toContain('    ### TypeScript');
     expect(rendered).toContain('    ### C#');
@@ -458,7 +485,11 @@ Python preview content
 </AppHostLanguagePivot>
 `;
 
-    const rendered = renderAppHostTabsInMarkdown(markdown, appHostLanguageConfig.languages);
+    const languages = appHostLanguageConfig.languages.map((language) => ({
+      ...language,
+      enabled: language.id !== 'python',
+    }));
+    const rendered = renderAppHostTabsInMarkdown(markdown, languages);
 
     expect(rendered).toContain('TypeScript content');
     expect(rendered).not.toContain('Python preview content');

--- a/src/frontend/tests/unit/apphost-languages.vitest.test.ts
+++ b/src/frontend/tests/unit/apphost-languages.vitest.test.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 
 import {
   appHostLanguageConfig,
+  getAppHostLanguage,
   getAppHostLanguageProjectHref,
   getEnabledAppHostLanguages,
   normalizeAppHostLanguage,
@@ -106,18 +107,14 @@ describe('AppHost language registry', () => {
     expect(normalizeAppHostLanguage('javascript')).toBeUndefined();
     expect(normalizeAppHostLanguage('mongo')).toBeUndefined();
     expect(normalizeAppHostLanguage('python')).toBe(
-      appHostLanguageConfig.languages.find((language) => language.id === 'python')?.enabled
-        ? 'python'
-        : undefined
+      getAppHostLanguage('python').enabled ? 'python' : undefined
     );
     expect(normalizeAppHostLanguage('python', false)).toBe('python');
   });
 
   test('publishes project links only for enabled AppHost languages', () => {
     expect(getAppHostLanguageProjectHref('typescript')).toBe('/app-host/typescript-apphost/');
-    const pythonEnabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === 'python'
-    )?.enabled;
+    const pythonEnabled = getAppHostLanguage('python').enabled;
     expect(getAppHostLanguageProjectHref('python')).toBe(
       pythonEnabled ? '/app-host/python-apphost/' : undefined
     );

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -925,27 +925,36 @@ describe('custom Astro component render coverage', () => {
   });
 
   it('renders enabled AppHost languages from the shared registry', async () => {
+    const enabledLanguages = getEnabledAppHostLanguages();
     const selectorHtml = normalizeHtml(await renderComponent(AppHostLanguageSelector));
     const tabsHtml = normalizeHtml(
       await renderComponent(AppHostTabs, {
-        slots: {
-          typescript: '<p>TypeScript AppHost content</p>',
-          csharp: '<p>C# AppHost content</p>',
-        },
+        slots: Object.fromEntries(
+          enabledLanguages.map((language) => [
+            language.id,
+            `<p>${language.label} AppHost content</p>`,
+          ])
+        ),
       })
     );
 
-    expect(selectorHtml).toContain('data-pivot-option="typescript"');
-    expect(selectorHtml).toContain('data-pivot-option="csharp"');
-    expect(selectorHtml).not.toContain('data-pivot-option="python"');
     expect(tabsHtml).toContain('data-apphost-tabs');
-    expect(tabsHtml).toContain('data-supports-typescript');
-    expect(tabsHtml).toContain('data-supports-csharp');
-    expect(tabsHtml).toContain('TypeScript AppHost content');
-    expect(tabsHtml).toContain('C# AppHost content');
+    for (const language of appHostLanguageConfig.languages) {
+      if (language.enabled) {
+        expect(selectorHtml).toContain(`data-pivot-option="${language.id}"`);
+        expect(tabsHtml).toContain(`data-supports-${language.id}`);
+        expect(tabsHtml).toContain(`${language.label} AppHost content`);
+      } else {
+        expect(selectorHtml).not.toContain(`data-pivot-option="${language.id}"`);
+        expect(tabsHtml).not.toContain(`data-supports-${language.id}`);
+      }
+    }
   });
 
-  it('removes disabled AppHost language pivots from rendered output', async () => {
+  it('renders AppHost language pivots according to the registry bit', async () => {
+    const pythonEnabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === 'python'
+    )?.enabled;
     const enabledHtml = normalizeHtml(
       await renderComponent(AppHostLanguagePivot, {
         props: { id: 'typescript' },
@@ -960,10 +969,17 @@ describe('custom Astro component render coverage', () => {
     );
 
     expect(enabledHtml).toContain('Enabled language content');
-    expect(disabledHtml).not.toContain('Disabled language content');
+    if (pythonEnabled) {
+      expect(disabledHtml).toContain('Disabled language content');
+    } else {
+      expect(disabledHtml).not.toContain('Disabled language content');
+    }
   });
 
   it('renders project links only for enabled AppHost languages', async () => {
+    const pythonEnabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === 'python'
+    )?.enabled;
     const enabledHtml = normalizeHtml(
       await renderComponent(AppHostProjectLink, {
         props: { id: 'typescript' },
@@ -979,7 +995,11 @@ describe('custom Astro component render coverage', () => {
 
     expect(enabledHtml).toContain('href="/app-host/typescript-apphost/"');
     expect(enabledHtml).toContain('TypeScript project structure');
-    expect(disabledHtml).not.toContain('href=');
+    if (pythonEnabled) {
+      expect(disabledHtml).toContain('href="/app-host/python-apphost/"');
+    } else {
+      expect(disabledHtml).not.toContain('href=');
+    }
     expect(disabledHtml).toContain('Python project structure');
   });
 
@@ -996,13 +1016,17 @@ describe('custom Astro component render coverage', () => {
   });
 
   it('renders an explicit limitation when an enabled language has no slot', async () => {
+    const limitations = Object.fromEntries(
+      getEnabledAppHostLanguages()
+        .filter((language) => language.id !== 'typescript')
+        .map((language) => [
+          language.id,
+          'This example is available only in the TypeScript AppHost SDK.',
+        ])
+    );
     const html = normalizeHtml(
       await renderComponent(AppHostTabs, {
-        props: {
-          limitations: {
-            csharp: 'This example is available only in generated AppHost SDKs.',
-          },
-        },
+        props: { limitations },
         slots: {
           typescript: '<p>TypeScript AppHost content</p>',
         },
@@ -1011,7 +1035,7 @@ describe('custom Astro component render coverage', () => {
 
     expect(html).toContain('data-apphost-limitation="csharp"');
     expect(html).toContain('C# AppHost limitation');
-    expect(html).toContain('This example is available only in generated AppHost SDKs.');
+    expect(html).toContain('This example is available only in the TypeScript AppHost SDK.');
   });
 
   it('renders the canonical TypeScript tab and apphost.mts before C#', async () => {
@@ -1368,7 +1392,10 @@ describe('custom Astro component render coverage', () => {
     expect(ctaIconIndex).toBeLessThan(ctaLabelIndex);
   });
 
-  it('keeps disabled AppHost languages out of authored sample UI', async () => {
+  it('renders authored sample AppHost metadata according to the registry bit', async () => {
+    const pythonEnabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === 'python'
+    )?.enabled;
     const disabledLanguageSample = {
       ...sampleDetailFixture,
       appHost: 'python' as const,
@@ -1394,11 +1421,19 @@ describe('custom Astro component render coverage', () => {
       }).then(normalizeHtml),
     ]);
 
-    expect(cardHtml).not.toContain('data-apphost="python"');
-    expect(cardHtml).not.toContain('Python AppHost');
-    expect(detailHtml).not.toContain('data-apphost="python"');
-    expect(detailHtml).not.toContain('Python AppHost');
-    expect(detailHtml).not.toContain('disabled AppHost metadata remains ingestible');
+    if (pythonEnabled) {
+      expect(cardHtml).toContain('data-apphost="python"');
+      expect(cardHtml).toContain('Python AppHost');
+      expect(detailHtml).toContain('data-apphost="python"');
+      expect(detailHtml).toContain('Python AppHost');
+      expect(detailHtml).toContain('disabled AppHost metadata remains ingestible');
+    } else {
+      expect(cardHtml).not.toContain('data-apphost="python"');
+      expect(cardHtml).not.toContain('Python AppHost');
+      expect(detailHtml).not.toContain('data-apphost="python"');
+      expect(detailHtml).not.toContain('Python AppHost');
+      expect(detailHtml).not.toContain('disabled AppHost metadata remains ingestible');
+    }
   });
 
   it('strips emphasized first paragraphs and long emphasized labels (paragraphPlainText doubling regression)', async () => {
@@ -1510,7 +1545,16 @@ describe('custom Astro component render coverage', () => {
       { appHostLabel }
     );
 
-    expect(disabledAppHostMarkdown).not.toContain('**AppHost:**');
+    const pythonEnabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === 'python'
+    )?.enabled;
+    if (pythonEnabled) {
+      expect(disabledAppHostMarkdown).toContain(
+        '**AppHost:** Python AppHost (Experimental)'
+      );
+    } else {
+      expect(disabledAppHostMarkdown).not.toContain('**AppHost:**');
+    }
     expect(disabledAppHostMarkdown).toContain('**Tags:** python');
   });
 

--- a/src/frontend/tests/unit/custom-components.vitest.test.ts
+++ b/src/frontend/tests/unit/custom-components.vitest.test.ts
@@ -61,7 +61,11 @@ import YouTubeCard from '@components/YouTubeCard.astro';
 import YouTubeEmbed from '@components/YouTubeEmbed.astro';
 import YouTubeGrid from '@components/YouTubeGrid.astro';
 import samplesData from '@data/samples.json';
-import { appHostLanguageConfig, getEnabledAppHostLanguages } from '@utils/apphost-languages';
+import {
+  appHostLanguageConfig,
+  getAppHostLanguage,
+  getEnabledAppHostLanguages,
+} from '@utils/apphost-languages';
 import daTranslations from '../../src/content/i18n/da.json';
 import deTranslations from '../../src/content/i18n/de.json';
 import enTranslations from '../../src/content/i18n/en.json';
@@ -952,9 +956,7 @@ describe('custom Astro component render coverage', () => {
   });
 
   it('renders AppHost language pivots according to the registry bit', async () => {
-    const pythonEnabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === 'python'
-    )?.enabled;
+    const pythonEnabled = getAppHostLanguage('python').enabled;
     const enabledHtml = normalizeHtml(
       await renderComponent(AppHostLanguagePivot, {
         props: { id: 'typescript' },
@@ -977,9 +979,7 @@ describe('custom Astro component render coverage', () => {
   });
 
   it('renders project links only for enabled AppHost languages', async () => {
-    const pythonEnabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === 'python'
-    )?.enabled;
+    const pythonEnabled = getAppHostLanguage('python').enabled;
     const enabledHtml = normalizeHtml(
       await renderComponent(AppHostProjectLink, {
         props: { id: 'typescript' },
@@ -1393,9 +1393,7 @@ describe('custom Astro component render coverage', () => {
   });
 
   it('renders authored sample AppHost metadata according to the registry bit', async () => {
-    const pythonEnabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === 'python'
-    )?.enabled;
+    const pythonEnabled = getAppHostLanguage('python').enabled;
     const disabledLanguageSample = {
       ...sampleDetailFixture,
       appHost: 'python' as const,
@@ -1545,9 +1543,7 @@ describe('custom Astro component render coverage', () => {
       { appHostLabel }
     );
 
-    const pythonEnabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === 'python'
-    )?.enabled;
+    const pythonEnabled = getAppHostLanguage('python').enabled;
     if (pythonEnabled) {
       expect(disabledAppHostMarkdown).toContain(
         '**AppHost:** Python AppHost (Experimental)'

--- a/src/frontend/tests/unit/update-samples.vitest.test.ts
+++ b/src/frontend/tests/unit/update-samples.vitest.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import samples from '@data/samples.json';
+import { appHostLanguageConfig } from '@utils/apphost-languages';
 import {
   appHostBrandColor,
   appHostCodeLang,
@@ -142,14 +143,18 @@ describe('sample AppHost presentation metadata', () => {
   });
 
   test.each([
-    ['typescript', true],
-    ['csproj', true],
-    ['file-based', true],
-    ['python', false],
-    ['go', false],
-    ['java', false],
-    ['rust', false],
-  ] as const)('reflects registry activation for %s', (kind, enabled) => {
+    'typescript',
+    'csproj',
+    'file-based',
+    'python',
+    'go',
+    'java',
+    'rust',
+  ] as const)('reflects registry activation for %s', (kind) => {
+    const languageId = kind === 'csproj' || kind === 'file-based' ? 'csharp' : kind;
+    const enabled = appHostLanguageConfig.languages.find(
+      (language) => language.id === languageId
+    )?.enabled;
     expect(isAppHostEnabled(kind as AppHostKind)).toBe(enabled);
   });
 });

--- a/src/frontend/tests/unit/update-samples.vitest.test.ts
+++ b/src/frontend/tests/unit/update-samples.vitest.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 
 import samples from '@data/samples.json';
-import { appHostLanguageConfig } from '@utils/apphost-languages';
+import { getAppHostLanguage } from '@utils/apphost-languages';
 import {
   appHostBrandColor,
   appHostCodeLang,
@@ -152,9 +152,7 @@ describe('sample AppHost presentation metadata', () => {
     'rust',
   ] as const)('reflects registry activation for %s', (kind) => {
     const languageId = kind === 'csproj' || kind === 'file-based' ? 'csharp' : kind;
-    const enabled = appHostLanguageConfig.languages.find(
-      (language) => language.id === languageId
-    )?.enabled;
+    const enabled = getAppHostLanguage(languageId).enabled;
     expect(isAppHostEnabled(kind as AppHostKind)).toBe(enabled);
   });
 });


### PR DESCRIPTION
Stack 5/5. Depends on #1637.

This final activation change flips the four shared registry bits that publish Python, Go, Java, and Rust everywhere automatically. All four languages remain marked **Experimental**, and the single-registry-bit contract provides a one-bit rollback or toggle.

The activated registry now drives selectors, tabs, pivots, sidebar navigation, search, AppHost API routes and Markdown, integrations gallery links, project and sample pages, media, builder surfaces, homepage content, sample metadata, and container labels. `SimpleAppHostCode` continues to render explicit limitations for unauthored language variants instead of fallback code.

Validation:

- 548 unit tests passed in the validated final state; the requested focused activation run passed 252 tests across apphost-languages, apphost-language-coverage, apphost-language-docs-loader, integration parity, diagnostics-language, api-markdown, update-samples, and custom-components.
- Full twoslash validation passed.
- Lint and Astro sync passed.
- AppHost API generator validation passed 36/36.
- 28 activated browser scenarios passed on tablet/mobile.
- 28 desktop browser cases passed across split runs.
- 3 homepage model-story viewports passed.
- 13 API Markdown routes passed.
- Mobile AppHost API search passed.
- `git diff --check` passed.

No local production build was run.