### PR TITLE
Hide the right TOC when the mobile TOC is visible

### DIFF
--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1550,7 +1550,7 @@ it configures at which point the mobile toc should be replaced with the normal t
   }
 }
 
-/* remember to also update this value accordingly */
+/* Keep this breakpoint in sync with the 99.999rem upper bound above. */
 @media (min-width: 100rem) {
   :root[data-has-toc] {
     --sl-content-pad-x: 1.5rem;
@@ -1567,18 +1567,6 @@ it configures at which point the mobile toc should be replaced with the normal t
 
   :root[data-has-toc] .lg\:sl-block {
     display: block;
-  }
-
-  :root[data-has-toc] .right-sidebar-panel > .sl-container {
-    max-width: calc(
-      (
-        (
-            100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 *
-              var(--sl-sidebar-pad-x)
-          ) *
-          0.2 /* MAGIC NUMBER 🥲 */
-      )
-    );
   }
 
   :root[data-has-toc] .content-panel > .sl-container {

--- a/src/frontend/src/styles/site.css
+++ b/src/frontend/src/styles/site.css
@@ -1490,6 +1490,20 @@ it configures at which point the mobile toc should be replaced with the normal t
     display: flex;
   }
 
+  /* The mobile TOC replaces the right sidebar in this range. Release
+     the reserved sidebar column so the main content can use the space. */
+  :root[data-has-toc] .right-sidebar-container {
+    width: 0;
+  }
+
+  :root[data-has-toc] .right-sidebar-panel {
+    display: none;
+  }
+
+  :root[data-has-sidebar][data-has-toc] .main-pane {
+    width: 100%;
+  }
+
   :root[data-has-toc] .content-panel > .sl-container {
     margin-inline: 0;
   }
@@ -1550,7 +1564,7 @@ it configures at which point the mobile toc should be replaced with the normal t
   }
 }
 
-/* Keep this breakpoint in sync with the 99.999rem upper bound above. */
+/* remember to also update this value accordingly */
 @media (min-width: 100rem) {
   :root[data-has-toc] {
     --sl-content-pad-x: 1.5rem;
@@ -1567,6 +1581,18 @@ it configures at which point the mobile toc should be replaced with the normal t
 
   :root[data-has-toc] .lg\:sl-block {
     display: block;
+  }
+
+  :root[data-has-toc] .right-sidebar-panel > .sl-container {
+    max-width: calc(
+      (
+        (
+            100vw - var(--sl-sidebar-width) - 2 * var(--sl-content-pad-x) - 2 *
+              var(--sl-sidebar-pad-x)
+          ) *
+          0.2 /* MAGIC NUMBER 🥲 */
+      )
+    );
   }
 
   :root[data-has-toc] .content-panel > .sl-container {

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -1259,41 +1259,71 @@ test('sidebar collapse toggle stays visible without overlapping the H1 on no-TOC
   ).toBe(true);
 });
 
-test('right TOC keeps its configured width across zoom-equivalent desktop widths', async ({
-  page,
-}) => {
+test('mobile TOC replaces the right TOC across zoom levels and display sizes', async ({ page }) => {
   test.skip(
     page.viewportSize()?.width !== 1440,
-    'The responsive TOC width matrix is covered once from the desktop project.'
+    'The responsive TOC zoom matrix is covered once from the desktop project.'
   );
 
   await page.goto('/app-host/certificate-configuration/');
   await dismissCookieConsentIfVisible(page);
   await waitForTopicSidebarReady(page);
 
-  const tocContainer = page.locator('.right-sidebar-panel > .sl-container');
+  const cdp = await page.context().newCDPSession(page);
+  const mobileToc = page.locator('#starlight__on-this-page--mobile');
+  const rightToc = page.locator('.right-sidebar-panel');
+  const cases = [
+    { resolution: '1366x768', width: 1366, height: 768, zoom: 1, mobile: true },
+    { resolution: '1440x900', width: 1440, height: 900, zoom: 1.25, mobile: true },
+    { resolution: '1920x1080', width: 1920, height: 1080, zoom: 1.25, mobile: true },
+    { resolution: '2560x1440', width: 2560, height: 1440, zoom: 1.75, mobile: true },
+    { resolution: '3840x2160', width: 3840, height: 2160, zoom: 3, mobile: true },
+    { resolution: '1920x1080', width: 1920, height: 1080, zoom: 1, mobile: false },
+    { resolution: '2560x1440', width: 2560, height: 1440, zoom: 1.5, mobile: false },
+    { resolution: '3840x2160', width: 3840, height: 2160, zoom: 2, mobile: false },
+  ];
 
-  for (const width of [1920, 1680, 1600, 1599, 1536, 1440, 1280, 1152]) {
-    await page.setViewportSize({ width, height: 900 });
-    await expect(tocContainer).toBeVisible();
+  try {
+    for (const testCase of cases) {
+      await cdp.send('Emulation.setDeviceMetricsOverride', {
+        width: Math.floor(testCase.width / testCase.zoom),
+        height: Math.floor(testCase.height / testCase.zoom),
+        deviceScaleFactor: testCase.zoom,
+        mobile: false,
+        screenWidth: testCase.width,
+        screenHeight: testCase.height,
+      });
 
-    const dimensions = await tocContainer.evaluate((container) => {
-      const panel = container.parentElement;
-      if (!panel) return null;
+      const label = `${testCase.resolution} at ${testCase.zoom * 100}% zoom`;
 
-      return {
-        configuredWidth: Number.parseFloat(getComputedStyle(panel).flexBasis),
-        renderedWidth: container.getBoundingClientRect().width,
-      };
-    });
+      if (testCase.mobile) {
+        await expect(mobileToc, `${label} should show the mobile TOC`).toBeVisible();
+        await expect(rightToc, `${label} should hide the right TOC`).toBeHidden();
+      } else {
+        await expect(mobileToc, `${label} should hide the mobile TOC`).toBeHidden();
+        await expect(rightToc, `${label} should show the right TOC`).toBeVisible();
+      }
 
-    expect(dimensions).not.toBeNull();
-    if (!dimensions) continue;
+      const layout = await page.locator('.main-pane').evaluate((mainPane) => {
+        const bounds = mainPane.getBoundingClientRect();
+        return {
+          documentOverflows:
+            document.documentElement.scrollWidth > document.documentElement.clientWidth,
+          rightEdge: bounds.right,
+          viewportWidth: window.innerWidth,
+        };
+      });
 
-    expect(
-      dimensions.renderedWidth,
-      `Expected the right TOC to retain its configured width at a ${width}px CSS viewport.`
-    ).toBeGreaterThanOrEqual(dimensions.configuredWidth - 1);
+      expect(layout.documentOverflows, `${label} should not overflow horizontally`).toBe(false);
+      if (testCase.mobile) {
+        expect(
+          Math.abs(layout.rightEdge - layout.viewportWidth),
+          `${label} should release the hidden right TOC column`
+        ).toBeLessThanOrEqual(1);
+      }
+    }
+  } finally {
+    await cdp.send('Emulation.clearDeviceMetricsOverride');
   }
 });
 

--- a/src/frontend/tests/e2e/ui-regressions.spec.ts
+++ b/src/frontend/tests/e2e/ui-regressions.spec.ts
@@ -1259,6 +1259,44 @@ test('sidebar collapse toggle stays visible without overlapping the H1 on no-TOC
   ).toBe(true);
 });
 
+test('right TOC keeps its configured width across zoom-equivalent desktop widths', async ({
+  page,
+}) => {
+  test.skip(
+    page.viewportSize()?.width !== 1440,
+    'The responsive TOC width matrix is covered once from the desktop project.'
+  );
+
+  await page.goto('/app-host/certificate-configuration/');
+  await dismissCookieConsentIfVisible(page);
+  await waitForTopicSidebarReady(page);
+
+  const tocContainer = page.locator('.right-sidebar-panel > .sl-container');
+
+  for (const width of [1920, 1680, 1600, 1599, 1536, 1440, 1280, 1152]) {
+    await page.setViewportSize({ width, height: 900 });
+    await expect(tocContainer).toBeVisible();
+
+    const dimensions = await tocContainer.evaluate((container) => {
+      const panel = container.parentElement;
+      if (!panel) return null;
+
+      return {
+        configuredWidth: Number.parseFloat(getComputedStyle(panel).flexBasis),
+        renderedWidth: container.getBoundingClientRect().width,
+      };
+    });
+
+    expect(dimensions).not.toBeNull();
+    if (!dimensions) continue;
+
+    expect(
+      dimensions.renderedWidth,
+      `Expected the right TOC to retain its configured width at a ${width}px CSS viewport.`
+    ).toBeGreaterThanOrEqual(dimensions.configuredWidth - 1);
+  }
+});
+
 test('Aspire 13.5 preserves published section anchors', async ({ page }) => {
   test.skip(
     page.viewportSize()?.width !== 1440,


### PR DESCRIPTION
## Summary

- Hide the desktop right-side table of contents whenever the mobile **On this page** dropdown is displayed.
- Release the hidden right TOC column so documentation content uses the available width.
- Add Chromium coverage using actual device metrics for multiple display resolutions and browser zoom levels.

## Validation

- Verified 55 resolution-and-zoom combinations across 1366x768, 1440x900, 1920x1080, 2560x1440, and 3840x2160 at 80%-400% zoom with no dual-TOC or horizontal-overflow cases.
- `pnpm --dir .\src\frontend exec playwright test tests/e2e/ui-regressions.spec.ts --grep "mobile TOC replaces|sidebar collapse toggle|docs reading hierarchy" --reporter=line`
- `pnpm --dir .\src\frontend exec prettier --check src/styles/site.css tests/e2e/ui-regressions.spec.ts --plugin prettier-plugin-astro`
- `pnpm --dir .\src\frontend exec eslint tests/e2e/ui-regressions.spec.ts --max-warnings 0`
- `git diff --check`